### PR TITLE
Move alerts to bottom of page

### DIFF
--- a/core/web/components/layouts/main.tsx
+++ b/core/web/components/layouts/main.tsx
@@ -156,7 +156,15 @@ export default function ({
         >
           <br />
           <div>
-            <div style={{ position: "fixed", zIndex: 999, width: alertWidth }}>
+            <div
+              style={{
+                position: "fixed",
+                zIndex: 999,
+                width: alertWidth,
+                left: contentAreaLeftPadding,
+                bottom: 0,
+              }}
+            >
               <SuccessAlert successHandler={successHandler} />
               <ErrorAlert errorHandler={errorHandler} />
             </div>


### PR DESCRIPTION
This PR moves our floating `successAlert` and `errorAlert` components to the bottom of the page, from the top.   Since some of our pages are so long, we still need a floating alert, but putting them on the bottom of the page won't cover up the titles or navigation.

![Screen Shot 2020-06-08 at 10 38 19 AM](https://user-images.githubusercontent.com/303226/84062665-891e8280-a974-11ea-8946-6cba223c8d5f.png)


closes https://github.com/grouparoo/grouparoo/issues/243