### PR TITLE
Allow next to load & transpile plugins from node_modules

### DIFF
--- a/core/web/client/client.ts
+++ b/core/web/client/client.ts
@@ -1,7 +1,7 @@
 import Axios, { AxiosRequestConfig, Method } from "axios";
 import Router from "next/router";
 import { isBrowser } from "../utils/isBrowser";
-import PackageJSON from "../../../package.json";
+import PackageJSON from "../../package.json";
 
 interface ClientCacheObject {
   locked: boolean;

--- a/core/web/env.js
+++ b/core/web/env.js
@@ -9,15 +9,34 @@ fs.writeFileSync(
   JSON.stringify(pluginManifest, null, 2)
 );
 
+// write the require path loader for the webpack plugin loader
+const pluginLoaderPaths = {
+  monorepo: "../../../plugins/${pluginName}/src/components/${file}.plugin",
+  dist: "../../node_modules/${pluginName}/src/components/${file}.plugin",
+};
+const pluginLoaderPath =
+  pluginLoaderPaths[process.env.GROUPAROO_MONOREPO_APP ? "monorepo" : "dist"];
+
+const loader = `import dynamic from "next/dynamic";
+
+export default function LoadPlugin (pluginName: string, file: string) {
+  return dynamic(() =>
+    import(\`${pluginLoaderPath}\`)
+  )
+};
+`;
+fs.writeFileSync(path.join(__dirname, "tmp", "pluginLoader.ts"), loader);
+
+// build the web ENVIRONMENT object
 const _exports = {
   API_VERSION: process.env.API_VERSION || "1",
-  GROUPAROO_MONOREPO_APP: process.env.GROUPAROO_MONOREPO_APP
+  GROUPAROO_MONOREPO_APP: process.env.GROUPAROO_MONOREPO_APP,
 };
 
 // pass plugin env/web to the build
-pluginManifest.plugins.forEach(plugin => {
+pluginManifest.plugins.forEach((plugin) => {
   if (plugin.grouparoo && plugin.grouparoo.env && plugin.grouparoo.env.web) {
-    plugin.grouparoo.env.web.forEach(e => {
+    plugin.grouparoo.env.web.forEach((e) => {
       _exports[e] = process.env[e];
     });
   }

--- a/core/web/env.js
+++ b/core/web/env.js
@@ -10,18 +10,15 @@ fs.writeFileSync(
 );
 
 // write the require path loader for the webpack plugin loader
-const pluginLoaderPaths = {
-  monorepo: "../../../plugins/${pluginName}/src/components/${file}.plugin",
-  dist: "../../node_modules/${pluginName}/src/components/${file}.plugin",
-};
-const pluginLoaderPath =
-  pluginLoaderPaths[process.env.GROUPAROO_MONOREPO_APP ? "monorepo" : "dist"];
-
 const loader = `import dynamic from "next/dynamic";
 
 export default function LoadPlugin (pluginName: string, file: string) {
   return dynamic(() =>
-    import(\`${pluginLoaderPath}\`)
+    import(\`${
+      process.env.GROUPAROO_MONOREPO_APP
+        ? "../../../plugins/${pluginName}/src/components/${file}.plugin"
+        : "../../node_modules/${pluginName}/src/components/${file}.plugin"
+    }\`)
   )
 };
 `;

--- a/core/web/hooks/usePlugin.ts
+++ b/core/web/hooks/usePlugin.ts
@@ -1,5 +1,5 @@
-import dynamic from "next/dynamic";
 import PluginManifest from "./../tmp/pluginManifest.json";
+import PluginLoader from "./../tmp/pluginLoader";
 
 export function usePlugins(key: string) {
   const pluginComponents = [];
@@ -26,23 +26,7 @@ export function usePlugins(key: string) {
               key: lastWordFromCamelCase(file),
             });
 
-            if (process.env.GROUPAROO_MONOREPO_APP) {
-              pluginComponents.push(
-                dynamic(() =>
-                  import(
-                    `../../../plugins/${pluginName}/src/components/${file}.plugin`
-                  )
-                )
-              );
-            } else {
-              pluginComponents.push(
-                dynamic(() =>
-                  import(
-                    `../../node_modules/${pluginName}/src/components/${file}.plugin`
-                  )
-                )
-              );
-            }
+            pluginComponents.push(PluginLoader(pluginName, file));
           });
         }
       }

--- a/core/web/next.config.js
+++ b/core/web/next.config.js
@@ -1,4 +1,6 @@
+const path = require("path");
 const env = require("./env");
+const { getPluginManifest } = require("../api/src/utils/pluginDetails");
 
 module.exports = {
   env,
@@ -10,28 +12,60 @@ module.exports = {
         {
           source: "/schedules/",
           destination: "/sources",
-          statusCode: 302
+          statusCode: 302,
         },
         {
           source: "/schedules",
           destination: "/sources",
-          statusCode: 302
-        }
+          statusCode: 302,
+        },
       ];
-    }
+    },
   },
 
   webpack: (config, options) => {
+    overwriteNextBabelLoaderToIncludePluginNodeModules(config);
+
     config.module.rules.push({
       test: /\.plugin\.js|\.plugin\.jsx|\.plugin\.ts|\.plugin\.tsx$/,
-      use: [options.defaultLoaders.babel]
+      use: [options.defaultLoaders.babel],
     });
 
     config.module.rules.push({
       test: /\.md$/,
-      use: "raw-loader"
+      use: "raw-loader",
     });
 
     return config;
+  },
+};
+
+let OVERWRITTEN = false;
+const overwriteNextBabelLoaderToIncludePluginNodeModules = (config) => {
+  if (OVERWRITTEN) {
+    return;
   }
+
+  const { plugins } = getPluginManifest();
+  const pluginNamesWithinNodeModules = [{ name: "@grouparoo/core" }]
+    .concat(plugins)
+    .map((p) => path.join("node_modules", p.name));
+
+  const NextBabelLoader = config.module.rules.filter(
+    (r) => r?.use?.loader === "next-babel-loader"
+  )[0];
+
+  const originalExclude = NextBabelLoader.exclude;
+
+  NextBabelLoader.exclude = (moduleName, ...args) => {
+    pluginNamesWithinNodeModules.forEach((pluginPath) => {
+      if (moduleName.indexOf(pluginPath) >= 0) {
+        return false;
+      }
+    });
+
+    return originalExclude(moduleName, ...args);
+  };
+
+  OVERWRITTEN = true;
 };

