### PR TITLE
Combine core tests and plugin tests to have simpler & faster CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,18 @@ jobs:
             - plugins/@grouparoo/postgres/node_modules
             - plugins/@grouparoo/sailthru/node_modules
             - tools/merger/node_modules
+            - plugins/@grouparoo/bigquery/dist
+            - plugins/@grouparoo/csv/dist
+            - plugins/@grouparoo/email-authentication/dist
+            - plugins/@grouparoo/files-local/dist
+            - plugins/@grouparoo/files-s3/dist
+            - plugins/@grouparoo/google-sheets/dist
+            - plugins/@grouparoo/logger/dist
+            - plugins/@grouparoo/mailchimp/dist
+            - plugins/@grouparoo/mysql/dist
+            - plugins/@grouparoo/newrelic/dist
+            - plugins/@grouparoo/postgres/dist
+            - plugins/@grouparoo/sailthru/dist
             - core/web/.next
             - core/api/dist
   license-checker:
@@ -125,7 +137,7 @@ jobs:
           command: mysql -e "create database grouparoo_test" -u root -h 127.0.0.1
       - run:
           name: test
-          command: ./node_modules/.bin/lerna run test --stream --concurrency 1 --ignore "@grouparoo/core"
+          command: ./node_modules/.bin/lerna exec ./node_modules/.bin/jest --stream --concurrency 1 --ignore "@grouparoo/core" --ignore "@grouparoo/app*" -- --ci --passWithNoTests
   complete:
     docker:
       - image: circleci/node:12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,30 +67,7 @@ jobs:
       - run:
           name: linter
           command: npm run lint
-  test-core-api:
-    docker:
-      - image: circleci/node:12
-      - image: redis:latest
-      - image: circleci/postgres:9
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache-options
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core/api && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd core/api && ./../node_modules/.bin/jest --ci --maxWorkers 4
-  test-core-web:
+  test-core:
     docker:
       - image: circleci/node:12
       - image: redis:latest
@@ -113,194 +90,10 @@ jobs:
           command: cd core/api && ./bin/create_test_databases
       - run:
           name: test
-          command: cd core/web && ./../node_modules/.bin/jest --ci --maxWorkers 4
+          command: cd core && ./../node_modules/.bin/jest --ci --maxWorkers 4
           environment:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
-  test-plugin-bigquery:
-    docker:
-      - image: circleci/node:12
-      - image: redis:latest
-      - image: circleci/postgres:9
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache-options
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core/api && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd plugins/@grouparoo/bigquery && npm run test
-  test-plugin-csv:
-    docker:
-      - image: circleci/node:12
-      - image: redis:latest
-      - image: circleci/postgres:9
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache-options
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core/api && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd plugins/@grouparoo/csv && npm run test
-  test-plugin-email-authentication:
-    docker:
-      - image: circleci/node:12
-      - image: redis:latest
-      - image: circleci/postgres:9
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache-options
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core/api && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd plugins/@grouparoo/email-authentication && npm run test
-  test-plugin-files-local:
-    docker:
-      - image: circleci/node:12
-      - image: redis:latest
-      - image: circleci/postgres:9
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache-options
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core/api && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd plugins/@grouparoo/files-local && npm run test
-  test-plugin-files-s3:
-    docker:
-      - image: circleci/node:12
-      - image: redis:latest
-      - image: circleci/postgres:9
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache-options
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core/api && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd plugins/@grouparoo/files-s3 && npm run test
-  test-plugin-google-sheets:
-    docker:
-      - image: circleci/node:12
-      - image: redis:latest
-      - image: circleci/postgres:9
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache-options
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core/api && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd plugins/@grouparoo/google-sheets && npm run test
-  test-plugin-logger:
-    docker:
-      - image: circleci/node:12
-      - image: redis:latest
-      - image: circleci/postgres:9
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache-options
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core/api && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd plugins/@grouparoo/logger && npm run test
-  test-plugin-mailchimp:
-    docker:
-      - image: circleci/node:12
-      - image: redis:latest
-      - image: circleci/postgres:9
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache-options
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core/api && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd plugins/@grouparoo/mailchimp && npm run test
-  test-plugin-mysql:
+  test-plugins:
     docker:
       - image: circleci/node:12
       - image: redis:latest
@@ -329,76 +122,7 @@ jobs:
           command: mysql -e "create database grouparoo_test" -u root -h 127.0.0.1
       - run:
           name: test
