### PR TITLE
pluguins provide uniqueProfilePropertyRuleBootstrapOptions

### DIFF
--- a/core/api/__tests__/actions/profilePropertyRules.ts
+++ b/core/api/__tests__/actions/profilePropertyRules.ts
@@ -29,7 +29,7 @@ describe("actions/profilePropertyRules", () => {
 
     source = await helper.factories.source();
     await source.setOptions({ table: "test table" });
-    await source.bootstrapUniqueProfilePropertyRule("userId", "integer");
+    await source.bootstrapUniqueProfilePropertyRule("userId", "integer", "id");
     await source.setMapping({ id: "userId" });
     await source.update({ state: "ready" });
   });

--- a/core/api/__tests__/actions/profiles.ts
+++ b/core/api/__tests__/actions/profiles.ts
@@ -168,7 +168,7 @@ describe("actions/profiles", () => {
 
       const foundTasks = await specHelper.findEnqueuedTasks("run:internalRun");
       const rulesCount = await ProfilePropertyRule.count();
-      expect(foundTasks.length).toBe(rulesCount);
+      expect(foundTasks.length).toBe(rulesCount + 1);
     });
 
     test("a writer can destroy a profile", async () => {

--- a/core/api/__tests__/actions/sources.ts
+++ b/core/api/__tests__/actions/sources.ts
@@ -1,6 +1,7 @@
 import { helper } from "./../utils/specHelper";
 import { specHelper } from "actionhero";
 import { Source } from "./../../src/models/Source";
+import { Option } from "./../../src/models/Option";
 import { App } from "./../../src/models/App";
 
 let actionhero;
@@ -52,6 +53,7 @@ describe("actions/sources", () => {
         name: "test source",
         type: "test-plugin-import",
         appGuid: app.guid,
+        options: { table: "users" },
       };
       const { error, source } = await specHelper.runAction(
         "source:create",
@@ -86,6 +88,7 @@ describe("actions/sources", () => {
         guid,
         key: "userId",
         type: "integer",
+        mappedColumn: "id",
       };
       const { profilePropertyRule, error } = await specHelper.runAction(
         "source:bootstrapUniqueProfilePropertyRule",
@@ -125,6 +128,9 @@ describe("actions/sources", () => {
     });
 
     test("a source with no options will see an empty preview", async () => {
+      const options = await Option.findAll({ where: { ownerGuid: guid } });
+      await Promise.all(options.map((o) => o.destroy()));
+
       connection.params = {
         csrfToken,
         guid,

--- a/core/api/__tests__/factories/profilePropertyRules.ts
+++ b/core/api/__tests__/factories/profilePropertyRules.ts
@@ -14,7 +14,7 @@ export default async (
 ) => {
   const source = await SourceFactory();
   await source.setOptions({ table: "__test_table" });
-  await source.bootstrapUniqueProfilePropertyRule("userId", "integer");
+  await source.bootstrapUniqueProfilePropertyRule("userId", "integer", "id");
   await source.setMapping({ userId: "userId" });
   await source.update({ state: "ready" });
   const sourceGuid = source.guid;

--- a/core/api/__tests__/integration/happyPath.ts
+++ b/core/api/__tests__/integration/happyPath.ts
@@ -88,6 +88,7 @@ describe("integration/happyPath", () => {
       guid: sourceGuid,
       key: "userId",
       type: "integer",
+      mappedColumn: "id",
     };
     const bootstrapResponse = await specHelper.runAction(
       "source:bootstrapUniqueProfilePropertyRule",

--- a/core/api/__tests__/integration/runs/internalRun.ts
+++ b/core/api/__tests__/integration/runs/internalRun.ts
@@ -29,9 +29,16 @@ describe("integration/runs/internalRun", () => {
     test("adding a profile property rule with a query creates a run and internalRun task", async () => {
       const source = await helper.factories.source();
       await source.setOptions({ table: "test table" });
-      await source.bootstrapUniqueProfilePropertyRule("userId", "integer");
+      await source.bootstrapUniqueProfilePropertyRule(
+        "userId",
+        "integer",
+        "id"
+      );
       await source.setMapping({ id: "userId" });
       await source.update({ state: "ready" });
+
+      await api.resque.queue.connection.redis.flushdb();
+      await Run.destroy({ truncate: true });
 
       const rule = await ProfilePropertyRule.create({
         sourceGuid: source.guid,

--- a/core/api/__tests__/models/profile.ts
+++ b/core/api/__tests__/models/profile.ts
@@ -69,7 +69,11 @@ describe("models/profile", () => {
     beforeAll(async () => {
       source = await helper.factories.source();
       await source.setOptions({ table: "test table" });
-      await source.bootstrapUniqueProfilePropertyRule("userId", "integer");
+      await source.bootstrapUniqueProfilePropertyRule(
+        "userId",
+        "integer",
+        "id"
+      );
       await source.setMapping({ id: "userId" });
       await source.update({ state: "ready" });
 
@@ -223,7 +227,11 @@ describe("models/profile", () => {
       beforeAll(async () => {
         const source = await helper.factories.source();
         await source.setOptions({ table: "test table" });
-        await source.bootstrapUniqueProfilePropertyRule("userId", "integer");
+        await source.bootstrapUniqueProfilePropertyRule(
+          "userId",
+          "integer",
+          "id"
+        );
         await source.setMapping({ id: "userId" });
         await source.update({ state: "ready" });
 
@@ -452,7 +460,11 @@ describe("models/profile", () => {
         type: "test-plugin-import",
       });
       await source.setOptions({ table: "test table" });
-      await source.bootstrapUniqueProfilePropertyRule("userId", "integer");
+      await source.bootstrapUniqueProfilePropertyRule(
+        "userId",
+        "integer",
+        "id"
+      );
       await source.setMapping({ id: "userId" });
       await source.update({ state: "ready" });
 
@@ -561,7 +573,11 @@ describe("models/profile", () => {
         name: "test import source",
         type: "import-from-test-template-app",
       });
-      await source.bootstrapUniqueProfilePropertyRule("userId", "integer");
+      await source.bootstrapUniqueProfilePropertyRule(
+        "userId",
+        "integer",
+        "id"
+      );
       await source.setMapping({ id: "userId" });
       await source.update({ state: "ready" });
 

--- a/core/api/__tests__/models/profileProperty.ts
+++ b/core/api/__tests__/models/profileProperty.ts
@@ -29,7 +29,7 @@ describe("models/profileProperty", () => {
   beforeAll(async () => {
     source = await helper.factories.source();
     await source.setOptions({ table: "test table" });
-    await source.bootstrapUniqueProfilePropertyRule("userId", "integer");
+    await source.bootstrapUniqueProfilePropertyRule("userId", "integer", "id");
     await source.setMapping({ id: "userId" });
     await source.update({ state: "ready" });
 

--- a/core/api/__tests__/models/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRule.ts
@@ -25,7 +25,7 @@ describe("models/profilePropertyRule", () => {
   test("creating a profile property rule for non-manual apps with options enqueued an internalRun", async () => {
     const rulesCount = await ProfilePropertyRule.count();
     const foundTasks = await specHelper.findEnqueuedTasks("run:internalRun");
-    expect(foundTasks.length).toBe(rulesCount - 1); // the bootstrapped rule does not get a run
+    expect(foundTasks.length).toBe(rulesCount);
   });
 
   test("a profile property rule cannot be created if the source does not have all the required options set", async () => {

--- a/core/api/__tests__/models/source.ts
+++ b/core/api/__tests__/models/source.ts
@@ -363,6 +363,7 @@ describe("models/source", () => {
         name: "test source",
         appGuid: app.guid,
       });
+      await source.setOptions({ table: "some table" });
     });
 
     afterAll(async () => {
@@ -372,7 +373,8 @@ describe("models/source", () => {
     test("bootstrapUniqueProfilePropertyRule will create a new profile property rule", async () => {
       const rule = await source.bootstrapUniqueProfilePropertyRule(
         "uniqueId",
-        "integer"
+        "integer",
+        "id"
       );
 
       expect(rule.key).toBe("uniqueId");
@@ -383,9 +385,17 @@ describe("models/source", () => {
       await rule.destroy();
     });
 
+    test("the plugin provides uniqueProfilePropertyRuleBootstrapOptions", async () => {
+      const rule = await ProfilePropertyRule.findOne({
+        where: { key: "userId" },
+      });
+      const options = await rule.getOptions();
+      expect(options).toEqual({ column: "__default_column" }); // from the plugin; see specHelper.ts
+    });
+
     test("bootstrapUniqueProfilePropertyRule will fail if the rule cannot be created", async () => {
       await expect(
-        source.bootstrapUniqueProfilePropertyRule("userId", "integer")
+        source.bootstrapUniqueProfilePropertyRule("userId", "integer", "id")
       ).rejects.toThrow(/already in use/);
     });
   });

--- a/core/api/__tests__/utils/specHelper.ts
+++ b/core/api/__tests__/utils/specHelper.ts
@@ -209,6 +209,11 @@ export namespace helper {
                 { id: 2, fname: "luigi", lname: "mario" },
               ];
             },
+            uniqueProfilePropertyRuleBootstrapOptions: async () => {
+              return {
+                column: "__default_column",
+              };
+            },
             profiles: async () => {
               return { importsCount: 0, nextHighWaterMark: 0 };
             },

--- a/core/api/src/actions/sources.ts
+++ b/core/api/src/actions/sources.ts
@@ -192,6 +192,7 @@ export class SourceBootstrapUniqueProfilePropertyRule extends Action {
       guid: { required: true },
       key: { required: true },
       type: { required: true },
+      mappedColumn: { required: true },
     };
   }
 
@@ -203,7 +204,8 @@ export class SourceBootstrapUniqueProfilePropertyRule extends Action {
 
     const rule = await source.bootstrapUniqueProfilePropertyRule(
       params.key,
-      params.type
+      params.type,
+      params.mappedColumn
     );
     response.profilePropertyRule = await rule.apiData();
     response.source = await source.apiData();

--- a/core/api/src/classes/plugin.ts
+++ b/core/api/src/classes/plugin.ts
@@ -65,6 +65,7 @@ export interface PluginConnection {
   methods?: {
     sourceOptions?: SourceOptionsMethod;
     sourcePreview?: SourcePreviewMethod;
+    uniqueProfilePropertyRuleBootstrapOptions?: UniqueProfilePropertyRuleBootstrapOptions;
     profiles?: ProfilesPluginMethod;
     profileProperty?: ProfilePropertyPluginMethod;
     nextFilter?: NextFilterPluginMethod;
@@ -183,6 +184,19 @@ export interface SourcePreviewMethod {
     source: Source,
     sourceOptions: SimpleSourceOptions
   ): Promise<Array<{ [column: string]: any }>>;
+}
+
+/**
+ * If a Profile Property Rule is created within the source creation workflow, what default options should that new rule get?
+ */
+export interface UniqueProfilePropertyRuleBootstrapOptions {
+  (
+    app: App,
+    appOptions: SimpleAppOptions,
+    source: Source,
+    sourceOptions: SimpleSourceOptions,
+    mappedColumn: string
+  ): Promise<SimpleProfilePropertyRuleOptions>;
 }
 
 /**

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -136,7 +136,8 @@ export interface PluginConnectionProfilePropertyRuleOption {
     appOptions: SimpleAppOptions,
     source: Source,
     sourceOptions: SimpleSourceOptions,
-    sourceMapping: SourceMapping
+    sourceMapping: SourceMapping,
+    profilePropertyRule: ProfilePropertyRule
   ) => Promise<
     Array<{
       key: string;
@@ -310,7 +311,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
     return OptionHelper.getOptions(this);
   }
 
-  async setOptions(options: SimpleSourceOptions) {
+  async setOptions(options: SimpleProfilePropertyRuleOptions) {
     return OptionHelper.setOptions(this, options);
   }
 
@@ -385,7 +386,8 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
         appOptions,
         source,
         sourceOptions,
-        sourceMapping
+        sourceMapping,
+        this
       );
 
       response.push({

--- a/core/web/components/forms/profilePropertyRule/edit.tsx
+++ b/core/web/components/forms/profilePropertyRule/edit.tsx
@@ -220,10 +220,10 @@ export default function ({
                       <tr>
                         <th></th>
                         <th>Key</th>
-                        {opt?.options[0].description ? (
+                        {opt?.options[0]?.description ? (
                           <th>Description</th>
                         ) : null}
-                        {opt?.options[0].examples ? <th>Examples</th> : null}
+                        {opt?.options[0]?.examples ? <th>Examples</th> : null}
                       </tr>
                     </thead>
                     <tbody>

--- a/core/web/components/forms/source/edit.tsx
+++ b/core/web/components/forms/source/edit.tsx
@@ -137,9 +137,6 @@ export default function ({
   return (
     <>
       <h2>Edit Source</h2>
-      <p>
-        <span className="text-muted">{source.guid}</span>
-      </p>
 
       <Row>
         <Col md={1}>

--- a/plugins/@grouparoo/mysql/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mysql/src/initializers/plugin.ts
@@ -6,6 +6,7 @@ import { exportProfile } from "./../lib/export/exportProfile";
 
 import { sourcePreview as tableSourcePreview } from "../lib/table-import/sourcePreview";
 import { sourceOptions as tableSourceOptions } from "../lib/table-import/sourceOptions";
+import { uniqueProfilePropertyRuleBootstrapOptions as tableUniqueProfilePropertyRuleBootstrapOptions } from "../lib/table-import/uniqueProfilePropertyRuleBootstrapOptions";
 import { profiles as tableProfiles } from "../lib/table-import/profiles";
 import { profileProperty as tableProfileProperty } from "../lib/table-import/profileProperty";
 import { profilePropertyRuleOptions as tableProfilePropertyRuleOptions } from "../lib/table-import/profilePropertyRuleOptions";
@@ -70,6 +71,7 @@ export class Plugins extends Initializer {
           methods: {
             sourceOptions: tableSourceOptions,
             sourcePreview: tableSourcePreview,
+            uniqueProfilePropertyRuleBootstrapOptions: tableUniqueProfilePropertyRuleBootstrapOptions,
             profiles: tableProfiles,
             profileProperty: tableProfileProperty,
             nextFilter: tableNextFilter,

--- a/plugins/@grouparoo/mysql/src/lib/table-import/uniqueProfilePropertyRuleBootstrapOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/uniqueProfilePropertyRuleBootstrapOptions.ts
@@ -1,0 +1,19 @@
+import {
+  App,
+  Source,
+  SimpleAppOptions,
+  SimpleSourceOptions,
+  SourceMapping,
+} from "@grouparoo/core";
+
+export async function uniqueProfilePropertyRuleBootstrapOptions(
+  app: App,
+  appOptions: SimpleAppOptions,
+  source: Source,
+  sourceOptions: SimpleSourceOptions,
+  mappedColumn: string
+) {
+  const options = { "aggregation method": "exact", column: mappedColumn };
+
+  return options;
+}

--- a/plugins/@grouparoo/postgres/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/postgres/src/initializers/plugin.ts
@@ -6,6 +6,7 @@ import { exportProfile } from "../lib/export/exportProfile";
 
 import { sourcePreview as tableSourcePreview } from "../lib/table-import/sourcePreview";
 import { sourceOptions as tableSourceOptions } from "../lib/table-import/sourceOptions";
+import { uniqueProfilePropertyRuleBootstrapOptions as tableUniqueProfilePropertyRuleBootstrapOptions } from "../lib/table-import/uniqueProfilePropertyRuleBootstrapOptions";
 import { profiles as tableProfiles } from "../lib/table-import/profiles";
 import { profileProperty as tableProfileProperty } from "../lib/table-import/profileProperty";
 import { profilePropertyRuleOptions as tableProfilePropertyRuleOptions } from "../lib/table-import/profilePropertyRuleOptions";
@@ -71,6 +72,7 @@ export class Plugins extends Initializer {
           methods: {
             sourceOptions: tableSourceOptions,
             sourcePreview: tableSourcePreview,
+            uniqueProfilePropertyRuleBootstrapOptions: tableUniqueProfilePropertyRuleBootstrapOptions,
             profiles: tableProfiles,
             profileProperty: tableProfileProperty,
             nextFilter: tableNextFilter,

--- a/plugins/@grouparoo/postgres/src/lib/table-import/uniqueProfilePropertyRuleBootstrapOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/uniqueProfilePropertyRuleBootstrapOptions.ts
@@ -1,0 +1,19 @@
+import {
+  App,
+  Source,
+  SimpleAppOptions,
+  SimpleSourceOptions,
+  SourceMapping,
+} from "@grouparoo/core";
+
+export async function uniqueProfilePropertyRuleBootstrapOptions(
+  app: App,
+  appOptions: SimpleAppOptions,
+  source: Source,
+  sourceOptions: SimpleSourceOptions,
+  mappedColumn: string
+) {
+  const options = { "aggregation method": "exact", column: mappedColumn };
+
+  return options;
+}


### PR DESCRIPTION
fixes https://www.pivotaltracker.com/story/show/172295631

When creating a new `Profile Property Rule` as part of the creation of a `Schedule` mapping, we need to know what the `options` are.  The options will be different for each plugin type, so we need a new method each plugin can define: `uniqueProfilePropertyRuleBootstrapOptions`.  

For example, the `postgres-table-import` plugin will return `{column: {{the column of the mapping}}, 'aggregation method': "exact"}`