### PR TITLE
Event backstop Task

### DIFF
--- a/core/api/__tests__/actions/events.ts
+++ b/core/api/__tests__/actions/events.ts
@@ -158,6 +158,34 @@ describe("actions/events", () => {
       expect(total).toBe(1);
     });
 
+    test("an administrator can list events (associated to a profile)", async () => {
+      connection.params = {
+        csrfToken,
+        associated: true,
+      };
+      const { error, events, total } = await specHelper.runAction(
+        "events:list",
+        connection
+      );
+      expect(error).toBeFalsy();
+      expect(events.length).toEqual(0);
+      expect(total).toBe(0);
+    });
+
+    test("an administrator can list events (not associated to a profile)", async () => {
+      connection.params = {
+        csrfToken,
+        associated: false,
+      };
+      const { error, events, total } = await specHelper.runAction(
+        "events:list",
+        connection
+      );
+      expect(error).toBeFalsy();
+      expect(events.length).toEqual(1);
+      expect(total).toBe(1);
+    });
+
     test("an administrator can autocomplete the types of events (no filter)", async () => {
       connection.params = {
         csrfToken,

--- a/core/api/__tests__/tasks/events/associateProfile.ts
+++ b/core/api/__tests__/tasks/events/associateProfile.ts
@@ -59,5 +59,23 @@ describe("tasks/event:associateProfile", () => {
       expect(event.profileGuid).toBe(profile.guid);
       expect(event.profileAssociatedAt).toBeTruthy();
     });
+
+    test("enqueuing this task multiple times for the same event will be de-duplicated", async () => {
+      const event = await helper.factories.event({
+        anonymousId: "abc123",
+      });
+
+      let foundTasks = await specHelper.findEnqueuedTasks(
+        "event:associateProfile"
+      );
+      expect(foundTasks.length).toEqual(1);
+
+      await task.enqueue("event:associateProfile", { eventGuid: event.guid });
+      await task.enqueue("event:associateProfile", { eventGuid: event.guid });
+      await task.enqueue("event:associateProfile", { eventGuid: event.guid });
+
+      foundTasks = await specHelper.findEnqueuedTasks("event:associateProfile");
+      expect(foundTasks.length).toEqual(1);
+    });
   });
 });