-          command: cd plugins/@grouparoo/mysql && npm run test
-  test-plugin-newrelic:
-    docker:
-      - image: circleci/node:12
-      - image: redis:latest
-      - image: circleci/postgres:9
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache-options
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core/api && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd plugins/@grouparoo/newrelic && npm run test
-  test-plugin-postgres:
-    docker:
-      - image: circleci/node:12
-      - image: redis:latest
-      - image: circleci/postgres:9
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache-options
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core/api && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd plugins/@grouparoo/postgres && npm run test
-  test-plugin-sailthru:
-    docker:
-      - image: circleci/node:12
-      - image: redis:latest
-      - image: circleci/postgres:9
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *cache-options
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core/api && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd plugins/@grouparoo/sailthru && npm run test
+          command: ./node_modules/.bin/lerna run test --stream --concurrency 1 --ignore "@grouparoo/core"
   complete:
     docker:
       - image: circleci/node:12
@@ -439,108 +163,24 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
-      - test-core-api:
+      - test-core:
           filters:
             <<: *ignored-branches
           requires:
             - build
-      - test-core-web:
+      - test-plugins:
           filters:
             <<: *ignored-branches
           requires:
-            - build
-      - test-plugin-bigquery:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-csv:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-email-authentication:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-files-local:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-files-s3:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-google-sheets:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-logger:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-mailchimp:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-mysql:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-newrelic:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-postgres:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-sailthru:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
+            - test-core
       - complete:
           filters:
             <<: *ignored-branches
           requires:
             - license-checker
             - linter
-            - test-core-api
-            - test-core-web
-            - test-plugin-bigquery
-            - test-plugin-csv
-            - test-plugin-email-authentication
-            - test-plugin-files-local
-            - test-plugin-files-s3
-            - test-plugin-google-sheets
-            - test-plugin-logger
-            - test-plugin-mailchimp
-            - test-plugin-mysql
-            - test-plugin-newrelic
-            - test-plugin-postgres
-            - test-plugin-sailthru
+            - test-core
+            - test-plugins
   #
   # Run the tests each week + publish
   test-grouparoo-nightly:
@@ -565,108 +205,24 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
-      - test-core-api:
+      - test-core:
           filters:
             <<: *ignored-branches
           requires:
             - build
-      - test-core-web:
+      - test-plugins:
           filters:
             <<: *ignored-branches
           requires:
-            - build
-      - test-plugin-bigquery:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-csv:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-email-authentication:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-files-local:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-files-s3:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-google-sheets:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-logger:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-mailchimp:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-mysql:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-newrelic:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-postgres:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
-      - test-plugin-sailthru:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - test-core-api
-            - test-core-web
+            - test-core
       - complete:
           filters:
             <<: *ignored-branches
           requires:
             - license-checker
             - linter
-            - test-core-api
-            - test-core-web
-            - test-plugin-bigquery
-            - test-plugin-csv
-            - test-plugin-email-authentication
-            - test-plugin-files-local
-            - test-plugin-files-s3
-            - test-plugin-google-sheets
-            - test-plugin-logger
-            - test-plugin-mailchimp
-            - test-plugin-mysql
-            - test-plugin-newrelic
-            - test-plugin-postgres
-            - test-plugin-sailthru
+            - test-core
+            - test-plugins
       - publish:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,8 +89,11 @@ jobs:
           name: create test databases
           command: cd core/api && ./bin/create_test_databases
       - run:
-          name: test
-          command: cd core && ./../node_modules/.bin/jest --ci --maxWorkers 4
+          name: test-api
+          command: cd core/api && ./../node_modules/.bin/jest --ci --maxWorkers 4
+      - run:
+          name: test-web
+          command: cd core/web && ./../node_modules/.bin/jest --ci --maxWorkers 4
           environment:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-plugins:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ workflows:
           filters:
             <<: *ignored-branches
           requires:
-            - test-core
+            - build
       - complete:
           filters:
             <<: *ignored-branches
@@ -214,7 +214,7 @@ workflows:
           filters:
             <<: *ignored-branches
           requires:
-            - test-core
+            - build
       - complete:
           filters:
             <<: *ignored-branches

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "version-stable": "lerna version patch --force-publish --yes",
     "clean": "lerna clean",
     "lint": "lerna run lint",
