### PR TITLE
Mixins

### DIFF
--- a/core/api/src/classes/plugin.ts
+++ b/core/api/src/classes/plugin.ts
@@ -1,5 +1,5 @@
 import { App, AppOption, SimpleAppOptions } from "../models/App";
-import { Source, SimpleSourceOptions, SourceMapping } from "../models/Source";
+import { Source, SimpleSourceOptions, SourceMappings } from "../models/Source";
 import { Destination, SimpleDestinationOptions } from "../models/Destination";
 import { Run } from "../models/Run";
 import {
@@ -70,7 +70,7 @@ export interface ProfilesPluginMethod {
     appOptions: SimpleAppOptions,
     source: Source,
     sourceOptions: SimpleSourceOptions,
-    sourceMapping: SourceMapping,
+    sourceMapping: SourceMappings,
     run: Run,
     limit: number,
     filter: RunFilter,
@@ -88,7 +88,7 @@ export interface ProfilePropertyPluginMethod {
     appOptions: SimpleAppOptions,
     source: Source,
     sourceOptions: SimpleSourceOptions,
-    sourceMapping: SourceMapping,
+    sourceMapping: SourceMappings,
     profilePropertyRule: ProfilePropertyRule,
     profilePropertyRuleOptions: SimpleProfilePropertyRuleOptions,
     profile: Profile
@@ -106,7 +106,7 @@ export interface NextFilterPluginMethod {
     appOptions: SimpleAppOptions,
     source: Source,
     sourceOptions: SimpleSourceOptions,
-    sourceMapping: SourceMapping,
+    sourceMapping: SourceMappings,
     schedule: Schedule,
     scheduleOptions: SimpleScheduleOptions,
     run: Run

--- a/core/api/src/index.ts
+++ b/core/api/src/index.ts
@@ -1,7 +1,7 @@
 // Models
 export { Profile } from "./models/Profile";
 export { App, SimpleAppOptions } from "./models/App";
-export { Source, SimpleSourceOptions, SourceMapping } from "./models/Source";
+export { Source, SimpleSourceOptions, SourceMappings } from "./models/Source";
 export { Schedule, SimpleScheduleOptions } from "./models/Schedule";
 export { Run } from "./models/Run";
 export { Import } from "./models/Import";

--- a/core/api/src/mixins/modelWithMapping.ts
+++ b/core/api/src/mixins/modelWithMapping.ts
@@ -1,0 +1,83 @@
+import { api } from "actionhero";
+import { LoggedModel } from "./../classes/loggedModel";
+import { HasMany, AfterDestroy } from "sequelize-typescript";
+import { Mapping } from "../models/Mapping";
+import { ProfilePropertyRule } from "../models/ProfilePropertyRule";
+
+export interface Mappings {
+  [key: string]: any;
+}
+
+export abstract class ModelWithMapping<T> extends LoggedModel<T> {
+  @HasMany(() => Mapping)
+  mappings: Mapping[];
+
+  @AfterDestroy
+  static async destroyDestinationMappings(instance) {
+    return Mapping.destroy({
+      where: { ownerGuid: instance.guid },
+    });
+  }
+
+  async getMapping() {
+    const MappingObject: Mappings = {};
+    const mappings = await this.$get("mappings");
+
+    for (const i in mappings) {
+      const mapping = mappings[i];
+      const rule = await mapping.$get("profilePropertyRule");
+      MappingObject[mapping.remoteKey] = rule.key;
+    }
+
+    return MappingObject;
+  }
+
+  async setMapping(mappings: Mappings) {
+    const transaction = await api.sequelize.transaction();
+
+    try {
+      await Mapping.destroy({
+        where: { ownerGuid: this.guid },
+        transaction,
+      });
+
+      const keys = Object.keys(mappings);
+      for (const i in keys) {
+        const remoteKey = keys[i];
+        const key = mappings[remoteKey];
+        const profilePropertyRule = await ProfilePropertyRule.findOne({
+          where: { key },
+        });
+
+        if (!profilePropertyRule) {
+          throw new Error(`cannot find profile property rule ${key}`);
+        }
+
+        await Mapping.create(
+          {
+            ownerGuid: this.guid,
+            ownerType: "destination",
+            profilePropertyRuleGuid: profilePropertyRule.guid,
+            remoteKey,
+          },
+          { transaction }
+        );
+      }
+
+      this.changed("updatedAt", true);
+      await this.save({ transaction });
+
+      await transaction.commit();
+
+      // if there's an afterSetMapping hook
+      if (typeof this.afterSetMapping === "function") {
+        await this.afterSetMapping();
+      }
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+
+  abstract async afterSetMapping?();
+}

--- a/core/api/src/mixins/modelWithMapping.ts
+++ b/core/api/src/mixins/modelWithMapping.ts
@@ -1,14 +1,13 @@
 import { api } from "actionhero";
+import { Model, HasMany, AfterDestroy } from "sequelize-typescript";
 import { LoggedModel } from "./../classes/loggedModel";
-import { HasMany, AfterDestroy } from "sequelize-typescript";
 import { Mapping } from "../models/Mapping";
 import { ProfilePropertyRule } from "../models/ProfilePropertyRule";
 
 export interface Mappings {
   [key: string]: any;
 }
-
-export abstract class ModelWithMapping<T> extends LoggedModel<T> {
+export abstract class ModelWithMappings<T> extends LoggedModel<T> {
   @HasMany(() => Mapping)
   mappings: Mapping[];
 
@@ -21,7 +20,7 @@ export abstract class ModelWithMapping<T> extends LoggedModel<T> {
 
   async getMapping() {
     const MappingObject: Mappings = {};
-    const mappings = await this.$get("mappings");
+    const mappings = await Mapping.findAll({ where: { ownerGuid: this.guid } });
 
     for (const i in mappings) {
       const mapping = mappings[i];
@@ -79,5 +78,5 @@ export abstract class ModelWithMapping<T> extends LoggedModel<T> {
     }
   }
 
-  abstract async afterSetMapping?();
+  abstract afterSetMapping?: () => Promise<any>;
 }

--- a/core/api/src/mixins/modelWithOptions.ts
+++ b/core/api/src/mixins/modelWithOptions.ts
@@ -1,0 +1,118 @@
+import { GrouparooPlugin, PluginConnection } from "../classes/plugin";
+import { api } from "actionhero";
+import { LoggedModel } from "./../classes/loggedModel";
+import { Column, HasMany, AfterDestroy } from "sequelize-typescript";
+import { Option } from "../models/Option";
+
+export interface SimpleOptions {
+  [key: string]: string;
+}
+
+export abstract class ModelWithOptions<T> extends LoggedModel<T> {
+  @Column
+  type: string;
+
+  @HasMany(() => Option, "ownerGuid")
+  _options: Option[]; // the underscore is needed as "options" is an internal method on sequelize instances
+
+  @AfterDestroy
+  static async destroyDestinationOptions(instance) {
+    return Option.destroy({
+      where: { ownerGuid: instance.guid },
+    });
+  }
+
+  async getOptions() {
+    const optionsObject: SimpleOptions = {};
+    const options = await this.$get("_options");
+
+    options.forEach((option) => {
+      optionsObject[option.key] = option.value;
+    });
+
+    return optionsObject;
+  }
+
+  async setOptions(options: SimpleOptions) {
+    const transaction = await api.sequelize.transaction();
+
+    try {
+      await this.validateOptions(options);
+
+      await Option.destroy({
+        where: { ownerGuid: this.guid },
+        transaction,
+      });
+
+      const keys = Object.keys(options);
+      for (const i in keys) {
+        const key = keys[i];
+        await Option.create(
+          {
+            ownerGuid: this.guid,
+            ownerType: "destination",
+            key,
+            value: options[key],
+          },
+          { transaction }
+        );
+      }
+
+      this.changed("updatedAt", true);
+      await this.save({ transaction });
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+
+  getPlugin() {
+    let match: {
+      plugin: GrouparooPlugin;
+      pluginConnection: PluginConnection;
+    } = { plugin: null, pluginConnection: null };
+
+    api.plugins.plugins.forEach((plugin: GrouparooPlugin) => {
+      if (plugin.connections) {
+        plugin.connections.forEach((pluginConnection) => {
+          if (pluginConnection.name === this.type) {
+            match = { plugin, pluginConnection };
+          }
+        });
+      }
+    });
+
+    return match;
+  }
+
+  async validateOptions(options: { [key: string]: string }) {
+    const requiredOptions = this.getRequiredOptions();
+    requiredOptions.forEach((requiredOption) => {
+      if (!options[requiredOption]) {
+        throw new Error(
+          `${requiredOption} is required for a destination of type ${this.type}`
+        );
+      }
+    });
+
+    const { pluginConnection } = this.getPlugin();
+    const allOptions = pluginConnection.options.map((o) => o.key);
+    for (const k in options) {
+      if (allOptions.indexOf(k) < 0) {
+        throw new Error(`${k} is not an option for a ${this.type} destination`);
+      }
+    }
+  }
+
+  private getRequiredOptions() {
+    const { pluginConnection } = this.getPlugin();
+
+    if (!pluginConnection) {
+      throw new Error(`cannot find a pluginConnection for type ${this.type}`);
+    }
+
+    return pluginConnection.options.filter((o) => o.required).map((o) => o.key);
+  }
+}

--- a/core/api/src/models/Mapping.ts
+++ b/core/api/src/models/Mapping.ts
@@ -13,7 +13,6 @@ import {
 import * as uuid from "uuid";
 import { ProfilePropertyRule } from "./ProfilePropertyRule";
 import { Schedule } from "./Schedule";
-import { Destination } from "./Destination";
 import { Source } from "./Source";
 
 @Table({ tableName: "mappings", paranoid: false })
@@ -39,9 +38,6 @@ export class Mapping extends Model<Mapping> {
   updatedAt: Date;
 
   @AllowNull(false)
-  @ForeignKey(() => Schedule)
-  @ForeignKey(() => Destination)
-  @ForeignKey(() => Source)
   @Column
   ownerGuid: string;
 
@@ -58,12 +54,6 @@ export class Mapping extends Model<Mapping> {
   @Length({ min: 1, max: 191 })
   @Column
   remoteKey: string;
-
-  @BelongsTo(() => Destination)
-  destination: Destination;
-
-  @BelongsTo(() => Source)
-  source: Source;
 
   @BelongsTo(() => ProfilePropertyRule)
   profilePropertyRule: ProfilePropertyRule;

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -19,7 +19,7 @@ import { LoggedModel } from "../classes/loggedModel";
 import { Profile } from "./Profile";
 import { ProfileProperty } from "./ProfileProperty";
 import { App, SimpleAppOptions } from "./App";
-import { Source, SimpleSourceOptions, SourceMapping } from "./Source";
+import { Source, SimpleSourceOptions, SourceMappings } from "./Source";
 import { Option } from "./Option";
 import { Group } from "./Group";
 import { GroupRule } from "./GroupRule";
@@ -109,7 +109,7 @@ export interface PluginConnectionProfilePropertyRuleOption {
     appOptions: SimpleAppOptions,
     source: Source,
     sourceOptions: SimpleSourceOptions,
-    sourceMapping: SourceMapping
+    sourceMapping: SourceMappings
   ) => Promise<
     Array<{
       key: string;
@@ -340,7 +340,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
 
   async pluginOptions() {
     const source = await this.$get("source");
-    const { pluginConnection } = source.getPlugin();
+    const { pluginConnection } = await source.getPlugin();
 
     if (!pluginConnection) {
       throw new Error(`cannot find a pluginConnection for type ${source.type}`);
@@ -408,7 +408,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
 
   private async getRequiredOptions() {
     const source = await this.$get("source");
-    const { pluginConnection } = source.getPlugin();
+    const { pluginConnection } = await source.getPlugin();
 
     if (!pluginConnection) {
       throw new Error(`cannot find a pluginConnection for type ${source.type}`);

--- a/core/api/src/models/Run.ts
+++ b/core/api/src/models/Run.ts
@@ -186,7 +186,7 @@ export class Run extends Model<Run> {
 
     const source = await schedule.$get("source");
     const app = await source.$get("app");
-    const { pluginConnection } = source.getPlugin();
+    const { pluginConnection } = await source.getPlugin();
     if (!pluginConnection || !pluginConnection?.methods.nextFilter) {
       return nextFilter;
     }

--- a/core/api/src/utils/mixins.ts
+++ b/core/api/src/utils/mixins.ts
@@ -1,0 +1,16 @@
+// from https://www.typescriptlang.org/docs/handbook/mixins.html + modifications for Sequelize
+
+export function applyMixins(derivedCtor: any, baseCtors: any[]) {
+  baseCtors.forEach((baseCtor) => {
+    Object.getOwnPropertyNames(baseCtor.prototype).forEach((name) => {
+      // we do not want to run the inherited class constructors (sequelzie specific)
+      if (name !== "constructor") {
+        Object.defineProperty(
+          derivedCtor.prototype,
+          name,
+          Object.getOwnPropertyDescriptor(baseCtor.prototype, name)
+        );
+      }
+    });
+  });
+}

--- a/plugins/@grouparoo/csv/src/lib/file-import/profiles.ts
+++ b/plugins/@grouparoo/csv/src/lib/file-import/profiles.ts
@@ -7,7 +7,7 @@ import {
   SimpleAppOptions,
   Source,
   SimpleSourceOptions,
-  SourceMapping,
+  SourceMappings,
   Run,
 } from "@grouparoo/core";
 
@@ -23,7 +23,7 @@ export async function profiles(
   appOptions: SimpleAppOptions,
   source: Source,
   sourceOptions: SimpleSourceOptions,
-  sourceMapping: SourceMapping,
+  sourceMapping: SourceMappings,
   run: Run,
   limit: number,
   filter: { [key: string]: any },

--- a/plugins/@grouparoo/mysql/src/lib/table-import/nextFilter.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/nextFilter.ts
@@ -4,7 +4,7 @@ import {
   SimpleAppOptions,
   Source,
   SimpleSourceOptions,
-  SourceMapping,
+  SourceMappings,
   Schedule,
   SimpleScheduleOptions,
   Run,
@@ -16,7 +16,7 @@ export async function nextFilter(
   appOptions: SimpleAppOptions,
   source: Source,
   sourceOptions: SimpleSourceOptions,
-  sourceMapping: SourceMapping,
+  sourceMapping: SourceMappings,
   schedule: Schedule,
   scheduleOptions: SimpleScheduleOptions,
   run: Run

--- a/plugins/@grouparoo/mysql/src/lib/table-import/profilePropertyRuleOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/profilePropertyRuleOptions.ts
@@ -3,7 +3,7 @@ import {
   SimpleAppOptions,
   Source,
   SimpleSourceOptions,
-  SourceMapping,
+  SourceMappings,
 } from "@grouparoo/core";
 import { sourcePreview } from "./sourcePreview";
 
@@ -18,7 +18,7 @@ export const profilePropertyRuleOptions = [
       appOptions: SimpleAppOptions,
       source: Source,
       sourceOptions: SimpleSourceOptions,
-      sourceMapping: SourceMapping
+      sourceMapping: SourceMappings
     ) => {
       const rows = await sourcePreview(app, appOptions, source, sourceOptions);
       const columns = Object.keys(rows[0]);

--- a/plugins/@grouparoo/mysql/src/lib/table-import/profiles.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/profiles.ts
@@ -7,7 +7,7 @@ import {
   SimpleAppOptions,
   Source,
   SimpleSourceOptions,
-  SourceMapping,
+  SourceMappings,
   Run,
 } from "@grouparoo/core";
 
@@ -17,7 +17,7 @@ export async function profiles(
   appOptions: SimpleAppOptions,
   source: Source,
   sourceOptions: SimpleSourceOptions,
-  sourceMapping: SourceMapping,
+  sourceMapping: SourceMappings,
   run: Run,
   limit: number,
   filter: { [key: string]: any },

--- a/plugins/@grouparoo/mysql/src/lib/table-import/scheduleOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/scheduleOptions.ts
@@ -3,7 +3,7 @@ import {
   SimpleAppOptions,
   Source,
   SimpleSourceOptions,
-  SourceMapping,
+  SourceMappings,
 } from "@grouparoo/core";
 import { sourcePreview } from "./sourcePreview";
 
@@ -18,7 +18,7 @@ export const scheduleOptions = [
       appOptions: SimpleAppOptions,
       source: Source,
       sourceOptions: SimpleSourceOptions,
-      sourceMapping: SourceMapping
+      sourceMapping: SourceMappings
     ) => {
       const rows = await sourcePreview(app, appOptions, source, sourceOptions);
 

--- a/plugins/@grouparoo/postgres/src/lib/table-import/nextFilter.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/nextFilter.ts
@@ -5,7 +5,7 @@ import {
   SimpleAppOptions,
   Source,
   SimpleSourceOptions,
-  SourceMapping,
+  SourceMappings,
   Schedule,
   SimpleScheduleOptions,
   Run,
@@ -17,7 +17,7 @@ export async function nextFilter(
   appOptions: SimpleAppOptions,
   source: Source,
   sourceOptions: SimpleSourceOptions,
-  sourceMapping: SourceMapping,
+  sourceMapping: SourceMappings,
   schedule: Schedule,
   scheduleOptions: SimpleScheduleOptions,
   run: Run

--- a/plugins/@grouparoo/postgres/src/lib/table-import/profiles.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/profiles.ts
@@ -8,7 +8,7 @@ import {
   SimpleAppOptions,
   Source,
   SimpleSourceOptions,
-  SourceMapping,
+  SourceMappings,
   Run,
 } from "@grouparoo/core";
 
@@ -18,7 +18,7 @@ export async function profiles(
   appOptions: SimpleAppOptions,
   source: Source,
   sourceOptions: SimpleSourceOptions,
-  sourceMapping: SourceMapping,
+  sourceMapping: SourceMappings,
   run: Run,
   limit: number,
   filter: { [key: string]: any },

--- a/plugins/@grouparoo/postgres/src/lib/table-import/scheduleOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/scheduleOptions.ts
@@ -3,7 +3,7 @@ import {
   SimpleAppOptions,
   Source,
   SimpleSourceOptions,
-  SourceMapping,
+  SourceMappings,
 } from "@grouparoo/core";
 import { sourcePreview } from "./sourcePreview";
 
@@ -18,7 +18,7 @@ export const scheduleOptions = [
       appOptions: SimpleAppOptions,
       source: Source,
       sourceOptions: SimpleSourceOptions,
-      sourceMapping: SourceMapping
+      sourceMapping: SourceMappings
     ) => {
       const rows = await sourcePreview(app, appOptions, source, sourceOptions);
 


### PR DESCRIPTION
Goals:

* implement a strategy for mixins which provides both the type definitions and the prototype overrides for javascript.  
* share code between models for common relations `Options` and `Mapping`


Notes:
* The `recommended` way of doing Mixins in typescript is kind of crazy - the interfaces combine nicely but you still need to manually mess with the prototypes of your classes: https://www.typescriptlang.org/docs/handbook/mixins.html
* This Sequelize advice is out of date and does not work: https://github.com/RobinBuschmann/sequelize-typescript/issues/487
* Sequelize messes with the insntances classes as part of the `constructor`.  Therefore, we should not run mixin constructors as part of `applyMixins ` 
* There are cyclc load order problems with Sequelize models requiring eachother before the mixins are applied.  This looks like a null class rather than raising a proper error :/