### PR TITLE
bootstrapUniqueProfilePropertyRule creates rules in ready state

### DIFF
--- a/core/api/__tests__/models/source.ts
+++ b/core/api/__tests__/models/source.ts
@@ -340,7 +340,7 @@ describe("models/source", () => {
 
       expect(rule.key).toBe("uniqueId");
       expect(rule.type).toBe("integer");
-      expect(rule.state).toBe("draft");
+      expect(rule.state).toBe("ready");
       expect(rule.unique).toBe(true);
 
       await rule.destroy();

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -410,7 +410,7 @@ export class Source extends LoggedModel<Source> {
     const rule = ProfilePropertyRule.build({
       key,
       type,
-      state: "draft",
+      state: "ready",
       unique: true,
       sourceGuid: this.guid,
     });

--- a/plugins/@grouparoo/mysql/src/lib/table-import/profileProperty.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/profileProperty.ts
@@ -30,6 +30,11 @@ export async function profileProperty(
     return;
   }
 
+  if (tableCol === column && aggregationMethod === "exact") {
+    // don't return userId where userId = userId
+    return;
+  }
+
   let aggSelect = `\`${column}\``;
   switch (aggregationMethod) {
     case "average":

--- a/plugins/@grouparoo/postgres/src/lib/table-import/profileProperty.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/profileProperty.ts
@@ -30,6 +30,11 @@ export async function profileProperty(
     return;
   }
 
+  if (tableCol === column && aggregationMethod === "exact") {
+    // don't return userId where userId = userId
+    return;
+  }
+
   let aggSelect = `"${column}"`;
   switch (aggregationMethod) {
     case "average":


### PR DESCRIPTION
* bootstrapUniqueProfilePropertyRule creates rules in ready state
* in table mode, the mySQL and Postgres sources don't run exact updates for the profilePropertyMatch, ie `select id from users where id = {{userId}}` - that's silly

solves https://www.pivotaltracker.com/story/show/172236174