### PR TITLE
After creating a new profile property rule, take the browser 'back' rather than /profilePropertyRules

### DIFF
--- a/core/web/pages/profilePropertyRule/[guid]/edit.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/edit.tsx
@@ -60,7 +60,7 @@ export default function Page(props) {
           response.profilePropertyRule.state === "ready" &&
           profilePropertyRule.state === "draft"
         ) {
-          Router.push(`/profilePropertyRules`);
+          Router.back();
         } else {
           successHandler.set({ message: "Profile Property Rule Updated" });
         }


### PR DESCRIPTION


closes https://github.com/grouparoo/grouparoo/issues/232