-    "test": "lerna run test --stream",
+    "test": "lerna run test --stream --concurrency 1",
     "nuke": "rm -rf node_modules && rm -rf core/node_modules && rm -rf plugins/*/*/node_modules && rm -rf apps/*/node_modules && rm -rf core/api/dist && rm -rf plugins/*/*/dist && rm -rf core/web/tmp",
     "update": "npm-check-updates -u && lerna exec -- npm-check-updates -u && npm run nuke && npm install"
   }

--- a/plugins/@grouparoo/logger/jest.config.js
+++ b/plugins/@grouparoo/logger/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.ts?$": "ts-jest",
+  },
+  testPathIgnorePatterns: ["<rootDir>/src", "<rootDir>/dist"],
+};

--- a/tools/merger/data/ci/base.yml.template
+++ b/tools/merger/data/ci/base.yml.template
@@ -31,6 +31,7 @@ jobs:
           <<: *cache-options
           paths:
 {{{node_module_list}}}
+{{{dist_list}}}
 {{{custom_cache}}}
             - core/web/.next
             - core/api/dist

--- a/tools/merger/data/ci/core/job.yml.template
+++ b/tools/merger/data/ci/core/job.yml.template
@@ -5,6 +5,7 @@
       - image: circleci/postgres:9
         environment:
           POSTGRES_PASSWORD: password
+      - image: selenium/standalone-chrome:latest
 {{{custom_docker}}}
     steps:
       - checkout
@@ -23,4 +24,6 @@
       - run:
           name: test
           command: cd {{{relative_path}}} && ./../node_modules/.bin/jest --ci --maxWorkers 4
+          environment:
+            SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
 {{{custom_test}}}

--- a/tools/merger/data/ci/core/job.yml.template
+++ b/tools/merger/data/ci/core/job.yml.template
@@ -22,8 +22,11 @@
           command: cd core/api && ./bin/create_test_databases
 {{{custom_steps}}}
       - run:
-          name: test
-          command: cd {{{relative_path}}} && ./../node_modules/.bin/jest --ci --maxWorkers 4
+          name: test-api
+          command: cd {{{relative_path}}}/api && ./../node_modules/.bin/jest --ci --maxWorkers 4
+      - run:
+          name: test-web
+          command: cd {{{relative_path}}}/web && ./../node_modules/.bin/jest --ci --maxWorkers 4
           environment:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
 {{{custom_test}}}

--- a/tools/merger/data/ci/core/web/docker.yml.template
+++ b/tools/merger/data/ci/core/web/docker.yml.template
@@ -1,1 +1,0 @@
-      - image: selenium/standalone-chrome:latest

--- a/tools/merger/data/ci/core/web/test.yml.template
+++ b/tools/merger/data/ci/core/web/test.yml.template
@@ -1,2 +1,0 @@
-          environment:
-            SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub

--- a/tools/merger/data/ci/plugin/job.yml.template
+++ b/tools/merger/data/ci/plugin/job.yml.template
@@ -29,5 +29,5 @@
 {{{custom_steps}}}
       - run:
           name: test
-          command: ./node_modules/.bin/lerna run test --stream --concurrency 1 --ignore "@grouparoo/core"
+          command: ./node_modules/.bin/lerna exec ./node_modules/.bin/jest --stream --concurrency 1 --ignore "@grouparoo/core" --ignore "@grouparoo/app*" -- --ci --passWithNoTests
 {{custom_test}}

--- a/tools/merger/data/ci/plugin/job.yml.template
+++ b/tools/merger/data/ci/plugin/job.yml.template
@@ -5,6 +5,7 @@
       - image: circleci/postgres:9
         environment:
           POSTGRES_PASSWORD: password
+      - image: circleci/mysql:5
 {{{custom_docker}}}
     steps:
       - checkout
@@ -19,8 +20,14 @@
       - run:
           name: create test databases
           command: cd core/api && ./bin/create_test_databases
+      - run:
+          name: install mysql client
+          command: sudo apt install -y mysql-client
+      - run:
+          name: create mysql databases
+          command: mysql -e "create database grouparoo_test" -u root -h 127.0.0.1
 {{{custom_steps}}}
       - run:
           name: test
-          command: cd {{{relative_path}}} && npm run test
+          command: ./node_modules/.bin/lerna run test --stream --concurrency 1 --ignore "@grouparoo/core"
 {{custom_test}}

