### PR TITLE
use env NEXT_DEVELOPMENT_MODE in dev and start scripts to use built site with `npm start`

### DIFF
--- a/apps/staging-public/package.json
+++ b/apps/staging-public/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "prepare": "cd node_modules/@grouparoo/core && GROUPAROO_MONOREPO_APP=staging-public npm run prepare",
-    "start": "cd node_modules/@grouparoo/core && NEXT_DEVELOPMENT_MODE=false GROUPAROO_MONOREPO_APP=staging-public ./api/bin/start",
+    "start": "cd node_modules/@grouparoo/core && GROUPAROO_MONOREPO_APP=staging-public ./api/bin/start",
     "dev": "cd node_modules/@grouparoo/core && GROUPAROO_MONOREPO_APP=staging-public ./api/bin/dev"
   },
   "grouparoo": {

--- a/core/api/bin/dev
+++ b/core/api/bin/dev
@@ -9,6 +9,8 @@ else
   EXECUTABLE="ts-node-dev"
 fi
 
+export NEXT_DEVELOPMENT_MODE=true
+
 "$EXECUTABLE" \
   --transpile-only \
   --ignore-watch=web \

--- a/core/api/bin/start
+++ b/core/api/bin/start
@@ -3,4 +3,6 @@
 cd "$(dirname "$0")"
 cd ..
 
+export NEXT_DEVELOPMENT_MODE=false
+
 node dist/server.js


### PR DESCRIPTION
solves https://www.pivotaltracker.com/story/show/172205576