### PR TITLE
Set config.servers.web.allowedRequestHosts from process.env.WEB_URL

### DIFF
--- a/core/api/src/config/servers/web.ts
+++ b/core/api/src/config/servers/web.ts
@@ -14,6 +14,8 @@ export const DEFAULT = {
         // i.e.: [ 'https://www.site.com' ]
         allowedRequestHosts: process.env.ALLOWED_HOSTS
           ? process.env.ALLOWED_HOSTS.split(",")
+          : process.env.WEB_URL
+          ? [process.env.WEB_URL]
           : [],
         // Port or Socket Path
         port: process.env.PORT || 8080,


### PR DESCRIPTION
This PR uses `process.env.WEB_URL` as the authoritative name of the host header that the API will respond to.  If requests hit the server with another HOST header, they will get a 302 redirect response.

closes https://github.com/grouparoo/grouparoo/issues/230