### PR TITLE
Do not throw if a profile cannot be sent to a destination if we are modifying the destination's attributes

### DIFF
--- a/core/api/__tests__/models/destination.ts
+++ b/core/api/__tests__/models/destination.ts
@@ -435,27 +435,6 @@ describe("models/destination", () => {
         await profile.destroy();
       });
 
-      test("previewing a profile not in any groups tracked by this destination will throw", async () => {
-        const profile = await helper.factories.profile();
-
-        const mapping = {
-          "primary-id": "userId",
-          email: "email",
-        };
-
-        const destinationGroupMemberships = {};
-        destinationGroupMemberships[group.guid] = "another-group-tag";
-
-        await expect(
-          destination.profilePreview(
-            profile,
-            mapping,
-            destinationGroupMemberships
-          )
-        ).rejects.toThrow(/will not be exported by this profile/);
-        await profile.destroy();
-      });
-
       describe("trackAllGroups", () => {
         test("no groups can be added or removed if the destination is tracking all groups", async () => {
           await destination.update({ trackAllGroups: true });

--- a/core/api/bin/dev
+++ b/core/api/bin/dev
@@ -14,11 +14,12 @@ export NEXT_DEVELOPMENT_MODE=true
 # in develeopment mode, often there is an orphan next.js/webpack process hanging around if the process crashes.
 GROUPAROO_PIDS=`ps | grep ts-node-dev | grep grouparoo | cut -f1 -d' '`
 for p in $GROUPAROO_PIDS; do
-  printf "stopping orphan process $p\r\n"
+  printf "stopping orphan process $p"
   kill -9 $p
 done
 
 "$EXECUTABLE" \
+  --max-old-space-size=4096 \
   --transpile-only \
   --ignore-watch=web \
   --ignore-watch='../web' \

--- a/core/api/bin/dev
+++ b/core/api/bin/dev
@@ -11,6 +11,13 @@ fi
 
 export NEXT_DEVELOPMENT_MODE=true
 
+# in develeopment mode, often there is an orphan next.js/webpack process hanging around if the process crashes.
+GROUPAROO_PIDS=`ps | grep ts-node-dev | grep grouparoo | cut -f1 -d' '`
+for p in $GROUPAROO_PIDS; do
+  printf "stopping orphan process $p\r\n"
+  kill -9 $p
+done
+
 "$EXECUTABLE" \
   --transpile-only \
   --ignore-watch=web \

--- a/core/api/bin/dev
+++ b/core/api/bin/dev
@@ -14,7 +14,7 @@ export NEXT_DEVELOPMENT_MODE=true
 # in develeopment mode, often there is an orphan next.js/webpack process hanging around if the process crashes.
 GROUPAROO_PIDS=`ps | grep ts-node-dev | grep grouparoo | cut -f1 -d' '`
 for p in $GROUPAROO_PIDS; do
-  printf "stopping orphan process $p"
+  printf "stopping orphan process $p\r\n"
   kill -9 $p
 done
 

--- a/core/api/bin/dev
+++ b/core/api/bin/dev
@@ -18,11 +18,14 @@ for p in $GROUPAROO_PIDS; do
   kill -9 $p
 done
 
-"$EXECUTABLE" \
+
+node \
   --max-old-space-size=4096 \
-  --transpile-only \
-  --ignore-watch=web \
-  --ignore-watch='../web' \
-  --no-deps \
-  --notify=false \
-  src/server.ts
+  -- "$EXECUTABLE" \
+    --transpile-only \
+    --ignore-watch=web \
+    --ignore-watch='../web' \
+    --no-deps \
+    --notify=false \
+      -- \
+      src/server.ts

--- a/core/api/src/actions/destinations.ts
+++ b/core/api/src/actions/destinations.ts
@@ -357,6 +357,14 @@ export class DestinationProfilePreview extends AuthenticatedAction {
       } catch {}
     }
 
+    if (
+      !params.mapping &&
+      !params.groupGuid &&
+      !params.destinationGroupMemberships
+    ) {
+      await destination.checkProfileWillBeExported(profile);
+    }
+
     response.profile = await destination.profilePreview(
       profile,
       mapping,

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -486,8 +486,6 @@ export class Destination extends LoggedModel<Destination> {
       [groupGuid: string]: string;
     }
   ) {
-    await this.checkProfileWillBeExported(profile);
-
     const profileProperties = await profile.properties();
     const mappingKeys = Object.keys(mapping);
     const mappedProfileProperties = {};
@@ -524,7 +522,7 @@ export class Destination extends LoggedModel<Destination> {
 
     if (intersectingGroupGuids.length === 0) {
       throw new Error(
-        `profile ${profile.guid} will not be exported by this profile`
+        `profile ${profile.guid} will not be exported by this destination`
       );
     }
 

--- a/core/web/next.config.js
+++ b/core/web/next.config.js
@@ -9,7 +9,7 @@ module.exports = {
     overwriteNextBabelLoaderToIncludePluginNodeModules(config);
 
     config.module.rules.push({
-      test: /\.plugin\.js|\.plugin\.jsx|\.plugin\.ts|\.plugin\.tsx$/,
+      test: /\.plugin\.js$|\.plugin\.jsx$|\.plugin\.ts$|\.plugin\.tsx$/,
       use: [options.defaultLoaders.babel],
     });
 


### PR DESCRIPTION
solves https://www.pivotaltracker.com/story/show/172730032

Also, this PR adds some speed-ups for development mode:
- Boots `ts-node-dev` with a max of 4GB of memory, vs the default of 2GB
- Reps old `ts-node-dev` orphan processes at boot, which are usually caused by failed webpack forks that ran out of memory. 