### PR TITLE
Grouparoo Plugins pre-compile JS + remove next.js webpack & babel hacks

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -87,6 +87,7 @@
     "@types/faker": "^4.1.11",
     "@types/jest": "^25.2.1",
     "@types/node": "^13.13.1",
+    "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.6",
     "@types/validator": "^13.0.0",
     "csv-parse": "^4.8.9",

--- a/core/web/components/forms/session/signIn.tsx
+++ b/core/web/components/forms/session/signIn.tsx
@@ -1,3 +1,4 @@
+import React from "react"; // needed because this is also used by a plugin
 import { useState } from "react";
 import Router from "next/router";
 import { Form, Button } from "react-bootstrap";

--- a/core/web/env.js
+++ b/core/web/env.js
@@ -7,7 +7,8 @@ const {
 } = require("../api/src/utils/pluginDetails");
 const pluginManifest = getPluginManifest();
 
-// prepare the paths we'll be using
+// prepare the paths we'll be using and start clean
+fs.rmdirSync(path.join(__dirname, "tmp"), { recursive: true });
 // the top-level folder needs to exist for webpack to scan, even if there are no plugins
 fs.mkdirpSync(path.join(__dirname, "tmp", "plugin"));
 

--- a/core/web/env.js
+++ b/core/web/env.js
@@ -7,8 +7,11 @@ const {
 } = require("../api/src/utils/pluginDetails");
 const pluginManifest = getPluginManifest();
 
+// prepare the paths we'll be using
+// the top-level folder needs to exist for webpack to scan, even if there are no plugins
+fs.mkdirpSync(path.join(__dirname, "tmp", "plugin"));
+
 // write the plugins manifest to a file for the web to consume