--- a/tools/merger/data/ci/plugin/mysql/docker.yml.template
+++ b/tools/merger/data/ci/plugin/mysql/docker.yml.template
@@ -1,1 +1,0 @@
-      - image: circleci/mysql:5

--- a/tools/merger/data/ci/plugin/mysql/steps.yml.template
+++ b/tools/merger/data/ci/plugin/mysql/steps.yml.template
@@ -1,6 +1,0 @@
-      - run:
-          name: install mysql client
-          command: sudo apt install -y mysql-client
-      - run:
-          name: create mysql databases
-          command: mysql -e "create database grouparoo_test" -u root -h 127.0.0.1

--- a/tools/merger/data/ci/plugin/workflow.yml.template
+++ b/tools/merger/data/ci/plugin/workflow.yml.template
@@ -2,4 +2,4 @@
           filters:
             <<: *ignored-branches
           requires:
-{{{core_job_name_list}}}
+            - build

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -48,7 +48,7 @@ class Generator {
 
   compile() {
     this.addCommands();
-    this.addCores();
+    this.addCore();
     this.addPlugins();
 
     this.bindJobMethods();
@@ -67,17 +67,13 @@ class Generator {
     this.addCommand("linter", "npm run lint");
   }
 
-  addCore(name) {
+  addCore() {
     this.jobList.push({
       type: "core",
-      job_name: `test-core-${name}`,
-      relative_path: `core/${name}`,
-      name,
+      job_name: `test-core`,
+      relative_path: `core`,
+      name: "core",
     });
-  }
-  addCores(name) {
-    this.addCore("api");
-    this.addCore("web");
   }
 
   getPlugin(fullPath) {
@@ -90,16 +86,22 @@ class Generator {
       relative_path,
     };
   }
-  addPlugins(name) {
+  addPlugins() {
     const pluginPaths = allPluginPaths(glob);
     let plugins = [];
     for (const fullPath of pluginPaths) {
       plugins.push(this.getPlugin(fullPath));
     }
     plugins.sort((a, b) => a.name.localeCompare(b.name));
-    for (const plugin of plugins) {
-      this.jobList.push(plugin);
-    }
+    // for (const plugin of plugins) {
+    //   this.jobList.push(plugin);
+    // }
+    this.jobList.push({
+      type: "plugin",
+      job_name: `test-plugins`,
+      relative_path: "",
+      name: "plugins",
+    });
   }
 
   bindJobMethod(job) {

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -123,7 +123,6 @@ class Generator {
   }
 
   node_module_list() {
-    const indent = 12;
     const packagePaths = allPackagePaths(glob);
     const relativePaths = [];
     for (const packagePath of packagePaths) {
@@ -135,6 +134,17 @@ class Generator {
     const prefix = " ".repeat(12) + "- ";
     return relativePaths
       .map((p) => `${prefix}${p}`)
+      .sort()
+      .join("\n");
+  }
+
+  dist_list() {
+    const pluginPaths = allPluginPaths(glob).map((p) =>
+      path.relative(this.rootPath, p)
+    );
+    const prefix = " ".repeat(12) + "- ";
+    return pluginPaths
+      .map((p) => `${prefix}${p}/dist`)
       .sort()
       .join("\n");
   }
@@ -171,7 +181,13 @@ class Generator {
     view[".Branch"] = "{{ .Branch }}";
     view[".Revision"] = "{{ .Revision }}";
 
-    const methods = ["node_module_list", "jobs", "workflows", "job_name_list"];
+    const methods = [
+      "node_module_list",
+      "dist_list",
+      "jobs",
+      "workflows",
+      "job_name_list",
+    ];
     for (const method of methods) {
       view[method] = this[method].bind(this);
     }


### PR DESCRIPTION
Should be simpler and faster!

<img width="926" alt="Screen Shot 2020-05-19 at 11 09 33 AM" src="https://user-images.githubusercontent.com/303226/82362460-3aa74500-99c1-11ea-9137-9e88ddf78b60.png">

For plugins, we can rely on lerna to run `npm test` in each package for us:
```
lerna run test --stream --concurrency 1 --ignore "@grouparoo/core"
```

---

This PR also simplifies top-level `npm test` which will test all the packages in this monorepo

![Screen Shot 2020-05-19 at 11 48 37 AM](https://user-images.githubusercontent.com/303226/82366223-b8218400-99c6-11ea-82cf-5b930a8fb976.png)
