### PR TITLE
Check in a readme for core

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,5 @@
+# Grouparoo
+
+**Achieve Marketing Autonomy**
+
+To learn more visit [www.grouparoo.com](https://www.grouparoo.com) or [github.com/grouparoo/grouparoo](https://github.com/grouparoo/grouparoo)

--- a/core/package.json
+++ b/core/package.json
@@ -35,8 +35,7 @@
     "lint": "npm run lint-api && npm run lint-web",
     "lint-api": "cd api && prettier --check src __tests__",
     "lint-web": "cd web && prettier --check pages components classes client utils hooks __tests__",
-    "import": "./api/bin/import",
-    "prepublish": "cp ../README.md ."
+    "import": "./api/bin/import"
   },
   "dependencies": {
     "@auth0/s3": "^1.0.0",

--- a/documents/development/publishing.md
+++ b/documents/development/publishing.md
@@ -2,12 +2,12 @@
 
 We use a combination of tools from `lerna` to handle publishing these packages.
 
-- We automatically publish a new `alpha` release on every successful CI run of the `master` branch.
+- We automatically publish a new `alpha` release every night from the `master` branch.
 
   - This builds will be tagged `prerelease` and match the `alpha namespace`, ie: `v1.2.3-alpha.5` and have the npm tag `next` (ie `npm install grouparoo@core --next)`
   - The `lerna-changelog` tool will automatically read closed & merged pull requests between the previous tag and now to build the notes for the [Github release](https://github.com/grouparoo/grouparoo/releases)
 
-- Automatically publish a new `latest` release on every successful CI run of the `release` branch.
+- Automatically publish a new `latest` release every night if there are changes to the `stable` branch.
   - This builds will match the `normal namespace`, ie: `v1.2.3`. They will be `npm install`'d in the normal way.
 
 CI uses a few secrets for authentication:
@@ -17,3 +17,7 @@ CI uses a few secrets for authentication:
 - A SSH key with write access to the `grouparoo/grouparoo` repo. This SSH key is only used for CI to checkout our repositories. CircleCI knows the private key and Github knows the public key.
 
 As a note, we cannot `Include administrators` on Github's branch protection for the master or release branches as lerna needs to push it's changes back to the master branch after bumping the version and publishing.
+
+---
+
+Aside from the above, our staging servers are automatically deployed against any change to the master branch (which has all its tests passing).


### PR DESCRIPTION
We skip the package lifecycle hooks, and adding a file within the lerna workflow breaks git integrity, so we cannot use a `preinstall` hook to copy the main README to core.   

This PR adds a basic readme to `@grouparoo/core` that points to the normal resource. 