### PR TITLE
default scopes filter state=ready

### DIFF
--- a/core/api/__tests__/actions/destinations.ts
+++ b/core/api/__tests__/actions/destinations.ts
@@ -38,18 +38,8 @@ describe("actions/destinations", () => {
       );
       csrfToken = sessionResponse.csrfToken;
 
-      connection.params = {
-        csrfToken,
-        name: "test app",
-        type: "test-plugin-app",
-        options: { fileGuid: "abc123" },
-      };
-      const appCreateResponse = await specHelper.runAction(
-        "app:create",
-        connection
-      );
-
-      app = appCreateResponse.app;
+      app = await helper.factories.app();
+      await app.update({ name: "test app" });
     });
 
     test("an administrator can create a new destination from an app", async () => {

--- a/core/api/__tests__/actions/groups.ts
+++ b/core/api/__tests__/actions/groups.ts
@@ -112,7 +112,7 @@ describe("actions/groups", () => {
 
     test("an administrator can view the destinations tracking a group", async () => {
       const destination = await helper.factories.destination();
-      const group = await Group.findOne({ where: { guid } });
+      const group = await Group.findByGuid(guid);
       await destination.trackGroup(group);
 
       connection.params = {
@@ -152,7 +152,7 @@ describe("actions/groups", () => {
 
     test("an administrator cannot destroy a group used by a destination", async () => {
       const destination = await helper.factories.destination();
-      const group = await Group.findOne({ where: { guid } });
+      const group = await Group.findByGuid(guid);
       await destination.trackGroup(group);
 
       connection.params = {

--- a/core/api/__tests__/actions/profilePropertyRules.ts
+++ b/core/api/__tests__/actions/profilePropertyRules.ts
@@ -73,6 +73,7 @@ describe("actions/profilePropertyRules", () => {
         sourceGuid: source.guid,
         key: "email",
         type: "string",
+        unique: "true",
       };
 
       const {
@@ -84,7 +85,8 @@ describe("actions/profilePropertyRules", () => {
       expect(error).toBeUndefined();
       expect(profilePropertyRule.guid).toBeTruthy();
       expect(profilePropertyRule.key).toBe("email");
-      expect(profilePropertyRule.unique).toBe(false);
+      expect(profilePropertyRule.unique).toBe(true);
+      expect(profilePropertyRule.state).toBe("draft");
       expect(profilePropertyRule.source.guid).toBe(source.guid);
       expect(pluginOptions[0].key).toBe("column");
 
@@ -104,9 +106,23 @@ describe("actions/profilePropertyRules", () => {
 
       expect(error).toBeUndefined();
       expect(profilePropertyRule.key).toBe("email");
-      expect(profilePropertyRule.unique).toBe(false);
+      expect(profilePropertyRule.unique).toBe(true);
       expect(profilePropertyRule.source.guid).toBe(source.guid);
       expect(pluginOptions[0].key).toBe("column");
+    });
+
+    test("an administrator can make a rule ready", async () => {
+      connection.params = {
+        csrfToken,
+        guid,
+        state: "ready",
+      };
+      const { error, profilePropertyRule } = await specHelper.runAction(
+        "profilePropertyRule:edit",
+        connection
+      );
+      expect(error).toBeUndefined();
+      expect(profilePropertyRule.state).toBe("ready");
     });
 
     test("an administrator can test a profile property rule", async () => {
@@ -175,7 +191,7 @@ describe("actions/profilePropertyRules", () => {
       expect(profilePropertyRules.length).toBe(2); // this + userId
       expect(profilePropertyRules[1].source.guid).toBe(source.guid);
       expect(profilePropertyRules[1].type).toBe("string");
-      expect(profilePropertyRules[1].unique).toBe(false);
+      expect(profilePropertyRules[1].unique).toBe(true);
       expect(total).toBe(2);
 
       expect(examples[profilePropertyRules[1].guid]).toEqual([
@@ -195,7 +211,7 @@ describe("actions/profilePropertyRules", () => {
         connection
       );
       expect(error).toBeUndefined();
-      expect(profilePropertyRules.length).toBe(1); // just userId
+      expect(profilePropertyRules.length).toBe(2); // userId + email
     });
 
     test("an administrator can list unique rules", async () => {
@@ -208,7 +224,7 @@ describe("actions/profilePropertyRules", () => {
         connection
       );
       expect(error).toBeUndefined();
-      expect(profilePropertyRules.length).toBe(1); // just userId
+      expect(profilePropertyRules.length).toBe(2); // userId + email
     });
 
     test("an administrator can see groups which rely on a profilePropertyRule", async () => {
@@ -220,6 +236,7 @@ describe("actions/profilePropertyRules", () => {
           match: "%@%",
         },
       ]);
+      await group.update({ state: "ready" });
 
       connection.params = {
         csrfToken,

--- a/core/api/__tests__/actions/profiles.ts
+++ b/core/api/__tests__/actions/profiles.ts
@@ -194,6 +194,7 @@ describe("actions/profiles", () => {
           type: "manual",
         });
         await group.save();
+        await group.update({ state: "ready" });
       });
 
       beforeAll(async () => {

--- a/core/api/__tests__/actions/profiles.ts
+++ b/core/api/__tests__/actions/profiles.ts
@@ -324,7 +324,6 @@ describe("actions/profiles", () => {
         };
         let response = await specHelper.runAction("profile:create", connection);
         mario = response.profile;
-        await helper.sleep(1501);
 
         connection.params = {
           csrfToken,
@@ -332,7 +331,6 @@ describe("actions/profiles", () => {
         };
         response = await specHelper.runAction("profile:create", connection);
         luigi = response.profile;
-        await helper.sleep(1501);
 
         connection.params = {
           csrfToken,
@@ -340,7 +338,6 @@ describe("actions/profiles", () => {
         };
         response = await specHelper.runAction("profile:create", connection);
         toad = response.profile;
-        await helper.sleep(1501);
 
         connection.params = {
           csrfToken,
@@ -348,7 +345,6 @@ describe("actions/profiles", () => {
         };
         response = await specHelper.runAction("profile:create", connection);
         peach = response.profile;
-        await helper.sleep(1501);
 
         connection.params = {
           csrfToken,
@@ -533,18 +529,6 @@ describe("actions/profiles", () => {
         );
         expect(error).toBeUndefined();
         expect(profiles.length).toBe(2);
-        expect(simpleProfileValues(profiles[0].properties).email).toBe(
-          "toad@mushroom-kingdom.gov"
-        );
-        expect(
-          simpleProfileValues(profiles[0].properties).userId
-        ).toBeUndefined();
-        expect(simpleProfileValues(profiles[1].properties).email).toBe(
-          "peach@mushroom-kingdom.gov"
-        );
-        expect(
-          simpleProfileValues(profiles[1].properties).userId
-        ).toBeUndefined();
         expect(total).toBe(2);
       });
 
@@ -560,12 +544,6 @@ describe("actions/profiles", () => {
         );
         expect(error).toBeUndefined();
         expect(profiles.length).toBe(2);
-        expect(simpleProfileValues(profiles[0].properties).email).toBe(
-          "toad@mushroom-kingdom.gov"
-        );
-        expect(simpleProfileValues(profiles[1].properties).email).toBe(
-          "peach@mushroom-kingdom.gov"
-        );
         expect(total).toBe(2);
       });
 

--- a/core/api/__tests__/actions/sources.ts
+++ b/core/api/__tests__/actions/sources.ts
@@ -27,10 +27,8 @@ describe("actions/sources", () => {
       email: "mario@example.com",
     });
 
-    app = await App.create({
-      name: "test app",
-      type: "test-plugin-app",
-    });
+    app = await helper.factories.app();
+    await app.update({ name: "test app" });
   });
 
   describe("administrator signed in", () => {

--- a/core/api/__tests__/factories/app.ts
+++ b/core/api/__tests__/factories/app.ts
@@ -22,5 +22,7 @@ export default async (props = {}) => {
     await instance.setOptions(mergedProps.options);
   }
 
+  await instance.update({ state: "ready" });
+
   return instance;
 };

--- a/core/api/__tests__/factories/destination.ts
+++ b/core/api/__tests__/factories/destination.ts
@@ -18,11 +18,7 @@ const data = async (props = {}) => {
 
 export default async (app?, props: { [key: string]: any } = {}) => {
   if (!app) {
-    // the postgres app has imports and exports
-    app = await AppFactory({ type: "test-plugin-app", options: {} });
-    await app.setOptions({
-      fileGuid: "abc123",
-    });
+    app = await AppFactory();
   }
 
   props.appGuid = app.guid;

--- a/core/api/__tests__/factories/destination.ts
+++ b/core/api/__tests__/factories/destination.ts
@@ -6,7 +6,7 @@ const data = async (props = {}) => {
   const defaultProps = {
     name: `destination ${faker.company.companyName()}-${Math.random()}`,
     type: "test-plugin-export",
-    options: {},
+    options: { table: "out table" },
     mapping: {},
 
     createdAt: new Date(),
@@ -33,6 +33,8 @@ export default async (app?, props: { [key: string]: any } = {}) => {
   if (Object.keys(mergedProps.mapping).length > 0) {
     await instance.setMapping(mergedProps.mapping);
   }
+
+  await instance.update({ state: "ready" });
 
   return instance;
 };

--- a/core/api/__tests__/factories/group.ts
+++ b/core/api/__tests__/factories/group.ts
@@ -14,5 +14,8 @@ const data = async (props = {}) => {
 };
 
 export default async (props = {}) => {
-  return Group.create(await data(props));
+  const instance = await Group.create(await data(props));
+  await instance.update({ state: "ready" });
+
+  return instance;
 };

--- a/core/api/__tests__/factories/profilePropertyRules.ts
+++ b/core/api/__tests__/factories/profilePropertyRules.ts
@@ -17,7 +17,6 @@ export default async (
   await source.bootstrapUniqueProfilePropertyRule("userId", "integer", "id");
   await source.setMapping({ userId: "userId" });
   await source.update({ state: "ready" });
-  const sourceGuid = source.guid;
 
   for (const key in props) {
     const type = props[key];
@@ -28,12 +27,13 @@ export default async (
     }
 
     const rule = await ProfilePropertyRule.create({
-      sourceGuid,
+      sourceGuid: source.guid,
       key,
       type,
       unique,
     });
 
     await rule.setOptions({ column: key });
+    await rule.update({ state: "ready" });
   }
 };

--- a/core/api/__tests__/factories/run.ts
+++ b/core/api/__tests__/factories/run.ts
@@ -14,13 +14,15 @@ const data = async (props = {}) => {
   return Object.assign({}, defaultProps, props);
 };
 
-export default async (schedule?, props: { [key: string]: any } = {}) => {
-  if (!schedule) {
-    schedule = await ScheduleFactory();
+export default async (owner?, props: { [key: string]: any } = {}) => {
+  if (!owner) {
+    owner = await ScheduleFactory();
   }
 
-  props.creatorGuid = schedule.guid;
-  props.creatorType = "schedule";
+  props.creatorGuid = owner.guid;
+  props.creatorType = owner.guid.match(/^sch_/)
+    ? "schedule"
+    : "profilePropertyRule";
 
   const instance = await Run.create(await data(props));
   return instance;

--- a/core/api/__tests__/factories/schedule.ts
+++ b/core/api/__tests__/factories/schedule.ts
@@ -5,7 +5,7 @@ import SourceFactory from "./source";
 const data = async (props = {}) => {
   const defaultProps = {
     name: `schedule ${faker.company.companyName()}-${Math.random()}`,
-    options: {},
+    options: { maxColumn: "updated_at" },
     mapping: {},
     recurring: false,
     recurringFrequency: null,
@@ -33,6 +33,8 @@ export default async (source?, props: { [key: string]: any } = {}) => {
   if (Object.keys(mergedProps.options).length > 0) {
     await instance.setOptions(mergedProps.options);
   }
+
+  await instance.update({ state: "ready" });
 
   return instance;
 };

--- a/core/api/__tests__/integration/happyPath.ts
+++ b/core/api/__tests__/integration/happyPath.ts
@@ -22,6 +22,7 @@ describe("integration/happyPath", () => {
   beforeAll(async () => {
     const env = await helper.prepareForAPITest();
     actionhero = env.actionhero;
+    helper.disableTestPluginImport();
   }, 1000 * 30);
 
   afterAll(async () => {
@@ -53,6 +54,7 @@ describe("integration/happyPath", () => {
       name: "test app",
       type: "test-plugin-app",
       options: { fileGuid: "abc123" },
+      state: "ready",
     };
     const { error, app } = await specHelper.runAction("app:create", connection);
 
@@ -115,6 +117,7 @@ describe("integration/happyPath", () => {
       key: "email",
       type: "string",
       unique: true,
+      state: "ready",
     };
     let { error } = await specHelper.runAction(
       "profilePropertyRule:create",
@@ -128,6 +131,7 @@ describe("integration/happyPath", () => {
       key: "firstName",
       type: "string",
       unique: false,
+      state: "ready",
     };
     await specHelper.runAction("profilePropertyRule:create", connection);
 
@@ -137,6 +141,7 @@ describe("integration/happyPath", () => {
       key: "lastName",
       type: "string",
       unique: false,
+      state: "ready",
     };
     await specHelper.runAction("profilePropertyRule:create", connection);
 
@@ -146,6 +151,7 @@ describe("integration/happyPath", () => {
       key: "ltv",
       type: "float",
       unique: false,
+      state: "ready",
     };
     await specHelper.runAction("profilePropertyRule:create", connection);
   });
@@ -198,6 +204,7 @@ describe("integration/happyPath", () => {
         csrfToken,
         name: "manual group",
         type: "manual",
+        state: "ready",
       };
 
       const { error, group } = await specHelper.runAction(
@@ -208,6 +215,7 @@ describe("integration/happyPath", () => {
       expect(group.guid).toBeTruthy();
       expect(group.name).toBe("manual group");
       expect(group.type).toBe("manual");
+      expect(group.state).toBe("ready");
       groupGuid = group.guid;
     });
 
@@ -277,6 +285,7 @@ describe("integration/happyPath", () => {
         name: "calculated group",
         type: "calculated",
         rules: [{ key: "lastName", op: "iLike", match: "mario" }],
+        state: "ready",
       };
 
       const { error, group } = await specHelper.runAction(
@@ -287,6 +296,7 @@ describe("integration/happyPath", () => {
       expect(group.guid).toBeTruthy();
       expect(group.name).toBe("calculated group");
       expect(group.type).toBe("calculated");
+      expect(group.state).not.toBe("draft");
       groupGuid = group.guid;
 
       // import

--- a/core/api/__tests__/models/app.ts
+++ b/core/api/__tests__/models/app.ts
@@ -213,6 +213,8 @@ describe("models/app", () => {
         name: "test app",
         type: "test-plugin-app",
       });
+      await app.setOptions({ fileGuid: "abc" });
+      await app.update({ state: "ready" });
 
       const source = await helper.factories.source(app);
 

--- a/core/api/__tests__/models/destination.ts
+++ b/core/api/__tests__/models/destination.ts
@@ -29,11 +29,7 @@ describe("models/destination", () => {
     let destination: Destination;
 
     beforeAll(async () => {
-      app = await App.create({
-        name: "test app",
-        type: "test-plugin-app",
-        options: { database: "db" },
-      });
+      app = await helper.factories.app();
     });
 
     afterEach(async () => {
@@ -77,11 +73,7 @@ describe("models/destination", () => {
         appGuid: app.guid,
       });
 
-      const otherApp = await App.create({
-        name: "other app",
-        type: "test-plugin-app",
-        options: { database: "db" },
-      });
+      const otherApp = await helper.factories.app();
       const destinationTwo = await Destination.create({
         type: "test-plugin-export",
         appGuid: otherApp.guid,
@@ -477,6 +469,7 @@ describe("models/destination", () => {
         name: "test app with temp methods",
         type: "test-template-app",
       });
+      await app.update({ state: "ready" });
     });
 
     afterAll(async () => {
@@ -586,6 +579,8 @@ describe("models/destination", () => {
         name: "test with real methods",
         type: "test-template-app",
       });
+      await app.setOptions({ test_key: "abc" });
+      await app.update({ state: "ready" });
     });
 
     test("destinations can show a preview", async () => {

--- a/core/api/__tests__/models/destination.ts
+++ b/core/api/__tests__/models/destination.ts
@@ -216,7 +216,11 @@ describe("models/destination", () => {
       });
 
       test("a destination cannot be changed to to the ready state if there are missing required options", async () => {
-        destination = await helper.factories.destination();
+        destination = await Destination.build({
+          appGuid: app.guid,
+          name: "missing options",
+          type: "test-plugin-export",
+        });
         await expect(destination.update({ state: "ready" })).rejects.toThrow();
       });
 
@@ -377,7 +381,13 @@ describe("models/destination", () => {
 
         it("informs all destinations if trackAllGroups is set", async () => {
           await destination.update({ trackAllGroups: true });
-          const otherDestination = await helper.factories.destination();
+
+          const otherApp = await helper.factories.app();
+          const otherDestination = await Destination.create({
+            name: "other destination",
+            appGuid: otherApp.guid,
+            type: "test-plugin-export",
+          });
           await otherDestination.update({ trackAllGroups: true });
 
           const profile = await helper.factories.profile();
@@ -400,6 +410,8 @@ describe("models/destination", () => {
           );
           expect(destinations.length).toEqual(2);
 
+          await otherDestination.destroy();
+          await otherApp.destroy();
           await group.removeProfile(profile);
         });
       });

--- a/core/api/__tests__/models/group.ts
+++ b/core/api/__tests__/models/group.ts
@@ -183,6 +183,7 @@ describe("models/group", () => {
         const group = await Group.create({
           name: "tracked group",
           type: "manual",
+          state: "ready",
         });
 
         const destination = await helper.factories.destination();

--- a/core/api/__tests__/models/group.ts
+++ b/core/api/__tests__/models/group.ts
@@ -395,7 +395,6 @@ describe("models/group", () => {
 
     test("changing group rules changes the state to initializing and enquires a run, and then back to ready when complete", async () => {
       await group.setRules([{ key: "firstName", match: "nobody", op: "eq" }]);
-      await group.reload();
       expect(group.state).toBe("initializing");
 
       let foundTasks = await specHelper.findEnqueuedTasks("group:run");
@@ -501,7 +500,6 @@ describe("models/group", () => {
       expect(group.calculatedAt).toBeFalsy();
       await group.setRules([{ key: "firstName", match: "Mario", op: "eq" }]);
       await group.runAddGroupMembers(run);
-      await group.reload();
       expect(group.calculatedAt).toBeTruthy();
     });
 
@@ -509,7 +507,6 @@ describe("models/group", () => {
       expect(group.calculatedAt).toBeFalsy();
       await group.setRules([{ key: "firstName", match: "Mario", op: "eq" }]);
       await group.runRemoveGroupMembers(run);
-      await group.reload();
       expect(group.calculatedAt).toBeTruthy();
     });
 
@@ -520,7 +517,6 @@ describe("models/group", () => {
       );
       await group.setRules([{ key: "firstName", match: "Mario", op: "eq" }]);
       await group.runAddGroupMembers(run);
-      await group.reload();
       expect((await group.nextCalculatedAt()).getTime()).toBeGreaterThan(
         new Date().getTime()
       );

--- a/core/api/__tests__/models/profile.ts
+++ b/core/api/__tests__/models/profile.ts
@@ -86,6 +86,7 @@ describe("models/profile", () => {
         key: "email",
         type: "email",
         unique: true,
+        state: "ready",
       });
 
       colorRule = await ProfilePropertyRule.create({
@@ -93,6 +94,7 @@ describe("models/profile", () => {
         key: "color",
         type: "string",
         unique: false,
+        state: "ready",
       });
 
       houseRule = await ProfilePropertyRule.create({
@@ -100,6 +102,7 @@ describe("models/profile", () => {
         key: "house",
         type: "string",
         unique: false,
+        state: "ready",
       });
 
       const profile = await Profile.create();
@@ -241,21 +244,25 @@ describe("models/profile", () => {
           sourceGuid: source.guid,
           key: "email",
           type: "string",
+          state: "ready",
         });
         await ProfilePropertyRule.create({
           sourceGuid: source.guid,
           key: "firstName",
           type: "string",
+          state: "ready",
         });
         await ProfilePropertyRule.create({
           sourceGuid: source.guid,
           key: "lastName",
           type: "string",
+          state: "ready",
         });
         await ProfilePropertyRule.create({
           sourceGuid: source.guid,
           key: "color",
           type: "string",
+          state: "ready",
         });
       });
 
@@ -412,6 +419,7 @@ describe("models/profile", () => {
       group = await Group.create({
         name: "test group",
         type: "manual",
+        state: "ready",
       });
 
       profile = await Profile.create();
@@ -451,8 +459,9 @@ describe("models/profile", () => {
       app = await App.create({
         name: "test app",
         type: "test-plugin-app",
-        options: {},
       });
+      await app.setOptions({ fileGuid: "abc123" });
+      await app.update({ state: "ready" });
 
       source = await Source.create({
         appGuid: app.guid,
@@ -473,6 +482,7 @@ describe("models/profile", () => {
         key: "email",
         type: "string",
         unique: true,
+        state: "ready",
       });
 
       group = await helper.factories.group({
@@ -566,6 +576,7 @@ describe("models/profile", () => {
         name: "test app",
         type: "test-template-app",
         options: {},
+        state: "ready",
       });
 
       source = await Source.create({

--- a/core/api/__tests__/models/profileProperty.ts
+++ b/core/api/__tests__/models/profileProperty.ts
@@ -44,26 +44,31 @@ describe("models/profileProperty", () => {
       sourceGuid: source.guid,
       key: "firstName",
       type: "string",
+      state: "ready",
     });
     emailRule = await ProfilePropertyRule.create({
       sourceGuid: source.guid,
       key: "email",
       type: "email",
+      state: "ready",
     });
     lastLoginRule = await ProfilePropertyRule.create({
       sourceGuid: source.guid,
       key: "lastLoginAt",
       type: "date",
+      state: "ready",
     });
     ltvRule = await ProfilePropertyRule.create({
       sourceGuid: source.guid,
       key: "ltv",
       type: "float",
+      state: "ready",
     });
     vipRule = await ProfilePropertyRule.create({
       sourceGuid: source.guid,
       key: "isVIP",
       type: "boolean",
+      state: "ready",
     });
   });
 

--- a/core/api/__tests__/models/run.ts
+++ b/core/api/__tests__/models/run.ts
@@ -375,6 +375,7 @@ describe("models/run", () => {
       const app = await App.create({
         name: "bad app",
         type: "test-error-app",
+        state: "ready",
       });
 
       const source = await Source.create({

--- a/core/api/__tests__/models/schedule.ts
+++ b/core/api/__tests__/models/schedule.ts
@@ -25,12 +25,7 @@ describe("models/schedule", () => {
 
     beforeAll(async () => {
       await helper.factories.profilePropertyRules();
-
-      app = await App.create({
-        name: "test app",
-        type: "test-plugin-app",
-        options: { fileGuid: "abc123" },
-      });
+      app = await helper.factories.app();
 
       source = await Source.create({
         name: "test source",
@@ -80,7 +75,6 @@ describe("models/schedule", () => {
         sourceGuid: source.guid,
       });
 
-      await schedule.reload();
       expect(schedule.name).toMatch(/test source schedule/);
 
       await schedule.destroy();
@@ -328,6 +322,7 @@ describe("models/schedule", () => {
       app = await App.create({
         name: "test app with real methods",
         type: "test-template-app",
+        state: "ready",
       });
 
       source = await Source.create({

--- a/core/api/__tests__/models/source.ts
+++ b/core/api/__tests__/models/source.ts
@@ -61,6 +61,22 @@ describe("models/source", () => {
   });
 
   describe("validations", () => {
+    test("the app must be in the ready state", async () => {
+      const app = await App.create({
+        type: "test-plugin-app",
+      });
+
+      await expect(
+        Source.create({
+          type: "test-plugin-import",
+          name: "test source",
+          appGuid: app.guid,
+        })
+      ).rejects.toThrow(/app .* not ready/);
+
+      await app.destroy();
+    });
+
     test("a source requires a plugin connection", async () => {
       await expect(
         Source.create({

--- a/core/api/__tests__/models/source.ts
+++ b/core/api/__tests__/models/source.ts
@@ -609,6 +609,8 @@ describe("models/source", () => {
         sourceGuid: source.guid,
         name: "test schedule",
       });
+      await schedule.setOptions({ maxColumn: "abc" });
+      await schedule.update({ state: "ready" });
 
       const previousRun = await helper.factories.run(schedule, {
         createdAt: new Date(0),

--- a/core/api/__tests__/tasks/groups/destroy.ts
+++ b/core/api/__tests__/tasks/groups/destroy.ts
@@ -85,8 +85,8 @@ describe("tasks/group:destroy", () => {
       await api.resque.queue.connection.redis.flushdb();
       await specHelper.runTask("group:destroy", foundTasks[0].args[0]); // remove the profiles
 
-      await group.reload();
-      expect(group.state).toBe("deleted");
+      const reloadedGroup = await Group.findByGuid(group.guid);
+      expect(reloadedGroup.state).toBe("deleted");
 
       _imports = await Import.findAll();
       expect(_imports.length).toBe(2);
@@ -120,7 +120,7 @@ describe("tasks/group:destroy", () => {
       let groupMemberCount = 0;
 
       const group = await Group.create({
-        name: "test group",
+        name: "test group 2",
         type: "calculated",
         state: "ready",
       });
@@ -142,8 +142,8 @@ describe("tasks/group:destroy", () => {
       await api.resque.queue.connection.redis.flushdb();
       await specHelper.runTask("group:destroy", foundTasks[0].args[0]); // remove the profiles
 
-      await group.reload();
-      expect(group.state).toBe("deleted");
+      const reloadedGroup = await Group.findByGuid(group.guid);
+      expect(reloadedGroup.state).toBe("deleted");
 
       imports = await Import.findAll();
       expect(imports.length).toBe(2);

--- a/core/api/__tests__/tasks/groups/exportToCSV.ts
+++ b/core/api/__tests__/tasks/groups/exportToCSV.ts
@@ -53,6 +53,7 @@ describe("tasks/group:exportToCSV", () => {
       });
 
       group = await Group.create({ name: "test group", type: "manual" });
+      await group.update({ state: "ready" });
       await group.addProfile(mario);
       await group.addProfile(luigi);
     });

--- a/core/api/__tests__/tasks/groups/run.ts
+++ b/core/api/__tests__/tasks/groups/run.ts
@@ -85,7 +85,6 @@ describe("tasks/group:run", () => {
       let imports = [];
       await group.setRules([{ key: "email", match: "%@%", op: "iLike" }]);
 
-      await group.reload();
       expect(group.state).toBe("initializing");
 
       foundTasks = await specHelper.findEnqueuedTasks("group:run");
@@ -141,7 +140,6 @@ describe("tasks/group:run", () => {
         },
       ]);
 
-      await group.reload();
       expect(group.state).toBe("initializing");
 
       imports = await Import.findAll();

--- a/core/api/__tests__/tasks/groups/updateMembers.ts
+++ b/core/api/__tests__/tasks/groups/updateMembers.ts
@@ -33,6 +33,7 @@ describe("tasks/group:updateMembers", () => {
       group = await Group.create({
         name: "test calculated group",
         type: "manual",
+        state: "ready",
       });
 
       await Profile.destroy({ truncate: true });

--- a/core/api/__tests__/tasks/profiles/export.ts
+++ b/core/api/__tests__/tasks/profiles/export.ts
@@ -98,6 +98,7 @@ describe("tasks/profile:export", () => {
         app = await App.create({
           name: "test app",
           type: "test-template-app",
+          state: "ready",
         });
 
         destination = await Destination.create({

--- a/core/api/src/actions/apps.ts
+++ b/core/api/src/actions/apps.ts
@@ -30,7 +30,7 @@ export class AppsList extends Action {
     });
 
     response.apps = await Promise.all(apps.map(async (app) => app.apiData()));
-    response.total = await App.count();
+    response.total = await App.scope(null).count();
   }
 }
 
@@ -73,10 +73,7 @@ export class AppOptionOptions extends Action {
   }
 
   async run({ params, response }) {
-    const app = await App.scope(null).findOne({ where: { guid: params.guid } });
-    if (!app) {
-      throw new Error("app not found");
-    }
+    const app = await App.findByGuid(params.guid);
 
     response.options = await app.appOptions();
   }
@@ -132,10 +129,7 @@ export class AppEdit extends Action {
   }
 
   async run({ params, response }) {
-    const app = await App.scope(null).findOne({ where: { guid: params.guid } });
-    if (!app) {
-      throw new Error("app not found");
-    }
+    const app = await App.findByGuid(params.guid);
     if (params.options) {
       await app.setOptions(params.options);
     }
@@ -159,11 +153,7 @@ export class AppTest extends Action {
   }
 
   async run({ params, response }) {
-    const app = await App.scope(null).findOne({ where: { guid: params.guid } });
-    if (!app) {
-      throw new Error("app not found");
-    }
-
+    const app = await App.findByGuid(params.guid);
     let { result, error } = await app.test(params.options);
     if (error) {
       error = String(error);
@@ -186,10 +176,7 @@ export class AppView extends Action {
   }
 
   async run({ params, response }) {
-    const app = await App.scope(null).findOne({ where: { guid: params.guid } });
-    if (!app) {
-      throw new Error("app not found");
-    }
+    const app = await App.findByGuid(params.guid);
     response.app = await app.apiData();
   }
 }
@@ -208,10 +195,7 @@ export class AppDestroy extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const app = await App.scope(null).findOne({ where: { guid: params.guid } });
-    if (!app) {
-      throw new Error("app not found");
-    }
+    const app = await App.findByGuid(params.guid);
     await app.destroy();
     response.success = true;
   }

--- a/core/api/src/actions/apps.ts
+++ b/core/api/src/actions/apps.ts
@@ -23,7 +23,7 @@ export class AppsList extends Action {
   }
 
   async run({ params, response }) {
-    const apps = await App.findAll({
+    const apps = await App.scope(null).findAll({
       limit: params.limit,
       offset: params.offset,
       order: params.order,
@@ -73,7 +73,7 @@ export class AppOptionOptions extends Action {
   }
 
   async run({ params, response }) {
-    const app = await App.findOne({ where: { guid: params.guid } });
+    const app = await App.scope(null).findOne({ where: { guid: params.guid } });
     if (!app) {
       throw new Error("app not found");
     }
@@ -132,7 +132,7 @@ export class AppEdit extends Action {
   }
 
   async run({ params, response }) {
-    const app = await App.findOne({ where: { guid: params.guid } });
+    const app = await App.scope(null).findOne({ where: { guid: params.guid } });
     if (!app) {
       throw new Error("app not found");
     }
@@ -159,7 +159,7 @@ export class AppTest extends Action {
   }
 
   async run({ params, response }) {
-    const app = await App.findOne({ where: { guid: params.guid } });
+    const app = await App.scope(null).findOne({ where: { guid: params.guid } });
     if (!app) {
       throw new Error("app not found");
     }
@@ -186,7 +186,7 @@ export class AppView extends Action {
   }
 
   async run({ params, response }) {
-    const app = await App.findOne({ where: { guid: params.guid } });
+    const app = await App.scope(null).findOne({ where: { guid: params.guid } });
     if (!app) {
       throw new Error("app not found");
     }
@@ -208,7 +208,7 @@ export class AppDestroy extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const app = await App.findOne({ where: { guid: params.guid } });
+    const app = await App.scope(null).findOne({ where: { guid: params.guid } });
     if (!app) {
       throw new Error("app not found");
     }

--- a/core/api/src/actions/apps.ts
+++ b/core/api/src/actions/apps.ts
@@ -12,6 +12,7 @@ export class AppsList extends Action {
     this.inputs = {
       limit: { required: true, default: 1000, formatter: parseInt },
       offset: { required: true, default: 0, formatter: parseInt },
+      state: { required: false },
       order: {
         required: true,
         default: [
@@ -23,14 +24,21 @@ export class AppsList extends Action {
   }
 
   async run({ params, response }) {
+    const where = {};
+
+    if (params.state) {
+      where["state"] = params.state;
+    }
+
     const apps = await App.scope(null).findAll({
+      where,
       limit: params.limit,
       offset: params.offset,
       order: params.order,
     });
 
     response.apps = await Promise.all(apps.map(async (app) => app.apiData()));
-    response.total = await App.scope(null).count();
+    response.total = await App.scope(null).count({ where });
   }
 }
 

--- a/core/api/src/actions/destinations.ts
+++ b/core/api/src/actions/destinations.ts
@@ -25,7 +25,7 @@ export class DestinationsList extends Action {
   }
 
   async run({ params, response }) {
-    const destinations = await Destination.findAll({
+    const destinations = await Destination.scope(null).findAll({
       limit: params.limit,
       offset: params.offset,
       order: params.order,
@@ -168,7 +168,7 @@ export class DestinationEdit extends Action {
   }
 
   async run({ params, response }) {
-    const destination = await Destination.findOne({
+    const destination = await Destination.scope(null).findOne({
       where: { guid: params.guid },
     });
 
@@ -201,7 +201,7 @@ export class DestinationConnectionOptions extends Action {
   }
 
   async run({ params, response }) {
-    const destination = await Destination.findOne({
+    const destination = await Destination.scope(null).findOne({
       where: { guid: params.guid },
     });
     if (!destination) {
@@ -227,7 +227,7 @@ export class DestinationPreview extends Action {
   }
 
   async run({ params, response }) {
-    const destination = await Destination.findOne({
+    const destination = await Destination.scope(null).findOne({
       where: { guid: params.guid },
     });
     if (!destination) {
@@ -256,7 +256,7 @@ export class DestinationTrackGroup extends Action {
   }
 
   async run({ params, response }) {
-    const destination = await Destination.findOne({
+    const destination = await Destination.scope(null).findOne({
       where: { guid: params.guid },
     });
     if (!destination) {
@@ -289,7 +289,7 @@ export class DestinationUnTrackGroup extends Action {
   }
 
   async run({ params, response }) {
-    const destination = await Destination.findOne({
+    const destination = await Destination.scope(null).findOne({
       where: { guid: params.guid },
     });
     if (!destination) {
@@ -321,7 +321,7 @@ export class DestinationView extends Action {
   }
 
   async run({ params, response }) {
-    const destination = await Destination.findOne({
+    const destination = await Destination.scope(null).findOne({
       where: { guid: params.guid },
     });
 
@@ -347,7 +347,7 @@ export class DestinationDestroy extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const destination = await Destination.findOne({
+    const destination = await Destination.scope(null).findOne({
       where: { guid: params.guid },
     });
 

--- a/core/api/src/actions/destinations.ts
+++ b/core/api/src/actions/destinations.ts
@@ -14,6 +14,7 @@ export class DestinationsList extends Action {
     this.inputs = {
       limit: { required: true, default: 1000, formatter: parseInt },
       offset: { required: true, default: 0, formatter: parseInt },
+      state: { required: false },
       order: {
         required: true,
         default: [
@@ -25,7 +26,14 @@ export class DestinationsList extends Action {
   }
 
   async run({ params, response }) {
+    const where = {};
+
+    if (params.state) {
+      where["state"] = params.state;
+    }
+
     const destinations = await Destination.scope(null).findAll({
+      where,
       limit: params.limit,
       offset: params.offset,
       order: params.order,
@@ -35,7 +43,7 @@ export class DestinationsList extends Action {
       destinations.map(async (conn) => conn.apiData())
     );
 
-    response.total = await Destination.scope(null).count();
+    response.total = await Destination.scope(null).count({ where });
   }
 }
 

--- a/core/api/src/actions/destinations.ts
+++ b/core/api/src/actions/destinations.ts
@@ -35,7 +35,7 @@ export class DestinationsList extends Action {
       destinations.map(async (conn) => conn.apiData())
     );
 
-    response.total = await Destination.count();
+    response.total = await Destination.scope(null).count();
   }
 }
 
@@ -168,14 +168,7 @@ export class DestinationEdit extends Action {
   }
 
   async run({ params, response }) {
-    const destination = await Destination.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-
-    if (!destination) {
-      throw new Error("destination not found");
-    }
-
+    const destination = await Destination.findByGuid(params.guid);
     await destination.update(params);
     if (params.options) {
       await destination.setOptions(params.options);
@@ -201,14 +194,7 @@ export class DestinationConnectionOptions extends Action {
   }
 
   async run({ params, response }) {
-    const destination = await Destination.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!destination) {
-      throw new Error("destination not found");
-    }
-    destination;
-
+    const destination = await Destination.findByGuid(params.guid);
     response.options = await destination.destinationConnectionOptions();
   }
 }
@@ -227,12 +213,7 @@ export class DestinationPreview extends Action {
   }
 
   async run({ params, response }) {
-    const destination = await Destination.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!destination) {
-      throw new Error("destination not found");
-    }
+    const destination = await Destination.findByGuid(params.guid);
 
     const options =
       typeof params.options === "string"
@@ -256,12 +237,7 @@ export class DestinationTrackGroup extends Action {
   }
 
   async run({ params, response }) {
-    const destination = await Destination.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!destination) {
-      throw new Error("destination not found");
-    }
+    const destination = await Destination.findByGuid(params.guid);
 
     const group = await Group.findOne({
       where: { guid: params.groupGuid },
@@ -289,12 +265,7 @@ export class DestinationUnTrackGroup extends Action {
   }
 
   async run({ params, response }) {
-    const destination = await Destination.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!destination) {
-      throw new Error("destination not found");
-    }
+    const destination = await Destination.findByGuid(params.guid);
 
     const group = await Group.findOne({
       where: { guid: params.groupGuid },
@@ -321,14 +292,7 @@ export class DestinationView extends Action {
   }
 
   async run({ params, response }) {
-    const destination = await Destination.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-
-    if (!destination) {
-      throw new Error("destination not found");
-    }
-
+    const destination = await Destination.findByGuid(params.guid);
     response.destination = await destination.apiData();
   }
 }
@@ -347,14 +311,7 @@ export class DestinationDestroy extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const destination = await Destination.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-
-    if (!destination) {
-      throw new Error("destination not found");
-    }
-
+    const destination = await Destination.findByGuid(params.guid);
     await destination.destroy();
     response.success = true;
   }

--- a/core/api/src/actions/exports.ts
+++ b/core/api/src/actions/exports.ts
@@ -52,11 +52,7 @@ export class ExportView extends Action {
   }
 
   async run({ params, response }) {
-    const _export = await Export.findOne({ where: { guid: params.guid } });
-    if (!_export) {
-      throw new Error("export not found");
-    }
-
+    const _export = await Export.findByGuid(params.guid);
     response.export = await _export.apiData();
   }
 }

--- a/core/api/src/actions/files.ts
+++ b/core/api/src/actions/files.ts
@@ -98,10 +98,7 @@ export class FileView extends Action {
   async run(data) {
     const { connection, params } = data;
 
-    const file = await File.findOne({ where: { guid: params.guid } });
-    if (!file) {
-      throw new Error("file not found");
-    }
+    const file = await File.findByGuid(params.guid);
     const { localPath } = await api.files.downloadToServer(file);
 
     const nameParts = file.path.split("/");
@@ -139,10 +136,7 @@ export class FileDestroy extends Action {
 
   async run({ response, params }) {
     response.success = false;
-    const file = await File.findOne({ where: { guid: params.guid } });
-    if (!file) {
-      throw new Error("file not found");
-    }
+    const file = await File.findByGuid(params.guid);
     await api.files.destroy(file);
     response.success = true;
   }

--- a/core/api/src/actions/groups.ts
+++ b/core/api/src/actions/groups.ts
@@ -13,6 +13,7 @@ export class GroupsList extends Action {
     this.inputs = {
       limit: { required: true, default: 1000, formatter: parseInt },
       offset: { required: true, default: 0, formatter: parseInt },
+      state: { required: false },
       order: {
         required: true,
         default: [
@@ -24,14 +25,21 @@ export class GroupsList extends Action {
   }
 
   async run({ params, response }) {
+    const where = {};
+
+    if (params.state) {
+      where["state"] = params.state;
+    }
+
     const groups = await Group.scope(null).findAll({
+      where,
       limit: params.limit,
       offset: params.offset,
       order: params.order,
     });
 
     response.groups = await Promise.all(groups.map(async (g) => g.apiData()));
-    response.total = await Group.scope(null).count();
+    response.total = await Group.scope(null).count({ where });
   }
 }
 

--- a/core/api/src/actions/groups.ts
+++ b/core/api/src/actions/groups.ts
@@ -63,6 +63,7 @@ export class GroupCreate extends Action {
       type: { required: true },
       matchType: { required: true, default: "all" },
       rules: { required: false },
+      state: { required: false },
     };
   }
 

--- a/core/api/src/actions/imports.ts
+++ b/core/api/src/actions/imports.ts
@@ -58,11 +58,7 @@ export class ViewImport extends Action {
   }
 
   async run({ response, params }) {
-    const _import = await Import.findOne({ where: { guid: params.guid } });
-    if (!_import) {
-      throw new Error("import not found");
-    }
-
+    const _import = await Import.findByGuid(params.guid);
     response.import = await _import.apiData();
   }
 }

--- a/core/api/src/actions/profilePropertyRules.ts
+++ b/core/api/src/actions/profilePropertyRules.ts
@@ -39,7 +39,7 @@ export class ProfilePropertyRulesList extends Action {
       where["unique"] = true;
     }
 
-    const profilePropertyRules = await ProfilePropertyRule.findAll({
+    const profilePropertyRules = await ProfilePropertyRule.scope(null).findAll({
       limit: params.limit,
       offset: params.offset,
       order: params.order,
@@ -99,7 +99,7 @@ export class ProfilePropertyRuleGroups extends Action {
   }
 
   async run({ params, response }) {
-    const profilePropertyRule = await ProfilePropertyRule.findOne({
+    const profilePropertyRule = await ProfilePropertyRule.scope(null).findOne({
       where: { guid: params.guid },
     });
 
@@ -180,7 +180,7 @@ export class ProfilePropertyRuleEdit extends Action {
   }
 
   async run({ params, response }) {
-    const profilePropertyRule = await ProfilePropertyRule.findOne({
+    const profilePropertyRule = await ProfilePropertyRule.scope(null).findOne({
       where: { guid: params.guid },
     });
     if (!profilePropertyRule) {
@@ -211,7 +211,7 @@ export class ProfilePropertyRuleView extends Action {
   }
 
   async run({ params, response }) {
-    const profilePropertyRule = await ProfilePropertyRule.findOne({
+    const profilePropertyRule = await ProfilePropertyRule.scope(null).findOne({
       where: { guid: params.guid },
     });
     if (!profilePropertyRule) {
@@ -236,7 +236,7 @@ export class ProfilePropertyRuleTest extends Action {
   }
 
   async run({ params, response }) {
-    const profilePropertyRule = await ProfilePropertyRule.findOne({
+    const profilePropertyRule = await ProfilePropertyRule.scope(null).findOne({
       where: { guid: params.guid },
     });
     if (!profilePropertyRule) {
@@ -261,7 +261,7 @@ export class ProfilePropertyRuleDestroy extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const profilePropertyRule = await ProfilePropertyRule.findOne({
+    const profilePropertyRule = await ProfilePropertyRule.scope(null).findOne({
       where: { guid: params.guid },
     });
     if (!profilePropertyRule) {

--- a/core/api/src/actions/profilePropertyRules.ts
+++ b/core/api/src/actions/profilePropertyRules.ts
@@ -67,7 +67,7 @@ export class ProfilePropertyRulesList extends Action {
       response.examples[rule.guid] = exampleValues;
     }
 
-    response.total = await ProfilePropertyRule.count();
+    response.total = await ProfilePropertyRule.scope(null).count();
   }
 }
 
@@ -99,13 +99,9 @@ export class ProfilePropertyRuleGroups extends Action {
   }
 
   async run({ params, response }) {
-    const profilePropertyRule = await ProfilePropertyRule.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-
-    if (!profilePropertyRule) {
-      throw new Error("profilePropertyRule not found");
-    }
+    const profilePropertyRule = await ProfilePropertyRule.findByGuid(
+      params.guid
+    );
 
     const groups = await Group.findAll({
       include: [
@@ -180,12 +176,9 @@ export class ProfilePropertyRuleEdit extends Action {
   }
 
   async run({ params, response }) {
-    const profilePropertyRule = await ProfilePropertyRule.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!profilePropertyRule) {
-      throw new Error("profilePropertyRule not found");
-    }
+    const profilePropertyRule = await ProfilePropertyRule.findByGuid(
+      params.guid
+    );
 
     if (params.options) {
       await profilePropertyRule.setOptions(params.options);
@@ -211,12 +204,9 @@ export class ProfilePropertyRuleView extends Action {
   }
 
   async run({ params, response }) {
-    const profilePropertyRule = await ProfilePropertyRule.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!profilePropertyRule) {
-      throw new Error("profilePropertyRule not found");
-    }
+    const profilePropertyRule = await ProfilePropertyRule.findByGuid(
+      params.guid
+    );
 
     response.profilePropertyRule = await profilePropertyRule.apiData();
     response.pluginOptions = await profilePropertyRule.pluginOptions();
@@ -236,12 +226,9 @@ export class ProfilePropertyRuleTest extends Action {
   }
 
   async run({ params, response }) {
-    const profilePropertyRule = await ProfilePropertyRule.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!profilePropertyRule) {
-      throw new Error("profilePropertyRule not found");
-    }
+    const profilePropertyRule = await ProfilePropertyRule.findByGuid(
+      params.guid
+    );
 
     response.test = (await profilePropertyRule.test()) || true;
   }
@@ -261,12 +248,10 @@ export class ProfilePropertyRuleDestroy extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const profilePropertyRule = await ProfilePropertyRule.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!profilePropertyRule) {
-      throw new Error("profilePropertyRule not found");
-    }
+    const profilePropertyRule = await ProfilePropertyRule.findByGuid(
+      params.guid
+    );
+
     await profilePropertyRule.destroy();
     response.success = true;
   }

--- a/core/api/src/actions/profiles.ts
+++ b/core/api/src/actions/profiles.ts
@@ -57,14 +57,7 @@ export class ProfilesList extends Action {
     }
 
     if (params.guid) {
-      const group = await Group.findOne({
-        where: { guid: params.guid },
-      });
-
-      if (!group) {
-        throw new Error("group not found");
-      }
-
+      const group = await Group.findByGuid(params.guid);
       const groupMembers: Array<GroupMember> = await group.$get(
         "groupMembers",
         {
@@ -171,13 +164,7 @@ export class ProfileImportAndUpdate extends Action {
   async run({ params, response }) {
     response.success = false;
 
-    const profile = await Profile.findOne({
-      where: { guid: params.guid },
-    });
-
-    if (!profile) {
-      throw new Error("profile not found");
-    }
+    const profile = await Profile.findByGuid(params.guid);
 
     await profile.import();
     await profile.updateGroupMembership();
@@ -204,10 +191,7 @@ export class ProfileEdit extends Action {
   }
 
   async run({ params, response }) {
-    const profile = await Profile.findOne({ where: { guid: params.guid } });
-    if (!profile) {
-      throw new Error("profile not found");
-    }
+    const profile = await Profile.findByGuid(params.guid);
     await profile.update(params);
     await profile.addOrUpdateProperties(params.properties);
     await profile.removeProperties(params.removedProperties);
@@ -231,10 +215,7 @@ export class ProfileView extends Action {
   }
 
   async run({ params, response }) {
-    const profile = await Profile.findOne({ where: { guid: params.guid } });
-    if (!profile) {
-      throw new Error("profile not found");
-    }
+    const profile = await Profile.findByGuid(params.guid);
     response.profile = await profile.apiData();
     response.groups = await profile.$get("groups");
   }
@@ -254,10 +235,7 @@ export class ProfileDestroy extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const profile = await Profile.findOne({ where: { guid: params.guid } });
-    if (!profile) {
-      throw new Error("profile not found");
-    }
+    const profile = await Profile.findByGuid(params.guid);
     await profile.destroy();
     response.success = true;
   }

--- a/core/api/src/actions/runs.ts
+++ b/core/api/src/actions/runs.ts
@@ -24,7 +24,7 @@ export class ListRuns extends Action {
     let guid = params.guid;
 
     if (guid && guid.match(/^src_/)) {
-      const schedule = await Schedule.findOne({
+      const schedule = await Schedule.scope(null).findOne({
         where: { sourceGuid: params.guid },
       });
       if (!schedule) {
@@ -60,7 +60,7 @@ export class ListRuns extends Action {
 
     const runs = await Run.scope(null).findAll(search);
     response.runs = await Promise.all(runs.map(async (app) => app.apiData()));
-    response.total = await Run.count({ where });
+    response.total = await Run.scope(null).count({ where });
   }
 }
 
@@ -77,10 +77,7 @@ export class RunView extends Action {
   }
 
   async run({ params, response }) {
-    const run = await Run.scope(null).findOne({ where: { guid: params.guid } });
-    if (!run) {
-      throw new Error("run not found");
-    }
+    const run = await Run.findByGuid(params.guid);
     response.run = await run.apiData();
     response.quantizedTimeline = await run.quantizedTimeline();
   }

--- a/core/api/src/actions/runs.ts
+++ b/core/api/src/actions/runs.ts
@@ -58,7 +58,7 @@ export class ListRuns extends Action {
       order: params.order,
     };
 
-    const runs = await Run.findAll(search);
+    const runs = await Run.scope(null).findAll(search);
     response.runs = await Promise.all(runs.map(async (app) => app.apiData()));
     response.total = await Run.count({ where });
   }
@@ -77,7 +77,7 @@ export class RunView extends Action {
   }
 
   async run({ params, response }) {
-    const run = await Run.findOne({ where: { guid: params.guid } });
+    const run = await Run.scope(null).findOne({ where: { guid: params.guid } });
     if (!run) {
       throw new Error("run not found");
     }

--- a/core/api/src/actions/schedules.ts
+++ b/core/api/src/actions/schedules.ts
@@ -23,7 +23,7 @@ export class SchedulesList extends Action {
   }
 
   async run({ params, response }) {
-    const schedules = await Schedule.findAll({
+    const schedules = await Schedule.scope(null).findAll({
       limit: params.limit,
       offset: params.offset,
       order: params.order,
@@ -121,7 +121,7 @@ export class ScheduleEdit extends Action {
   }
 
   async run({ params, response }) {
-    const schedule = await Schedule.findOne({
+    const schedule = await Schedule.scope(null).findOne({
       where: { guid: params.guid },
     });
 
@@ -151,7 +151,7 @@ export class ScheduleView extends Action {
   }
 
   async run({ params, response }) {
-    const schedule = await Schedule.findOne({
+    const schedule = await Schedule.scope(null).findOne({
       where: { guid: params.guid },
     });
 
@@ -178,7 +178,7 @@ export class ScheduleDestroy extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const schedule = await Schedule.findOne({
+    const schedule = await Schedule.scope(null).findOne({
       where: { guid: params.guid },
     });
 

--- a/core/api/src/actions/schedules.ts
+++ b/core/api/src/actions/schedules.ts
@@ -33,7 +33,7 @@ export class SchedulesList extends Action {
       schedules.map(async (conn) => conn.apiData())
     );
 
-    response.total = await Schedule.count();
+    response.total = await Schedule.scope(null).count();
   }
 }
 
@@ -51,14 +51,7 @@ export class ScheduleRun extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const schedule = await Schedule.findOne({
-      where: { guid: params.guid },
-    });
-
-    if (!schedule) {
-      throw new Error("schedule not found");
-    }
-
+    const schedule = await Schedule.findByGuid(params.guid);
     await schedule.enqueueRun();
     response.success = true;
   }
@@ -121,14 +114,7 @@ export class ScheduleEdit extends Action {
   }
 
   async run({ params, response }) {
-    const schedule = await Schedule.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-
-    if (!schedule) {
-      throw new Error("schedule not found");
-    }
-
+    const schedule = await Schedule.findByGuid(params.guid);
     if (params.options) {
       await schedule.setOptions(params.options);
     }
@@ -151,14 +137,7 @@ export class ScheduleView extends Action {
   }
 
   async run({ params, response }) {
-    const schedule = await Schedule.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-
-    if (!schedule) {
-      throw new Error("schedule not found");
-    }
-
+    const schedule = await Schedule.findByGuid(params.guid);
     response.schedule = await schedule.apiData();
     response.pluginOptions = await schedule.pluginOptions();
   }
@@ -178,14 +157,7 @@ export class ScheduleDestroy extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const schedule = await Schedule.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-
-    if (!schedule) {
-      throw new Error("schedule not found");
-    }
-
+    const schedule = await Schedule.findByGuid(params.guid);
     await schedule.destroy();
     response.success = true;
   }

--- a/core/api/src/actions/schedules.ts
+++ b/core/api/src/actions/schedules.ts
@@ -12,6 +12,7 @@ export class SchedulesList extends Action {
     this.inputs = {
       limit: { required: true, default: 1000, formatter: parseInt },
       offset: { required: true, default: 0, formatter: parseInt },
+      state: { required: false },
       order: {
         required: true,
         default: [
@@ -23,7 +24,14 @@ export class SchedulesList extends Action {
   }
 
   async run({ params, response }) {
+    const where = {};
+
+    if (params.state) {
+      where["state"] = params.state;
+    }
+
     const schedules = await Schedule.scope(null).findAll({
+      where,
       limit: params.limit,
       offset: params.offset,
       order: params.order,
@@ -33,7 +41,7 @@ export class SchedulesList extends Action {
       schedules.map(async (conn) => conn.apiData())
     );
 
-    response.total = await Schedule.scope(null).count();
+    response.total = await Schedule.scope(null).count({ where });
   }
 }
 

--- a/core/api/src/actions/settings.ts
+++ b/core/api/src/actions/settings.ts
@@ -43,12 +43,7 @@ export class SettingEdit extends Action {
   }
 
   async run({ response, params }) {
-    let setting = await Setting.findOne({ where: { guid: params.guid } });
-
-    if (!setting) {
-      throw new Error("setting not found");
-    }
-
+    let setting = await Setting.findByGuid(params.guid);
     setting = await plugin.updateSetting(
       setting.pluginName,
       setting.key,

--- a/core/api/src/actions/sources.ts
+++ b/core/api/src/actions/sources.ts
@@ -31,7 +31,7 @@ export class SourcesList extends Action {
       where["state"] = params.state;
     }
 
-    const sources = await Source.findAll({
+    const sources = await Source.scope(null).findAll({
       where,
       limit: params.limit,
       offset: params.offset,
@@ -138,7 +138,9 @@ export class SourceView extends Action {
   }
 
   async run({ params, response }) {
-    const source = await Source.findOne({ where: { guid: params.guid } });
+    const source = await Source.scope(null).findOne({
+      where: { guid: params.guid },
+    });
     if (!source) {
       throw new Error("source not found");
     }
@@ -165,7 +167,9 @@ export class SourceEdit extends Action {
   }
 
   async run({ params, response }) {
-    const source = await Source.findOne({ where: { guid: params.guid } });
+    const source = await Source.scope(null).findOne({
+      where: { guid: params.guid },
+    });
     if (!source) {
       throw new Error("source not found");
     }
@@ -197,7 +201,9 @@ export class SourceBootstrapUniqueProfilePropertyRule extends Action {
   }
 
   async run({ params, response }) {
-    const source = await Source.findOne({ where: { guid: params.guid } });
+    const source = await Source.scope(null).findOne({
+      where: { guid: params.guid },
+    });
     if (!source) {
       throw new Error("source not found");
     }
@@ -225,7 +231,9 @@ export class sourceConnectionOptions extends Action {
   }
 
   async run({ params, response }) {
-    const source = await Source.findOne({ where: { guid: params.guid } });
+    const source = await Source.scope(null).findOne({
+      where: { guid: params.guid },
+    });
     if (!source) {
       throw new Error("source not found");
     }
@@ -248,7 +256,9 @@ export class sourcePreview extends Action {
   }
 
   async run({ params, response }) {
-    const source = await Source.findOne({ where: { guid: params.guid } });
+    const source = await Source.scope(null).findOne({
+      where: { guid: params.guid },
+    });
     if (!source) {
       throw new Error("source not found");
     }
@@ -275,7 +285,9 @@ export class SourceDestroy extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const source = await Source.findOne({ where: { guid: params.guid } });
+    const source = await Source.scope(null).findOne({
+      where: { guid: params.guid },
+    });
     if (!source) {
       throw new Error("source not found");
     }

--- a/core/api/src/actions/sources.ts
+++ b/core/api/src/actions/sources.ts
@@ -42,7 +42,7 @@ export class SourcesList extends Action {
       sources.map(async (source) => source.apiData())
     );
 
-    response.total = await Source.count({ where });
+    response.total = await Source.scope(null).count({ where });
   }
 }
 
@@ -138,12 +138,7 @@ export class SourceView extends Action {
   }
 
   async run({ params, response }) {
-    const source = await Source.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!source) {
-      throw new Error("source not found");
-    }
+    const source = await Source.findByGuid(params.guid);
     response.source = await source.apiData();
   }
 }
@@ -167,12 +162,7 @@ export class SourceEdit extends Action {
   }
 
   async run({ params, response }) {
-    const source = await Source.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!source) {
-      throw new Error("source not found");
-    }
+    const source = await Source.findByGuid(params.guid);
     if (params.options) {
       await source.setOptions(params.options);
     }
@@ -201,12 +191,7 @@ export class SourceBootstrapUniqueProfilePropertyRule extends Action {
   }
 
   async run({ params, response }) {
-    const source = await Source.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!source) {
-      throw new Error("source not found");
-    }
+    const source = await Source.findByGuid(params.guid);
 
     const rule = await source.bootstrapUniqueProfilePropertyRule(
       params.key,
@@ -231,13 +216,7 @@ export class sourceConnectionOptions extends Action {
   }
 
   async run({ params, response }) {
-    const source = await Source.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!source) {
-      throw new Error("source not found");
-    }
-
+    const source = await Source.findByGuid(params.guid);
     response.options = await source.sourceConnectionOptions();
   }
 }
@@ -256,12 +235,7 @@ export class sourcePreview extends Action {
   }
 
   async run({ params, response }) {
-    const source = await Source.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!source) {
-      throw new Error("source not found");
-    }
+    const source = await Source.findByGuid(params.guid);
 
     const options =
       typeof params.options === "string"
@@ -285,12 +259,7 @@ export class SourceDestroy extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const source = await Source.scope(null).findOne({
-      where: { guid: params.guid },
-    });
-    if (!source) {
-      throw new Error("source not found");
-    }
+    const source = await Source.findByGuid(params.guid);
     await source.destroy();
     response.success = true;
   }

--- a/core/api/src/actions/teamMembers.ts
+++ b/core/api/src/actions/teamMembers.ts
@@ -45,10 +45,7 @@ export class TeamMemberCreate extends Action {
   }
 
   async run({ params, response }) {
-    const team = await Team.findOne({ where: { guid: params.guid } });
-    if (!team) {
-      throw new Error("team not found");
-    }
+    const team = await Team.findByGuid(params.guid);
     const teamMember = new TeamMember({
       firstName: params.firstName,
       lastName: params.lastName,
@@ -104,13 +101,7 @@ export class TeamMemberEdit extends Action {
   }
 
   async run({ params, response }) {
-    const teamMember = await TeamMember.findOne({
-      where: { guid: params.guid },
-    });
-
-    if (!teamMember) {
-      throw new Error("team member not found");
-    }
+    const teamMember = await TeamMember.findByGuid(params.guid);
 
     await teamMember.update(params);
 
@@ -136,12 +127,7 @@ export class TeamMemberDestroy extends Action {
 
   async run({ params, response, session: { teamMember: myself } }) {
     response.success = false;
-    const teamMember = await TeamMember.findOne({
-      where: { guid: params.guid },
-    });
-    if (!teamMember) {
-      throw new Error("team member not found");
-    }
+    const teamMember = await TeamMember.findByGuid(params.guid);
     if (myself.guid === teamMember.guid) {
       throw new Error("you cannot delete yourself");
     }

--- a/core/api/src/actions/teams.ts
+++ b/core/api/src/actions/teams.ts
@@ -106,10 +106,7 @@ export class TeamEdit extends Action {
   }
 
   async run({ params, response }) {
-    const team = await Team.findOne({ where: { guid: params.guid } });
-    if (!team) {
-      throw new Error("team not found");
-    }
+    const team = await Team.findByGuid(params.guid);
     await team.update(params);
     response.team = await team.apiData();
   }
@@ -167,12 +164,7 @@ export class TeamDestroy extends Action {
 
   async run({ params, response }) {
     response.success = false;
-    const team = await Team.findOne({ where: { guid: params.guid } });
-
-    if (!team) {
-      throw new Error("team not found");
-    }
-
+    const team = await Team.findByGuid(params.guid);
     await team.destroy();
     response.success = true;
   }

--- a/core/api/src/classes/loggedModel.ts
+++ b/core/api/src/classes/loggedModel.ts
@@ -146,4 +146,24 @@ export abstract class LoggedModel<T> extends Model<T> {
   }
 
   abstract apiData(): Promise<{ [key: string]: any }>;
+
+  /**
+   * Find an instance of this class, regardless of scope
+   */
+  static async findByGuid(guid: string): Promise<any> {
+    // static class definitions or type defining are not yet available in TS.  See:
+    // * https://github.com/microsoft/TypeScript/issues/14600
+    // * https://github.com/microsoft/TypeScript/issues/34516
+    // * https://github.com/microsoft/TypeScript/issues/33892
+
+    // So, each model will implement this method
+
+    throw new Error("not implemented");
+
+    // const instance: T = await this.scope(null).findOne({ where: { guid } });
+    // if (!instance) {
+    //   throw new Error(`cannot find ${this.name} ${guid}`);
+    // }
+    // return instance;
+  }
 }

--- a/core/api/src/models/App.ts
+++ b/core/api/src/models/App.ts
@@ -5,12 +5,13 @@ import {
   Default,
   Length,
   AllowNull,
-  BeforeValidate,
   BeforeSave,
   DataType,
   BeforeDestroy,
   AfterDestroy,
   HasMany,
+  DefaultScope,
+  Scopes,
 } from "sequelize-typescript";
 import { Op } from "sequelize";
 import { LoggedModel } from "../classes/loggedModel";
@@ -32,6 +33,9 @@ const STATE_TRANSITIONS = [
   { from: "draft", to: "ready", checks: ["validateOptions"] },
 ];
 
+@DefaultScope(() => ({
+  where: { state: "ready" },
+}))
 @Table({ tableName: "apps", paranoid: false })
 export class App extends LoggedModel<App> {
   guidPrefix() {

--- a/core/api/src/models/App.ts
+++ b/core/api/src/models/App.ts
@@ -185,4 +185,14 @@ export class App extends LoggedModel<App> {
     const { plugin } = await this.getPlugin();
     return plugin?.icon;
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/App.ts
+++ b/core/api/src/models/App.ts
@@ -11,7 +11,6 @@ import {
   AfterDestroy,
   HasMany,
   DefaultScope,
-  Scopes,
 } from "sequelize-typescript";
 import { Op } from "sequelize";
 import { LoggedModel } from "../classes/loggedModel";
@@ -19,6 +18,7 @@ import { Source } from "./Source";
 import { Option } from "./Option";
 import { OptionHelper } from "./../modules/optionHelper";
 import { StateMachine } from "./../modules/stateMachine";
+import { Destination } from "./Destination";
 
 export interface AppOption {
   key: string;
@@ -98,6 +98,15 @@ export class App extends LoggedModel<App> {
     if (sources.length > 0) {
       throw new Error(
         `cannot delete this app, source ${sources[0].guid} relies on it`
+      );
+    }
+
+    const destinations = await Destination.scope(null).findAll({
+      where: { appGuid: instance.guid },
+    });
+    if (destinations.length > 0) {
+      throw new Error(
+        `cannot delete this app, destination ${destinations[0].guid} relies on it`
       );
     }
   }

--- a/core/api/src/models/App.ts
+++ b/core/api/src/models/App.ts
@@ -92,7 +92,7 @@ export class App extends LoggedModel<App> {
 
   @BeforeDestroy
   static async checkDependents(instance: App) {
-    const sources = await Source.findAll({
+    const sources = await Source.scope(null).findAll({
       where: { appGuid: instance.guid },
     });
     if (sources.length > 0) {

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -437,6 +437,14 @@ export class Destination extends LoggedModel<Destination> {
 
   // --- Class Methods --- //
 
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
+
   /**
    * Determine which destinations are interested in this profile due to the groups they are tracking
    */

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -150,7 +150,7 @@ export class Destination extends LoggedModel<Destination> {
   @AfterSave
   static async buildDestinationGroupsWhenTrackingAll(instance: Destination) {
     if (instance.trackAllGroups === true) {
-      const groups = await Group.findAll();
+      const groups = await Group.scope(null).findAll();
       for (const i in groups) {
         await DestinationGroup.findOrCreate({
           where: { groupGuid: groups[i].guid, destinationGuid: instance.guid },
@@ -203,10 +203,10 @@ export class Destination extends LoggedModel<Destination> {
   }
 
   async apiData() {
-    const app = await this.$get("app");
+    const app = await this.$get("app", { scope: null });
     const mapping = await this.getMapping();
     const options = await this.getOptions();
-    const groups = await this.$get("groups");
+    const groups = await this.$get("groups", { scope: null });
     const { pluginConnection } = await this.getPlugin();
     const previewAvailable = await this.previewAvailable();
 
@@ -315,7 +315,7 @@ export class Destination extends LoggedModel<Destination> {
 
   async destinationConnectionOptions() {
     const { pluginConnection } = await this.getPlugin();
-    const app = await this.$get("app");
+    const app = await this.$get("app", { scope: null });
     const appOptions = await app.getOptions();
 
     if (!pluginConnection.methods.destinationOptions) {
@@ -338,7 +338,7 @@ export class Destination extends LoggedModel<Destination> {
     }
 
     const { pluginConnection } = await this.getPlugin();
-    const app = await this.$get("app");
+    const app = await this.$get("app", { scope: null });
     const appOptions = await app.getOptions();
 
     if (!pluginConnection.methods.destinationPreview) {
@@ -362,7 +362,7 @@ export class Destination extends LoggedModel<Destination> {
     newGroups: Array<Group>
   ) {
     const options = await this.getOptions();
-    const app = await this.$get("app");
+    const app = await this.$get("app", { scope: null });
     let method: ExportProfilePluginMethod;
     const { pluginConnection } = await this.getPlugin();
     method = pluginConnection.methods.exportProfile;
@@ -386,9 +386,9 @@ export class Destination extends LoggedModel<Destination> {
     const oldGroupNames = oldGroups.map((g) => g.name);
     const newGroupNames = newGroups.map((g) => g.name);
     const newGroupGuids = newGroups.map((g) => g.guid);
-    const destinationGroupGuids = (await this.$get("groups")).map(
-      (g) => g.guid
-    );
+    const destinationGroupGuids = (
+      await this.$get("groups", { scope: null })
+    ).map((g) => g.guid);
     let toDelete = true;
     newGroupGuids.forEach((newGroupGuid) => {
       if (destinationGroupGuids.includes(newGroupGuid)) {

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -15,6 +15,7 @@ import {
   AfterSave,
   AfterDestroy,
   DataType,
+  DefaultScope,
 } from "sequelize-typescript";
 import { LoggedModel } from "../classes/loggedModel";
 import { App } from "./App";
@@ -40,6 +41,9 @@ const STATE_TRANSITIONS = [
   { from: "draft", to: "ready", checks: ["validateOptions"] },
 ];
 
+@DefaultScope(() => ({
+  where: { state: "ready" },
+}))
 @Table({ tableName: "destinations", paranoid: false })
 export class Destination extends LoggedModel<Destination> {
   guidPrefix() {

--- a/core/api/src/models/DestinationGroup.ts
+++ b/core/api/src/models/DestinationGroup.ts
@@ -56,4 +56,14 @@ export class DestinationGroup extends LoggedModel<DestinationGroup> {
       createdAt: this.createdAt,
     };
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/Export.ts
+++ b/core/api/src/models/Export.ts
@@ -13,6 +13,7 @@ import {
   DataType,
   AfterDestroy,
   Default,
+  Scopes,
 } from "sequelize-typescript";
 import * as uuid from "uuid";
 import { Import } from "./Import";
@@ -186,13 +187,11 @@ export class Export extends Model<Export> {
   }
 
   async apiData() {
-    const destination = await this.$get("destination");
-    // const app = await destination.$get("app");
+    const destination = await this.$get("destination", { scope: null });
 
     return {
       guid: this.guid,
       destination: destination ? await destination.apiData() : null,
-      // destinationGuid: this.destinationGuid,
       profileGuid: this.profileGuid,
       startedAt: this.startedAt,
       completedAt: this.completedAt,
@@ -228,5 +227,15 @@ export class Export extends Model<Export> {
     }
 
     return { count: _exports.length, days };
+  }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
   }
 }

--- a/core/api/src/models/ExportImport.ts
+++ b/core/api/src/models/ExportImport.ts
@@ -58,4 +58,14 @@ export class ExportImport extends Model<ExportImport> {
       createdAt: this.createdAt,
     };
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/File.ts
+++ b/core/api/src/models/File.ts
@@ -57,4 +57,14 @@ export class File extends LoggedModel<File> {
       createdAt: this.createdAt,
     };
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -758,4 +758,14 @@ export class Group extends LoggedModel<Group> {
 
     return { where: whereContainer, include };
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -12,6 +12,7 @@ import {
   BeforeDestroy,
   AfterDestroy,
   Is,
+  DefaultScope,
 } from "sequelize-typescript";
 import { api, task } from "actionhero";
 import { Op } from "sequelize";
@@ -62,6 +63,9 @@ const STATE_TRANSITIONS = [
   { from: "ready", to: "deleted", checks: [] },
 ];
 
+@DefaultScope(() => ({
+  where: { state: "ready" },
+}))
 @Table({ tableName: "groups", paranoid: false })
 export class Group extends LoggedModel<Group> {
   guidPrefix() {

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -64,7 +64,7 @@ const STATE_TRANSITIONS = [
 ];
 
 @DefaultScope(() => ({
-  where: { state: "ready" },
+  where: { state: { [Op.ne]: "draft" } },
 }))
 @Table({ tableName: "groups", paranoid: false })
 export class Group extends LoggedModel<Group> {

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -377,9 +377,7 @@ export class Group extends LoggedModel<Group> {
       oldProfileProperties[key] = properties[key].value;
     }
 
-    const oldGroupGuids = (await profile.$get("groups", { scope: null })).map(
-      (g) => g.guid
-    );
+    const oldGroupGuids = (await profile.$get("groups")).map((g) => g.guid);
 
     return Import.build({
       rawData: destinationGuid ? { _meta: { destinationGuid } } : {},

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -377,7 +377,9 @@ export class Group extends LoggedModel<Group> {
       oldProfileProperties[key] = properties[key].value;
     }
 
-    const oldGroupGuids = (await profile.$get("groups")).map((g) => g.guid);
+    const oldGroupGuids = (await profile.$get("groups", { scope: null })).map(
+      (g) => g.guid
+    );
 
     return Import.build({
       rawData: destinationGuid ? { _meta: { destinationGuid } } : {},

--- a/core/api/src/models/GroupMember.ts
+++ b/core/api/src/models/GroupMember.ts
@@ -59,7 +59,7 @@ export class GroupMember extends Model<GroupMember> {
 
   @AfterCreate
   static async logCreate(instance: GroupMember) {
-    const group = await instance.$get("group", { scope: null });
+    const group = await instance.$get("group");
 
     await Log.create({
       topic: "groupMember",
@@ -74,7 +74,7 @@ export class GroupMember extends Model<GroupMember> {
 
   @AfterDestroy
   static async logDestroy(instance: GroupMember) {
-    const group = await instance.$get("group", { scope: null });
+    const group = await instance.$get("group");
 
     await Log.create({
       topic: "groupMember",

--- a/core/api/src/models/GroupMember.ts
+++ b/core/api/src/models/GroupMember.ts
@@ -59,7 +59,7 @@ export class GroupMember extends Model<GroupMember> {
 
   @AfterCreate
   static async logCreate(instance: GroupMember) {
-    const group = await instance.$get("group");
+    const group = await instance.$get("group", { scope: null });
 
     await Log.create({
       topic: "groupMember",
@@ -74,7 +74,7 @@ export class GroupMember extends Model<GroupMember> {
 
   @AfterDestroy
   static async logDestroy(instance: GroupMember) {
-    const group = await instance.$get("group");
+    const group = await instance.$get("group", { scope: null });
 
     await Log.create({
       topic: "groupMember",

--- a/core/api/src/models/GroupMember.ts
+++ b/core/api/src/models/GroupMember.ts
@@ -95,4 +95,14 @@ export class GroupMember extends Model<GroupMember> {
       removedAt: this.removedAt,
     };
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/GroupRule.ts
+++ b/core/api/src/models/GroupRule.ts
@@ -86,4 +86,14 @@ export class GroupRule extends Model<GroupRule> {
       updatedAt: this.updatedAt,
     };
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/Import.ts
+++ b/core/api/src/models/Import.ts
@@ -254,6 +254,16 @@ export class Import extends Model<Import> {
     }
   }
 
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
+
   static async sweep(limit: number) {
     const days = parseInt(
       (await plugin.readSetting("core", "sweeper-delete-old-imports-days"))

--- a/core/api/src/models/Log.ts
+++ b/core/api/src/models/Log.ts
@@ -94,6 +94,16 @@ export class Log extends Model<Log> {
     };
   }
 
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
+
   static async sweep() {
     // NOTE: we cannot use the plugin module as requiring it would create a cyclic loop (Setting->LoggedModel->Log)
     const Setting = require("./Setting").Setting;

--- a/core/api/src/models/Mapping.ts
+++ b/core/api/src/models/Mapping.ts
@@ -61,4 +61,14 @@ export class Mapping extends LoggedModel<Mapping> {
       updatedAt: this.updatedAt,
     };
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/Option.ts
+++ b/core/api/src/models/Option.ts
@@ -53,4 +53,14 @@ export class Option extends LoggedModel<Option> {
       updatedAt: this.updatedAt,
     };
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/Profile.ts
+++ b/core/api/src/models/Profile.ts
@@ -363,4 +363,14 @@ export class Profile extends LoggedModel<Profile> {
 
     return message;
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/Profile.ts
+++ b/core/api/src/models/Profile.ts
@@ -212,7 +212,7 @@ export class Profile extends LoggedModel<Profile> {
 
   async updateGroupMembership() {
     const results = {};
-    const groups = await Group.scope(null).findAll();
+    const groups = await Group.findAll();
 
     for (const i in groups) {
       const group = groups[i];
@@ -227,7 +227,7 @@ export class Profile extends LoggedModel<Profile> {
     let oldSimpleProperties = {};
     let oldGroups = [];
 
-    const groups = await this.$get("groups", { scope: null });
+    const groups = await this.$get("groups");
 
     const destinations = await Destination.destinationsForGroups(groups);
     const properties = await this.properties();

--- a/core/api/src/models/Profile.ts
+++ b/core/api/src/models/Profile.ts
@@ -211,8 +211,9 @@ export class Profile extends LoggedModel<Profile> {
   }
 
   async updateGroupMembership() {
-    const groups = await Group.findAll();
     const results = {};
+    const groups = await Group.scope(null).findAll();
+
     for (const i in groups) {
       const group = groups[i];
       const belongs = await group.updateProfileMembership(this);
@@ -226,7 +227,7 @@ export class Profile extends LoggedModel<Profile> {
     let oldSimpleProperties = {};
     let oldGroups = [];
 
-    const groups = await this.$get("groups");
+    const groups = await this.$get("groups", { scope: null });
 
     const destinations = await Destination.destinationsForGroups(groups);
     const properties = await this.properties();

--- a/core/api/src/models/ProfileProperty.ts
+++ b/core/api/src/models/ProfileProperty.ts
@@ -217,4 +217,14 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
       }
     }
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -423,7 +423,15 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
     };
   }
 
-  // --- Class Cache Methods --- //
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 
   static async clearCache() {
     CACHE = {

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -14,6 +14,7 @@ import {
   ForeignKey,
   BelongsTo,
   HasMany,
+  DefaultScope,
 } from "sequelize-typescript";
 import { Op } from "sequelize";
 import { env, api, task } from "actionhero";
@@ -152,6 +153,9 @@ let CACHE: ProfilePropertyRulesCache = {
   data: {},
 };
 
+@DefaultScope(() => ({
+  where: { state: "ready" },
+}))
 @Table({ tableName: "profilePropertyRules", paranoid: false })
 export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
   guidPrefix() {

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -212,7 +212,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
 
   @BeforeSave
   static async ensureOptions(instance: ProfilePropertyRule) {
-    const source = await instance.$get("source");
+    const source = await instance.$get("source", { scope: null });
     await source.validateOptions();
   }
 
@@ -244,7 +244,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
 
   @AfterCreate
   static async buildManualProfileProperties(instance: ProfilePropertyRule) {
-    const source = await instance.$get("source");
+    const source = await instance.$get("source", { scope: null });
     const app = await source.$get("app");
     if (app.type === "manual") {
       await internalRun("profilePropertyRule", instance.guid);
@@ -306,7 +306,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
   async test(options?: SimpleProfilePropertyRuleOptions) {
     const profile = await Profile.findOne({ order: api.sequelize.random() });
     if (profile) {
-      const source = await this.$get("source");
+      const source = await this.$get("source", { scope: null });
       return source.importProfileProperty(profile, this, options);
     }
   }
@@ -355,7 +355,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
   }
 
   async pluginOptions() {
-    const source = await this.$get("source");
+    const source = await this.$get("source", { scope: null });
     const { pluginConnection } = await source.getPlugin();
 
     if (!pluginConnection) {
@@ -408,7 +408,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
 
   async apiData() {
     const options = await this.getOptions();
-    const source = await this.$get("source");
+    const source = await this.$get("source", { scope: null });
 
     return {
       guid: this.guid,

--- a/core/api/src/models/Run.ts
+++ b/core/api/src/models/Run.ts
@@ -202,14 +202,14 @@ export class Run extends Model<Run> {
   async getNextFilter() {
     let nextFilter: RunFilter = {};
 
-    const schedule = await this.$get("schedule");
+    const schedule = await this.$get("schedule", { scope: null });
     if (!schedule) {
       // the run might not have been started by a schedule
       return nextFilter;
     }
 
-    const source = await schedule.$get("source");
-    const app = await source.$get("app");
+    const source = await schedule.$get("source", { scope: null });
+    const app = await source.$get("app", { scope: null });
     const { pluginConnection } = await source.getPlugin();
     if (!pluginConnection || !pluginConnection?.methods.nextFilter) {
       return nextFilter;

--- a/core/api/src/models/Run.ts
+++ b/core/api/src/models/Run.ts
@@ -331,4 +331,14 @@ export class Run extends Model<Run> {
       updatedAt: this.updatedAt,
     };
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/Schedule.ts
+++ b/core/api/src/models/Schedule.ts
@@ -347,4 +347,14 @@ export class Schedule extends LoggedModel<Schedule> {
 
     return { importsCount, nextHighWaterMark };
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/Schedule.ts
+++ b/core/api/src/models/Schedule.ts
@@ -14,6 +14,7 @@ import {
   BeforeSave,
   AfterDestroy,
   DataType,
+  DefaultScope,
 } from "sequelize-typescript";
 import { Op } from "sequelize";
 import { LoggedModel } from "../classes/loggedModel";
@@ -54,6 +55,9 @@ const STATE_TRANSITIONS = [
   { from: "draft", to: "ready", checks: ["validateOptions"] },
 ];
 
+@DefaultScope(() => ({
+  where: { state: "ready" },
+}))
 @Table({ tableName: "schedules", paranoid: false })
 export class Schedule extends LoggedModel<Schedule> {
   guidPrefix() {

--- a/core/api/src/models/Schedule.ts
+++ b/core/api/src/models/Schedule.ts
@@ -96,14 +96,14 @@ export class Schedule extends LoggedModel<Schedule> {
 
   @BeforeSave
   static async ensureSourceOptions(instance: Schedule) {
-    const source = await instance.$get("source");
+    const source = await instance.$get("source", { scope: null });
     const sourceOptions = await source.getOptions();
     await source.validateOptions(sourceOptions);
   }
 
   @BeforeSave
   static async ensureSourceMapping(instance: Schedule) {
-    const source = await instance.$get("source");
+    const source = await instance.$get("source", { scope: null });
     const sourceMapping = await source.getMapping();
     if (!sourceMapping || Object.keys(sourceMapping).length === 0) {
       throw new Error("source has no mapping");
@@ -128,14 +128,14 @@ export class Schedule extends LoggedModel<Schedule> {
   @BeforeValidate
   static async ensureName(instance: Schedule) {
     if (!instance.name) {
-      const source = await instance.$get("source");
+      const source = await instance.$get("source", { scope: null });
       instance.name = `${source.name} schedule`;
     }
   }
 
   @BeforeSave
   static async ensureUniqueName(instance: Schedule) {
-    const count = await Schedule.count({
+    const count = await Schedule.scope(null).count({
       where: {
         guid: { [Op.ne]: instance.guid },
         name: instance.name,
@@ -149,7 +149,7 @@ export class Schedule extends LoggedModel<Schedule> {
 
   @BeforeCreate
   static async ensureOnePerSource(instance: Schedule) {
-    const existingCount = await Schedule.count({
+    const existingCount = await Schedule.scope(null).count({
       where: {
         sourceGuid: instance.sourceGuid,
       },
@@ -218,7 +218,7 @@ export class Schedule extends LoggedModel<Schedule> {
   }
 
   async pluginOptions() {
-    const source = await this.$get("source");
+    const source = await this.$get("source", { scope: null });
     const { pluginConnection } = await source.getPlugin();
 
     const response: Array<{
@@ -240,7 +240,7 @@ export class Schedule extends LoggedModel<Schedule> {
       return response;
     }
 
-    const app = await source.$get("app");
+    const app = await source.$get("app", { scope: null });
     const appOptions = await app.getOptions();
     const sourceOptions = await source.getOptions();
     const sourceMapping = await source.getMapping();
@@ -268,7 +268,7 @@ export class Schedule extends LoggedModel<Schedule> {
   }
 
   async apiData() {
-    const source = await this.$get("source");
+    const source = await this.$get("source", { scope: null });
     const options = await this.getOptions();
 
     return {
@@ -293,8 +293,8 @@ export class Schedule extends LoggedModel<Schedule> {
   }
 
   async run(run: Run, limit: number, highWaterMark: string | number) {
-    const source = await this.$get("source");
-    const app = await source.$get("app");
+    const source = await this.$get("source", { scope: null });
+    const app = await source.$get("app", { scope: null });
     const { pluginConnection } = await source.getPlugin();
     const method = pluginConnection.methods.profiles;
 

--- a/core/api/src/models/Setting.ts
+++ b/core/api/src/models/Setting.ts
@@ -37,4 +37,14 @@ export class Setting extends LoggedModel<Setting> {
       updatedAt: this.updatedAt,
     };
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -475,4 +475,14 @@ export class Source extends LoggedModel<Source> {
       }
     }
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -238,7 +238,7 @@ export class Source extends LoggedModel<Source> {
       return;
     }
 
-    const app = await this.$get("app", { scope: null });
+    const app = await this.$get("app");
     const appOptions = await app.getOptions();
     const sourceOptions = await this.getOptions();
     const sourceMapping = await this.getMapping();
@@ -260,7 +260,7 @@ export class Source extends LoggedModel<Source> {
 
   async sourceConnectionOptions() {
     const { pluginConnection } = await this.getPlugin();
-    const app = await this.$get("app", { scope: null });
+    const app = await this.$get("app");
     const appOptions = await app.getOptions();
 
     if (!pluginConnection.methods.sourceOptions) {
@@ -283,7 +283,7 @@ export class Source extends LoggedModel<Source> {
     }
 
     const { pluginConnection } = await this.getPlugin();
-    const app = await this.$get("app", { scope: null });
+    const app = await this.$get("app");
     const appOptions = await app.getOptions();
 
     if (!pluginConnection.methods.sourcePreview) {
@@ -308,7 +308,7 @@ export class Source extends LoggedModel<Source> {
     let profilePropertyRules: ProfilePropertyRule[];
 
     if (includeApp) {
-      app = await this.$get("app", { scope: null });
+      app = await this.$get("app");
     }
     if (includeSchedule) {
       schedule = await this.$get("schedule", {
@@ -463,7 +463,7 @@ export class Source extends LoggedModel<Source> {
         typeof pluginConnection.methods
           .uniqueProfilePropertyRuleBootstrapOptions === "function"
       ) {
-        const app = await this.$get("app", { scope: null });
+        const app = await this.$get("app");
         const appOptions = await app.getOptions();
         const options = await this.getOptions();
         const ruleOptions = await pluginConnection.methods.uniqueProfilePropertyRuleBootstrapOptions(

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -13,6 +13,7 @@ import {
   ForeignKey,
   Default,
   DataType,
+  DefaultScope,
 } from "sequelize-typescript";
 import { Op } from "sequelize";
 import { LoggedModel } from "../classes/loggedModel";
@@ -39,6 +40,9 @@ const STATE_TRANSITIONS = [
   },
 ];
 
+@DefaultScope(() => ({
+  where: { state: "ready" },
+}))
 @Table({ tableName: "sources", paranoid: false })
 export class Source extends LoggedModel<Source> {
   guidPrefix() {
@@ -297,10 +301,14 @@ export class Source extends LoggedModel<Source> {
       app = await this.$get("app");
     }
     if (includeSchedule) {
-      schedule = await this.$get("schedule");
+      schedule = await this.$get("schedule", {
+        scope: null,
+      });
     }
     if (includeProfilePropertyRules) {
-      profilePropertyRules = await this.$get("profilePropertyRules");
+      profilePropertyRules = await this.$get("profilePropertyRules", {
+        scope: null,
+      });
     }
 
     const options = await this.getOptions();

--- a/core/api/src/models/Team.ts
+++ b/core/api/src/models/Team.ts
@@ -75,4 +75,14 @@ export class Team extends LoggedModel<Team> {
       membersCount,
     };
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/models/TeamMember.ts
+++ b/core/api/src/models/TeamMember.ts
@@ -80,4 +80,14 @@ export class TeamMember extends LoggedModel<TeamMember> {
     const match: boolean = await bcrypt.compare(password, this.passwordHash);
     return match;
   }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 }

--- a/core/api/src/modules/mappingHelper.ts
+++ b/core/api/src/modules/mappingHelper.ts
@@ -18,6 +18,9 @@ export namespace MappingHelper {
     for (const i in mappings) {
       const mapping = mappings[i];
       const rule = await mapping.$get("profilePropertyRule");
+      if (!rule) {
+        throw new Error(`cannot find profile property rule or it is not ready`);
+      }
       MappingObject[mapping.remoteKey] = rule.key;
     }
 

--- a/core/api/src/modules/mappingHelper.ts
+++ b/core/api/src/modules/mappingHelper.ts
@@ -40,7 +40,9 @@ export namespace MappingHelper {
       for (const i in keys) {
         const remoteKey = keys[i];
         const key = mappings[remoteKey];
-        const profilePropertyRule = await ProfilePropertyRule.findOne({
+        const profilePropertyRule = await ProfilePropertyRule.scope(
+          null
+        ).findOne({
           where: { key },
         });
 

--- a/core/api/src/modules/optionHelper.ts
+++ b/core/api/src/modules/optionHelper.ts
@@ -204,7 +204,7 @@ export namespace OptionHelper {
     const type = await getInstanceType(instance);
 
     if (!pluginConnection) {
-      throw new Error(`cannot find a schedule for type ${type}`);
+      throw new Error(`cannot find a pluginConnection for type ${type}`);
     }
 
     if (!pluginConnection.scheduleOptions) {
@@ -223,7 +223,7 @@ export namespace OptionHelper {
     const type = await getInstanceType(instance);
 
     if (!pluginConnection) {
-      throw new Error(`cannot find a profile property rule for type ${type}`);
+      throw new Error(`cannot find a pluginConnection for type ${type}`);
     }
 
     if (!pluginConnection.profilePropertyRuleOptions) {
@@ -240,7 +240,7 @@ export namespace OptionHelper {
     const type = await getInstanceType(instance);
 
     if (!pluginApp) {
-      throw new Error(`cannot find a app for type ${type}`);
+      throw new Error(`cannot find a pluginApp for type ${type}`);
     }
 
     return pluginApp.options.filter((o) => o.required).map((o) => o.key);
@@ -253,7 +253,7 @@ export namespace OptionHelper {
 
     if (!type || instance instanceof ProfilePropertyRule) {
       if (instance["sourceGuid"]) {
-        const source = await Source.findOne({
+        const source = await Source.scope(null).findOne({
           where: { guid: instance["sourceGuid"] },
         });
         if (source) {

--- a/core/api/src/tasks/group/destroy.ts
+++ b/core/api/src/tasks/group/destroy.ts
@@ -27,21 +27,11 @@ export class RunGroup extends Task {
         (await plugin.readSetting("core", "runs-profile-batch-size")).value
       );
 
-    const group = await Group.findOne({
-      where: { guid: params.groupGuid },
-    });
-    if (!group) {
-      throw new Error(`cannot find group ${params.groupGuid}`);
-    }
+    const group = await Group.findByGuid(params.groupGuid);
 
     let run: Run;
     if (params.runGuid) {
-      run = await Run.findOne({
-        where: { guid: params.runGuid },
-      });
-      if (!run) {
-        throw new Error(`cannot find run ${params.runGuid}`);
-      }
+      run = await Run.findByGuid(params.runGuid);
     } else {
       run = await Run.create({
         creatorGuid: group.guid,

--- a/core/api/src/tasks/group/exportToCSV.ts
+++ b/core/api/src/tasks/group/exportToCSV.ts
@@ -24,12 +24,7 @@ export class RunGroup extends Task {
         (await plugin.readSetting("core", "runs-profile-batch-size")).value
       );
 
-    const group = await Group.findOne({
-      where: { guid: params.groupGuid },
-    });
-    if (!group) {
-      throw new Error(`cannot find group ${params.groupGuid}`);
-    }
+    const group = await Group.findByGuid(params.groupGuid);
 
     // TODO: this is going to take a long time...
     const { filename, cleanName } = await groupExportToCSV(group, limit);

--- a/core/api/src/tasks/group/run.ts
+++ b/core/api/src/tasks/group/run.ts
@@ -35,21 +35,11 @@ export class RunGroup extends Task {
         (await plugin.readSetting("core", "runs-profile-batch-size")).value
       );
 
-    const group = await Group.findOne({
-      where: { guid: params.groupGuid },
-    });
-    if (!group) {
-      throw new Error(`cannot find group ${params.groupGuid}`);
-    }
+    const group = await Group.findByGuid(params.groupGuid);
 
     let run: Run;
     if (params.runGuid) {
-      run = await Run.findOne({
-        where: { guid: params.runGuid },
-      });
-      if (!run) {
-        throw new Error(`cannot find run ${params.runGuid}`);
-      }
+      run = await Run.findByGuid(params.runGuid);
       if (run.state === "stopped") {
         return;
       }

--- a/core/api/src/tasks/group/updateMembers.ts
+++ b/core/api/src/tasks/group/updateMembers.ts
@@ -29,21 +29,11 @@ export class RunGroup extends Task {
       );
     const destinationGuid = params.destinationGuid;
 
-    const group = await Group.findOne({
-      where: { guid: params.groupGuid },
-    });
-    if (!group) {
-      throw new Error(`cannot find group ${params.groupGuid}`);
-    }
+    const group = await Group.findByGuid(params.groupGuid);
 
     let run: Run;
     if (params.runGuid) {
-      run = await Run.findOne({
-        where: { guid: params.runGuid },
-      });
-      if (!run) {
-        throw new Error(`cannot find run ${params.runGuid}`);
-      }
+      run = await Run.findByGuid(params.runGuid);
     } else {
       run = await Run.create({
         creatorGuid: group.guid,

--- a/core/api/src/tasks/imports/associateProfile.ts
+++ b/core/api/src/tasks/imports/associateProfile.ts
@@ -17,12 +17,7 @@ export class AssociateProfileToImport extends RetryableTask {
 
   async run(params) {
     const { importGuid } = params;
-    const _import = await Import.findOne({
-      where: { guid: importGuid },
-    });
-    if (!_import) {
-      throw new Error(`import ${importGuid} not found`);
-    }
+    const _import = await Import.findByGuid(importGuid);
 
     try {
       const { profile, isNew } = await _import.associateProfile();

--- a/core/api/src/tasks/profile/export.ts
+++ b/core/api/src/tasks/profile/export.ts
@@ -20,10 +20,7 @@ export class ProfileExport extends RetryableTask {
   }
 
   async run(params) {
-    const profile = await Profile.findOne({ where: { guid: params.guid } });
-    if (!profile) {
-      throw new Error(`cannot find profile with guid: ${params.guid}`);
-    }
+    const profile = await Profile.findByGuid(params.guid);
 
     const imports = await Import.findAll({
       where: {

--- a/core/api/src/tasks/profile/importAndUpdate.ts
+++ b/core/api/src/tasks/profile/importAndUpdate.ts
@@ -28,13 +28,7 @@ export class ProfileImportAndUpdate extends RetryableTask {
   }
 
   async run(params) {
-    const profile = await Profile.findOne({
-      where: { guid: params.guid },
-    });
-
-    if (!profile) {
-      throw new Error(`cannot find profile with guid: ${params.guid}`);
-    }
+    const profile = await Profile.findByGuid(params.guid);
 
     const oldProfileProperties = await profile.properties();
 

--- a/core/api/src/tasks/runs/determineState.ts
+++ b/core/api/src/tasks/runs/determineState.ts
@@ -18,11 +18,7 @@ export class DetermineRunState extends Task {
     const runGuid = params.runGuid;
     const attempts = params.attempts || 0;
 
-    const run = await Run.findOne({ where: { guid: runGuid } });
-
-    if (!run) {
-      throw new Error(`cannot find run ${runGuid}`);
-    }
+    const run = await Run.findByGuid(runGuid);
 
     await run.determineState();
     await run.reload();

--- a/core/api/src/tasks/runs/internalRun.ts
+++ b/core/api/src/tasks/runs/internalRun.ts
@@ -26,10 +26,7 @@ export class DetermineRunState extends Task {
         (await plugin.readSetting("core", "runs-profile-batch-size")).value
       );
 
-    const run = await Run.findOne({ where: { guid: params.runGuid } });
-    if (!run) {
-      throw new Error(`run ${params.runGuid} not found`);
-    }
+    const run = await Run.findByGuid(params.runGuid);
 
     if (run.state === "stopped") {
       return;

--- a/core/api/src/tasks/schedule/run.ts
+++ b/core/api/src/tasks/schedule/run.ts
@@ -26,22 +26,14 @@ export class RunSchedule extends Task {
         (await plugin.readSetting("core", "runs-profile-batch-size")).value
       );
 
-    const schedule = await Schedule.findOne({
-      where: { guid: params.scheduleGuid },
-    });
-    if (!schedule) {
-      throw new Error(`cannot find schedule ${params.scheduleGuid}`);
-    }
+    const schedule = await Schedule.findByGuid(params.scheduleGuid);
     if (schedule.state !== "ready") {
       throw new Error(`schedule ${params.scheduleGuid} is not ready`);
     }
 
     let run: Run;
     if (params.runGuid) {
-      run = await Run.findOne({ where: { guid: params.runGuid } });
-      if (!run) {
-        throw new Error(`cannot find run ${params.runGuid}`);
-      }
+      run = await Run.findByGuid(params.runGuid);
     } else {
       run = await Run.create({
         creatorGuid: schedule.guid,

--- a/core/api/src/tasks/schedule/updateSchedules.ts
+++ b/core/api/src/tasks/schedule/updateSchedules.ts
@@ -35,7 +35,7 @@ export class UpdateSchedules extends Task {
         continue;
       }
 
-      const lastCompleteRun = await Run.findOne({
+      const lastCompleteRun = await Run.scope(null).findOne({
         where: {
           creatorGuid: schedule.guid,
           creatorType: "schedule",

--- a/core/web/components/forms/destination/mapping.tsx
+++ b/core/web/components/forms/destination/mapping.tsx
@@ -46,7 +46,7 @@ export default function ({ apiVersion, errorHandler, successHandler, query }) {
     const prrResponse = await execApi(
       "get",
       `/api/${apiVersion}/profilePropertyRules`,
-      { unique: false }
+      { unique: false, state: "ready" }
     );
     if (prrResponse?.profilePropertyRules) {
       setProfilePropertyRules(prrResponse.profilePropertyRules);

--- a/core/web/components/forms/group/add.tsx
+++ b/core/web/components/forms/group/add.tsx
@@ -11,7 +11,12 @@ export default function ({ apiVersion, errorHandler, successHandler }) {
 
   async function onSubmit(data) {
     setLoading(true);
-    const response = await execApi("post", `/api/${apiVersion}/group`, data);
+    const state = data.type === "manual" ? "ready" : "draft";
+    const response = await execApi(
+      "post",
+      `/api/${apiVersion}/group`,
+      Object.assign({}, data, { state })
+    );
     setLoading(false);
     if (response?.group) {
       successHandler.set({ message: "Group Created" });

--- a/plugins/@grouparoo/csv/__tests__/integration/csv.ts
+++ b/plugins/@grouparoo/csv/__tests__/integration/csv.ts
@@ -94,6 +94,7 @@ describe("integration/runs/csv", () => {
         csrfToken,
         name: "test import app",
         type: "csv",
+        state: "ready",
       };
       const appResponse = await specHelper.runAction("app:create", session);
       expect(appResponse.error).toBeUndefined();
@@ -199,6 +200,7 @@ describe("integration/runs/csv", () => {
         key: "email",
         type: "string",
         unique: true,
+        state: "ready",
       };
 
       const {

--- a/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
+++ b/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
@@ -96,6 +96,7 @@ describe("integration/runs/google-sheets", () => {
           client_email: GOOGLE_SERVICE_CLIENT_EMAIL,
           private_key: GOOGLE_SERVICE_PRIVATE_KEY,
         },
+        state: "ready",
       };
       const appResponse = await specHelper.runAction("app:create", session);
       expect(appResponse.error).toBeUndefined();
@@ -208,6 +209,7 @@ describe("integration/runs/google-sheets", () => {
         key: "email",
         type: "string",
         unique: true,
+        state: "ready",
       };
 
       const {

--- a/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-export.ts
+++ b/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-export.ts
@@ -99,6 +99,7 @@ describe("integration/runs/mailchimp", () => {
       name: "test app",
       type: "mailchimp",
       options: { apiKey: MAILCHIMP_API_KEY },
+      state: "ready",
     };
     const appResponse = await specHelper.runAction("app:create", session);
     expect(appResponse.error).toBeUndefined();

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-query-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-query-import.ts
@@ -116,6 +116,7 @@ describe("integration/runs/mysql", () => {
       name: "test app",
       type: "mysql",
       options: MYSQL_OPTIONS,
+      state: "ready",
     };
     const appResponse = await specHelper.runAction("app:create", session);
     expect(appResponse.error).toBeUndefined();

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -147,6 +147,7 @@ describe("integration/runs/mysql", () => {
       name: "test app",
       type: "mysql",
       options: MYSQL_OPTIONS,
+      state: "ready",
     };
     const appResponse = await specHelper.runAction("app:create", session);
     expect(appResponse.error).toBeUndefined();

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-query-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-query-import.ts
@@ -44,9 +44,6 @@ describe("integration/runs/postgres", () => {
   let csrfToken;
   let app;
   let source;
-  let schedule;
-  let destination;
-  let group;
 
   beforeAll(async () => {
     const env = await helper.prepareForAPITest();
@@ -115,6 +112,7 @@ describe("integration/runs/postgres", () => {
         port: config.sequelize.port,
         database: config.sequelize.database,
       },
+      state: "ready",
     };
     const appResponse = await specHelper.runAction("app:create", session);
     expect(appResponse.error).toBeUndefined();

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
@@ -136,6 +136,7 @@ describe("integration/runs/postgres", () => {
         port: config.sequelize.port,
         database: config.sequelize.database,
       },
+      state: "ready",
     };
     const appResponse = await specHelper.runAction("app:create", session);
     expect(appResponse.error).toBeUndefined();


### PR DESCRIPTION
Pros: 
* Objects will be "ready" by default; less `{where: {state: 'ready'}}`

Cons: 
* All the actions that might want to deal with not-yet-ready objects need to remove the default scope.  
* The list views should de-scope by default (so drafts can be shown), but lots of other pages use the `profilePropertyRules:list` action, so consumers still need the scope filter in the params.
* All the default `$get` methods use the default scope... so if you have a parent who isn't ready (ie: tests), things are going to get complicated

Misc:
* Added `findByGuid` to all models.  This helper should be used when finding one instance... it will ignore scopes and throw if it can't be found.  this helps mitigate Con 1.