### PR TITLE
Prevent Sailthru duplicate lists

### DIFF
--- a/plugins/@grouparoo/sailthru/__tests__/fixtures/export-profile.js
+++ b/plugins/@grouparoo/sailthru/__tests__/fixtures/export-profile.js
@@ -15,7 +15,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     { error: 99, errormsg: "User not found with email: brian@bleonard.com" },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:44:57 GMT",
+      "Thu, 16 Apr 2020 21:57:49 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -29,7 +29,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Remaining",
       "35999",
       "X-Rate-Limit-Reset",
-      "1586814300",
+      "1587074280",
       "Connection",
       "close",
       "Transfer-Encoding",
@@ -53,7 +53,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     { error: 99, errormsg: "User not found with email: brian@bleonard.com" },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:44:57 GMT",
+      "Thu, 16 Apr 2020 21:57:50 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -67,7 +67,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Remaining",
       "35998",
       "X-Rate-Limit-Reset",
-      "1586814300",
+      "1587074280",
       "Connection",
       "close",
       "Transfer-Encoding",
@@ -86,16 +86,16 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
       ok: true,
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:44:57 GMT",
+      "Thu, 16 Apr 2020 21:57:51 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -109,7 +109,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Remaining",
       "35999",
       "X-Rate-Limit-Reset",
-      "1586814300",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -134,15 +134,15 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:44:58 GMT",
+      "Thu, 16 Apr 2020 21:57:51 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -156,7 +156,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Remaining",
       "35997",
       "X-Rate-Limit-Reset",
-      "1586814300",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -181,15 +181,15 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:44:58 GMT",
+      "Thu, 16 Apr 2020 21:57:51 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -203,7 +203,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Remaining",
       "35996",
       "X-Rate-Limit-Reset",
