### PR TITLE
CLI command to update teams with missing permissions - updateTeamPermissions

### DIFF
--- a/core/api/bin/updateTeamPermissions
+++ b/core/api/bin/updateTeamPermissions
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const { Process, log } = require("actionhero");
+const { Team, Permission } = require("../dist");
+
+async function main() {
+  const app = new Process();
+  await app.initialize();
+
+  const teams = await Team.findAll();
+  for (const i in teams) {
+    await updateTeamPermissions(teams[i]);
+  }
+
+  console.log("Done!");
+  process.exit(0);
+}
+
+async function updateTeamPermissions(team) {
+  log("");
+  log(`updating permissions for team: ${team.name} (${team.guid})`);
+  const permissionsWithStatus = await Team.buildPermissions(team);
+  permissionsWithStatus.map(({ isNew, permission }) => {
+    log(
+      `     ${permission.topic}${isNew ? " (NEW)" : ""}`,
+      isNew ? "notice" : "info",
+      { read: permission.read, write: permission.write }
+    );
+  });
+}
+
+main();

--- a/core/api/bin/updateTeamPermissions
+++ b/core/api/bin/updateTeamPermissions
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const { Process, log } = require("actionhero");
-const { Team, Permission } = require("../dist");
+const { Team } = require("../dist");
 
 async function main() {
   const app = new Process();

--- a/core/api/src/models/Team.ts
+++ b/core/api/src/models/Team.ts
@@ -59,6 +59,10 @@ export class Team extends LoggedModel<Team> {
 
   @AfterSave
   static async buildPermissions(instance: Team) {
+    const permissionsWithStatus: Array<{
+      isNew: boolean;
+      permission: Permission;
+    }> = [];
     const topics = Permission.topics();
     for (const i in topics) {
       const topic = topics[i];
@@ -81,7 +85,11 @@ export class Team extends LoggedModel<Team> {
       if (instance.permissionAllWrite !== null) {
         await permission.update({ write: instance.permissionAllWrite });
       }
+
+      permissionsWithStatus.push({ isNew, permission });
     }
+
+    return permissionsWithStatus;
   }
 
   @BeforeDestroy

--- a/core/package.json
+++ b/core/package.json
@@ -44,7 +44,7 @@
     "@nivo/line": "^0.61.1",
     "actionhero": "^22.0.9",
     "ah-next-plugin": "^0.2.1",
-    "ah-sequelize-plugin": "^2.0.4",
+    "ah-sequelize-plugin": "^2.1.0",
     "axios": "^0.19.2",
     "bcrypt": "^4.0.1",
     "bootstrap": "^4.4.1",

--- a/tools/license-checker/check
+++ b/tools/license-checker/check
@@ -10,7 +10,7 @@ const excludePackages = [
   "newrelic@6.7.0",
   "@newrelic/aws-sdk@1.1.2",
   "@newrelic/koa@3.0.0",
-  "@newrelic/native-metrics@5.0.0",
+  "@newrelic/native-metrics@5.1.0",
   "@newrelic/superagent@2.0.1",
   "emitter-component@1.1.1",
 ];

--- a/tools/license-checker/check
+++ b/tools/license-checker/check
@@ -5,15 +5,20 @@ const path = require("path");
 const fs = require("fs");
 const { allPackageFiles } = require("../shared/packages");
 
-const excludePackages = [
-  // custom exclusions for newrelic
-  "newrelic@6.7.0",
-  "@newrelic/aws-sdk@1.1.2",
-  "@newrelic/koa@3.0.0",
-  "@newrelic/native-metrics@5.1.0",
-  "@newrelic/superagent@2.0.1",
-  "emitter-component@1.1.1",
-];
+const excludePackages = ["emitter-component@1.1.1"];
+
+// custom exclusions for newrelic
+const newRelicPackJSON = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, "..", "..", "node_modules", "newrelic", "package.json")
+  )
+);
+excludePackages.push(`newrelic@${newRelicPackJSON.version}`);
+for (const pkg in newRelicPackJSON.dependencies) {
+  if (pkg.match(`@newrelic`)) {
+    excludePackages.push(`${pkg}@${newRelicPackJSON.dependencies[pkg]}`);
+  }
+}
 
 const onlyAllow = [
   "MPL-2.0",

--- a/tools/license-checker/check
+++ b/tools/license-checker/check
@@ -7,7 +7,7 @@ const { allPackageFiles } = require("../shared/packages");
 
 const excludePackages = [
   // custom exclusions for newrelic
-  "newrelic@6.6.0",
+  "newrelic@6.7.0",
   "@newrelic/aws-sdk@1.1.2",
   "@newrelic/koa@3.0.0",
   "@newrelic/native-metrics@5.0.0",

--- a/tools/license-checker/check
+++ b/tools/license-checker/check
@@ -1,24 +1,20 @@
 #!/usr/bin/env node
+
 const checker = require("license-checker");
 const glob = require("glob");
 const path = require("path");
 const fs = require("fs");
 const { allPackageFiles } = require("../shared/packages");
 
-const excludePackages = ["emitter-component@1.1.1"];
-
-// custom exclusions for newrelic
-const newRelicPackJSON = JSON.parse(
-  fs.readFileSync(
-    path.join(__dirname, "..", "..", "node_modules", "newrelic", "package.json")
-  )
-);
-excludePackages.push(`newrelic@${newRelicPackJSON.version}`);
-for (const pkg in newRelicPackJSON.dependencies) {
-  if (pkg.match(`@newrelic`)) {
-    excludePackages.push(`${pkg}@${newRelicPackJSON.dependencies[pkg]}`);
-  }
-}
+const excludePackages = [
+  // custom exclusions for newrelic
+  "newrelic@6.7.0",
+  "@newrelic/aws-sdk@1.1.2",
+  "@newrelic/koa@3.0.0",
+  "@newrelic/native-metrics@5.1.0",
+  "@newrelic/superagent@2.0.1",
+  "emitter-component@1.1.1",
+];
 
 const onlyAllow = [
   "MPL-2.0",


### PR DESCRIPTION
If a team is missing a certain permission topic, you might not be able to log in.  the new `updateTeamPermissions` CLI command will check all teams and make sure that they have a `Permission` for each `topic`.  Global settings and defaults will be followed

<img width="892" alt="Screen Shot 2020-05-07 at 10 41 21 AM" src="https://user-images.githubusercontent.com/303226/81327133-a992ae80-904f-11ea-859c-a03e8ba384ab.png">