--- a/core/web/next.config.js
+++ b/core/web/next.config.js
@@ -51,9 +51,13 @@ const overwriteNextBabelLoaderToIncludePluginNodeModules = (config) => {
     .concat(plugins)
     .map((p) => path.join("node_modules", p.name));
 
-  const NextBabelLoader = config.module.rules.filter(
-    (r) => r?.use?.loader === "next-babel-loader"
-  )[0];
+  const NextBabelLoader = config.module.rules.filter((r) => {
+    if (r.use && r.use.loader === "next-babel-loader") {
+      return true;
+    } else {
+      return false;
+    }
+  })[0];
 
   const originalExclude = NextBabelLoader.exclude;
 


### PR DESCRIPTION
Closes https://www.pivotaltracker.com/story/show/171189466

Allows the app to be distributed via NPM and overwrites next.js' default webpack loader to allow to transpilaition of files within node_modules.  This includes `@grouparoo/core` and plugins.

This PR also statically writes a special loader for the frontend to find plugins.  Since webpack pre-scans the directories for files to transpile, we need to only have static references to paths that exist in this deployment.  `if`/`switch` statements are not allowed.  The web app uses the `env` building step to write a new typescript helper at runtime, before the webpack process begins. 

Related to https://github.com/zeit/next.js/issues/11411 and https://github.com/evantahler/next-subproject-example