### PR TITLE
Convert mustache keys to and from mustache rule guids for advanced SQL queries

### DIFF
--- a/core/api/__tests__/models/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRule.ts
@@ -554,13 +554,14 @@ describe("models/profilePropertyRule", () => {
 
       // +2 checking the options
       // +2 from the afterSave hook updating the rule
-      expect(queryCounter).toBe(6);
+      // +n for the mustache builder
+      expect(queryCounter).toBeGreaterThan(2);
       await expect(rule.setOptions({ column: "throw" })).rejects.toThrow(
         /throw/
       );
 
       // no change
-      expect(queryCounter).toBe(9);
+      expect(queryCounter).toBeGreaterThan(2);
       await rule.destroy();
     });
 

--- a/core/api/__tests__/models/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRule.ts
@@ -193,6 +193,18 @@ describe("models/profilePropertyRule", () => {
     );
   });
 
+  test("options will have mustache keys converted to mustache guids", async () => {
+    const rule = await ProfilePropertyRule.findOne({ where: { key: "email" } });
+    await rule.setOptions({
+      column: "{{   email}}@example.com",
+    });
+    let options = await rule.getOptions();
+    expect(options).toEqual({ column: "{{ email }}@example.com" }); //appears normal (but formatted) to the user
+
+    const rawOption = await Option.findOne({ where: { ownerGuid: rule.guid } });
+    expect(rawOption.value).toBe(`{{ ${rule.guid} }}@example.com`);
+  });
+
   test("a profile property rule cannot be created in the ready state with missing required options", async () => {
     const source = await helper.factories.source();
     const rule = ProfilePropertyRule.build({
@@ -209,10 +221,9 @@ describe("models/profilePropertyRule", () => {
   });
 
   test("if there is no change to options, the internalRun will not be enqueued", async () => {
-    await api.resque.queue.connection.redis.flushdb();
     const rule = await ProfilePropertyRule.findOne({ where: { key: "email" } });
-    const existingOptions = await rule.getOptions();
-    expect(existingOptions).toEqual({ column: "id" });
+    await rule.setOptions({ column: "id" });
+    await api.resque.queue.connection.redis.flushdb();
 
     await rule.setOptions({ column: "id" });
 

--- a/core/api/__tests__/models/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRule.ts
@@ -576,6 +576,23 @@ describe("models/profilePropertyRule", () => {
       await rule.destroy();
     });
 
+    test("options cannot be saved if they fail testing import against a profile", async () => {
+      const profile = await helper.factories.profile();
+      const rule = await ProfilePropertyRule.create({
+        key: "test",
+        type: "string",
+        sourceGuid: source.guid,
+        state: "ready",
+      });
+
+      await expect(rule.setOptions({ column: "throw" })).rejects.toThrow(
+        /throw/
+      );
+
+      expect(await rule.getOptions()).toEqual({});
+      await rule.destroy();
+    });
+
     test("the profile property rule can be tested against the existing options or potential new options", async () => {
       const profile = await helper.factories.profile();
       const rule = await ProfilePropertyRule.create({

--- a/core/api/__tests__/modules/plugin.ts
+++ b/core/api/__tests__/modules/plugin.ts
@@ -4,6 +4,7 @@ import { Setting } from "./../../src/models/Setting";
 import { Run } from "./../../src/models/Run";
 import { Import } from "./../../src/models/Import";
 import { specHelper } from "actionhero";
+import { ProfilePropertyRule } from "../../src/models/ProfilePropertyRule";
 let actionhero;
 
 describe("modules/plugin", () => {
@@ -123,6 +124,25 @@ describe("modules/plugin", () => {
           "Profile Created at 1970-01-01 00:00:00"
         );
       });
+    });
+
+    test("replaceTemplateProfilePropertyKeysWithProfilePropertyGuid and replaceTemplateProfilePropertyGuidsWithProfilePropertyKeys", async () => {
+      const rule = await ProfilePropertyRule.findOne({
+        where: { key: "userId" },
+      });
+      const initialString = "select * from users where id = {{ userId }}";
+      const replacedWithGuid = await plugin.replaceTemplateProfilePropertyKeysWithProfilePropertyGuid(
+        initialString
+      );
+      expect(replacedWithGuid).toEqual(
+        `select * from users where id = {{ ${rule.guid} }}`
+      );
+
+      expect(
+        await plugin.replaceTemplateProfilePropertyGuidsWithProfilePropertyKeys(
+          replacedWithGuid
+        )
+      ).toEqual(initialString);
     });
 
     describe("createImport", () => {

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -320,6 +320,8 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
   }
 
   async test(options?: SimpleProfilePropertyRuleOptions) {
+    console.log(options);
+
     const profile = await Profile.findOne({ order: api.sequelize.random() });
     if (profile) {
       const source = await Source.findByGuid(this.sourceGuid);
@@ -341,6 +343,8 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
   }
 
   async setOptions(options: SimpleProfilePropertyRuleOptions) {
+    await this.test(options);
+
     for (const i in options) {
       options[
         i
@@ -348,8 +352,6 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
         options[i]
       );
     }
-
-    await this.test(options);
 
     return OptionHelper.setOptions(this, options);
   }

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -328,10 +328,29 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
   }
 
   async getOptions() {
-    return OptionHelper.getOptions(this);
+    const options = await OptionHelper.getOptions(this);
+    for (const i in options) {
+      options[
+        i
+      ] = await plugin.replaceTemplateProfilePropertyGuidsWithProfilePropertyKeys(
+        options[i]
+      );
+    }
+
+    return options;
   }
 
   async setOptions(options: SimpleProfilePropertyRuleOptions) {
+    for (const i in options) {
+      options[
+        i
+      ] = await plugin.replaceTemplateProfilePropertyKeysWithProfilePropertyGuid(
+        options[i]
+      );
+    }
+
+    await this.test(options);
+
     return OptionHelper.setOptions(this, options);
   }
 

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -320,8 +320,6 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
   }
 
   async test(options?: SimpleProfilePropertyRuleOptions) {
-    console.log(options);
-
     const profile = await Profile.findOne({ order: api.sequelize.random() });
     if (profile) {
       const source = await Source.findByGuid(this.sourceGuid);

--- a/core/api/src/modules/plugin.ts
+++ b/core/api/src/modules/plugin.ts
@@ -228,6 +228,10 @@ export namespace plugin {
    * Takes a string with mustache variables and replaces them with the proper values for a schedule and run
    */
   export async function replaceTemplateRunVariables(string: string, run?: Run) {
+    if (string.indexOf("{{") < 0) {
+      return string;
+    }
+
     const data = {
       now: expandDates(new Date()),
       run: {},
@@ -275,9 +279,13 @@ export namespace plugin {
    * Takes a string with mustache variables and replaces them with the proper values for a profile
    */
   export async function replaceTemplateProfileVariables(
-    string,
+    string: string,
     profile: Profile
   ): Promise<string> {
+    if (string.indexOf("{{") < 0) {
+      return string;
+    }
+
     const data = {
       now: expandDates(new Date()),
       createdAt: expandDates(profile.createdAt),
@@ -291,6 +299,48 @@ export namespace plugin {
         properties[key].value instanceof Date
           ? expandDates(properties[key].value)
           : properties[key].value;
+    }
+
+    return Mustache.render(string, data);
+  }
+
+  /**
+   * Takes a string with mustache variable (keys) and replaces them with the profile property guids
+   * ie: `select * where id = {{ userId }}` => `select * where id = {{ ppr_abc123 }}`
+   */
+  export async function replaceTemplateProfilePropertyKeysWithProfilePropertyGuid(
+    string: string
+  ): Promise<string> {
+    if (string.indexOf("{{") < 0) {
+      return string;
+    }
+
+    const profilePropertyRules = await ProfilePropertyRule.findAll();
+    const data = {};
+    for (const i in profilePropertyRules) {
+      const rule = profilePropertyRules[i];
+      data[rule.key] = `{{ ${rule.guid} }}`;
+    }
+
+    return Mustache.render(string, data);
+  }
+
+  /**
+   * Takes a string with mustache variable (guids) and replaces them with the profile property keys
+   * ie: `select * where id = {{ ppr_abc123 }}` => `select * where id = {{ userId }}`
+   */
+  export async function replaceTemplateProfilePropertyGuidsWithProfilePropertyKeys(
+    string: string
+  ): Promise<string> {
+    if (string.indexOf("{{") < 0) {
+      return string;
+    }
+
+    const profilePropertyRules = await ProfilePropertyRule.findAll();
+    const data = {};
+    for (const i in profilePropertyRules) {
+      const rule = profilePropertyRules[i];
+      data[rule.guid] = `{{ ${rule.key} }}`;
     }
 
     return Mustache.render(string, data);

--- a/core/api/src/modules/plugin.ts
+++ b/core/api/src/modules/plugin.ts
@@ -315,7 +315,7 @@ export namespace plugin {
       return string;
     }
 
-    const profilePropertyRules = await ProfilePropertyRule.findAll();
+    const profilePropertyRules = await ProfilePropertyRule.cached();
     const data = {};
     for (const i in profilePropertyRules) {
       const rule = profilePropertyRules[i];
@@ -336,7 +336,7 @@ export namespace plugin {
       return string;
     }
 
-    const profilePropertyRules = await ProfilePropertyRule.findAll();
+    const profilePropertyRules = await ProfilePropertyRule.cached();
     const data = {};
     for (const i in profilePropertyRules) {
       const rule = profilePropertyRules[i];

--- a/core/web/components/forms/profilePropertyRule/edit.tsx
+++ b/core/web/components/forms/profilePropertyRule/edit.tsx
@@ -19,6 +19,7 @@ export default function ({
   const [types, setTypes] = useState([]);
   const [pluginOptions, setPluginOptions] = useState([]);
   const [filterOptions, setFilterOptions] = useState([]);
+  const [profilePropertyRules, setProfilePropertyRules] = useState([]);
   const [profilePropertyRule, setProfilePropertyRule] = useState({
     key: "",
     guid: "",
@@ -44,6 +45,7 @@ export default function ({
       await loadOptions();
       await loadFilterOptions();
       await load();
+      await loadProfilePropertyRules();
     }
 
     loadAll();
@@ -60,6 +62,18 @@ export default function ({
       setProfilePropertyRule(response.profilePropertyRule);
       setPluginOptions(response.pluginOptions);
       setLocalFilters(response.profilePropertyRule.filters);
+    }
+  }
+
+  async function loadProfilePropertyRules() {
+    setLoading(true);
+    const response = await execApi(
+      "get",
+      `/api/${apiVersion}/profilePropertyRules`
+    );
+    setLoading(false);
+    if (response?.profilePropertyRules) {
+      setProfilePropertyRules(response.profilePropertyRules);
     }
   }
 
@@ -325,24 +339,55 @@ export default function ({
 
                 {/* text options */}
                 {opt.type === "textarea" ? (
-                  <Form.Group controlId="key">
-                    <Form.Control
-                      required
-                      as="textarea"
-                      rows={5}
-                      value={profilePropertyRule.options[opt.key]}
-                      onChange={(e) => updateOption(opt.key, e.target["value"])}
-                      placeholder="select statement with mustache template"
-                      style={{
-                        fontFamily:
-                          'SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-                        color: "#e83e8c",
-                      }}
-                    />
-                    <Form.Control.Feedback type="invalid">
-                      Key is required
-                    </Form.Control.Feedback>
-                  </Form.Group>
+                  <>
+                    <Form.Group controlId="key">
+                      <Form.Control
+                        required
+                        as="textarea"
+                        rows={5}
+                        value={profilePropertyRule.options[opt.key]}
+                        onChange={(e) =>
+                          updateOption(opt.key, e.target["value"])
+                        }
+                        placeholder="select statement with mustache template"
+                        style={{
+                          fontFamily:
+                            'SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                          color: "#e83e8c",
+                        }}
+                      />
+                      <Form.Control.Feedback type="invalid">
+                        Key is required
+                      </Form.Control.Feedback>
+                    </Form.Group>
+                    <p>
+                      Profile Property Variables:{" "}
+                      <Badge variant="light">{`{{ now }}`}</Badge>
+                      &nbsp;
+                      <Badge variant="light">{`{{ createdAt }}`}</Badge>&nbsp;
+                      <Badge variant="light">{`{{ updatedAt }}`}</Badge>&nbsp;
+                      {profilePropertyRules
+                        .sort((a, b) => {
+                          if (a.key > b.key) {
+                            return 1;
+                          } else {
+                            return -1;
+                          }
+                        })
+                        .map((ppr) => (
+                          <>
+                            <Badge variant="light">{`{{ ${ppr.key} }}`}</Badge>
+                            &nbsp;
+                          </>
+                        ))}
+                    </p>
+                    <p>
+                      For dates, you can expand them to the <code>sql</code>,{" "}
+                      <code>date</code>, <code>time</code>, or <code>iso</code>{" "}
+                      formats, ie:{" "}
+                      <Badge variant="light">{`{{ now.sql }}`}</Badge>
+                    </p>
+                  </>
                 ) : null}
               </div>
             ))}


### PR DESCRIPTION
closes https://www.pivotaltracker.com/story/show/171907414

Users will continue to type & see `select * from users where id = {{ userId }}` but on the backend we'll be storing `select * from users where id =  {{ prr_abc123 }}`.  This will make us more resilient to key changes. 