-      "1586814300",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -217,23 +217,23 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
 nock("https://api.sailthru.com:443", { encodedQueryParams: true })
   .post(
     "/user",
-    "api_key=29831a903632490eb5e1722df107f06ac&format=json&json=%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%2C%22keys%22%3A%7B%22email%22%3A%22brian%40bleonard.com%22%7D%2C%22keysconflict%22%3A%22merge%22%2C%22lists%22%3A%7B%7D%2C%22vars%22%3A%7B%22first_name%22%3A%22Evan%22%7D%2C%22fields%22%3A%7B%22keys%22%3A1%7D%7D&sig=NOCK"
+    "api_key=29831a903632490eb5e1722df107f06ac&format=json&json=%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%2C%22keys%22%3A%7B%22email%22%3A%22brian%40bleonard.com%22%7D%2C%22keysconflict%22%3A%22merge%22%2C%22lists%22%3A%7B%7D%2C%22vars%22%3A%7B%22first_name%22%3A%22Evan%22%7D%2C%22fields%22%3A%7B%22keys%22%3A1%7D%7D&sig=NOCK"
   )
   .once()
   .reply(
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
       ok: true,
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:44:58 GMT",
+      "Thu, 16 Apr 2020 21:57:52 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -247,7 +247,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Remaining",
       "35998",
       "X-Rate-Limit-Reset",
-      "1586814300",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -265,16 +265,16 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     api_key: "29831a903632490eb5e1722df107f06ac",
     format: "json",
     json:
-      "%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%2C%22fields%22%3A%7B%22keys%22%3A1%2C%22vars%22%3A1%2C%22lists%22%3A1%7D%7D",
+      "%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%2C%22fields%22%3A%7B%22keys%22%3A1%2C%22vars%22%3A1%2C%22lists%22%3A1%7D%7D",
     sig: "NOCK",
   })
   .reply(
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
       vars: { first_name: "Evan" },
@@ -282,7 +282,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:44:59 GMT",
+      "Thu, 16 Apr 2020 21:57:52 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -296,7 +296,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Remaining",
       "35995",
       "X-Rate-Limit-Reset",
-      "1586814300",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -321,15 +321,15 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:44:59 GMT",
+      "Thu, 16 Apr 2020 21:57:52 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -341,9 +341,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35999",
+      "35994",
       "X-Rate-Limit-Reset",
-      "1586814300",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -357,23 +357,23 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
 nock("https://api.sailthru.com:443", { encodedQueryParams: true })
   .post(
     "/user",
-    "api_key=29831a903632490eb5e1722df107f06ac&format=json&json=%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%2C%22keys%22%3A%7B%22email%22%3A%22brian%40bleonard.com%22%7D%2C%22keysconflict%22%3A%22merge%22%2C%22lists%22%3A%7B%7D%2C%22vars%22%3A%7B%22first_name%22%3A%22Brian%22%7D%2C%22fields%22%3A%7B%22keys%22%3A1%7D%7D&sig=NOCK"
+    "api_key=29831a903632490eb5e1722df107f06ac&format=json&json=%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%2C%22keys%22%3A%7B%22email%22%3A%22brian%40bleonard.com%22%7D%2C%22keysconflict%22%3A%22merge%22%2C%22lists%22%3A%7B%7D%2C%22vars%22%3A%7B%22first_name%22%3A%22Brian%22%7D%2C%22fields%22%3A%7B%22keys%22%3A1%7D%7D&sig=NOCK"
   )
   .once()
   .reply(
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
       ok: true,
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:44:59 GMT",
+      "Thu, 16 Apr 2020 21:57:53 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -387,7 +387,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Remaining",
       "35997",
       "X-Rate-Limit-Reset",
-      "1586814300",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -405,16 +405,16 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     api_key: "29831a903632490eb5e1722df107f06ac",
     format: "json",
     json:
-      "%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%2C%22fields%22%3A%7B%22keys%22%3A1%2C%22vars%22%3A1%2C%22lists%22%3A1%7D%7D",
+      "%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%2C%22fields%22%3A%7B%22keys%22%3A1%2C%22vars%22%3A1%2C%22lists%22%3A1%7D%7D",
     sig: "NOCK",
   })
   .reply(
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
       vars: { first_name: "Brian" },
@@ -422,7 +422,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:01 GMT",
+      "Thu, 16 Apr 2020 21:57:53 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -434,9 +434,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35999",
+      "35993",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -461,15 +461,15 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:01 GMT",
+      "Thu, 16 Apr 2020 21:57:53 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -481,9 +481,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35998",
+      "35992",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -497,23 +497,23 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
 nock("https://api.sailthru.com:443", { encodedQueryParams: true })
   .post(
     "/user",
-    "api_key=29831a903632490eb5e1722df107f06ac&format=json&json=%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%2C%22keys%22%3A%7B%22email%22%3A%22brian%40bleonard.com%22%7D%2C%22keysconflict%22%3A%22merge%22%2C%22lists%22%3A%7B%7D%2C%22vars%22%3A%7B%22first_name%22%3Anull%7D%2C%22fields%22%3A%7B%22keys%22%3A1%7D%7D&sig=NOCK"
+    "api_key=29831a903632490eb5e1722df107f06ac&format=json&json=%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%2C%22keys%22%3A%7B%22email%22%3A%22brian%40bleonard.com%22%7D%2C%22keysconflict%22%3A%22merge%22%2C%22lists%22%3A%7B%7D%2C%22vars%22%3A%7B%22first_name%22%3Anull%7D%2C%22fields%22%3A%7B%22keys%22%3A1%7D%7D&sig=NOCK"
   )
   .once()
   .reply(
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
       ok: true,
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:01 GMT",
+      "Thu, 16 Apr 2020 21:57:53 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -525,9 +525,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35999",
+      "35996",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -545,16 +545,16 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     api_key: "29831a903632490eb5e1722df107f06ac",
     format: "json",
     json:
-      "%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%2C%22fields%22%3A%7B%22keys%22%3A1%2C%22vars%22%3A1%2C%22lists%22%3A1%7D%7D",
+      "%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%2C%22fields%22%3A%7B%22keys%22%3A1%2C%22vars%22%3A1%2C%22lists%22%3A1%7D%7D",
     sig: "NOCK",
   })
   .reply(
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
       vars: { first_name: null },
@@ -562,7 +562,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:02 GMT",
+      "Thu, 16 Apr 2020 21:57:54 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -574,9 +574,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35997",
+      "35991",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -601,15 +601,15 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:02 GMT",
+      "Thu, 16 Apr 2020 21:57:54 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -621,9 +621,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35996",
+      "35990",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -635,25 +635,237 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     ]
   );
 nock("https://api.sailthru.com:443", { encodedQueryParams: true })