--- a/core/api/__tests__/tasks/events/associateProfile.ts
+++ b/core/api/__tests__/tasks/events/associateProfile.ts
@@ -42,7 +42,6 @@ describe("tasks/event:associateProfile", () => {
         "event:associateProfile"
       );
       expect(foundTasks.length).toEqual(1);
-      expect(foundTasks[0].timestamp).toBeNull();
     });
 
     test("it will create a new profile from provided event data", async () => {

--- a/core/api/__tests__/tasks/events/associateProfiles.ts
+++ b/core/api/__tests__/tasks/events/associateProfiles.ts
@@ -1,0 +1,48 @@
+import { helper } from "../../utils/specHelper";
+import { task, specHelper } from "actionhero";
+
+let actionhero, api;
+
+describe("tasks/event:associateProfiles", () => {
+  beforeAll(async () => {
+    const env = await helper.prepareForAPITest();
+    actionhero = env.actionhero;
+    api = env.api;
+    await helper.factories.profilePropertyRules();
+  }, 1000 * 30);
+
+  afterAll(async () => {
+    await helper.shutdown(actionhero);
+  });
+
+  beforeEach(async () => {
+    await api.resque.queue.connection.redis.flushdb();
+  });
+
+  describe("event:associateProfile", () => {
+    test("can be enqueued", async () => {
+      await task.enqueue("event:associateProfiles", {});
+      const foundTasks = await specHelper.findEnqueuedTasks(
+        "event:associateProfiles"
+      );
+      expect(foundTasks.length).toEqual(1);
+    });
+
+    test("it will enqueue new tasks to associate not-yet associated events", async () => {
+      const event = await helper.factories.event({
+        anonymousId: "abc123",
+      });
+
+      // delete the associate task that was created along with the event
+      await api.resque.queue.connection.redis.flushdb();
+
+      await specHelper.runTask("event:associateProfiles", {});
+
+      const foundTasks = await specHelper.findEnqueuedTasks(
+        "event:associateProfile"
+      );
+      expect(foundTasks.length).toBe(1);
+      expect(foundTasks[0].args[0].eventGuid).toBe(event.guid);
+    });
+  });
+});

--- a/core/api/src/actions/events.ts
+++ b/core/api/src/actions/events.ts
@@ -11,6 +11,7 @@ export class EventsList extends AuthenticatedAction {
     this.inputs = {
       profileGuid: { required: false },
       type: { required: false },
+      associated: { required: false },
       data: { required: false },
       limit: { required: true, default: 1000, formatter: parseInt },
       offset: { required: true, default: 0, formatter: parseInt },
@@ -34,6 +35,7 @@ export class EventsList extends AuthenticatedAction {
     const events = await api.events.model.findAll({
       profileGuid: params.profileGuid,
       type: params.type,
+      associated: params.associated,
       data: Object.keys(data).length > 0 ? data : undefined,
       limit: params.limit,
       offset: params.offset,
@@ -43,6 +45,7 @@ export class EventsList extends AuthenticatedAction {
     const total = await api.events.model.count({
       profileGuid: params.profileGuid,
       type: params.type,
+      associated: params.associated,
       data: Object.keys(data).length > 0 ? data : undefined,
     });
 

--- a/core/api/src/classes/eventBackendSequelize.ts
+++ b/core/api/src/classes/eventBackendSequelize.ts
@@ -67,6 +67,7 @@ export class Event extends EventPrototype {
       ipAddress?: string;
       type?: string;
       data?: { [key: string]: any };
+      associated?: boolean;
       limit?: number;
       offset?: number;
       order?: Array<[string, string]>;
@@ -77,6 +78,7 @@ export class Event extends EventPrototype {
       ipAddress,
       type,
       data,
+      associated,
       limit,
       offset,
       order,
@@ -97,6 +99,12 @@ export class Event extends EventPrototype {
         includeWhere["key"] = i;
         includeWhere["value"] = data[i];
       }
+    }
+    if (associated === true) {
+      where["profileGuid"] = { [Op.ne]: null };
+    }
+    if (associated === false) {
+      where["profileGuid"] = { [Op.eq]: null };
     }
 
     const sequelizeEvents = await SequelizeEvent.findAll({
@@ -120,10 +128,11 @@ export class Event extends EventPrototype {
       profileGuid?: string;
       ipAddress?: string;
       type?: string;
+      associated?: boolean;
       data?: { [key: string]: any };
     } = {}
   ) {
-    const { profileGuid, ipAddress, type, data } = options;
+    const { profileGuid, ipAddress, type, associated, data } = options;
     const where = {};
     const includeWhere = {};
     if (profileGuid) {
@@ -141,7 +150,12 @@ export class Event extends EventPrototype {
         includeWhere["value"] = data[i];
       }
     }
-
+    if (associated === true) {
+      where["profileGuid"] = { [Op.ne]: null };
+    }
+    if (associated === false) {
+      where["profileGuid"] = { [Op.eq]: null };
+    }
     return SequelizeEvent.count({
       include: [
         {

--- a/core/api/src/classes/events.ts
+++ b/core/api/src/classes/events.ts
@@ -32,6 +32,7 @@ export interface EventPrototype extends EventArgs {
     ipAddress?: string;
     type?: string;
     data?: { [key: string]: any };
+    associated?: boolean;
     limit?: number;
     offset?: number;
     order?: Array<[string, string]>;
@@ -40,6 +41,7 @@ export interface EventPrototype extends EventArgs {
     profileGuid?: string;
     ipAddress?: string;
     type?: string;
+    associated?: boolean;
     data?: { [key: string]: any };
   }) => Promise<number>;
   types: (options: {

--- a/core/api/src/tasks/events/associateProfile.ts
+++ b/core/api/src/tasks/events/associateProfile.ts
@@ -3,7 +3,7 @@ import { EventPrototype } from "../../classes/events";
 import { App } from "../../models/App";
 import { RetryableTask } from "../../classes/retryableTask";
 
-export class AssociateProfileToImport extends RetryableTask {
+export class EventAssociateProfile extends RetryableTask {
   constructor() {
     super();
     this.name = "event:associateProfile";

--- a/core/api/src/tasks/events/associateProfiles.ts
+++ b/core/api/src/tasks/events/associateProfiles.ts
@@ -1,0 +1,40 @@
+import { api, Task, task, log } from "actionhero";
+import { EventPrototype } from "../../classes/events";
+
+export class EventsAssociateProfiles extends Task {
+  constructor() {
+    super();
+    this.name = "event:associateProfiles";
+    this.description =
+      "ensure that events are associated to profiles, even if they were created outside of our API";
+    this.frequency = 60 * 1000;
+    this.queue = "events";
+    this.inputs = {};
+  }
+
+  async run(params) {
+    const limit = 1000;
+    let offset = 0;
+    let events: EventPrototype[] = [];
+
+    while (events.length > 0 || offset === 0) {
+      events = await api.events.model.findAll({
+        associated: false,
+        limit,
+        offset,
+      });
+
+      for (const i in events) {
+        await task.enqueue("event:associateProfile", {
+          eventGuid: events[i].guid,
+        });
+      }
+
+      if (events.length > 0) {
+        log(`enqueued ${events.length} events for association`);
+      }
+
+      offset = offset + limit;
+    }
+  }
+}

--- a/core/api/src/tasks/group/destroy.ts
+++ b/core/api/src/tasks/group/destroy.ts
@@ -3,7 +3,7 @@ import { Group } from "../../models/Group";
 import { Run } from "../../models/Run";
 import { plugin } from "../../modules/plugin";
 
-export class RunGroup extends Task {
+export class GroupDestroy extends Task {
   constructor() {
     super();
     this.name = "group:destroy";

--- a/core/api/src/tasks/group/exportToCSV.ts
+++ b/core/api/src/tasks/group/exportToCSV.ts
@@ -3,7 +3,7 @@ import { Group } from "../../models/Group";
 import { plugin } from "../../modules/plugin";
 import { groupExportToCSV } from "../../modules/groupExport";
 
-export class RunGroup extends Task {
+export class GroupExportToCSV extends Task {
   constructor() {
     super();
     this.name = "group:exportToCSV";

--- a/core/api/src/tasks/group/updateCalculatedGroups.ts
+++ b/core/api/src/tasks/group/updateCalculatedGroups.ts
@@ -5,7 +5,7 @@ import { plugin } from "../../modules/plugin";
 import { Op } from "sequelize";
 import Moment from "moment";
 
-export class RunSchedule extends RetryableTask {
+export class GroupsUpdateCalculatedGroups extends RetryableTask {
   constructor() {
     super();
     this.name = "group:updateCalculatedGroups";

--- a/core/api/src/tasks/imports/associateProfile.ts
+++ b/core/api/src/tasks/imports/associateProfile.ts
@@ -3,7 +3,7 @@ import { RetryableTask } from "../../classes/retryableTask";
 import { Import } from "../../models/Import";
 import { Run } from "../../models/Run";
 
-export class AssociateProfileToImport extends RetryableTask {
+export class ImportAssociateProfile extends RetryableTask {
   constructor() {
     super();
     this.name = "import:associateProfile";

--- a/core/api/src/tasks/runs/determineState.ts
+++ b/core/api/src/tasks/runs/determineState.ts
@@ -1,7 +1,7 @@
 import { Task, task, log, config } from "actionhero";
 import { Run } from "../../models/Run";
 
-export class DetermineRunState extends Task {
+export class RunDetermineState extends Task {
   constructor() {
     super();
     this.name = "run:determineState";

--- a/core/api/src/tasks/runs/internalRun.ts
+++ b/core/api/src/tasks/runs/internalRun.ts
@@ -4,7 +4,7 @@ import { Import } from "../../models/Import";
 import { Profile } from "../../models/Profile";
 import { plugin } from "../../modules/plugin";
 
-export class DetermineRunState extends Task {
+export class RunInternalRun extends Task {
   constructor() {
     super();
     this.name = "run:internalRun";

--- a/core/api/src/tasks/schedule/run.ts
+++ b/core/api/src/tasks/schedule/run.ts
@@ -3,7 +3,7 @@ import { Schedule } from "../../models/Schedule";
 import { Run } from "../../models/Run";
 import { plugin } from "../../modules/plugin";
 
-export class RunSchedule extends Task {
+export class ScheduleRun extends Task {
   constructor() {
     super();
     this.name = "schedule:run";


### PR DESCRIPTION
the `event:associateProfiles` task will run every minute and enqueue an `event:associateProfile` task to find/build a Profile for each event that has not yet been associated to a Profile.  This enables us to support events written directly to the Grouparoo database in addition to those events created via our API.