### PR TITLE
Hide tabs not ready

### DIFF
--- a/core/web/components/forms/source/mapping.tsx
+++ b/core/web/components/forms/source/mapping.tsx
@@ -129,7 +129,7 @@ export default function ({ apiVersion, errorHandler, successHandler, query }) {
     const response = await execApi(
       "put",
       `/api/${apiVersion}/source/${guid}`,
-      Object.assign(source, { state: "ready" })
+      Object.assign({}, source, { state: "ready" })
     );
     if (response?.source) {
       successHandler.set({ message: "Source updated" });

--- a/core/web/components/layouts/tabbedContainer.tsx
+++ b/core/web/components/layouts/tabbedContainer.tsx
@@ -55,7 +55,7 @@ export default function ({
         <Breadcrumb.Item href={`/${pluralize(type)}`}>
           {capitalize(pluralize(type))}
         </Breadcrumb.Item>
-        <Breadcrumb.Item>{name !== "" ? name : "draft"}</Breadcrumb.Item>
+        <Breadcrumb.Item>{name !== "" ? name : "Draft"}</Breadcrumb.Item>
         <Breadcrumb.Item>{capitalize(key)}</Breadcrumb.Item>
       </Breadcrumb>
 

--- a/core/web/pages/destination/[guid].tsx
+++ b/core/web/pages/destination/[guid].tsx
@@ -8,7 +8,7 @@ import ExportsList from "../../components/lists/exports";
 import { useApi } from "./../../hooks/useApi";
 
 export default function (props) {
-  const [destination, setDestination] = useState({ name: "" });
+  const [destination, setDestination] = useState({ name: "", state: "draft" });
   const { execApi } = useApi(props.errorHandler);
 
   useEffect(() => {
@@ -39,7 +39,7 @@ export default function (props) {
       errorHandler={props.errorHandler}
       apiVersion={props.apiVersion}
       type="destination"
-      defaultTab="groups"
+      defaultTab={destination.state === "draft" ? "edit" : "groups"}
       query={props.query}
     >
       <Fragment key="edit">
@@ -51,15 +51,19 @@ export default function (props) {
         </Card>
       </Fragment>
 
-      <Fragment key="groups">
-        <h1>Groups</h1>
-        <DestinationGroups {...props} />
-      </Fragment>
+      {destination.state !== "draft" ? (
+        <Fragment key="groups">
+          <h1>Groups</h1>
+          <DestinationGroups {...props} />
+        </Fragment>
+      ) : null}
 
-      <Fragment key="exports">
-        <h1>Exports</h1>
-        <ExportsList {...props} />
-      </Fragment>
+      {destination.state !== "draft" ? (
+        <Fragment key="exports">
+          <h1>Exports</h1>
+          <ExportsList {...props} />
+        </Fragment>
+      ) : null}
 
       <Fragment key="mapping">
         <h1>Mapping</h1>

--- a/core/web/pages/profilePropertyRule/[guid].tsx
+++ b/core/web/pages/profilePropertyRule/[guid].tsx
@@ -13,6 +13,7 @@ import Link from "next/link";
 export default function (props) {
   const [profilePropertyRule, setProfilePropertyRule] = useState({
     key: "",
+    state: "draft",
     source: { name: "", guid: "" },
   });
   const { execApi } = useApi(props.errorHandler);
@@ -52,23 +53,31 @@ export default function (props) {
         </Card.Body>
       </Card>
     </Fragment>,
-
-    <Fragment key="profiles">
-      {profilePropertyRule.key === "" ? (
-        <Loader />
-      ) : (
-        <ProfilesList {...profilesListProps} />
-      )}
-    </Fragment>,
-
-    <Fragment key="groups">
-      <ProfilePropertyRulesGroupsList {...props} />
-    </Fragment>,
-
-    <Fragment key="runs">
-      <RunsList {...props} />
-    </Fragment>,
   ];
+
+  if (profilePropertyRule.state !== "draft") {
+    Tabs.push(
+      <Fragment key="profiles">
+        {profilePropertyRule.key === "" ? (
+          <Loader />
+        ) : (
+          <ProfilesList {...profilesListProps} />
+        )}
+      </Fragment>
+    );
+
+    Tabs.push(
+      <Fragment key="groups">
+        <ProfilePropertyRulesGroupsList {...props} />
+      </Fragment>
+    );
+
+    Tabs.push(
+      <Fragment key="runs">
+        <RunsList {...props} />
+      </Fragment>
+    );
+  }
 
   {
     plugins.map((PluginComponent, idx) => {

--- a/core/web/pages/source/[guid]/index.tsx
+++ b/core/web/pages/source/[guid]/index.tsx
@@ -14,6 +14,7 @@ export default function (props) {
   const { execApi } = useApi(errorHandler);
   const [source, setSource] = useState({
     name: "",
+    state: "draft",
     previewAvailable: false,
     schedule: { guid: "" },
   });
@@ -65,7 +66,7 @@ export default function (props) {
         </Fragment>
       ) : null}
 
-      {hasSchedule ? (
+      {hasSchedule && source.state !== "draft" ? (
         <Fragment key="schedule">
           <h1>Edit Schedule</h1>
           <Card border="success">
@@ -76,7 +77,7 @@ export default function (props) {
         </Fragment>
       ) : null}
 
-      {hasSchedule ? (
+      {hasSchedule && source.state !== "draft" ? (
         <Fragment key="runs">
           <h1>Runs</h1>
           <RunsList {...props} />


### PR DESCRIPTION
When a Destination or Profile Property Rule is not ready yet, hide some tabs.

Fixes https://www.pivotaltracker.com/story/show/172320247