### PR TITLE
Set NULL to the value when there are no rows.

### DIFF
--- a/plugins/@grouparoo/mysql/src/lib/table-import/profileProperty.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/profileProperty.ts
@@ -66,13 +66,11 @@ export async function profileProperty(
   const client = await connect(appOptions);
   try {
     const rows = await client.asyncQuery(parameterizedQuery);
-    if (rows) {
-      row = rows[0];
-      for (const remoteKey in sourceMapping) {
-        const profileKey = sourceMapping[remoteKey];
-        if (row[remoteKey] && !row[profileKey]) {
-          row[profileKey] = row[remoteKey];
-        }
+    const row = rows[0] || {};
+    for (const remoteKey in sourceMapping) {
+      const profileKey = sourceMapping[remoteKey];
+      if (!row.hasOwnProperty(profileKey)) {
+        row[profileKey] = row[remoteKey] || null;
       }
     }
   } catch (error) {


### PR DESCRIPTION
I came across a table that 1 to 1 with my users table but sparsely populated. That is, it didn't have all the user ids in it. So I needed an `exact` query, but it crashed when there was no row for that user.
I'm not exactly sure the right thing to do in this spot, but I think it's something like this to make that value `NULL`.

For example users table has 1000 rows.
User_demographics table has 300 with a unique indexed `user_id` in it for the users that have filled out their info. The property was using `user_demographics.income` or whatever. So now 300 will have their income and 700 will have `NULL` in the property.