### PR TITLE
Display streaming model logs

### DIFF
--- a/core/api/src/actions/navigation.ts
+++ b/core/api/src/actions/navigation.ts
@@ -121,7 +121,7 @@ export class NavigationList extends OptionallyAuthenticatedAction {
         platformItems.push({
           type: "link",
           title: "Logs",
-          href: "/logs",
+          href: "/logs/list",
         });
 
         platformItems.push({

--- a/core/web/components/log/stream.tsx
+++ b/core/web/components/log/stream.tsx
@@ -1,0 +1,75 @@
+import { useState, useEffect } from "react";
+import { useApi } from "../../hooks/useApi";
+import { useRealtimeModelStream } from "../../hooks/useRealtimeModelStream";
+
+import { LogAPIData } from "../../utils/apiData";
+const limit = 1000;
+
+export default function LogsList(props) {
+  const [logs, setLogs] = useState<LogAPIData[]>(props.logs);
+  const [latestTimestamp, setLatestTimestamp] = useState(0);
+
+  // websocket
+  useRealtimeModelStream("log", handleMessage);
+
+  useEffect(() => {
+    const listElement = document.getElementById("logs-stream");
+    listElement.scrollTop = listElement.scrollHeight;
+  }, [latestTimestamp]);
+
+  function handleMessage({ model }) {
+    console.log(model);
+    setLogs((logs) => {
+      logs.push(model);
+      while (logs.length > limit) logs.shift();
+      return logs;
+    });
+    setLatestTimestamp(new Date().getTime());
+  }
+
+  return (
+    <>
+      <h1>Logs Stream</h1>
+
+      <div
+        id="logs-stream"
+        style={{
+          backgroundColor: "black",
+          color: "white",
+          height: 800,
+          overflow: "auto",
+        }}
+      >
+        <ul
+          style={{
+            listStyleType: "none",
+            paddingLeft: 10,
+          }}
+        >
+          {logs.map((log) => (
+            <li key={`log-${log.guid}`}>
+              <span>[ {formatCreatedAt(log.createdAt)} ]</span>{" "}
+              <strong>
+                <a href={`/object/${log.ownerGuid}`}>
+                  {log.topic}/{log.verb}
+                </a>
+              </strong>{" "}
+              <span className="text-light">{log.message}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}
+
+LogsList.hydrate = async (ctx) => {
+  const { execApi } = useApi(ctx);
+  const { logs } = await execApi("get", `/logs`, { limit });
+  return { logs: logs.reverse() };
+};
+
+function formatCreatedAt(timestamp) {
+  const [date, time] = new Date(timestamp).toLocaleString().split(",");
+  return `${date} ${time}`;
+}

--- a/core/web/components/tabs/logs.tsx
+++ b/core/web/components/tabs/logs.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+export default function ({ active }) {
+  return (
+    <>
+      <nav className="nav nav-tabs" role="tablist">
+        <Link href="/logs/list">
+          <a
+            className={
+              active === "list"
+                ? "nav-item nav-link active"
+                : "nav-item nav-link"
+            }
+          >
+            List
+          </a>
+        </Link>
+        <Link href="/logs/stream">
+          <a
+            className={
+              active === "stream"
+                ? "nav-item nav-link active"
+                : "nav-item nav-link"
+            }
+          >
+            Stream
+          </a>
+        </Link>
+      </nav>
+      <br />
+    </>
+  );
+}

--- a/core/web/components/visualizations/totals.tsx
+++ b/core/web/components/visualizations/totals.tsx
@@ -117,6 +117,8 @@ export default function (props) {
 
   return (
     <>
+      <h2>Totals</h2>
+
       <Row>
         <Col>
           <BigNumber

--- a/core/web/pages/dashboard.tsx
+++ b/core/web/pages/dashboard.tsx
@@ -36,7 +36,6 @@ export default function Page(props) {
         <HeaderTitle title="Dashboard" />
         <h1>Dashboard</h1>
 
-        <h2>Totals</h2>
         <TotalsList {...props} />
       </>
     );

--- a/core/web/pages/logs/list.tsx
+++ b/core/web/pages/logs/list.tsx
@@ -1,0 +1,20 @@
+import Head from "next/head";
+import LogsList from "../../components/log/list";
+import LogsTabs from "../../components/tabs/logs";
+
+export default function Page(props) {
+  return (
+    <>
+      <Head>
+        <title>Grouparoo: Logs</title>
+      </Head>
+
+      <LogsTabs active="list" />
+      <LogsList {...props} />
+    </>
+  );
+}
+
+Page.getInitialProps = async (ctx) => {
+  return LogsList.hydrate(ctx);
+};

--- a/core/web/pages/logs/stream.tsx
+++ b/core/web/pages/logs/stream.tsx
@@ -1,5 +1,6 @@
 import Head from "next/head";
-import LogsList from "../components/log/list";
+import LogsStream from "../../components/log/stream";
+import LogsTabs from "../../components/tabs/logs";
 
 export default function Page(props) {
   return (
@@ -8,11 +9,12 @@ export default function Page(props) {
         <title>Grouparoo: Logs</title>
       </Head>
 
-      <LogsList {...props} />
+      <LogsTabs active="stream" />
+      <LogsStream {...props} />
     </>
   );
 }
 
 Page.getInitialProps = async (ctx) => {
-  return LogsList.hydrate(ctx);
+  return LogsStream.hydrate(ctx);
 };


### PR DESCRIPTION
Show streaming logs as they happen.  A new page under `/logs/stream`

<img width="1551" alt="Screen Shot 2020-06-09 at 2 55 04 PM" src="https://user-images.githubusercontent.com/303226/84205172-6cac4400-aa61-11ea-89bb-bbcd6bb7208c.png">
