### PR TITLE
clear redis out after tests too

### DIFF
--- a/core/api/__tests__/utils/specHelper.ts
+++ b/core/api/__tests__/utils/specHelper.ts
@@ -101,6 +101,7 @@ export namespace helper {
   }
 
   export async function shutdown(server1, server2?) {
+    await api.resque.queue.connection.redis.flushdb();
     await Promise.all(
       [server1, server2].map(async (server) => {
         if (server) {


### PR DESCRIPTION
prevents possible pollution into redis database and executing code.