-fs.mkdirpSync(path.join(__dirname, "tmp"));
 fs.writeFileSync(
   path.join(__dirname, "tmp", "pluginManifest.json"),
   JSON.stringify(pluginManifest, null, 2)

--- a/core/web/env.js
+++ b/core/web/env.js
@@ -8,6 +8,7 @@ const {
 const pluginManifest = getPluginManifest();
 
 // write the plugins manifest to a file for the web to consume
+fs.mkdirpSync(path.join(__dirname, "tmp"));
 fs.writeFileSync(
   path.join(__dirname, "tmp", "pluginManifest.json"),
   JSON.stringify(pluginManifest, null, 2)
@@ -21,14 +22,14 @@ pluginManifest.plugins.forEach((plugin) => {
   if (plugin && plugin.grouparoo && plugin.grouparoo.webComponents) {
     for (const k in plugin.grouparoo.webComponents) {
       plugin.grouparoo.webComponents[k].forEach((file) => {
+        const pluginFile =
+          grouparooMonorepoApp || runningCoreDirectly()
+            ? `../../../../../../../../plugins/${pluginName}/dist/components/${file}.plugin.js`
+            : `../../../../../../../../../${pluginName}/dist/components/${file}.plugin.js`;
         fs.mkdirpSync(path.join(__dirname, "tmp", "plugin", k, pluginName));
         fs.writeFileSync(
           path.join(__dirname, "tmp", "plugin", k, pluginName, `${file}.tsx`),
-          `export { default } from ${
-            grouparooMonorepoApp || runningCoreDirectly()
-              ? `"../../../../../../../../plugins/${pluginName}/dist/components/${file}.plugin.js"`
-              : `"../../../../../../../../../${pluginName}/dist/components/${file}.plugin.js"`
-          }
+          `export { default } from "${pluginFile}"
 console.info("[ Grouparoo Plugin ] '${file}' from ${pluginName}");
 `
         );

--- a/core/web/env.js
+++ b/core/web/env.js
@@ -18,7 +18,7 @@ fs.writeFileSync(
 // We do not want to use wildcard strings in the import statement to save webpack from scanning all of our directories
 pluginManifest.plugins.forEach((plugin) => {
   const pluginName = plugin.name;
-  if (plugin?.grouparoo?.webComponents) {
+  if (plugin && plugin.grouparoo && plugin.grouparoo.webComponents) {
     for (const k in plugin.grouparoo.webComponents) {
       plugin.grouparoo.webComponents[k].forEach((file) => {
         fs.mkdirpSync(path.join(__dirname, "tmp", "plugin", k, pluginName));

--- a/core/web/hooks/usePlugin.tsx
+++ b/core/web/hooks/usePlugin.tsx
@@ -1,5 +1,6 @@
-import PluginManifest from "./../tmp/pluginManifest.json";
-import PluginLoader from "./../tmp/pluginLoader";
+import PluginManifest from "../tmp/pluginManifest.json";
+import dynamic from "next/dynamic";
+import Loader from "./../components/loader";
 
 export function usePlugins(key: string) {
   const pluginComponents = [];
@@ -26,7 +27,16 @@ export function usePlugins(key: string) {
               key: lastWordFromCamelCase(file),
             });
 
-            pluginComponents.push(PluginLoader(pluginName, file));
+            const LoaderFunction = (props) => {
+              const Plugin = dynamic(
+                () => import(`../tmp/plugin/${key}/${pluginName}/${file}`),
+                { loading: () => <Loader /> }
+              );
+
+              return <Plugin {...props} />;
+            };
+
+            pluginComponents.push(LoaderFunction);
           });
         }
       }

--- a/core/web/next.config.js
+++ b/core/web/next.config.js
@@ -1,18 +1,9 @@
-const path = require("path");
 const env = require("./env");
-const { getPluginManifest } = require("../api/src/utils/pluginDetails");
 
 module.exports = {
   env,
 
   webpack: (config, options) => {
-    overwriteNextBabelLoaderToIncludePluginNodeModules(config);
-
-    config.module.rules.push({
-      test: /\.plugin\.js$|\.plugin\.jsx$|\.plugin\.ts$|\.plugin\.tsx$/,
-      use: [options.defaultLoaders.babel],
-    });
-
     config.module.rules.push({
       test: /\.md$/,
       use: "raw-loader",
@@ -20,35 +11,4 @@ module.exports = {
 
     return config;
   },
-};
-
-const overwriteNextBabelLoaderToIncludePluginNodeModules = (config) => {
-  const { plugins } = getPluginManifest();
-  const pluginNamesWithinNodeModules = [{ name: "@grouparoo/core" }]
-    .concat(plugins)
-    .map((p) => path.join("node_modules", p.name));
-
-  const NextBabelLoader = config.module.rules.filter((r) => {
-    if (r.use && r.use.loader === "next-babel-loader") {
-      return true;
-    } else {
-      return false;
-    }
-  })[0];
-
-  if (!NextBabelLoader) {
-    return;
-  }
-
-  const originalExclude = NextBabelLoader.exclude;
-
-  NextBabelLoader.exclude = (moduleName, ...args) => {
-    for (const i in pluginNamesWithinNodeModules) {
-      if (moduleName.indexOf(pluginNamesWithinNodeModules[i]) >= 0) {
-        return false;
-      }
-    }
-
-    return originalExclude(moduleName, ...args);
-  };
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "clean": "lerna clean",
     "lint": "lerna run lint",
     "test": "lerna run test",
-    "nuke": "rm -rf node_modules && rm -rf core/node_modules && rm -rf plugins/*/*/node_modules && rm -rf apps/*/node_modules && rm -rf core/api/dist && rm -rf plugins/*/*/dist",
+    "nuke": "rm -rf node_modules && rm -rf core/node_modules && rm -rf plugins/*/*/node_modules && rm -rf apps/*/node_modules && rm -rf core/api/dist && rm -rf plugins/*/*/dist && rm -rf core/web/tmp",
     "update": "npm-check-updates -u && lerna exec -- npm-check-updates -u && npm run nuke && npm install"
   }
 }

--- a/plugins/@grouparoo/email-authentication/package-lock.json
+++ b/plugins/@grouparoo/email-authentication/package-lock.json
@@ -4106,16 +4106,6 @@
       "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
       "dev": true
     },
-    "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
-    },
     "react-bootstrap": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.0.1.tgz",
@@ -4134,17 +4124,6 @@
         "react-transition-group": "^4.0.0",
         "uncontrollable": "^7.0.0",
         "warning": "^4.0.3"
-      }
-    },
-    "react-dom": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
       }
     },
     "react-is": {
@@ -4601,15 +4580,6 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.1.1"
-      }
-    },
-    "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "semver": {

--- a/plugins/@grouparoo/email-authentication/package.json
+++ b/plugins/@grouparoo/email-authentication/package.json
@@ -27,9 +27,7 @@
     "lint": "prettier --check src __tests__"
   },
   "dependencies": {
-    "react": "^16.13.1",
-    "react-bootstrap": "^1.0.0",
-    "react-dom": "^16.13.1"
+    "react-bootstrap": "^1.0.0"
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
@@ -39,9 +37,12 @@
     "@grouparoo/core": "^0.1.2-alpha.5",
     "@types/jest": "^25.2.1",
     "@types/node": "^13.13.1",
+    "@types/react": "^16.9.35",
     "actionhero": "^22.1.0",
     "jest": "^25.4.0",
     "prettier": "^2.0.5",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
     "ts-jest": "^25.4.0",
     "typescript": "3.8.3"
   },

--- a/plugins/@grouparoo/email-authentication/src/components/emailSignIn.plugin.tsx
+++ b/plugins/@grouparoo/email-authentication/src/components/emailSignIn.plugin.tsx
@@ -1,5 +1,10 @@
+import React from "react"; // needed so help TS know what to compile in
 import SignIn from "@grouparoo/core/web/components/forms/session/signIn";
 
 export default function (props) {
-  return <SignIn {...props} />;
+  return (
+    <>
+      <SignIn {...props} />
+    </>
+  );
 }

--- a/plugins/@grouparoo/email-authentication/tsconfig.json
+++ b/plugins/@grouparoo/email-authentication/tsconfig.json
@@ -7,8 +7,9 @@
     "target": "es2018",
     "esModuleInterop": true,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "jsx": "react"
   },
   "include": ["./src/**/*"],
-  "exclude": ["./../node_modules", "./src/components"]
+  "exclude": ["./../node_modules"]
 }


### PR DESCRIPTION
Our app has been getting slower and slower to develop.  This is largely due to the hacks we added to the `next-babel-loader` to find our UI Plugins.  This PR **removes the need for the webpack/babel hacks entirely**!  This is accomplished with a 2-phase approach:

1. Plugins pre-compile their TSX into JS.  This allows core to skip the transpile step (TS or Babel).  This. has a negative effect when developing UI components in plugins, but we can use `tsc --watch` just like we do when developing API plugins to accomplish something akin to hot reloading.  Since we are relying on typescript to do the transpiling, we need to ensure that:
  * `jsx: react` is enabled in each plugin's `tsconfig.json`
  * ensure that `react`, `react-dom`, and `@types/react` are devDependencies of each plugin. 
  * as a hint to the Typescript compiler, `import React from "react";` will likely be needed within each UI module

2. To avoid wepack scanning the whole file tree, we need to avoid any `require`/`import` statements with variables.  To avoid this, we can traverse the list of plugins at boot and write to disk single file import statement for each plugin:

```ts
// from `core/web/tmp/plugin/session/sign-in/@grouparoo/email-authentication/emailSignin.tsx`
export { default } from "../../../../../../../../plugins/@grouparoo/email-authentication/dist/components/emailSignIn.plugin.js"
console.info("[ Grouparoo Plugin ] 'emailSignIn' from @grouparoo/email-authentication");
```
In this way, webpack can statically analyze the dependancies, and only load in what it needs.  Since we build these import files at boot, we can still add/remove/modify components rather easily.  There's nothing to change for plugin developers or consumers. 

We hook into next.js' boot process (in `env.js`, which is consumed by `next.config.js`) to build these files.

TODO:
- After this is merged, update the internal plugins
- After this is merged, test that this works in a new pre-release project from NPM (ensure that the paths are all correct)