### PR TITLE
destinations can choose properties to export, regardless of mapping

### DIFF
--- a/core/api/__tests__/actions/apps.ts
+++ b/core/api/__tests__/actions/apps.ts
@@ -70,6 +70,21 @@ describe("actions/apps", () => {
       expect(names).toContain("test-plugin-app");
     });
 
+    test("an administrator can get the options for the app options", async () => {
+      connection.params = {
+        csrfToken,
+        guid,
+      };
+      const { error, options } = await specHelper.runAction(
+        "app:optionOptions",
+        connection
+      );
+      expect(error).toBeUndefined();
+      expect(options).toEqual({
+        fileGuid: { options: ["a", "b"], type: "list" },
+      });
+    });
+
     test("an administrator can test the app options with the saved app options", async () => {
       connection.params = {
         csrfToken,

--- a/core/api/__tests__/models/app.ts
+++ b/core/api/__tests__/models/app.ts
@@ -219,9 +219,14 @@ describe("models/app", () => {
           {
             name: "test-template-app",
             options: [{ key: "test_key", required: true }],
-            test: async () => {
-              testCounter++;
-              return true;
+            methods: {
+              test: async () => {
+                testCounter++;
+                return true;
+              },
+              appOptions: async () => {
+                return { fileGuid: { type: "list", options: ["a", "b"] } };
+              },
             },
           },
         ],
@@ -255,6 +260,13 @@ describe("models/app", () => {
     test("plugins can provide icons", async () => {
       const apiData = await app.apiData();
       expect(apiData.icon).toBe("/path/to/icon.svg");
+    });
+
+    test("it can return the appOptions from the plugin", async () => {
+      const options = await app.appOptions();
+      expect(options).toEqual({
+        fileGuid: { type: "list", options: ["a", "b"] },
+      });
     });
 
     test("it can run a plugin's test method", async () => {

--- a/core/api/__tests__/models/destination.ts
+++ b/core/api/__tests__/models/destination.ts
@@ -420,8 +420,10 @@ describe("models/destination", () => {
           {
             name: "test-template-app",
             options: [],
-            test: async () => {
-              return true;
+            methods: {
+              test: async () => {
+                return true;
+              },
             },
           },
         ],
@@ -497,8 +499,10 @@ describe("models/destination", () => {
           {
             name: "test-template-app",
             options: [{ key: "test_key", required: true }],
-            test: async () => {
-              return true;
+            methods: {
+              test: async () => {
+                return true;
+              },
             },
           },
         ],

--- a/core/api/__tests__/models/profile.ts
+++ b/core/api/__tests__/models/profile.ts
@@ -517,8 +517,10 @@ describe("models/profile", () => {
           {
             name: "test-template-app",
             options: [],
-            test: async () => {
-              return true;
+            methods: {
+              test: async () => {
+                return true;
+              },
             },
           },
         ],

--- a/core/api/__tests__/models/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRule.ts
@@ -285,8 +285,10 @@ describe("models/profilePropertyRule", () => {
           {
             name: "test-template-app",
             options: [],
-            test: async () => {
-              return true;
+            methods: {
+              test: async () => {
+                return true;
+              },
             },
           },
         ],

--- a/core/api/__tests__/models/run.ts
+++ b/core/api/__tests__/models/run.ts
@@ -322,8 +322,10 @@ describe("models/run", () => {
           {
             name: "test-error-app",
             options: [],
-            test: async () => {
-              return true;
+            methods: {
+              test: async () => {
+                return true;
+              },
             },
           },
         ],

--- a/core/api/__tests__/models/schedule.ts
+++ b/core/api/__tests__/models/schedule.ts
@@ -285,8 +285,10 @@ describe("models/schedule", () => {
           {
             name: "test-template-app",
             options: [],
-            test: async () => {
-              return true;
+            methods: {
+              test: async () => {
+                return true;
+              },
             },
           },
         ],

--- a/core/api/__tests__/tasks/profiles/export.ts
+++ b/core/api/__tests__/tasks/profiles/export.ts
@@ -72,8 +72,10 @@ describe("tasks/profile:export", () => {
             {
               name: "test-template-app",
               options: [],
-              test: async () => {
-                return true;
+              methods: {
+                test: async () => {
+                  return true;
+                },
               },
             },
           ],

--- a/core/api/__tests__/utils/specHelper.ts
+++ b/core/api/__tests__/utils/specHelper.ts
@@ -150,8 +150,13 @@ export namespace helper {
               required: true,
             },
           ],
-          test: async () => {
-            return true;
+          methods: {
+            test: async () => {
+              return true;
+            },
+            appOptions: async () => {
+              return { fileGuid: { type: "list", options: ["a", "b"] } };
+            },
           },
         },
       ],

--- a/core/api/src/actions/apps.ts
+++ b/core/api/src/actions/apps.ts
@@ -60,6 +60,28 @@ export class AppOptions extends Action {
   }
 }
 
+export class AppOptionOptions extends Action {
+  constructor() {
+    super();
+    this.name = "app:optionOptions";
+    this.description = "return option choices from this app";
+    this.outputExample = {};
+    this.middleware = ["authenticated-team-member", "role-read"];
+    this.inputs = {
+      guid: { required: true },
+    };
+  }
+
+  async run({ params, response }) {
+    const app = await App.findOne({ where: { guid: params.guid } });
+    if (!app) {
+      throw new Error("app not found");
+    }
+
+    response.options = await app.appOptions();
+  }
+}
+
 export class AppCreate extends Action {
   constructor() {
     super();

--- a/core/api/src/actions/sources.ts
+++ b/core/api/src/actions/sources.ts
@@ -209,7 +209,7 @@ export class sourceConnectionOptions extends Action {
     this.outputExample = {};
     this.middleware = ["authenticated-team-member", "role-read"];
     this.inputs = {
-      guid: { required: false },
+      guid: { required: true },
     };
   }
 

--- a/core/api/src/classes/plugin.ts
+++ b/core/api/src/classes/plugin.ts
@@ -31,7 +31,24 @@ export interface GrouparooPlugin {
 export interface PluginApp {
   name: string;
   options: AppOption[];
-  test: TestPluginMethod;
+  methods: {
+    test: TestPluginMethod;
+    appOptions?: AppOptionsMethod;
+  };
+}
+
+/**
+ * Method to return the options available to this app.
+ * Returns a collection of data to display to the user.
+ */
+export interface AppOptionsMethod {
+  (): Promise<{
+    [optionName: string]: {
+      type: string;
+      options?: string[];
+      descriptions?: string[];
+    };
+  }>;
 }
 
 /**

--- a/core/api/src/classes/plugin.ts
+++ b/core/api/src/classes/plugin.ts
@@ -62,7 +62,6 @@ export interface PluginConnection {
   options: ConnectionOption[];
   profilePropertyRuleOptions?: PluginConnectionProfilePropertyRuleOption[];
   scheduleOptions?: PluginConnectionScheduleOption[];
-  ignoreMapping?: boolean;
   methods?: {
     sourceOptions?: SourceOptionsMethod;
     sourcePreview?: SourcePreviewMethod;

--- a/core/api/src/config/routes.ts
+++ b/core/api/src/config/routes.ts
@@ -41,6 +41,7 @@ export const DEFAULT = {
         { path: "/:apiVersion/runs", action: "runs:list" },
         { path: "/:apiVersion/run/:guid", action: "run:view" },
         { path: "/:apiVersion/appOptions", action: "app:options" },
+        { path: "/:apiVersion/app/:guid/optionOptions", action: "app:optionOptions" },
         { path: "/:apiVersion/app/:guid", action: "app:view" },
         { path: "/:apiVersion/sources/connectionApps", action: "sources:connectionApps" },
         { path: "/:apiVersion/source/:guid", action: "source:view" },

--- a/core/api/src/initializers/plugins.ts
+++ b/core/api/src/initializers/plugins.ts
@@ -23,8 +23,10 @@ export class Plugins extends Initializer {
         {
           name: "manual",
           options: [],
-          test: async () => {
-            return true;
+          methods: {
+            test: async () => {
+              return true;
+            },
           },
         },
       ],

--- a/core/api/src/models/App.ts
+++ b/core/api/src/models/App.ts
@@ -110,7 +110,7 @@ export class App extends LoggedModel<App> {
     }
 
     try {
-      result = await pluginApp.test(this, options);
+      result = await pluginApp.methods.test(this, options);
     } catch (err) {
       error = err;
       result = false;
@@ -118,6 +118,16 @@ export class App extends LoggedModel<App> {
     }
 
     return { result, error };
+  }
+
+  async appOptions() {
+    const { pluginApp } = await this.getPlugin();
+
+    if (!pluginApp.methods.appOptions) {
+      return {};
+    }
+
+    return pluginApp.methods.appOptions();
   }
 
   async getOptions() {

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -345,11 +345,8 @@ export class Destination extends LoggedModel<Destination> {
     const options = await this.getOptions();
     const app = await this.$get("app");
     let method: ExportProfilePluginMethod;
-    let ignoreMapping = false;
-
     const { pluginConnection } = await this.getPlugin();
     method = pluginConnection.methods.exportProfile;
-    ignoreMapping = pluginConnection.ignoreMapping;
 
     if (!method) {
       throw new Error(`cannot find an export method for app type ${app.type}`);
@@ -362,15 +359,10 @@ export class Destination extends LoggedModel<Destination> {
     const mappingKeys = Object.keys(mapping);
     let mappedOldProfileProperties = {};
     let mappedNewProfileProperties = {};
-    if (!ignoreMapping) {
-      mappingKeys.forEach((k) => {
-        mappedOldProfileProperties[k] = oldProfileProperties[mapping[k]];
-        mappedNewProfileProperties[k] = newProfileProperties[mapping[k]];
-      });
-    } else {
-      mappedOldProfileProperties = Object.assign({}, oldProfileProperties);
-      mappedNewProfileProperties = Object.assign({}, newProfileProperties);
-    }
+    mappingKeys.forEach((k) => {
+      mappedOldProfileProperties[k] = oldProfileProperties[mapping[k]];
+      mappedNewProfileProperties[k] = newProfileProperties[mapping[k]];
+    });
 
     const oldGroupNames = oldGroups.map((g) => g.name);
     const newGroupNames = newGroups.map((g) => g.name);

--- a/core/web/components/forms/app/edit.tsx
+++ b/core/web/components/forms/app/edit.tsx
@@ -9,6 +9,7 @@ export default function ({ apiVersion, errorHandler, successHandler, query }) {
   const { execApi } = useApi(errorHandler);
   const [loading, setLoading] = useState(false);
   const [types, setTypes] = useState([]);
+  const [optionOptions, setOptionOptions] = useState([]);
   const [testResult, setTestResult] = useState({ result: null, error: null });
   const [ranTest, setRanTest] = useState(false);
   const [app, setApp] = useState({
@@ -36,6 +37,14 @@ export default function ({ apiVersion, errorHandler, successHandler, query }) {
     const typesResponse = await execApi("get", `/api/${apiVersion}/appOptions`);
     if (typesResponse?.types) {
       setTypes(typesResponse.types);
+    }
+
+    const optionsResponse = await execApi(
+      "get",
+      `/api/${apiVersion}/app/${guid}/optionOptions`
+    );
+    if (optionsResponse?.options) {
+      setOptionOptions(optionsResponse.options);
     }
 
     setLoading(false);
@@ -165,13 +174,42 @@ export default function ({ apiVersion, errorHandler, successHandler, query }) {
                     ) : null}
                     <code>{opt.key}</code>: <small>{opt.description}</small>
                   </Form.Label>
-                  <Form.Control
-                    type="text"
-                    required={opt.required}
-                    placeholder={opt.placeholder || "..."}
-                    value={app.options[opt.key] || ""}
-                    onChange={(e) => updateOption(e)}
-                  />
+                  {(() => {
+                    if (optionOptions[opt.key]?.type === "list") {
+                      return (
+                        <Form.Control
+                          as="select"
+                          required={opt.required}
+                          defaultValue={app.options[opt.key] || ""}
+                          onChange={(e) => updateOption(e)}
+                        >
+                          <option value={""} disabled>
+                            Choose an option
+                          </option>
+                          {optionOptions[opt.key].options.map((o, idx) => (
+                            <option key={`opt~${opt.key}-${o}`} value={o}>
+                              {o}{" "}
+                              {optionOptions[opt.key]?.descriptions &&
+                              optionOptions[opt.key]?.descriptions[idx]
+                                ? ` | ${
+                                    optionOptions[opt.key]?.descriptions[idx]
+                                  }`
+                                : null}
+                            </option>
+                          ))}
+                        </Form.Control>
+                      );
+                    } else {
+                      return (
+                        <Form.Control
+                          required={opt.required}
+                          type="text"
+                          defaultValue={app.options[opt.key]}
+                          onChange={(e) => updateOption(e)}
+                        />
+                      );
+                    }
+                  })()}
                 </Form.Group>
               );
             })}

--- a/core/web/components/forms/destination/mapping.tsx
+++ b/core/web/components/forms/destination/mapping.tsx
@@ -151,21 +151,14 @@ export default function ({ apiVersion, errorHandler, successHandler, query }) {
         <thead>
           <tr>
             <th>Sending?</th>
-            <th>Remote Column</th>
             <th>Grouparoo Profile Property Rule</th>
+            <th>Remote Column</th>
           </tr>
         </thead>
         <tbody>
           {previewColumns.map((col) => (
             <tr key={`destination-${col}`}>
               <td>{destination.mapping[col] ? "✅" : null}</td>
-              <td>
-                <h5>{col}</h5>
-                {preview
-                  .map((p) => p[col])
-                  .slice(0, 3)
-                  .join(", ")}
-              </td>
               <td>
                 <Form.Group>
                   <Form.Control
@@ -186,6 +179,13 @@ export default function ({ apiVersion, errorHandler, successHandler, query }) {
                       .slice(0, 3)
                       .join(", ")
                   : null}
+              </td>
+              <td>
+                <h5>{col}</h5>
+                {preview
+                  .map((p) => p[col])
+                  .slice(0, 3)
+                  .join(", ")}
               </td>
             </tr>
           ))}

--- a/plugins/@grouparoo/csv/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/csv/src/initializers/plugin.ts
@@ -24,7 +24,7 @@ export class Plugins extends Initializer {
         {
           name: "csv",
           options: [],
-          test,
+          methods: { test },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/google-sheets/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/google-sheets/src/initializers/plugin.ts
@@ -37,7 +37,7 @@ export class Plugins extends Initializer {
               placeholder: "e.g. -----BEGIN PRIVATE KEY-----\nMII ...",
             },
           ],
-          test,
+          methods: { test },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/logger/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/logger/src/initializers/plugin.ts
@@ -44,7 +44,6 @@ export class Plugins extends Initializer {
           description: "export profiles to a log file for debugging",
           app: "logger",
           options: [],
-          ignoreMapping: true,
           methods: {
             exportProfile,
             destinationOptions,

--- a/plugins/@grouparoo/logger/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/logger/src/initializers/plugin.ts
@@ -2,6 +2,7 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
+import { appOptions } from "./../lib/appOptions";
 import { exportProfile } from "./../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
 
@@ -30,9 +31,10 @@ export class Plugins extends Initializer {
               key: "stdout",
               required: false,
               description: "set to 'true' to also log to Grouparoo's console",
+              placeholder: "true",
             },
           ],
-          test,
+          methods: { test, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/logger/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/logger/src/lib/appOptions.ts
@@ -1,0 +1,12 @@
+export async function appOptions() {
+  return {
+    stdout: {
+      type: "list",
+      options: ["true", "false"],
+      descriptions: [
+        "log the output to the console",
+        "do not log to the console",
+      ],
+    },
+  };
+}

--- a/plugins/@grouparoo/logger/src/lib/export/exportProfile.ts
+++ b/plugins/@grouparoo/logger/src/lib/export/exportProfile.ts
@@ -26,7 +26,7 @@ export async function exportProfile(
   const line =
     JSON.stringify({
       time: new Date(),
-      profile,
+      guid: profile.guid,
       oldProfileProperties,
       newProfileProperties,
       oldGroups,

--- a/plugins/@grouparoo/mailchimp/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mailchimp/src/initializers/plugin.ts
@@ -29,7 +29,7 @@ export class Plugins extends Initializer {
               description: "your mailchimp api key",
             },
           ],
-          test,
+          methods: { test },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/mysql/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mysql/src/initializers/plugin.ts
@@ -49,7 +49,7 @@ export class Plugins extends Initializer {
               description: "the mysql user's password",
             },
           ],
-          test,
+          methods: { test },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/postgres/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/postgres/src/initializers/plugin.ts
@@ -49,7 +49,7 @@ export class Plugins extends Initializer {
               description: "the postgres user's password",
             },
           ],
-          test,
+          methods: { test },
         },
       ],
       connections: [


### PR DESCRIPTION
* if the destination plugin does not provide a preview, we choose which profile properties to send directly.  We then create a 1-to-1 mapping.  The existing `Destination` plumbing will only send the selected/mapped properties to the plugin's `export` method.
* apps provide `appOptions` to use in the UI 


<img width="1422" alt="Screen Shot 2020-04-09 at 3 47 04 PM" src="https://user-images.githubusercontent.com/303226/78947111-5db50f80-7a79-11ea-80e9-d7a64dcc01d6.png">

This removes the ability for a destination to choose to `ignoreMapping` (removed from the plugin class)