### PR TITLE
Log the version of Grouparoo and node.js at boot

### DIFF
--- a/core/api/src/server.ts
+++ b/core/api/src/server.ts
@@ -33,9 +33,13 @@ for (const i in pluginManifest.plugins) {
   }
 }
 
-import { Process } from "actionhero";
+import { Process, log } from "actionhero";
 
 async function main() {
+  log(
+    `Starting Grouparoo v${process.env.npm_package_dependencies__grouparoo_core} on node.js v${process.env.npm_config_node_version}`,
+    "notice"
+  );
   const app = new Process();
 
   app.registerProcessSignals((exitCode) => {


### PR DESCRIPTION
i.e.
> 2020-06-09T18:59:03.836Z - notice: Starting Grouparoo v^0.1.4-alpha.0 on node.js v12.16.1

This will help debugging issues that come up with community members (ie: https://github.com/grouparoo/grouparoo/issues/192)