### PR TITLE
Rely on node's require system to determine the location of modules

### DIFF
--- a/bin/prepare
+++ b/bin/prepare
@@ -2,8 +2,14 @@
 
 set -e
 
-if [[ $NODE_ENV == "development" || -z $NODE_ENV ]]; then
-  npm run bootstrap-flat
-else
+if [[ $NODE_ENV == "production" ]]; then
   npm run bootstrap-hoist
+elif [[ $NODE_ENV == "staging" ]]; then
+  npm run bootstrap-hoist
+elif [[ $NODE_ENV == "test" ]]; then
+  npm run bootstrap-hoist
+elif [[ ! -z $CI ]]; then
+  npm run bootstrap-hoist
+else
+  npm run bootstrap-flat
 fi

--- a/bin/prepare
+++ b/bin/prepare
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+if [[ $NODE_ENV == "development" || -z $NODE_ENV ]]; then
+  npm run bootstrap-flat
+else
+  npm run bootstrap-hoist
+fi

--- a/core/api/src/config/plugins.ts
+++ b/core/api/src/config/plugins.ts
@@ -1,29 +1,12 @@
-import { join } from "path";
-import fs from "fs";
+import path from "path";
 import { getPluginManifest } from "../utils/pluginDetails";
 import InjectedPlugins from "./pluginInjection";
 
-let localNodeModulesPath: string;
-if (
-  fs.existsSync(
-    join(__dirname, "..", "..", "..", "node_modules", "ah-sequelize-plugin")
-  )
-) {
-  // things are installed under this project
-  localNodeModulesPath = join(__dirname, "..", "..", "..", "node_modules");
-} else {
-  // we are installed along-side this project
-  localNodeModulesPath = join(
-    __dirname,
-    "..",
-    "..",
-    "..",
-    "..",
-    "..",
-    "..",
-    "node_modules"
-  );
-}
+// let npm handle the path detection for us!
+const localNodeModulesPath = path.join(
+  path.dirname(require.resolve("react/package.json")),
+  ".."
+);
 
 const pluginManifest = getPluginManifest();
 const parentPlugins = {};
@@ -58,10 +41,10 @@ export const DEFAULT = {
     return Object.assign(
       {
         "ah-sequelize-plugin": {
-          path: join(localNodeModulesPath, "ah-sequelize-plugin"),
+          path: path.join(localNodeModulesPath, "ah-sequelize-plugin"),
         },
         "ah-next-plugin": {
-          path: join(localNodeModulesPath, "ah-next-plugin"),
+          path: path.join(localNodeModulesPath, "ah-next-plugin"),
         },
       },
       parentPlugins,

--- a/core/web/next.config.js
+++ b/core/web/next.config.js
@@ -2,14 +2,14 @@ const path = require("path");
 const fs = require("fs");
 const {
   getPluginManifest,
-  runningCoreDirectly,
   getParentPath,
 } = require("../api/src/utils/pluginDetails");
 require("./plugins"); // prepare plugins
 
-const nodeModulesPath = runningCoreDirectly()
-  ? path.resolve(__dirname, "..", "node_modules")
-  : path.resolve(__dirname, "..", "..", "..", "..", "node_modules");
+const nodeModulesPath = path.join(
+  path.dirname(require.resolve("react/package.json")),
+  ".."
+);
 
 // pass plugin env/web to the build for
 const env = {};

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "test": "lerna run test --stream --concurrency 1",
     "nuke": "rm -rf node_modules && rm -rf core/node_modules && rm -rf plugins/*/*/node_modules && rm -rf apps/*/node_modules && rm -rf core/api/dist && rm -rf plugins/*/*/dist && rm -rf core/web/tmp",
     "update": "npm-check-updates -u && lerna exec -- npm-check-updates -u && npm run nuke && npm install",
-    "heroku-postbuild": "lerna bootstrap --hoist --strict --ignore-scripts"
+    "heroku-postbuild": "lerna bootstrap --hoist --strict --ignore-scripts && npm rebuild"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "prettier": "^2.0.5"
   },
   "scripts": {
-    "prepare": "npm run bootstrap",
-    "bootstrap": "lerna bootstrap --strict",
+    "prepare": "./bin/prepare",
+    "bootstrap-flat": "lerna bootstrap --strict",
+    "bootstrap-hoist": "lerna bootstrap --strict --hoist",
     "license-checker": "./tools/license-checker/check",
     "version-alpha": "lerna version prerelease --preid alpha --force-publish --yes",
     "version-stable": "lerna version patch --force-publish --yes",
@@ -32,7 +33,6 @@
     "lint": "lerna run lint",
     "test": "lerna run test --stream --concurrency 1",
     "nuke": "rm -rf node_modules && rm -rf core/node_modules && rm -rf plugins/*/*/node_modules && rm -rf apps/*/node_modules && rm -rf core/api/dist && rm -rf plugins/*/*/dist && rm -rf core/web/tmp",
-    "update": "npm-check-updates -u && lerna exec -- npm-check-updates -u && npm run nuke && npm install",
-    "heroku-postbuild": "lerna bootstrap --hoist --strict --ignore-scripts && npm rebuild"
+    "update": "npm-check-updates -u && lerna exec -- npm-check-updates -u && npm run nuke && npm install"
   }
 }

--- a/tools/license-checker/check
+++ b/tools/license-checker/check
@@ -8,7 +8,7 @@ const { allPackageFiles } = require("../shared/packages");
 
 const excludePackages = [
   // custom exclusions for newrelic
-  "newrelic@6.7.0",
+  "newrelic@6.8.0",
   "@newrelic/aws-sdk@1.1.2",
   "@newrelic/koa@3.0.0",
   "@newrelic/native-metrics@5.1.0",


### PR DESCRIPTION
Since we need the application to run in both `monorepo+hoist` and `monorepo+normal` install modes, we need to be smarter about how we figure out the paths of our plugins and root-react packages.  We can get help from the `require()` pathing system!

This should make it possible to run the Grouparoo monorepo in "normal install" mode locally and in CI, but switch over to "hoisted" packages on Heroku to save space. 