### PR TITLE
React is a Peer Dependency for UI plugins

### DIFF
--- a/core/web/next.config.js
+++ b/core/web/next.config.js
@@ -11,6 +11,12 @@ module.exports = {
       "node_modules",
       "react"
     );
+    config.resolve.alias["react-dom"] = path.resolve(
+      __dirname,
+      "..",
+      "node_modules",
+      "react-dom"
+    );
 
     config.module.rules.push({
       test: /\.md$/,

--- a/core/web/next.config.js
+++ b/core/web/next.config.js
@@ -1,9 +1,17 @@
+const path = require("path");
 const env = require("./env");
 
 module.exports = {
   env,
 
   webpack: (config, options) => {
+    config.resolve.alias["react"] = path.resolve(
+      __dirname,
+      "..",
+      "node_modules",
+      "react"
+    );
+
     config.module.rules.push({
       test: /\.md$/,
       use: "raw-loader",

--- a/plugins/@grouparoo/email-authentication/package.json
+++ b/plugins/@grouparoo/email-authentication/package.json
@@ -31,7 +31,9 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "22.1.0"
+    "actionhero": "22.1.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.2-alpha.5",
@@ -41,8 +43,6 @@
     "actionhero": "^22.1.0",
     "jest": "^25.4.0",
     "prettier": "^2.0.5",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "ts-jest": "^25.4.0",
     "typescript": "3.8.3"
   },


### PR DESCRIPTION
To avoid [this error](https://reactjs.org/warnings/invalid-hook-call-warning.html), we need to ensure that our plugins and core are using the same react & react-dom import.  Not version... actually the same files in node_modules.

To accomplish this:
* plugins should not have react as a dependency, just a peer-dependency
* core will alias it's own react & react-dom in all cases (in next.config.js)