### PR TITLE
Build normal CI on push, but publish once a day

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,11 +346,116 @@ jobs:
       - run: git config --global user.name "Grouparoo Bot"
       - run: SKIP_APP_BUILD=true ./bin/build
       - run: ./bin/publish
-#
-# Run all the tests in parallel
 workflows:
   version: 2
-  test-grouparoo:
+  #
+  # Run the tests on push
+  test-grouparoo-push:
+    jobs:
+      - build:
+          filters:
+            <<: *ignored-branches
+      - license-checker:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
+      - linter:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
+      - test-core-api:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
+      - test-core-web:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
+      - test-plugin-csv:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - test-core-api
+            - test-core-web
+      - test-plugin-email-authentication:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - test-core-api
+            - test-core-web
+      - test-plugin-google-sheets:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - test-core-api
+            - test-core-web
+      - test-plugin-logger:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - test-core-api
+            - test-core-web
+      - test-plugin-mailchimp:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - test-core-api
+            - test-core-web
+      - test-plugin-mysql:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - test-core-api
+            - test-core-web
+      - test-plugin-newrelic:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - test-core-api
+            - test-core-web
+      - test-plugin-postgres:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - test-core-api
+            - test-core-web
+      - test-plugin-sailthru:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - test-core-api
+            - test-core-web
+      - complete:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - license-checker
+            - linter
+            - test-core-api
+            - test-core-web
+            - test-plugin-csv
+            - test-plugin-email-authentication
+            - test-plugin-google-sheets
+            - test-plugin-logger
+            - test-plugin-mailchimp
+            - test-plugin-mysql
+            - test-plugin-newrelic
+            - test-plugin-postgres
+            - test-plugin-sailthru
+  #
+  # Run the tests each night + publish
+  test-grouparoo-nightly:
+    triggers:
+      - schedule:
+          cron: "4 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - build:
           filters:

--- a/tools/merger/data/ci/base.yml.template
+++ b/tools/merger/data/ci/base.yml.template
@@ -1,6 +1,7 @@
 # THIS FILE IS AUTO-GENERATED. DO NOT CHANGE IT DIRECTLY.
 # SEE tools/merger TO MAKE CHANGES.
 #
+
 version: 2
 #
 # Define common steps all parts of the test workflow use
@@ -45,11 +46,37 @@ jobs:
 
 {{{publish}}}
 
-#
-# Run all the tests in parallel
 workflows:
   version: 2
-  test-grouparoo:
+
+  #
+  # Run the tests on push
+  test-grouparoo-push:
+    jobs:
+      - build:
+          filters:
+            <<: *ignored-branches
+
+{{{workflows}}}
+
+      - complete:
+          filters:
+            <<: *ignored-branches
+          requires:
+{{{job_name_list}}}
+
+  #
+  # Run the tests each night + publish
+  test-grouparoo-nightly:
+    triggers:
+       - schedule:
+           cron: "4 0 * * *"
+           filters:
+             branches:
+               only:
+                 - master
+
+
     jobs:
       - build:
           filters:


### PR DESCRIPTION
It's a bit much to publish to NPM on each merge to master.  Let's build the pre-releases once a day (if there's anything new).  

CI should now:
- run the normal workflow on each PR/Push (excluding the publish step)
- run the normal workflow at UTC 4am & also run the publish step