+  .get("/list")
+  .once()
+  .query({
+    api_key: "29831a903632490eb5e1722df107f06ac",
+    format: "json",
+    json: "%7B%22list%22%3A%22Test%20Group%201%22%7D",
+    sig: "NOCK",
+  })
+  .reply(404, { error: 15, errormsg: "Unknown list: Test Group 1" }, [
+    "Date",
+    "Thu, 16 Apr 2020 21:57:55 GMT",
+    "Server",
+    "Sailthru",
+    "X-Content-Type-Options",
+    "nosniff",
+    "X-XSS-Protection",
+    "1; mode=block",
+    "X-Frame-Options",
+    "SAMEORIGIN",
+    "X-Rate-Limit-Limit",
+    "36000",
+    "X-Rate-Limit-Remaining",
+    "35999",
+    "X-Rate-Limit-Reset",
+    "1587074280",
+    "Connection",
+    "close",
+    "Transfer-Encoding",
+    "chunked",
+    "Content-Type",
+    "application/json",
+  ]);
+nock("https://api.sailthru.com:443", { encodedQueryParams: true })
+  .get("/list")
+  .once()
+  .query({
+    api_key: "29831a903632490eb5e1722df107f06ac",
+    format: "json",
+    json: "%7B%22list%22%3A%22Test%20Group%201%22%7D",
+    sig: "NOCK",
+  })
+  .reply(404, { error: 15, errormsg: "Unknown list: Test Group 1" }, [
+    "Date",
+    "Thu, 16 Apr 2020 21:57:55 GMT",
+    "Server",
+    "Sailthru",
+    "X-Content-Type-Options",
+    "nosniff",
+    "X-XSS-Protection",
+    "1; mode=block",
+    "X-Frame-Options",
+    "SAMEORIGIN",
+    "X-Rate-Limit-Limit",
+    "36000",
+    "X-Rate-Limit-Remaining",
+    "35998",
+    "X-Rate-Limit-Reset",
+    "1587074280",
+    "Connection",
+    "close",
+    "Transfer-Encoding",
+    "chunked",
+    "Content-Type",
+    "application/json",
+  ]);
+nock("https://api.sailthru.com:443", { encodedQueryParams: true })
+  .post(
+    "/list",
+    "api_key=29831a903632490eb5e1722df107f06ac&format=json&json=%7B%22list%22%3A%22Test%20Group%201%22%7D&sig=NOCK"
+  )
+  .once()
+  .reply(
+    200,
+    {
+      list: "Test Group 1",
+      type: "natural",
+      list_id: "5e98d4e3a4768b553b47202a",
+    },
+    [
+      "Date",
+      "Thu, 16 Apr 2020 21:57:55 GMT",
+      "Server",
+      "Sailthru",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-XSS-Protection",
+      "1; mode=block",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-Rate-Limit-Limit",
+      "4800",
+      "X-Rate-Limit-Remaining",
+      "4799",
+      "X-Rate-Limit-Reset",
+      "1587074280",
+      "Vary",
+      "Accept-Encoding",
+      "Content-Length",
+      "77",
+      "Connection",
+      "close",
+      "Content-Type",
+      "application/json",
+    ]
+  );
+nock("https://api.sailthru.com:443", { encodedQueryParams: true })
+  .get("/list")
+  .once()
+  .query({
+    api_key: "29831a903632490eb5e1722df107f06ac",
+    format: "json",
+    json: "%7B%22list%22%3A%22Test%20Group%202%22%7D",
+    sig: "NOCK",
+  })
+  .reply(404, { error: 15, errormsg: "Unknown list: Test Group 2" }, [
+    "Date",
+    "Thu, 16 Apr 2020 21:57:56 GMT",
+    "Server",
+    "Sailthru",
+    "X-Content-Type-Options",
+    "nosniff",
+    "X-XSS-Protection",
+    "1; mode=block",
+    "X-Frame-Options",
+    "SAMEORIGIN",
+    "X-Rate-Limit-Limit",
+    "36000",
+    "X-Rate-Limit-Remaining",
+    "35997",
+    "X-Rate-Limit-Reset",
+    "1587074280",
+    "Connection",
+    "close",
+    "Transfer-Encoding",
+    "chunked",
+    "Content-Type",
+    "application/json",
+  ]);
+nock("https://api.sailthru.com:443", { encodedQueryParams: true })
+  .get("/list")
+  .once()
+  .query({
+    api_key: "29831a903632490eb5e1722df107f06ac",
+    format: "json",
+    json: "%7B%22list%22%3A%22Test%20Group%202%22%7D",
+    sig: "NOCK",
+  })
+  .reply(404, { error: 15, errormsg: "Unknown list: Test Group 2" }, [
+    "Date",
+    "Thu, 16 Apr 2020 21:57:57 GMT",
+    "Server",
+    "Sailthru",
+    "X-Content-Type-Options",
+    "nosniff",
+    "X-XSS-Protection",
+    "1; mode=block",
+    "X-Frame-Options",
+    "SAMEORIGIN",
+    "X-Rate-Limit-Limit",
+    "36000",
+    "X-Rate-Limit-Remaining",
+    "35996",
+    "X-Rate-Limit-Reset",
+    "1587074280",
+    "Connection",
+    "close",
+    "Transfer-Encoding",
+    "chunked",
+    "Content-Type",
+    "application/json",
+  ]);
+nock("https://api.sailthru.com:443", { encodedQueryParams: true })
+  .post(
+    "/list",
+    "api_key=29831a903632490eb5e1722df107f06ac&format=json&json=%7B%22list%22%3A%22Test%20Group%202%22%7D&sig=NOCK"
+  )
+  .once()
+  .reply(
+    200,
+    {
+      list: "Test Group 2",
+      type: "natural",
+      list_id: "5e98d4e538f5396d4b2a2c00",
+    },
+    [
+      "Date",
+      "Thu, 16 Apr 2020 21:57:57 GMT",
+      "Server",
+      "Sailthru",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-XSS-Protection",
+      "1; mode=block",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-Rate-Limit-Limit",
+      "4800",
+      "X-Rate-Limit-Remaining",
+      "4798",
+      "X-Rate-Limit-Reset",
+      "1587074280",
+      "Vary",
+      "Accept-Encoding",
+      "Content-Length",
+      "77",
+      "Connection",
+      "close",
+      "Content-Type",
+      "application/json",
+    ]
+  );
+nock("https://api.sailthru.com:443", { encodedQueryParams: true })
   .post(
     "/user",
-    "api_key=29831a903632490eb5e1722df107f06ac&format=json&json=%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%2C%22keys%22%3A%7B%22email%22%3A%22brian%40bleonard.com%22%7D%2C%22keysconflict%22%3A%22merge%22%2C%22lists%22%3A%7B%22Test%20Group%201%22%3A1%2C%22Test%20Group%202%22%3A1%7D%2C%22vars%22%3A%7B%22first_name%22%3A%22Brian%22%7D%2C%22fields%22%3A%7B%22keys%22%3A1%7D%7D&sig=NOCK"
+    "api_key=29831a903632490eb5e1722df107f06ac&format=json&json=%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%2C%22keys%22%3A%7B%22email%22%3A%22brian%40bleonard.com%22%7D%2C%22keysconflict%22%3A%22merge%22%2C%22lists%22%3A%7B%22Test%20Group%201%22%3A1%2C%22Test%20Group%202%22%3A1%7D%2C%22vars%22%3A%7B%22first_name%22%3A%22Brian%22%7D%2C%22fields%22%3A%7B%22keys%22%3A1%7D%7D&sig=NOCK"
   )
   .once()
   .reply(
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
       ok: true,
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:02 GMT",
+      "Thu, 16 Apr 2020 21:57:57 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -665,9 +877,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35998",
+      "35995",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -685,27 +897,27 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     api_key: "29831a903632490eb5e1722df107f06ac",
     format: "json",
     json:
-      "%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%2C%22fields%22%3A%7B%22keys%22%3A1%2C%22vars%22%3A1%2C%22lists%22%3A1%7D%7D",
+      "%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%2C%22fields%22%3A%7B%22keys%22%3A1%2C%22vars%22%3A1%2C%22lists%22%3A1%7D%7D",
     sig: "NOCK",
   })
   .reply(
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
       vars: { first_name: "Brian" },
       lists: {
-        "Test Group 1": "Mon, 13 Apr 2020 14:45:02 -0700",
-        "Test Group 2": "Mon, 13 Apr 2020 14:45:02 -0700",
+        "Test Group 1": "Thu, 16 Apr 2020 14:57:57 -0700",
+        "Test Group 2": "Thu, 16 Apr 2020 14:57:57 -0700",
       },
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:03 GMT",
+      "Thu, 16 Apr 2020 21:57:58 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -717,9 +929,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35995",
+      "35989",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -744,15 +956,106 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:03 GMT",
+      "Thu, 16 Apr 2020 21:57:58 GMT",
+      "Server",
+      "Sailthru",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-XSS-Protection",
+      "1; mode=block",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-Rate-Limit-Limit",
+      "36000",
+      "X-Rate-Limit-Remaining",
+      "35988",
+      "X-Rate-Limit-Reset",
+      "1587074280",
+      "Vary",
+      "Accept-Encoding",
+      "Content-Length",
+      "172",
+      "Connection",
+      "close",
+      "Content-Type",
+      "application/json",
+    ]
+  );
+nock("https://api.sailthru.com:443", { encodedQueryParams: true })
+  .get("/list")
+  .once()
+  .query({
+    api_key: "29831a903632490eb5e1722df107f06ac",
+    format: "json",
+    json: "%7B%22list%22%3A%22Test%20Group%201%22%7D",
+    sig: "NOCK",
+  })
+  .reply(
+    200,
+    {
+      list_id: "5e98d4e3a4768b553b47202a",
+      list: "Test Group 1",
+      create_time: "Thu, 16 Apr 2020 14:57:55 -0700",
+      send_time: null,
+      count: 1,
+      type: "normal",
+      primary: false,
+    },
+    [
+      "Date",
+      "Thu, 16 Apr 2020 21:57:58 GMT",
+      "Server",
+      "Sailthru",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-XSS-Protection",
+      "1; mode=block",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-Rate-Limit-Limit",
+      "36000",
+      "X-Rate-Limit-Remaining",
+      "35995",
+      "X-Rate-Limit-Reset",
+      "1587074280",
+      "Vary",
+      "Accept-Encoding",
+      "Content-Length",
+      "167",
+      "Connection",
+      "close",
+      "Content-Type",
+      "application/json",
+    ]
+  );
+nock("https://api.sailthru.com:443", { encodedQueryParams: true })
+  .post(
+    "/user",
+    "api_key=29831a903632490eb5e1722df107f06ac&format=json&json=%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%2C%22keys%22%3A%7B%22email%22%3A%22brian%40bleonard.com%22%7D%2C%22keysconflict%22%3A%22merge%22%2C%22lists%22%3A%7B%22Test%20Group%201%22%3A1%2C%22Test%20Group%202%22%3A0%7D%2C%22vars%22%3A%7B%22first_name%22%3A%22Brian%22%7D%2C%22fields%22%3A%7B%22keys%22%3A1%7D%7D&sig=NOCK"
+  )
+  .once()
+  .reply(
+    200,
+    {
+      keys: {
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
+        cookie:
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
+        email: "brian@bleonard.com",
+      },
+      ok: true,
+    },
+    [
+      "Date",
+      "Thu, 16 Apr 2020 21:57:58 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -766,51 +1069,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Remaining",
       "35994",
       "X-Rate-Limit-Reset",
-      "1586814360",
-      "Vary",
-      "Accept-Encoding",
-      "Content-Length",
-      "172",
-      "Connection",
-      "close",
-      "Content-Type",
-      "application/json",
-    ]
-  );
-nock("https://api.sailthru.com:443", { encodedQueryParams: true })
-  .post(
-    "/user",
-    "api_key=29831a903632490eb5e1722df107f06ac&format=json&json=%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%2C%22keys%22%3A%7B%22email%22%3A%22brian%40bleonard.com%22%7D%2C%22keysconflict%22%3A%22merge%22%2C%22lists%22%3A%7B%22Test%20Group%201%22%3A1%2C%22Test%20Group%202%22%3A0%7D%2C%22vars%22%3A%7B%22first_name%22%3A%22Brian%22%7D%2C%22fields%22%3A%7B%22keys%22%3A1%7D%7D&sig=NOCK"
-  )
-  .once()
-  .reply(
-    200,
-    {
-      keys: {
-        sid: "5e94dd593dda157bf51bdfea",
-        cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
-        email: "brian@bleonard.com",
-      },
-      ok: true,
-    },
-    [
-      "Date",
-      "Mon, 13 Apr 2020 21:45:03 GMT",
-      "Server",
-      "Sailthru",
-      "X-Content-Type-Options",
-      "nosniff",
-      "X-XSS-Protection",
-      "1; mode=block",
-      "X-Frame-Options",
-      "SAMEORIGIN",
-      "X-Rate-Limit-Limit",
-      "36000",
-      "X-Rate-Limit-Remaining",
-      "35997",
-      "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -828,24 +1087,24 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     api_key: "29831a903632490eb5e1722df107f06ac",
     format: "json",
     json:
-      "%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%2C%22fields%22%3A%7B%22keys%22%3A1%2C%22vars%22%3A1%2C%22lists%22%3A1%7D%7D",
+      "%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%2C%22fields%22%3A%7B%22keys%22%3A1%2C%22vars%22%3A1%2C%22lists%22%3A1%7D%7D",
     sig: "NOCK",
   })
   .reply(
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
       vars: { first_name: "Brian" },
-      lists: { "Test Group 1": "Mon, 13 Apr 2020 14:45:02 -0700" },
+      lists: { "Test Group 1": "Thu, 16 Apr 2020 14:57:57 -0700" },
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:04 GMT",
+      "Thu, 16 Apr 2020 21:57:59 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -857,9 +1116,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35993",
+      "35999",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -884,15 +1143,15 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     200,
     {
       keys: {
-        sid: "5e94dd593dda157bf51bdfea",
+        sid: "5e98d4dfdb4f0f46bf07c5d3",
         cookie:
-          "f663ec890541c567b1e9c301243b047e5e94dd593dda157bf51bdfea35b8968420dadb3319f95b8043112bb9",
+          "4d758b8be4d5575dff4006c9317a3c535e98d4dfdb4f0f46bf07c5d3e0af1f67eba3115c529ffdb2b0d168ae",
         email: "brian@bleonard.com",
       },
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:04 GMT",
+      "Thu, 16 Apr 2020 21:57:59 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -904,9 +1163,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35992",
+      "35998",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074280",
       "Vary",
       "Accept-Encoding",
       "Content-Length",
@@ -924,12 +1183,12 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     api_key: "29831a903632490eb5e1722df107f06ac",
     format: "json",
     json:
-      "%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%7D",
+      "%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%7D",
     sig: "NOCK",
   })
   .reply(200, { ok: true }, [
     "Date",
-    "Mon, 13 Apr 2020 21:45:04 GMT",
+    "Thu, 16 Apr 2020 21:58:00 GMT",
     "Server",
     "Sailthru",
     "X-Content-Type-Options",
@@ -943,7 +1202,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     "X-Rate-Limit-Remaining",
     "4799",
     "X-Rate-Limit-Reset",
-    "1586814360",
+    "1587074340",
     "Content-Length",
     "11",
     "Connection",
@@ -966,7 +1225,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     { error: 99, errormsg: "User not found with email: brian@bleonard.com" },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:07 GMT",
+      "Thu, 16 Apr 2020 21:58:01 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -978,9 +1237,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35991",
+      "35999",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074340",
       "Connection",
       "close",
       "Transfer-Encoding",
@@ -1004,7 +1263,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     { error: 99, errormsg: "User not found with email: brian@bleonard.com" },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:07 GMT",
+      "Thu, 16 Apr 2020 21:58:01 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -1018,7 +1277,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Remaining",
       "4798",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074340",
       "Connection",
       "close",
       "Transfer-Encoding",
@@ -1042,7 +1301,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     { error: 99, errormsg: "User not found with email: brian@bleonard.com" },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:07 GMT",
+      "Thu, 16 Apr 2020 21:58:02 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -1054,9 +1313,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35990",
+      "35998",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074340",
       "Connection",
       "close",
       "Transfer-Encoding",
@@ -1072,18 +1331,18 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     api_key: "29831a903632490eb5e1722df107f06ac",
     format: "json",
     json:
-      "%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%2C%22fields%22%3A%7B%22keys%22%3A1%2C%22vars%22%3A1%2C%22lists%22%3A1%7D%7D",
+      "%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%2C%22fields%22%3A%7B%22keys%22%3A1%2C%22vars%22%3A1%2C%22lists%22%3A1%7D%7D",
     sig: "NOCK",
   })
   .reply(
     400,
     {
       error: 99,
-      errormsg: "User not found with sid: 5e94dd593dda157bf51bdfea",
+      errormsg: "User not found with sid: 5e98d4dfdb4f0f46bf07c5d3",
     },
     [
       "Date",
-      "Mon, 13 Apr 2020 21:45:07 GMT",
+      "Thu, 16 Apr 2020 21:58:02 GMT",
       "Server",
       "Sailthru",
       "X-Content-Type-Options",
@@ -1095,9 +1354,9 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
       "X-Rate-Limit-Limit",
       "36000",
       "X-Rate-Limit-Remaining",
-      "35989",
+      "35997",
       "X-Rate-Limit-Reset",
-      "1586814360",
+      "1587074340",
       "Connection",
       "close",
       "Transfer-Encoding",
@@ -1113,12 +1372,12 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     api_key: "29831a903632490eb5e1722df107f06ac",
     format: "json",
     json:
-      "%7B%22id%22%3A%225e94dd593dda157bf51bdfea%22%2C%22key%22%3A%22sid%22%7D",
+      "%7B%22id%22%3A%225e98d4dfdb4f0f46bf07c5d3%22%2C%22key%22%3A%22sid%22%7D",
     sig: "NOCK",
   })
   .reply(200, { ok: true }, [
     "Date",
-    "Mon, 13 Apr 2020 21:45:08 GMT",
+    "Thu, 16 Apr 2020 21:58:02 GMT",
     "Server",
     "Sailthru",
     "X-Content-Type-Options",
@@ -1132,7 +1391,7 @@ nock("https://api.sailthru.com:443", { encodedQueryParams: true })
     "X-Rate-Limit-Remaining",
     "4797",
     "X-Rate-Limit-Reset",
-    "1586814360",
+    "1587074340",
     "Content-Length",
     "11",
     "Connection",

--- a/plugins/@grouparoo/sailthru/src/lib/client.ts
+++ b/plugins/@grouparoo/sailthru/src/lib/client.ts
@@ -98,6 +98,22 @@ export default class SailthruClient {
     }
     return response.lists;
   }
+  async getList(name: string) {
+    try {
+      const response: any = await this.get("list", { list: name });
+      return response;
+    } catch (err) {
+      if (err.error === 15) {
+        // just not made yet
+        return null;
+      }
+      throw err;
+    }
+  }
+  async createList(name: string) {
+    const response: any = await this.post("list", { list: name });
+    return response;
+  }
 
   async get(apiName: string, options = {}) {
     return this.promiseFetch("apiGet", apiName, options);

--- a/plugins/@grouparoo/sailthru/src/lib/export/exportProfile.ts
+++ b/plugins/@grouparoo/sailthru/src/lib/export/exportProfile.ts
@@ -169,7 +169,7 @@ async function ensureList(client, name, make) {
       await client.createList(name);
     } else {
       // wait some amount of milliseconds and see if someone else made it
-      const randMilli = Math.random() * 750;
+      const randMilli = Math.random() * 4000;
       await sleep(randMilli);
       await ensureList(client, name, true);
     }

--- a/plugins/@grouparoo/sailthru/src/lib/export/exportProfile.ts
+++ b/plugins/@grouparoo/sailthru/src/lib/export/exportProfile.ts
@@ -103,6 +103,10 @@ function formatList(name) {
 
 const MAX_DELETE_ATTEMPTS = 5;
 async function sleep(time = 1000) {
+  // don't sleep as much in tests bc intermittent timeout issues
+  if (process.env.NODE_ENV === "test") {
+    time = 1;
+  }
   return new Promise((resolve) => {
     setTimeout(resolve, time);
   });


### PR DESCRIPTION
Sailthru is supposed to be unique on list names, but still somehow has a race condition when adding users/lists in parallel.
Check for the list first and spread out it's creation.