### PR TITLE
Plugin connection pool

### DIFF
--- a/core/api/__tests__/actions/schedules.ts
+++ b/core/api/__tests__/actions/schedules.ts
@@ -94,6 +94,7 @@ describe("actions/schedules", () => {
         expect(error).toBeUndefined();
         expect(schedule.guid).toBeTruthy();
         expect(schedule.name).toBe("new schedule name");
+        expect(schedule.state).toBe("draft");
       });
 
       test("an administrator can view a schedule", async () => {
@@ -116,6 +117,21 @@ describe("actions/schedules", () => {
         expect(schedule.source.app.type).toBe("test-plugin-app");
 
         expect(pluginOptions[0].key).toBe("maxColumn");
+      });
+
+      test("an schedule can be made ready", async () => {
+        connection.params = {
+          csrfToken,
+          guid,
+          options: { maxColumn: "createdAt" },
+          state: "ready",
+        };
+        const { error, schedule } = await specHelper.runAction(
+          "schedule:edit",
+          connection
+        );
+        expect(error).toBeUndefined();
+        expect(schedule.state).toBe("ready");
       });
 
       test("an administrator can request a schedule run and enqueue a runConnection task", async () => {

--- a/core/api/__tests__/models/profile.ts
+++ b/core/api/__tests__/models/profile.ts
@@ -236,7 +236,7 @@ describe("models/profile", () => {
       let source: Source;
 
       beforeAll(async () => {
-        const source = await helper.factories.source();
+        source = await helper.factories.source();
         await source.setOptions({ table: "test table" });
         await source.bootstrapUniqueProfilePropertyRule(
           "userId",
@@ -287,6 +287,7 @@ describe("models/profile", () => {
       });
 
       afterAll(async () => {
+        await source.setMapping({});
         await ProfilePropertyRule.destroy({ truncate: true });
         await source.destroy();
       });
@@ -665,8 +666,6 @@ describe("models/profile", () => {
       });
     });
   });
-
-  describe("#updateGroupMembership", () => {});
 
   describe("events", () => {
     let profile: Profile;

--- a/core/api/__tests__/tasks/profiles/importAndUpdate.ts
+++ b/core/api/__tests__/tasks/profiles/importAndUpdate.ts
@@ -127,8 +127,7 @@ describe("tasks/profile:importAndUpdate", () => {
         expect(runs.length).toBe(2);
         await runA.reload();
         await runB.reload();
-        expect(runA.profilesCreated).toBe(1);
-        expect(runB.profilesCreated).toBe(0);
+        expect(runA.profilesCreated + runB.profilesCreated).toBe(1);
         expect(runA.profilesImported).toBe(1);
         expect(runB.profilesImported).toBe(1);
         expect(runA.profilesExported).toBe(0);

--- a/core/api/__tests__/tasks/schedule/run.ts
+++ b/core/api/__tests__/tasks/schedule/run.ts
@@ -16,10 +16,21 @@ describe("tasks/schedule:run", () => {
 
   describe("schedule:run", () => {
     test("can be enqueued", async () => {
-      await task.enqueue("schedule:run", { scheduleGuid: "abc123" });
+      await task.enqueue("schedule:run", {
+        scheduleGuid: "abc123",
+        runGuid: "abc123",
+      });
       const found = await specHelper.findEnqueuedTasks("schedule:run");
       expect(found.length).toEqual(1);
       expect(found[0].timestamp).toBeNull();
+    });
+
+    test("throws without a runGuid", async () => {
+      await expect(
+        task.enqueue("schedule:run", {
+          runGuid: "abc123",
+        })
+      ).rejects.toThrow(/scheduleGuid is a required input/);
     });
   });
 });

--- a/core/api/__tests__/tasks/schedule/updateSchedules.ts
+++ b/core/api/__tests__/tasks/schedule/updateSchedules.ts
@@ -13,6 +13,7 @@ describe("tasks/schedule:updateSchedules", () => {
 
   beforeEach(async () => {
     await api.resque.queue.connection.redis.flushdb();
+    await Run.destroy({ truncate: true });
   });
 
   afterAll(async () => {

--- a/core/api/src/classes/plugin.ts
+++ b/core/api/src/classes/plugin.ts
@@ -44,6 +44,8 @@ export interface PluginApp {
   options: AppOption[];
   addible?: boolean;
   methods: {
+    connect?: ConnectPluginAppMethod;
+    disconnect?: DisconnectPluginAppMethod;
     test: TestPluginMethod;
     appOptions?: AppOptionsMethod;
   };
@@ -178,10 +180,31 @@ export interface ExportProfilePluginMethod {
 export interface ConnectionOption extends AppOption {}
 
 /**
- * Method is used to test the connection options for the app.  Returns either a boolean or throws an error to be displayed to the user
+ * Method is used to test the connection options for the app.  Returns either a boolean or throws an error to be displayed to the user.
+ * The test method will disconnect and connect before use, if those methods are present for this app type.
  */
 export interface TestPluginMethod {
   (argument: { app: App; appOptions: SimpleAppOptions }): Promise<boolean>;
+}
+
+/**
+ * This method is used to build a connection object for this App.  It will be shared with multiple sources & destinations related to this app on the same server.
+ * This is useful when your App has a kept-alive wire connection, like mySQL or Postgres, or you need an API token to reuse.
+ * The connection itself should be able to handle reconnection attempts, keep-alive, etc,
+ */
+export interface ConnectPluginAppMethod {
+  (argument: { app: App; appOptions: SimpleAppOptions }): Promise<any>;
+}
+
+/**
+ * Disconnect this app's persistent connection
+ */
+export interface DisconnectPluginAppMethod {
+  (argument: {
+    app: App;
+    appOptions: SimpleAppOptions;
+    connection: any;
+  }): Promise<void>;
 }
 
 /**

--- a/core/api/src/classes/plugin.ts
+++ b/core/api/src/classes/plugin.ts
@@ -98,6 +98,7 @@ export interface PluginConnection {
  */
 export interface ProfilesPluginMethod {
   (argument: {
+    connection: any;
     schedule: Schedule;
     app: App;
     appOptions: SimpleAppOptions;
@@ -122,6 +123,7 @@ export interface ProfilesPluginMethodResponse {
  */
 export interface ProfilePropertyPluginMethod {
   (argument: {
+    connection: any;
     app: App;
     appOptions: SimpleAppOptions;
     source: Source;
@@ -147,6 +149,7 @@ export type ProfilePropertyPluginMethodResponse =
  */
 export interface NextFilterPluginMethod {
   (argument: {
+    connection: any;
     app: App;
     appOptions: SimpleAppOptions;
     source: Source;
@@ -164,6 +167,7 @@ export interface NextFilterPluginMethod {
  */
 export interface ExportProfilePluginMethod {
   (argument: {
+    connection: any;
     app: App;
     appOptions: SimpleAppOptions;
     destination: Destination;
@@ -178,14 +182,6 @@ export interface ExportProfilePluginMethod {
 }
 
 export interface ConnectionOption extends AppOption {}
-
-/**
- * Method is used to test the connection options for the app.  Returns either a boolean or throws an error to be displayed to the user.
- * The test method will disconnect and connect before use, if those methods are present for this app type.
- */
-export interface TestPluginMethod {
-  (argument: { app: App; appOptions: SimpleAppOptions }): Promise<boolean>;
-}
 
 /**
  * This method is used to build a connection object for this App.  It will be shared with multiple sources & destinations related to this app on the same server.
@@ -208,13 +204,27 @@ export interface DisconnectPluginAppMethod {
 }
 
 /**
+ * Method is used to test the connection options for the app.  Returns either a boolean or throws an error to be displayed to the user.
+ * The test method will disconnect and connect before use, if those methods are present for this app type.
+ */
+export interface TestPluginMethod {
+  (argument: {
+    app: App;
+    appOptions: SimpleAppOptions;
+    connection: any;
+  }): Promise<boolean>;
+}
+
+/**
  * Method to return the options available to this source.
  * Returns a collection of data to display to the user.
  */
 export interface SourceOptionsMethod {
-  (argument: { app: App; appOptions: SimpleAppOptions }): Promise<
-    SourceOptionsMethodResponse
-  >;
+  (argument: {
+    connection: any;
+    app: App;
+    appOptions: SimpleAppOptions;
+  }): Promise<SourceOptionsMethodResponse>;
 }
 
 export interface SourceOptionsMethodResponse {
@@ -232,6 +242,7 @@ export interface SourceOptionsMethodResponse {
  */
 export interface SourcePreviewMethod {
   (argument: {
+    connection: any;
     app: App;
     appOptions: SimpleAppOptions;
     source: Source;
@@ -249,6 +260,7 @@ export interface SourcePreviewMethodResponseRow {
  */
 export interface SourceFilterMethod {
   (argument: {
+    connection: any;
     app: App;
     appOptions: SimpleAppOptions;
     source: Source;
@@ -270,6 +282,7 @@ export interface SourceFilterMethodResponseRow {
  */
 export interface UniqueProfilePropertyRuleBootstrapOptions {
   (argument: {
+    connection: any;
     app: App;
     appOptions: SimpleAppOptions;
     source: Source;
@@ -283,9 +296,11 @@ export interface UniqueProfilePropertyRuleBootstrapOptions {
  * Returns a collection of data to display to the user.
  */
 export interface DestinationOptionsMethod {
-  (argument: { app: App; appOptions: SimpleAppOptions }): Promise<
-    DestinationOptionsMethodResponse
-  >;
+  (argument: {
+    connection: any;
+    app: App;
+    appOptions: SimpleAppOptions;
+  }): Promise<DestinationOptionsMethodResponse>;
 }
 
 export interface DestinationOptionsMethodResponse {
@@ -301,6 +316,7 @@ export interface DestinationOptionsMethodResponse {
  */
 export interface DestinationMappingOptionsMethod {
   (argument: {
+    connection: any;
     app: App;
     appOptions: SimpleAppOptions;
     destination: Destination;

--- a/core/api/src/initializers/plugins.ts
+++ b/core/api/src/initializers/plugins.ts
@@ -19,7 +19,7 @@ export class Plugins extends Initializer {
     super();
     this.name = "plugins";
     this.loadPriority = 999;
-    this.stopPriority = 1;
+    this.stopPriority = 400;
   }
 
   async initialize() {

--- a/core/api/src/initializers/plugins.ts
+++ b/core/api/src/initializers/plugins.ts
@@ -6,6 +6,9 @@ declare module "actionhero" {
   export interface Api {
     plugins: {
       plugins: Array<GrouparooPlugin>;
+      persistentConnections: {
+        [guid: string]: any;
+      };
     };
   }
 }
@@ -20,6 +23,7 @@ export class Plugins extends Initializer {
   async initialize() {
     api.plugins = {
       plugins: [],
+      persistentConnections: {},
     };
 
     // --- Add the core plugin --- //

--- a/core/api/src/initializers/plugins.ts
+++ b/core/api/src/initializers/plugins.ts
@@ -1,6 +1,7 @@
 import { Initializer, api } from "actionhero";
 import { GrouparooPlugin } from "../classes/plugin";
 import { plugin } from "../modules/plugin";
+import { App } from "../models/App";
 
 declare module "actionhero" {
   export interface Api {
@@ -18,6 +19,7 @@ export class Plugins extends Initializer {
     super();
     this.name = "plugins";
     this.loadPriority = 999;
+    this.stopPriority = 1;
   }
 
   async initialize() {
@@ -52,5 +54,12 @@ export class Plugins extends Initializer {
         },
       ],
     });
+  }
+
+  async stop() {
+    for (const guid in api.plugins.persistentConnections) {
+      const app = await App.findByGuid(guid);
+      await app.disconnect();
+    }
   }
 }

--- a/core/api/src/initializers/plugins.ts
+++ b/core/api/src/initializers/plugins.ts
@@ -19,7 +19,7 @@ export class Plugins extends Initializer {
     super();
     this.name = "plugins";
     this.loadPriority = 999;
-    this.stopPriority = 400;
+    this.stopPriority = 299;
   }
 
   async initialize() {

--- a/core/api/src/migrations/000001-createApps.js
+++ b/core/api/src/migrations/000001-createApps.js
@@ -38,6 +38,10 @@ module.exports = {
       unique: true,
       fields: ["name"],
     });
+
+    await migration.addIndex(TABLE, ["state"], {
+      fields: ["state"],
+    });
   },
 
   down: async function (migration) {

--- a/core/api/src/migrations/000003-createDestinations.js
+++ b/core/api/src/migrations/000003-createDestinations.js
@@ -52,6 +52,10 @@ module.exports = {
     await migration.addIndex(TABLE, ["appGuid"], {
       fields: ["appGuid"],
     });
+
+    await migration.addIndex(TABLE, ["state"], {
+      fields: ["state"],
+    });
   },
 
   down: async function (migration) {

--- a/core/api/src/migrations/000009-createGroups.js
+++ b/core/api/src/migrations/000009-createGroups.js
@@ -48,6 +48,10 @@ module.exports = {
       unique: true,
       fields: ["name"],
     });
+
+    await migration.addIndex(TABLE, ["state"], {
+      fields: ["state"],
+    });
   },
 
   down: async function (migration) {

--- a/core/api/src/migrations/000010-createImports.js
+++ b/core/api/src/migrations/000010-createImports.js
@@ -101,6 +101,10 @@ module.exports = {
     await migration.addIndex(TABLE, ["profileGuid"], {
       fields: ["profileGuid"],
     });
+
+    await migration.addIndex(TABLE, ["profileUpdatedAt"], {
+      fields: ["profileUpdatedAt"],
+    });
   },
 
   down: async function (migration) {

--- a/core/api/src/migrations/000015-createProfilePropertyRules.js
+++ b/core/api/src/migrations/000015-createProfilePropertyRules.js
@@ -48,6 +48,10 @@ module.exports = {
       fields: ["key"],
       unique: true,
     });
+
+    await migration.addIndex(TABLE, ["state"], {
+      fields: ["state"],
+    });
   },
 
   down: async function (migration) {

--- a/core/api/src/migrations/000017-createRuns.js
+++ b/core/api/src/migrations/000017-createRuns.js
@@ -77,6 +77,10 @@ module.exports = {
     await migration.addIndex(TABLE, ["creatorGuid"], {
       fields: ["creatorGuid"],
     });
+
+    await migration.addIndex(TABLE, ["state"], {
+      fields: ["state"],
+    });
   },
 
   down: async function (migration) {

--- a/core/api/src/migrations/000018-createSchedules.js
+++ b/core/api/src/migrations/000018-createSchedules.js
@@ -52,6 +52,10 @@ module.exports = {
     await migration.addIndex(TABLE, ["sourceGuid"], {
       fields: ["sourceGuid"],
     });
+
+    await migration.addIndex(TABLE, ["state"], {
+      fields: ["state"],
+    });
   },
 
   down: async function (migration) {

--- a/core/api/src/migrations/000020-createSources.js
+++ b/core/api/src/migrations/000020-createSources.js
@@ -47,6 +47,10 @@ module.exports = {
     await migration.addIndex(TABLE, ["appGuid"], {
       fields: ["appGuid"],
     });
+
+    await migration.addIndex(TABLE, ["state"], {
+      fields: ["state"],
+    });
   },
 
   down: async function (migration) {

--- a/core/api/src/models/App.ts
+++ b/core/api/src/models/App.ts
@@ -230,13 +230,27 @@ export class App extends LoggedModel<App> {
     }
 
     try {
-      const connection = await this.connect(options);
+      let connection;
+      if (pluginApp.methods.connect) {
+        connection = await pluginApp.methods.connect({
+          app: this,
+          appOptions: options,
+        });
+      }
+
       result = await pluginApp.methods.test({
         app: this,
         appOptions: options,
         connection,
       });
-      await this.disconnect();
+
+      if (pluginApp.methods.disconnect) {
+        await pluginApp.methods.disconnect({
+          connection,
+          app: this,
+          appOptions: options,
+        });
+      }
     } catch (err) {
       error = err;
       result = false;

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -450,18 +450,24 @@ export class Destination extends LoggedModel<Destination> {
   async destinationConnectionOptions() {
     const { pluginConnection } = await this.getPlugin();
     const app = await this.$get("app");
+    const connection = await app.getConnection();
     const appOptions = await app.getOptions();
 
     if (!pluginConnection.methods.destinationOptions) {
       throw new Error(`cannot return destination options for ${this.type}`);
     }
 
-    return pluginConnection.methods.destinationOptions({ app, appOptions });
+    return pluginConnection.methods.destinationOptions({
+      connection,
+      app,
+      appOptions,
+    });
   }
 
   async destinationMappingOptions() {
     const { pluginConnection } = await this.getPlugin();
     const app = await this.$get("app");
+    const connection = await app.getConnection();
     const appOptions = await app.getOptions();
     const destinationOptions = await this.getOptions();
 
@@ -472,6 +478,7 @@ export class Destination extends LoggedModel<Destination> {
     }
 
     return pluginConnection.methods.destinationMappingOptions({
+      connection,
       app,
       appOptions,
       destination: this,
@@ -539,6 +546,7 @@ export class Destination extends LoggedModel<Destination> {
   ) {
     const options = await this.getOptions();
     const app = await this.$get("app");
+    const connection = await app.getConnection();
     let method: ExportProfilePluginMethod;
     const { pluginConnection } = await this.getPlugin();
     method = pluginConnection.methods.exportProfile;
@@ -611,6 +619,7 @@ export class Destination extends LoggedModel<Destination> {
       await _export.associateImports(imports);
 
       const success = await method({
+        connection,
         app,
         appOptions,
         destination: this,

--- a/core/api/src/models/Profile.ts
+++ b/core/api/src/models/Profile.ts
@@ -233,9 +233,11 @@ export class Profile extends LoggedModel<Profile> {
 
     let hash = {};
     const sources = await Source.findAll({ where: { state: "ready" } });
-    for (const i in sources) {
-      hash = Object.assign(hash, await sources[i].import(this));
-    }
+    await Promise.all(
+      sources.map((source) =>
+        source.import(this).then((data) => (hash = Object.assign(hash, data)))
+      )
+    );
 
     if (toSave) {
       await this.addOrUpdateProperties(hash);

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -378,8 +378,10 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
     }
 
     const response = OptionHelper.validateOptions(this, options, allowEmpty);
-    client.set(cacheKey, "true"); // do not await
-    client.expire(cacheKey, CACHE_TTL / 1000);
+    if (CACHE_TTL > 0) {
+      await client.set(cacheKey, "true");
+      await client.expire(cacheKey, CACHE_TTL / 1000);
+    }
     return response;
   }
 

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -134,6 +134,7 @@ export interface PluginConnectionProfilePropertyRuleOption {
   description: string;
   type: string;
   options: (argument: {
+    connection: any;
     app: App;
     appOptions: SimpleAppOptions;
     source: Source;
@@ -417,6 +418,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
       }>;
     }> = [];
     const app = await App.findByGuid(source.appGuid);
+    const connection = await app.getConnection();
     const appOptions = await app.getOptions();
     const sourceOptions = await source.getOptions();
     const sourceMapping = await source.getMapping();
@@ -424,6 +426,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
     for (const i in pluginConnection.profilePropertyRuleOptions) {
       const opt = pluginConnection.profilePropertyRuleOptions[i];
       const options = await opt.options({
+        connection,
         app,
         appOptions,
         source,
@@ -503,10 +506,12 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
     const sourceOptions = await source.getOptions();
     const sourceMapping = await source.getMapping();
     const app = await App.findByGuid(source.appGuid);
+    const connection = await app.getConnection();
     const appOptions = await app.getOptions();
 
     const method = pluginConnection.methods.sourceFilters;
     const options = await method({
+      connection,
       app,
       appOptions,
       source,

--- a/core/api/src/models/Run.ts
+++ b/core/api/src/models/Run.ts
@@ -235,6 +235,7 @@ export class Run extends Model<Run> {
 
     const source = await Source.findByGuid(schedule.sourceGuid);
     const app = await App.findByGuid(source.appGuid);
+    const connection = await app.getConnection();
     const { pluginConnection } = await source.getPlugin();
     if (!pluginConnection || !pluginConnection?.methods.nextFilter) {
       return nextFilter;
@@ -246,6 +247,7 @@ export class Run extends Model<Run> {
     const scheduleOptions = await schedule.getOptions();
 
     return pluginConnection.methods.nextFilter({
+      connection,
       app,
       appOptions,
       source,

--- a/core/api/src/models/Schedule.ts
+++ b/core/api/src/models/Schedule.ts
@@ -35,6 +35,7 @@ export interface PluginConnectionScheduleOption {
   description: string;
   type: string;
   options: (argument: {
+    connection: any;
     app: App;
     appOptions: SimpleAppOptions;
     source: Source;
@@ -248,6 +249,7 @@ export class Schedule extends LoggedModel<Schedule> {
     }
 
     const app = await source.$get("app");
+    const connection = await app.getConnection();
     const appOptions = await app.getOptions();
     const sourceOptions = await source.getOptions();
     const sourceMapping = await source.getMapping();
@@ -255,6 +257,7 @@ export class Schedule extends LoggedModel<Schedule> {
     for (const i in pluginConnection.scheduleOptions) {
       const opt = pluginConnection.scheduleOptions[i];
       const options = await opt.options({
+        connection,
         app,
         appOptions,
         source,
@@ -313,6 +316,7 @@ export class Schedule extends LoggedModel<Schedule> {
     const sourceOptions = await source.getOptions();
     const sourceMapping = await source.getMapping();
     await app.validateOptions(appOptions);
+    const connection = await app.getConnection();
     await source.validateOptions(sourceOptions);
 
     let filter = {};
@@ -327,6 +331,7 @@ export class Schedule extends LoggedModel<Schedule> {
     try {
       const response = await method({
         schedule: this,
+        connection,
         app,
         appOptions,
         source,

--- a/core/api/src/models/Schedule.ts
+++ b/core/api/src/models/Schedule.ts
@@ -295,9 +295,20 @@ export class Schedule extends LoggedModel<Schedule> {
   }
 
   async enqueueRun() {
+    const run = await Run.create({
+      creatorGuid: this.guid,
+      creatorType: "schedule",
+      state: "running",
+    });
+
+    log(
+      `[ run ] starting run ${run.guid} for schedule ${this.guid}, ${this.name}`,
+      "notice"
+    );
+
     await task.enqueue(
       "schedule:run",
-      { scheduleGuid: this.guid },
+      { scheduleGuid: this.guid, runGuid: run.guid },
       "schedules"
     );
   }

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -357,7 +357,8 @@ export class Source extends LoggedModel<Source> {
 
     await profilePropertyRule.validateOptions(
       profilePropertyRuleOptionsOverride,
-      false
+      false,
+      true
     );
 
     const { pluginConnection } = await this.getPlugin();
@@ -431,17 +432,17 @@ export class Source extends LoggedModel<Source> {
       profileProperties,
     };
 
-    for (const i in rules) {
-      const rule = rules[i];
-      const response = await this.importProfileProperty(
-        profile,
-        rule,
-        null,
-        null,
-        preloadedArgs
-      );
-      hash[rule.key] = response;
-    }
+    await Promise.all(
+      rules.map((rule) =>
+        this.importProfileProperty(
+          profile,
+          rule,
+          null,
+          null,
+          preloadedArgs
+        ).then((response) => (hash[rule.key] = response))
+      )
+    );
 
     // remove null and undefined as we cannot set that value
     const hashKeys = Object.keys(hash);

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -415,14 +415,20 @@ export class Source extends LoggedModel<Source> {
       where: { state: "ready" },
     });
 
+    const profileProperties = await profile.properties();
     const app = await this.$get("app");
+    const appOptions = await app.getOptions();
+    const connection = await app.getConnection();
+    const sourceOptions = await this.getOptions();
+    const sourceMapping = await this.getMapping();
+
     const preloadedArgs = {
       app,
-      connection: await app.getConnection(),
-      appOptions: await app.getOptions(),
-      sourceOptions: await this.getOptions(),
-      sourceMapping: await this.getMapping(),
-      profileProperties: await profile.properties(),
+      connection,
+      appOptions,
+      sourceOptions,
+      sourceMapping,
+      profileProperties,
     };
 
     for (const i in rules) {

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -225,13 +225,18 @@ export class Source extends LoggedModel<Source> {
   async sourceConnectionOptions() {
     const { pluginConnection } = await this.getPlugin();
     const app = await this.$get("app");
+    const connection = await app.getConnection();
     const appOptions = await app.getOptions();
 
     if (!pluginConnection.methods.sourceOptions) {
       return {};
     }
 
-    return pluginConnection.methods.sourceOptions({ app, appOptions });
+    return pluginConnection.methods.sourceOptions({
+      connection,
+      app,
+      appOptions,
+    });
   }
 
   async sourcePreview(sourceOptions?: SimpleSourceOptions) {
@@ -248,6 +253,7 @@ export class Source extends LoggedModel<Source> {
 
     const { pluginConnection } = await this.getPlugin();
     const app = await this.$get("app");
+    const connection = await app.getConnection();
     const appOptions = await app.getOptions();
 
     if (!pluginConnection.methods.sourcePreview) {
@@ -255,6 +261,7 @@ export class Source extends LoggedModel<Source> {
     }
 
     return pluginConnection.methods.sourcePreview({
+      connection,
       app,
       appOptions,
       source: this,
@@ -359,6 +366,7 @@ export class Source extends LoggedModel<Source> {
     }
 
     const app = await this.$get("app");
+    const connection = await app.getConnection();
     const appOptions = await app.getOptions();
     const sourceOptions = await this.getOptions();
     const sourceMapping = await this.getMapping();
@@ -373,6 +381,7 @@ export class Source extends LoggedModel<Source> {
     }
 
     return method({
+      connection,
       app,
       appOptions,
       source: this,
@@ -446,11 +455,13 @@ export class Source extends LoggedModel<Source> {
           .uniqueProfilePropertyRuleBootstrapOptions === "function"
       ) {
         const app = await this.$get("app");
+        const connection = await app.getConnection();
         const appOptions = await app.getOptions();
         const options = await this.getOptions();
         const ruleOptions = await pluginConnection.methods.uniqueProfilePropertyRuleBootstrapOptions(
           {
             app,
+            connection,
             appOptions,
             source: this,
             sourceOptions: options,

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -20,7 +20,7 @@ import { LoggedModel } from "../classes/loggedModel";
 import { Schedule } from "./Schedule";
 import { ProfilePropertyRule } from "./ProfilePropertyRule";
 import { Option } from "./Option";
-import { App } from "./App";
+import { App, AppOption } from "./App";
 import { Run } from "./Run";
 import { Profile } from "./Profile";
 import { Mapping } from "./Mapping";
@@ -338,7 +338,15 @@ export class Source extends LoggedModel<Source> {
     profile: Profile,
     profilePropertyRule: ProfilePropertyRule,
     profilePropertyRuleOptionsOverride?: OptionHelper.SimpleOptions,
-    profilePropertyRuleFiltersOverride?: ProfilePropertyRuleFiltersWithKey[]
+    profilePropertyRuleFiltersOverride?: ProfilePropertyRuleFiltersWithKey[],
+    preloadedArgs: {
+      app?: App;
+      connection?: any;
+      appOptions?: OptionHelper.SimpleOptions;
+      sourceOptions?: OptionHelper.SimpleOptions;
+      sourceMapping?: MappingHelper.Mappings;
+      profileProperties?: {};
+    } = {}
   ) {
     if (
       profilePropertyRule.state !== "ready" &&
@@ -365,16 +373,19 @@ export class Source extends LoggedModel<Source> {
       return;
     }
 
-    const app = await this.$get("app");
-    const connection = await app.getConnection();
-    const appOptions = await app.getOptions();
-    const sourceOptions = await this.getOptions();
-    const sourceMapping = await this.getMapping();
+    const app = preloadedArgs.app || (await this.$get("app"));
+    const connection = preloadedArgs.connection || (await app.getConnection());
+    const appOptions = preloadedArgs.appOptions || (await app.getOptions());
+    const sourceOptions =
+      preloadedArgs.sourceOptions || (await this.getOptions());
+    const sourceMapping =
+      preloadedArgs.sourceMapping || (await this.getMapping());
 
     // we may not have the profile property needed to make the mapping (ie: userId is not set on this anonymous profile)
     if (Object.values(sourceMapping).length > 0) {
       const profilePropertyRuleMappingKey = Object.values(sourceMapping)[0];
-      const profileProperties = await profile.properties();
+      const profileProperties =
+        preloadedArgs.profileProperties || (await profile.properties());
       if (!profileProperties[profilePropertyRuleMappingKey]) {
         return;
       }
@@ -404,9 +415,25 @@ export class Source extends LoggedModel<Source> {
       where: { state: "ready" },
     });
 
+    const app = await this.$get("app");
+    const preloadedArgs = {
+      app,
+      connection: await app.getConnection(),
+      appOptions: await app.getOptions(),
+      sourceOptions: await this.getOptions(),
+      sourceMapping: await this.getMapping(),
+      profileProperties: await profile.properties(),
+    };
+
     for (const i in rules) {
       const rule = rules[i];
-      const response = await this.importProfileProperty(profile, rule);
+      const response = await this.importProfileProperty(
+        profile,
+        rule,
+        null,
+        null,
+        preloadedArgs
+      );
       hash[rule.key] = response;
     }
 

--- a/core/api/src/modules/mappingHelper.ts
+++ b/core/api/src/modules/mappingHelper.ts
@@ -19,7 +19,9 @@ export namespace MappingHelper {
       const mapping = mappings[i];
       const rule = await mapping.$get("profilePropertyRule");
       if (!rule) {
-        throw new Error(`cannot find profile property rule or it is not ready`);
+        throw new Error(
+          `cannot find profile property rule or this source/destination not ready (remoteKey: ${mapping.remoteKey})`
+        );
       }
       MappingObject[mapping.remoteKey] = rule.key;
     }

--- a/core/api/src/tasks/schedule/run.ts
+++ b/core/api/src/tasks/schedule/run.ts
@@ -12,7 +12,7 @@ export class ScheduleRun extends Task {
     this.queue = "schedules";
     this.inputs = {
       scheduleGuid: { required: true },
-      runGuid: { required: false },
+      runGuid: { required: true },
       limit: { required: false },
       highWaterMark: { required: false },
     };
@@ -31,21 +31,7 @@ export class ScheduleRun extends Task {
       throw new Error(`schedule ${params.scheduleGuid} is not ready`);
     }
 
-    let run: Run;
-    if (params.runGuid) {
-      run = await Run.findByGuid(params.runGuid);
-    } else {
-      run = await Run.create({
-        creatorGuid: schedule.guid,
-        creatorType: "schedule",
-        state: "running",
-      });
-
-      log(
-        `[ run ] starting run ${run.guid} for schedule ${schedule.guid}, ${schedule.name}`,
-        "notice"
-      );
-    }
+    const run = await Run.findByGuid(params.runGuid);
 
     const { importsCount, nextHighWaterMark } = await schedule.run(
       run,

--- a/core/api/src/tasks/schedule/updateSchedules.ts
+++ b/core/api/src/tasks/schedule/updateSchedules.ts
@@ -1,4 +1,4 @@
-import { Task, task } from "actionhero";
+import { Task, task, log } from "actionhero";
 import { Schedule } from "../../models/Schedule";
 import { Run } from "../../models/Run";
 
@@ -50,7 +50,21 @@ export class UpdateSchedules extends Task {
       }
 
       if (!lastCompleteRun || delta > schedule.recurringFrequency) {
-        await task.enqueue("schedule:run", { scheduleGuid: schedule.guid });
+        const run = await Run.create({
+          creatorGuid: schedule.guid,
+          creatorType: "schedule",
+          state: "running",
+        });
+
+        await task.enqueue("schedule:run", {
+          scheduleGuid: schedule.guid,
+          runGuid: run.guid,
+        });
+
+        log(
+          `[ run ] starting run ${run.guid} for schedule ${schedule.guid}, ${schedule.name}`,
+          "notice"
+        );
       }
     }
   }

--- a/core/web/components/runs/list.tsx
+++ b/core/web/components/runs/list.tsx
@@ -1,5 +1,5 @@
 import { useApi } from "../../hooks/useApi";
-import { Fragment, useState } from "react";
+import { Fragment, useState, useEffect } from "react";
 import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
 import { useHistoryPagination } from "../../hooks/useHistoryPagination";
 import { Row, Col, ButtonGroup, Button, Alert } from "react-bootstrap";
@@ -12,7 +12,7 @@ import RunDurationChart from "../visualizations/runDurations";
 import { RunAPIData } from "../../utils/apiData";
 
 export default function RunsList(props) {
-  const { errorHandler, query } = props;
+  const { errorHandler, runsHandler, query } = props;
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);
   const [total, setTotal] = useState(props.total);
@@ -28,6 +28,13 @@ export default function RunsList(props) {
   useSecondaryEffect(() => {
     load();
   }, [limit, offset, stateFilter, errorFilter]);
+
+  useEffect(() => {
+    runsHandler.subscribe("runs-list", load);
+    return () => {
+      runsHandler.unsubscribe("runs-list");
+    };
+  }, []);
 
   async function load() {
     const params = { limit, offset };

--- a/core/web/pages/_app.tsx
+++ b/core/web/pages/_app.tsx
@@ -15,6 +15,7 @@ import { TeamHandler } from "../utils/teamHandler";
 import { TeamMemberHandler } from "../utils/teamMembersHandler";
 import { AppHandler } from "../utils/appHandler";
 import { GroupHandler } from "../utils/groupHandler";
+import { RunsHandler } from "../utils/runsHandler";
 import { SourceHandler } from "../utils/sourceHandler";
 import { DestinationHandler } from "../utils/destinationHandler";
 import { ProfileHandler } from "../utils/profileHandler";
@@ -30,6 +31,7 @@ const teamHandler = new TeamHandler();
 const teamMemberHandler = new TeamMemberHandler();
 const appHandler = new AppHandler();
 const groupHandler = new GroupHandler();
+const runsHandler = new RunsHandler();
 const sourceHandler = new SourceHandler();
 const destinationHandler = new DestinationHandler();
 const profileHandler = new ProfileHandler();
@@ -64,6 +66,7 @@ export default function GrouparooWebApp(props) {
     teamMemberHandler,
     appHandler,
     groupHandler,
+    runsHandler,
     sourceHandler,
     destinationHandler,
     profileHandler,

--- a/core/web/pages/destination/new.tsx
+++ b/core/web/pages/destination/new.tsx
@@ -19,8 +19,7 @@ export default function Page(props) {
     const response = await execApi("post", `/destination`, destination);
     if (response?.destination) {
       Router.push({
-        pathname: `/destination/${response.destination.guid}`,
-        query: { tab: "edit" },
+        pathname: `/destination/${response.destination.guid}/edit`,
       });
     }
   };

--- a/core/web/pages/source/[guid]/runs.tsx
+++ b/core/web/pages/source/[guid]/runs.tsx
@@ -6,7 +6,7 @@ import SourceTabs from "../../../components/tabs/source";
 import { Button } from "react-bootstrap";
 
 export default function Page(props) {
-  const { errorHandler, successHandler, source } = props;
+  const { errorHandler, successHandler, runsHandler, source } = props;
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);
 
@@ -15,6 +15,7 @@ export default function Page(props) {
     try {
       await execApi("post", `/schedule/${source.schedule.guid}/run`);
       successHandler.set({ message: "run enqueued" });
+      runsHandler.set({});
     } finally {
       setLoading(false);
     }

--- a/core/web/utils/runsHandler.ts
+++ b/core/web/utils/runsHandler.ts
@@ -1,0 +1,3 @@
+import { EventDispatcher } from "./eventDispatcher";
+
+export class RunsHandler extends EventDispatcher {}

--- a/plugins/@grouparoo/bigquery/__tests__/query-import/import-property.ts
+++ b/plugins/@grouparoo/bigquery/__tests__/query-import/import-property.ts
@@ -12,6 +12,7 @@ process.chdir(`${__dirname}/../../../../../core/api`);
 import path from "path";
 
 import { profileProperty } from "../../src/lib/query-import/profileProperty";
+import { connect } from "../../src/lib/connect";
 
 import { loadAppOptions, updater } from "../utils/nockHelper";
 import { helper } from "../../../../../core/api/__tests__/utils/specHelper";
@@ -39,7 +40,10 @@ let actionhero;
 
 async function getPropertyValue(query: string) {
   const profilePropertyRuleOptions = { query };
+  const connection = await connect({ appOptions, app: null });
+
   return profileProperty({
+    connection,
     appOptions,
     profile,
     profilePropertyRuleOptions,

--- a/plugins/@grouparoo/bigquery/__tests__/table-import/import-property.ts
+++ b/plugins/@grouparoo/bigquery/__tests__/table-import/import-property.ts
@@ -12,6 +12,7 @@ process.chdir(`${__dirname}/../../../../../core/api`);
 import path from "path";
 
 import { profileProperty } from "../../src/lib/table-import/profileProperty";
+import { connect } from "../../src/lib/connect";
 
 import { loadAppOptions, updater } from "../utils/nockHelper";
 import { helper } from "../../../../../core/api/__tests__/utils/specHelper";
@@ -53,8 +54,10 @@ async function getPropertyValue(
   }
 
   const profilePropertyRuleFilters = useProfilePropertyRuleFilters || [];
+  const connection = await connect({ appOptions, app: null });
 
   return profileProperty({
+    connection,
     appOptions,
     profile: useProfile,
     sourceOptions,

--- a/plugins/@grouparoo/bigquery/__tests__/table-import/next-filter.ts
+++ b/plugins/@grouparoo/bigquery/__tests__/table-import/next-filter.ts
@@ -12,6 +12,7 @@ process.chdir(`${__dirname}/../../../../../core/api`);
 import path from "path";
 
 import { nextFilter } from "../../src/lib/table-import/nextFilter";
+import { connect } from "../../src/lib/connect";
 
 import { loadAppOptions, updater } from "../utils/nockHelper";
 import { helper } from "../../../../../core/api/__tests__/utils/specHelper";
@@ -36,7 +37,9 @@ const appOptions: SimpleAppOptions = loadAppOptions(newNock);
 const sourceOptions = { table: "purchases" };
 
 async function runIt({ scheduleOptions }) {
+  const connection = await connect({ appOptions, app: null });
   const response = await nextFilter({
+    connection,
     appOptions,
     sourceOptions,
     scheduleOptions,

--- a/plugins/@grouparoo/bigquery/__tests__/table-import/profiles.ts
+++ b/plugins/@grouparoo/bigquery/__tests__/table-import/profiles.ts
@@ -12,6 +12,7 @@ process.chdir(`${__dirname}/../../../../../core/api`);
 import path from "path";
 
 import { profiles } from "../../src/lib/table-import/profiles";
+import { connect } from "../../src/lib/connect";
 
 import { loadAppOptions, updater } from "../utils/nockHelper";
 import { helper } from "../../../../../core/api/__tests__/utils/specHelper";
@@ -46,7 +47,9 @@ async function runIt({ filter, highWaterMark, limit }) {
     imports.push(row);
     return null;
   });
+  const connection = await connect({ appOptions, app: null });
   const { nextHighWaterMark, importsCount } = await profiles({
+    connection,
     run,
     appOptions,
     sourceMapping,

--- a/plugins/@grouparoo/bigquery/__tests__/table-import/schedule-options.ts
+++ b/plugins/@grouparoo/bigquery/__tests__/table-import/schedule-options.ts
@@ -12,6 +12,7 @@ process.chdir(`${__dirname}/../../../../../core/api`);
 import path from "path";
 
 import { scheduleOptions } from "../../src/lib/table-import/scheduleOptions";
+import { connect } from "../../src/lib/connect";
 
 import { loadAppOptions, updater } from "../utils/nockHelper";
 import { helper } from "../../../../../core/api/__tests__/utils/specHelper";
@@ -38,8 +39,10 @@ const sourceOptions = { table: "purchases" };
 async function getColumns() {
   const columnOption = scheduleOptions[0];
   const optionMethod = columnOption.options;
+  const connection = await connect({ appOptions, app: null });
 
   const response = await optionMethod({
+    connection,
     appOptions,
     sourceOptions,
     app: null,

--- a/plugins/@grouparoo/bigquery/__tests__/table-import/source-filters.ts
+++ b/plugins/@grouparoo/bigquery/__tests__/table-import/source-filters.ts
@@ -12,6 +12,7 @@ process.chdir(`${__dirname}/../../../../../core/api`);
 import path from "path";
 
 import { sourceFilters } from "../../src/lib/table-import/sourceFilters";
+import { connect } from "../../src/lib/connect";
 
 import { loadAppOptions, updater } from "../utils/nockHelper";
 import { helper } from "@grouparoo/core/api/__tests__/utils/specHelper";
@@ -36,7 +37,9 @@ const appOptions: SimpleAppOptions = loadAppOptions(newNock);
 const sourceOptions = { table: "purchases" };
 
 async function getFilters() {
+  const connection = await connect({ appOptions, app: null });
   const response = await sourceFilters({
+    connection,
     appOptions,
     sourceOptions,
     app: null,

--- a/plugins/@grouparoo/bigquery/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/bigquery/src/initializers/plugin.ts
@@ -1,6 +1,8 @@
 import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
+import { connect } from "./../lib/connect";
+import { disconnect } from "./../lib/disconnect";
 import { test } from "./../lib/test";
 
 import { sourcePreview as tableSourcePreview } from "../lib/table-import/sourcePreview";
@@ -59,7 +61,7 @@ export class Plugins extends Initializer {
               placeholder: "e.g. -----BEGIN PRIVATE KEY-----\nMII ...",
             },
           ],
-          methods: { test },
+          methods: { test, connect, disconnect },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/bigquery/src/lib/connect.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/connect.ts
@@ -1,14 +1,15 @@
 import { BigQuery } from "@google-cloud/bigquery";
-import { SimpleAppOptions } from "@grouparoo/core";
+import { ConnectPluginAppMethod } from "@grouparoo/core";
 
-export async function connect(options: SimpleAppOptions) {
-  const projectId = options.project_id || "";
-  const dataset = options.dataset || "";
-  const client_email = options.client_email || "";
-  const private_key = (options.private_key || "").replace(/\\n/g, "\n");
+export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
+  const projectId = appOptions.project_id || "";
+  const dataset = appOptions.dataset || "";
+  const client_email = appOptions.client_email || "";
+  const private_key = (appOptions.private_key || "").replace(/\\n/g, "\n");
   const client = new BigQuery({
     projectId,
     credentials: { client_email, private_key },
   });
+
   return client.dataset(dataset);
-}
+};

--- a/plugins/@grouparoo/bigquery/src/lib/disconnect.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/disconnect.ts
@@ -1,0 +1,5 @@
+import { DisconnectPluginAppMethod } from "@grouparoo/core";
+
+export const disconnect: DisconnectPluginAppMethod = async ({ connection }) => {
+  // nothing to do?
+};

--- a/plugins/@grouparoo/bigquery/src/lib/query-import/profileProperty.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/query-import/profileProperty.ts
@@ -1,4 +1,3 @@
-import { connect } from "../connect";
 import { validateQuery } from "../validateQuery";
 import {
   ProfilePropertyPluginMethod,
@@ -7,8 +6,8 @@ import {
 } from "@grouparoo/core";
 
 export const profileProperty: ProfilePropertyPluginMethod = async ({
+  connection,
   profile,
-  appOptions,
   profilePropertyRuleOptions,
 }) => {
   const parameterizedQuery = await plugin.replaceTemplateProfileVariables(
@@ -18,14 +17,13 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
   validateQuery(parameterizedQuery);
 
   let response: ProfilePropertyPluginMethodResponse;
-  const bigqueryClient = await connect(appOptions);
   try {
     const options = {
       query: parameterizedQuery,
     };
 
     // Run the query
-    const [rows] = await bigqueryClient.query(options);
+    const [rows] = await connection.query(options);
 
     // Get the results
     if (rows && rows.length > 0) {

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/nextFilter.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/nextFilter.ts
@@ -1,4 +1,3 @@
-import { connect } from "../connect";
 import { NextFilterPluginMethod } from "@grouparoo/core";
 
 export function getFilterValue(result) {
@@ -19,7 +18,7 @@ export function getFilterValue(result) {
 }
 
 export const nextFilter: NextFilterPluginMethod = async ({
-  appOptions,
+  connection,
   sourceOptions,
   scheduleOptions,
 }) => {
@@ -32,9 +31,8 @@ export const nextFilter: NextFilterPluginMethod = async ({
   const { column } = scheduleOptions;
   const query = `SELECT MAX(\`${column}\`) AS \`max\` FROM \`${table}\``;
 
-  const client = await connect(appOptions);
   const options = { query };
-  const [rows] = await client.query(options);
+  const [rows] = await connection.query(options);
 
   if (rows.length === 0) {
     return filter;

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/profileProperty.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/profileProperty.ts
@@ -1,4 +1,3 @@
-import { connect } from "../connect";
 import { validateQuery } from "../validateQuery";
 import { getColumns, makeWhereClause, castValue } from "../util";
 
@@ -8,8 +7,8 @@ import {
 } from "@grouparoo/core";
 
 export const profileProperty: ProfilePropertyPluginMethod = async ({
+  connection,
   profile,
-  appOptions,
   sourceOptions,
   sourceMapping,
   profilePropertyRuleOptions,
@@ -30,8 +29,7 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
     return;
   }
 
-  const client = await connect(appOptions);
-  const columns = await getColumns(client, table);
+  const columns = await getColumns(connection, table);
   const profileData = await profile.properties();
 
   if (!profileData.hasOwnProperty(profilePropertyMatch)) {
@@ -124,7 +122,7 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
 
   let response: ProfilePropertyPluginMethodResponse;
   try {
-    const [rows] = await client.query(options);
+    const [rows] = await connection.query(options);
     if (rows && rows.length > 0) {
       const row: { [key: string]: any } = rows[0];
       response = castValue(row.__result);

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/profilePropertyRuleOptions.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/profilePropertyRuleOptions.ts
@@ -1,5 +1,4 @@
 import { PluginConnectionProfilePropertyRuleOption } from "@grouparoo/core";
-import { connect } from "../connect";
 import { getSampleRows } from "../util";
 
 export const profilePropertyRuleOptions: PluginConnectionProfilePropertyRuleOption[] = [
@@ -8,9 +7,8 @@ export const profilePropertyRuleOptions: PluginConnectionProfilePropertyRuleOpti
     required: true,
     description: "where the data comes from",
     type: "typeahead",
-    options: async ({ appOptions, sourceOptions }) => {
-      const client = await connect(appOptions);
-      const rows = await getSampleRows(client, sourceOptions.table);
+    options: async ({ connection, sourceOptions }) => {
+      const rows = await getSampleRows(connection, sourceOptions.table);
       const columns = Object.keys(rows[0]);
       return columns.map((col) => {
         return {

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/profiles.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/profiles.ts
@@ -1,12 +1,11 @@
-import { connect } from "../connect";
 import { validateQuery } from "../validateQuery";
 import { plugin, ProfilesPluginMethod } from "@grouparoo/core";
 import { getColumns, makeWhereClause, castRow } from "../util";
 
 export const profiles: ProfilesPluginMethod = async ({
+  connection,
   schedule,
   run,
-  appOptions,
   sourceMapping,
   source,
   limit,
@@ -23,8 +22,7 @@ export const profiles: ProfilesPluginMethod = async ({
   const filterCol = hasFilter ? Object.keys(filter)[0] : null;
   const filterVal = hasFilter ? Object.values(filter)[0] : null;
 
-  const client = await connect(appOptions);
-  const columns = await getColumns(client, table);
+  const columns = await getColumns(connection, table);
 
   const params = [];
   const types = [];
@@ -47,7 +45,7 @@ export const profiles: ProfilesPluginMethod = async ({
   validateQuery(query);
 
   const options = { query, params, types };
-  const [rows] = await client.query(options);
+  const [rows] = await connection.query(options);
   for (const row of rows) {
     const result = castRow(row);
     await plugin.createImport(sourceMapping, run, result);

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/scheduleOptions.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/scheduleOptions.ts
@@ -1,5 +1,4 @@
 import { PluginConnectionScheduleOption } from "@grouparoo/core";
-import { connect } from "../connect";
 import { getColumns, supportedEquality, getSampleRows } from "../util";
 
 export const scheduleOptions: PluginConnectionScheduleOption[] = [
@@ -8,11 +7,10 @@ export const scheduleOptions: PluginConnectionScheduleOption[] = [
     required: true,
     description: "which column to scan for changes",
     type: "list",
-    options: async ({ appOptions, sourceOptions }) => {
+    options: async ({ connection, sourceOptions }) => {
       const { table } = sourceOptions;
-      const client = await connect(appOptions);
-      const columns = await getColumns(client, table);
-      const rows = await getSampleRows(client, table, columns);
+      const columns = await getColumns(connection, table);
+      const rows = await getSampleRows(connection, table, columns);
 
       // only handle columns that support >=
       const choices = [];

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/sourceFilters.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/sourceFilters.ts
@@ -1,14 +1,13 @@
 import { SourceFilterMethod } from "@grouparoo/core";
-import { connect } from "../connect";
 import { getColumns, supportedEquality } from "../util";
 
 export const sourceFilters: SourceFilterMethod = async ({
+  connection,
   sourceOptions,
   appOptions,
 }) => {
   const { table } = sourceOptions;
-  const client = await connect(appOptions);
-  const columns = await getColumns(client, table);
+  const columns = await getColumns(connection, table);
 
   const options = [];
 

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/sourceOptions.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/sourceOptions.ts
@@ -1,14 +1,11 @@
-import { connect } from "../connect";
 import { SourceOptionsMethod } from "@grouparoo/core";
 
-export const sourceOptions: SourceOptionsMethod = async ({ appOptions }) => {
+export const sourceOptions: SourceOptionsMethod = async ({ connection }) => {
   const response = {
     table: { type: "list", options: [] },
   };
 
-  const client = await connect(appOptions);
-
-  const [tables] = await client.getTables();
+  const [tables] = await connection.getTables();
   for (const i in tables) {
     const tableName = tables[i].id;
     response.table.options.push(tableName);

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/sourcePreview.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/sourcePreview.ts
@@ -1,11 +1,9 @@
-import { connect } from "../connect";
 import { getSampleRows } from "../util";
 import { SourcePreviewMethod } from "@grouparoo/core";
 
 export const sourcePreview: SourcePreviewMethod = async ({
-  appOptions,
+  connection,
   sourceOptions,
 }) => {
-  const client = await connect(appOptions);
-  return await getSampleRows(client, sourceOptions.table);
+  return await getSampleRows(connection, sourceOptions.table);
 };

--- a/plugins/@grouparoo/bigquery/src/lib/test.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/test.ts
@@ -1,11 +1,9 @@
-import { connect } from "./connect";
 import { TestPluginMethod } from "@grouparoo/core";
 
-export const test: TestPluginMethod = async ({ appOptions }) => {
-  const client = await connect(appOptions);
+export const test: TestPluginMethod = async ({ connection }) => {
   const query = 'SELECT "grouparoo" as message';
   const options = { query };
-  const response = await client.query(options);
+  const response = await connection.query(options);
   const isValid = response[0][0].message === "grouparoo";
   return isValid;
 };

--- a/plugins/@grouparoo/bigquery/src/lib/util.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/util.ts
@@ -2,7 +2,7 @@ import { BigQuery } from "@google-cloud/bigquery";
 import { validateQuery } from "./validateQuery";
 
 export async function getColumns(
-  client,
+  connection,
   tableName: string
 ): Promise<{ [colName: string]: any }> {
   const query = `SELECT column_name, data_type FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = @tableName`;
@@ -14,7 +14,7 @@ export async function getColumns(
   };
 
   // Run the query
-  const [rows] = await client.query(options);
+  const [rows] = await connection.query(options);
   const response = {};
   for (const row of rows) {
     response[row.column_name] = row;
@@ -139,7 +139,7 @@ export function castValue(value) {
 }
 
 export async function getSampleRows(
-  client,
+  connection,
   tableName,
   columns?
 ): Promise<Array<{ [colName: string]: any }>> {
@@ -148,7 +148,7 @@ export async function getSampleRows(
   validateQuery(query);
 
   const options = { query };
-  const [rows] = await client.query(options);
+  const [rows] = await connection.query(options);
 
   const response = [];
   if (rows.length > 0) {
@@ -156,7 +156,7 @@ export async function getSampleRows(
   } else {
     // use columns for preview
     if (!columns) {
-      columns = await getColumns(client, tableName);
+      columns = await getColumns(connection, tableName);
       const sample = {};
       Object.keys(columns).forEach((colName) => {
         sample[colName] = castValue(null);

--- a/plugins/@grouparoo/csv/__tests__/integration/csv.ts
+++ b/plugins/@grouparoo/csv/__tests__/integration/csv.ts
@@ -253,7 +253,13 @@ describe("integration/runs/csv", () => {
         expect(found[0].args[0].scheduleGuid).toBe(schedule.guid);
 
         // run the schedule
+        const run = await Run.create({
+          creatorGuid: schedule.guid,
+          creatorType: "schedule",
+          state: "running",
+        });
         await specHelper.runTask("schedule:run", {
+          runGuid: run.guid,
           scheduleGuid: schedule.guid,
         });
 
@@ -317,11 +323,7 @@ describe("integration/runs/csv", () => {
         const profilesCount = await Profile.count();
         expect(profilesCount).toBe(10);
 
-        const run = await Run.findOne({
-          where: { creatorGuid: schedule.guid },
-          order: [["createdAt", "desc"]],
-          limit: 1,
-        });
+        await run.reload();
         expect(run.state).toBe("complete");
         expect(run.importsCreated).toBe(10);
         expect(run.profilesCreated).toBe(10);
@@ -364,8 +366,14 @@ describe("integration/runs/csv", () => {
         expect(found[1].args[0].scheduleGuid).toBe(schedule.guid);
 
         // run the schedule
+        const run = await Run.create({
+          creatorGuid: schedule.guid,
+          creatorType: "schedule",
+          state: "running",
+        });
         await specHelper.runTask("schedule:run", {
           scheduleGuid: schedule.guid,
+          runGuid: run.guid,
         });
 
         // run the schedule task again to enqueue the determineState task
@@ -430,11 +438,7 @@ describe("integration/runs/csv", () => {
         const profilesCount = await Profile.count();
         expect(profilesCount).toBe(10);
 
-        const run = await Run.findOne({
-          where: { creatorGuid: schedule.guid },
-          order: [["createdAt", "desc"]],
-          limit: 1,
-        });
+        await run.reload();
         expect(run.state).toBe("complete");
         expect(run.importsCreated).toBe(10);
         expect(run.profilesCreated).toBe(0);

--- a/plugins/@grouparoo/csv/src/lib/file-import/profilePropertyRuleOptions.ts
+++ b/plugins/@grouparoo/csv/src/lib/file-import/profilePropertyRuleOptions.ts
@@ -7,12 +7,13 @@ export const profilePropertyRuleOptions: PluginConnectionProfilePropertyRuleOpti
     required: true,
     description: "where the data comes from",
     type: "typeahead",
-    options: async ({ app, appOptions, source, sourceOptions }) => {
+    options: async ({ app, appOptions, source, sourceOptions, connection }) => {
       const rows = await sourcePreview({
         app,
         appOptions,
         source,
         sourceOptions,
+        connection,
       });
       const columns = Object.keys(rows[0]);
       return columns.map((col) => {

--- a/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
+++ b/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
@@ -262,7 +262,13 @@ describe("integration/runs/google-sheets", () => {
         expect(found[0].args[0].scheduleGuid).toBe(schedule.guid);
 
         // run the schedule
+        const run = await Run.create({
+          creatorGuid: schedule.guid,
+          creatorType: "schedule",
+          state: "running",
+        });
         await specHelper.runTask("schedule:run", {
+          runGuid: run.guid,
           scheduleGuid: schedule.guid,
         });
 
@@ -326,11 +332,7 @@ describe("integration/runs/google-sheets", () => {
         const profilesCount = await Profile.count();
         expect(profilesCount).toBe(10);
 
-        const run = await Run.findOne({
-          where: { creatorGuid: schedule.guid },
-          order: [["createdAt", "desc"]],
-          limit: 1,
-        });
+        await run.reload();
         expect(run.state).toBe("complete");
         expect(run.importsCreated).toBe(10);
         expect(run.profilesCreated).toBe(10);
@@ -373,7 +375,13 @@ describe("integration/runs/google-sheets", () => {
         expect(found[1].args[0].scheduleGuid).toBe(schedule.guid);
 
         // run the schedule
+        const run = await Run.create({
+          creatorGuid: schedule.guid,
+          creatorType: "schedule",
+          state: "running",
+        });
         await specHelper.runTask("schedule:run", {
+          runGuid: run.guid,
           scheduleGuid: schedule.guid,
         });
 
@@ -439,11 +447,7 @@ describe("integration/runs/google-sheets", () => {
         const profilesCount = await Profile.count();
         expect(profilesCount).toBe(10);
 
-        const run = await Run.findOne({
-          where: { creatorGuid: schedule.guid },
-          order: [["createdAt", "desc"]],
-          limit: 1,
-        });
+        await run.reload();
         expect(run.state).toBe("complete");
         expect(run.importsCreated).toBe(10);
         expect(run.profilesCreated).toBe(0);

--- a/plugins/@grouparoo/google-sheets/src/lib/sheet-import/profilePropertyRuleOptions.ts
+++ b/plugins/@grouparoo/google-sheets/src/lib/sheet-import/profilePropertyRuleOptions.ts
@@ -7,12 +7,13 @@ export const profilePropertyRuleOptions: PluginConnectionProfilePropertyRuleOpti
     required: true,
     description: "where the data comes from",
     type: "typeahead",
-    options: async ({ app, appOptions, source, sourceOptions }) => {
+    options: async ({ app, appOptions, source, sourceOptions, connection }) => {
       const rows = await sourcePreview({
         app,
         appOptions,
         source,
         sourceOptions,
+        connection,
       });
       const columns = Object.keys(rows[0]);
       return columns.map((col) => {

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-query-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-query-import.ts
@@ -60,7 +60,7 @@ describe("integration/runs/mysql", () => {
   });
 
   beforeAll(async () => {
-    client = await connect(MYSQL_OPTIONS);
+    client = await connect({ appOptions: MYSQL_OPTIONS, app: null });
 
     await client.asyncQuery(`drop table if exists ${sourceTableName}`);
     await client.asyncQuery(createSourceTableSQL);

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -88,7 +88,7 @@ describe("integration/runs/mysql", () => {
   });
 
   beforeAll(async () => {
-    client = await connect(MYSQL_OPTIONS);
+    client = await connect({ appOptions: MYSQL_OPTIONS, app: null });
 
     await client.asyncQuery(`drop table if exists ${sourceTableName}`);
     await client.asyncQuery("drop table if exists output_users");

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -415,7 +415,13 @@ describe("integration/runs/mysql", () => {
       expect(found[0].args[0].scheduleGuid).toBe(schedule.guid);
 
       // run the schedule
+      const run = await Run.create({
+        creatorGuid: schedule.guid,
+        creatorType: "schedule",
+        state: "running",
+      });
       await specHelper.runTask("schedule:run", {
+        runGuid: run.guid,
         scheduleGuid: schedule.guid,
       });
 
@@ -478,10 +484,7 @@ describe("integration/runs/mysql", () => {
       const profilesCount = await Profile.count();
       expect(profilesCount).toBe(10);
 
-      const run = await Run.findOne({
-        order: [["createdAt", "desc"]],
-        limit: 1,
-      });
+      await run.reload();
       expect(run.state).toBe("complete");
       expect(run.importsCreated).toBe(10);
       expect(run.profilesCreated).toBe(10);
@@ -530,7 +533,13 @@ describe("integration/runs/mysql", () => {
       expect(success).toBe(true);
 
       // run the schedule
+      const run = await Run.create({
+        creatorGuid: schedule.guid,
+        creatorType: "schedule",
+        state: "running",
+      });
       await specHelper.runTask("schedule:run", {
+        runGuid: run.guid,
         scheduleGuid: schedule.guid,
       });
 
@@ -593,11 +602,7 @@ describe("integration/runs/mysql", () => {
       const profilesCount = await Profile.count();
       expect(profilesCount).toBe(10);
 
-      const run = await Run.findOne({
-        where: { creatorGuid: schedule.guid },
-        order: [["createdAt", "desc"]],
-        limit: 1,
-      });
+      await run.reload();
       expect(run.state).toBe("complete");
       expect(run.importsCreated).toBe(1);
       expect(run.profilesCreated).toBe(0);

--- a/plugins/@grouparoo/mysql/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mysql/src/initializers/plugin.ts
@@ -2,6 +2,8 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
+import { connect } from "./../lib/connect";
+import { disconnect } from "./../lib/disconnect";
 import { exportProfile } from "./../lib/export/exportProfile";
 
 import { sourcePreview as tableSourcePreview } from "../lib/table-import/sourcePreview";
@@ -51,7 +53,7 @@ export class Plugins extends Initializer {
               description: "the mysql user's password",
             },
           ],
-          methods: { test },
+          methods: { test, connect, disconnect },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/mysql/src/lib/connect.ts
+++ b/plugins/@grouparoo/mysql/src/lib/connect.ts
@@ -1,12 +1,12 @@
 import mysql from "mysql";
 import { promisify } from "util";
-import { SimpleAppOptions } from "@grouparoo/core";
+import { ConnectPluginAppMethod } from "@grouparoo/core";
 
-interface QueryResultObject {
+export interface QueryResultObject {
   [key: string]: any;
 }
 
-export async function connect(appOptions: SimpleAppOptions) {
+export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
   const client = mysql.createConnection(appOptions);
   await promisify(client.connect).bind(client)();
 
@@ -37,4 +37,4 @@ export async function connect(appOptions: SimpleAppOptions) {
   const asyncEnd = promisify(client.end).bind(client);
 
   return Object.assign(client, { asyncQuery, asyncEnd });
-}
+};

--- a/plugins/@grouparoo/mysql/src/lib/disconnect.ts
+++ b/plugins/@grouparoo/mysql/src/lib/disconnect.ts
@@ -1,0 +1,5 @@
+import { DisconnectPluginAppMethod } from "@grouparoo/core";
+
+export const disconnect: DisconnectPluginAppMethod = async ({ connection }) => {
+  await connection.asyncEnd();
+};

--- a/plugins/@grouparoo/mysql/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/destinationMappingOptions.ts
@@ -1,16 +1,14 @@
 import { DestinationMappingOptionsMethod } from "@grouparoo/core";
-import { connect } from "../connect";
 
 export const destinationMappingOptions: DestinationMappingOptionsMethod = async ({
+  connection,
   appOptions,
   destinationOptions,
 }) => {
-  const client = await connect(appOptions);
-  const rows = await client.asyncQuery(
+  const rows = await connection.asyncQuery(
     `SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = ? AND table_name = ?`,
     [appOptions.database, destinationOptions.table]
   );
-  await client.asyncEnd();
 
   const columns = [];
   for (const i in rows) {

--- a/plugins/@grouparoo/mysql/src/lib/export/destinationOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/destinationOptions.ts
@@ -1,7 +1,7 @@
-import { connect } from "../connect";
 import { DestinationOptionsMethod } from "@grouparoo/core";
 
 export const destinationOptions: DestinationOptionsMethod = async ({
+  connection,
   appOptions,
 }) => {
   const response = {
@@ -15,8 +15,7 @@ export const destinationOptions: DestinationOptionsMethod = async ({
   const tables = [];
   const columns = [];
 
-  const client = await connect(appOptions);
-  const rows = await client.asyncQuery(
+  const rows = await connection.asyncQuery(
     `SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = ?`,
     [appOptions.database]
   );
@@ -24,7 +23,7 @@ export const destinationOptions: DestinationOptionsMethod = async ({
   for (const i in rows) {
     const tableName: string = rows[i].table_name;
     tables.push(tableName);
-    const colRows = await client.asyncQuery(
+    const colRows = await connection.asyncQuery(
       `SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = ? AND table_name = ?`,
       [appOptions.database, tableName]
     );
@@ -34,8 +33,6 @@ export const destinationOptions: DestinationOptionsMethod = async ({
       }
     });
   }
-
-  await client.end();
 
   tables.sort();
   columns.sort();

--- a/plugins/@grouparoo/mysql/src/lib/query-import/profileProperty.ts
+++ b/plugins/@grouparoo/mysql/src/lib/query-import/profileProperty.ts
@@ -1,4 +1,3 @@
-import { connect } from "../connect";
 import { validateQuery } from "../validateQuery";
 import {
   ProfilePropertyPluginMethod,
@@ -6,6 +5,7 @@ import {
 } from "@grouparoo/core";
 
 export const profileProperty: ProfilePropertyPluginMethod = async ({
+  connection,
   profile,
   appOptions,
   profilePropertyRule,
@@ -24,9 +24,10 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
   validateQuery(parameterizedQuery);
 
   let response: ProfilePropertyPluginMethodResponse;
-  const client = await connect(appOptions);
   try {
-    const rows = await client.asyncQuery(parameterizedQuery);
+    const rows: Array<{ [k: string]: any }> = await connection.asyncQuery(
+      parameterizedQuery
+    );
     if (rows && rows.length > 0) {
       const row = rows[0];
       response = Object.values(row)[0];
@@ -35,8 +36,6 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
     throw new Error(
       `Error with MySQL SQL Statement: Query - \`${parameterizedQuery}\`, Error - ${error}`
     );
-  } finally {
-    await client.asyncEnd();
   }
 
   return response;

--- a/plugins/@grouparoo/mysql/src/lib/table-import/nextFilter.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/nextFilter.ts
@@ -1,7 +1,7 @@
-import { connect } from "../connect";
 import { plugin, NextFilterPluginMethod } from "@grouparoo/core";
 
 export const nextFilter: NextFilterPluginMethod = async ({
+  connection,
   appOptions,
   sourceOptions,
   scheduleOptions,
@@ -13,10 +13,10 @@ export const nextFilter: NextFilterPluginMethod = async ({
 
   const table = sourceOptions.table;
   const query = `SELECT MAX(??) as max FROM ??`;
-
-  const client = await connect(appOptions);
-  const rows = await client.asyncQuery(query, [scheduleOptions.column, table]);
-  await client.asyncEnd();
+  const rows = await connection.asyncQuery(query, [
+    scheduleOptions.column,
+    table,
+  ]);
 
   filter[scheduleOptions.column] = rows[0].max;
 

--- a/plugins/@grouparoo/mysql/src/lib/table-import/profileProperty.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/profileProperty.ts
@@ -1,4 +1,3 @@
-import { connect } from "../connect";
 import { validateQuery } from "../validateQuery";
 import {
   ProfilePropertyPluginMethod,
@@ -7,7 +6,7 @@ import {
 
 export const profileProperty: ProfilePropertyPluginMethod = async ({
   profile,
-  appOptions,
+  connection,
   sourceOptions,
   sourceMapping,
   profilePropertyRule,
@@ -100,9 +99,8 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
   validateQuery(parameterizedQuery);
 
   let response: ProfilePropertyPluginMethodResponse;
-  const client = await connect(appOptions);
   try {
-    const rows = await client.asyncQuery(parameterizedQuery);
+    const rows = await connection.asyncQuery(parameterizedQuery);
     if (rows && rows.length > 0) {
       response = rows[0].__result;
     }
@@ -110,8 +108,6 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
     throw new Error(
       `Error with MySQL SQL Statement: Query - \`${parameterizedQuery}\`, Error - ${error}`
     );
-  } finally {
-    await client.asyncEnd();
   }
 
   return response;

--- a/plugins/@grouparoo/mysql/src/lib/table-import/profiles.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/profiles.ts
@@ -1,9 +1,8 @@
-import { connect } from "../connect";
 import { validateQuery } from "../validateQuery";
 import { plugin, ProfilesPluginMethod } from "@grouparoo/core";
 
 export const profiles: ProfilesPluginMethod = async ({
-  appOptions,
+  connection,
   sourceMapping,
   run,
   source,
@@ -26,15 +25,11 @@ export const profiles: ProfilesPluginMethod = async ({
 
   validateQuery(query);
 
-  const client = await connect(appOptions);
-
-  const rows = await client.asyncQuery(query, [table, limit, offset]);
+  const rows = await connection.asyncQuery(query, [table, limit, offset]);
   for (const i in rows) {
     await plugin.createImport(sourceMapping, run, rows[i]);
     importsCount++;
   }
-
-  await client.asyncEnd();
 
   const nextHighWaterMark = offset + limit;
   return { importsCount, nextHighWaterMark };

--- a/plugins/@grouparoo/mysql/src/lib/table-import/sourceOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/sourceOptions.ts
@@ -1,11 +1,12 @@
-import { connect } from "../connect";
 import { SourceOptionsMethod } from "@grouparoo/core";
 
-export const sourceOptions: SourceOptionsMethod = async ({ appOptions }) => {
+export const sourceOptions: SourceOptionsMethod = async ({
+  connection,
+  appOptions,
+}) => {
   const response = { table: { type: "typeahead", options: [] } };
 
-  const client = await connect(appOptions);
-  const tables = await client.asyncQuery(
+  const tables = await connection.asyncQuery(
     `SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = ?`,
     [appOptions.database]
   );
@@ -15,6 +16,5 @@ export const sourceOptions: SourceOptionsMethod = async ({ appOptions }) => {
     response.table.options.push(tableName);
   }
 
-  await client.asyncEnd();
   return response;
 };

--- a/plugins/@grouparoo/mysql/src/lib/table-import/sourcePreview.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/sourcePreview.ts
@@ -1,18 +1,16 @@
-import { connect } from "../connect";
 import { SourcePreviewMethod } from "@grouparoo/core";
 
 export const sourcePreview: SourcePreviewMethod = async ({
-  appOptions,
+  connection,
   sourceOptions,
 }) => {
   const response = [];
 
-  const client = await connect(appOptions);
-  const preview = await client.asyncQuery(
+  const preview = await connection.asyncQuery(
     `SELECT * FROM ?? ORDER BY RAND() LIMIT 10 `,
     [sourceOptions.table]
   );
   preview.map((row) => response.push(row));
-  await client.asyncEnd();
+
   return response;
 };

--- a/plugins/@grouparoo/mysql/src/lib/test.ts
+++ b/plugins/@grouparoo/mysql/src/lib/test.ts
@@ -1,10 +1,7 @@
-import { connect } from "./connect";
 import { TestPluginMethod } from "@grouparoo/core";
 
-export const test: TestPluginMethod = async ({ appOptions }) => {
-  const client = await connect(appOptions);
-  const rows = await client.asyncQuery("SELECT 'grouparoo' as message");
-  await client.asyncEnd();
+export const test: TestPluginMethod = async ({ connection }) => {
+  const rows = await connection.asyncQuery("SELECT 'grouparoo' as message");
   const isValid = rows[0].message === "grouparoo";
   return isValid;
 };

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
@@ -404,7 +404,13 @@ describe("integration/runs/postgres", () => {
       expect(found[0].args[0].scheduleGuid).toBe(schedule.guid);
 
       // run the schedule
+      const run = await Run.create({
+        creatorGuid: schedule.guid,
+        creatorType: "schedule",
+        state: "running",
+      });
       await specHelper.runTask("schedule:run", {
+        runGuid: run.guid,
         scheduleGuid: schedule.guid,
       });
 
@@ -467,10 +473,7 @@ describe("integration/runs/postgres", () => {
       const profilesCount = await Profile.count();
       expect(profilesCount).toBe(10);
 
-      const run = await Run.findOne({
-        order: [["createdAt", "desc"]],
-        limit: 1,
-      });
+      await run.reload();
       expect(run.state).toBe("complete");
       expect(run.importsCreated).toBe(10);
       expect(run.profilesCreated).toBe(10);
@@ -523,7 +526,13 @@ describe("integration/runs/postgres", () => {
       expect(success).toBe(true);
 
       // run the schedule
+      const run = await Run.create({
+        creatorGuid: schedule.guid,
+        creatorType: "schedule",
+        state: "running",
+      });
       await specHelper.runTask("schedule:run", {
+        runGuid: run.guid,
         scheduleGuid: schedule.guid,
       });
 
@@ -586,11 +595,7 @@ describe("integration/runs/postgres", () => {
       const profilesCount = await Profile.count();
       expect(profilesCount).toBe(10);
 
-      const run = await Run.findOne({
-        where: { creatorGuid: schedule.guid },
-        order: [["createdAt", "desc"]],
-        limit: 1,
-      });
+      await run.reload();
       expect(run.state).toBe("complete");
       expect(run.importsCreated).toBe(1);
       expect(run.profilesCreated).toBe(0);

--- a/plugins/@grouparoo/postgres/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/postgres/src/initializers/plugin.ts
@@ -2,6 +2,8 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
+import { connect } from "./../lib/connect";
+import { disconnect } from "./../lib/disconnect";
 import { exportProfile } from "../lib/export/exportProfile";
 
 import { sourcePreview as tableSourcePreview } from "../lib/table-import/sourcePreview";
@@ -51,7 +53,7 @@ export class Plugins extends Initializer {
               description: "the postgres user's password",
             },
           ],
-          methods: { test },
+          methods: { test, connect, disconnect },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/postgres/src/lib/connect.ts
+++ b/plugins/@grouparoo/postgres/src/lib/connect.ts
@@ -1,8 +1,8 @@
 import { Client } from "pg";
-import { SimpleAppOptions } from "@grouparoo/core";
+import { ConnectPluginAppMethod } from "@grouparoo/core";
 
-export async function connect(options: SimpleAppOptions) {
-  const client = new Client(options);
+export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
+  const client = new Client(appOptions);
   await client.connect();
   return client;
-}
+};

--- a/plugins/@grouparoo/postgres/src/lib/disconnect.ts
+++ b/plugins/@grouparoo/postgres/src/lib/disconnect.ts
@@ -1,0 +1,5 @@
+import { DisconnectPluginAppMethod } from "@grouparoo/core";
+
+export const disconnect: DisconnectPluginAppMethod = async ({ connection }) => {
+  await connection.end();
+};

--- a/plugins/@grouparoo/postgres/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/export/destinationMappingOptions.ts
@@ -1,13 +1,12 @@
 import { DestinationMappingOptionsMethod } from "@grouparoo/core";
-import { connect } from "../connect";
 import format from "pg-format";
 
 export const destinationMappingOptions: DestinationMappingOptionsMethod = async ({
+  connection,
   appOptions,
   destinationOptions,
 }) => {
-  const client = await connect(appOptions);
-  const { rows } = await client.query(
+  const { rows } = await connection.query(
     format(
       `SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_catalog = %L AND table_schema = %L AND table_name = %L`,
       appOptions.database,
@@ -15,7 +14,6 @@ export const destinationMappingOptions: DestinationMappingOptionsMethod = async 
       destinationOptions.table
     )
   );
-  await client.end();
 
   const columns = [];
   for (const i in rows) {

--- a/plugins/@grouparoo/postgres/src/lib/export/destinationOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/export/destinationOptions.ts
@@ -1,8 +1,8 @@
 import format from "pg-format";
-import { connect } from "../connect";
 import { DestinationOptionsMethod } from "@grouparoo/core";
 
 export const destinationOptions: DestinationOptionsMethod = async ({
+  connection,
   appOptions,
 }) => {
   const response = {
@@ -16,8 +16,7 @@ export const destinationOptions: DestinationOptionsMethod = async ({
   const tables = [];
   const columns = [];
 
-  const client = await connect(appOptions);
-  const { rows } = await client.query(
+  const { rows } = await connection.query(
     format(
       `SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_catalog = %L AND table_schema = %L`,
       appOptions.database,
@@ -28,7 +27,7 @@ export const destinationOptions: DestinationOptionsMethod = async ({
   for (const i in rows) {
     const tableName: string = rows[i].table_name;
     tables.push(tableName);
-    const { rows: colRows } = await client.query(
+    const { rows: colRows } = await connection.query(
       format(
         `SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_catalog = %L AND table_schema = %L AND table_name = %L`,
         appOptions.database,
@@ -42,8 +41,6 @@ export const destinationOptions: DestinationOptionsMethod = async ({
       }
     });
   }
-
-  await client.end();
 
   tables.sort();
   columns.sort();

--- a/plugins/@grouparoo/postgres/src/lib/query-import/profileProperty.ts
+++ b/plugins/@grouparoo/postgres/src/lib/query-import/profileProperty.ts
@@ -1,4 +1,3 @@
-import { connect } from "../connect";
 import { validateQuery } from "../validateQuery";
 import {
   ProfilePropertyPluginMethod,
@@ -6,6 +5,7 @@ import {
 } from "@grouparoo/core";
 
 export const profileProperty: ProfilePropertyPluginMethod = async ({
+  connection,
   profile,
   appOptions,
   profilePropertyRule,
@@ -24,9 +24,8 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
   validateQuery(parameterizedQuery);
 
   let response: ProfilePropertyPluginMethodResponse;
-  const client = await connect(appOptions);
   try {
-    const { rows } = await client.query(parameterizedQuery);
+    const { rows } = await connection.query(parameterizedQuery);
     if (rows && rows.length > 0) {
       const row: { [key: string]: any } = rows[0];
       response = Object.values(row)[0];
@@ -35,8 +34,6 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
     throw new Error(
       `Error with Postgres SQL Statement: Query - \`${parameterizedQuery}\`, Error - ${error}`
     );
-  } finally {
-    await client.end();
   }
 
   return response;

--- a/plugins/@grouparoo/postgres/src/lib/table-import/nextFilter.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/nextFilter.ts
@@ -1,9 +1,8 @@
 import format from "pg-format";
-import { connect } from "../connect";
 import { plugin, NextFilterPluginMethod } from "@grouparoo/core";
 
 export const nextFilter: NextFilterPluginMethod = async ({
-  appOptions,
+  connection,
   sourceOptions,
   scheduleOptions,
 }) => {
@@ -19,9 +18,7 @@ export const nextFilter: NextFilterPluginMethod = async ({
     table
   );
 
-  const client = await connect(appOptions);
-  const response = await client.query(query);
-  await client.end();
+  const response = await connection.query(query);
 
   filter[scheduleOptions.column] = response.rows[0].max;
 

--- a/plugins/@grouparoo/postgres/src/lib/table-import/profileProperty.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/profileProperty.ts
@@ -1,4 +1,3 @@
-import { connect } from "../connect";
 import { validateQuery } from "../validateQuery";
 import {
   ProfilePropertyPluginMethod,
@@ -7,6 +6,7 @@ import {
 
 export const profileProperty: ProfilePropertyPluginMethod = async ({
   profile,
+  connection,
   appOptions,
   profilePropertyRule,
   sourceOptions,
@@ -100,9 +100,8 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
   validateQuery(parameterizedQuery);
 
   let response: ProfilePropertyPluginMethodResponse;
-  const client = await connect(appOptions);
   try {
-    const { rows } = await client.query(parameterizedQuery);
+    const { rows } = await connection.query(parameterizedQuery);
     if (rows && rows.length > 0) {
       response = rows[0].__result;
     }
@@ -110,8 +109,6 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
     throw new Error(
       `Error with Postgres SQL Statement: Query - \`${parameterizedQuery}\`, Error - ${error}`
     );
-  } finally {
-    await client.end();
   }
 
   return response;

--- a/plugins/@grouparoo/postgres/src/lib/table-import/profiles.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/profiles.ts
@@ -1,11 +1,10 @@
 import format from "pg-format";
-import { connect } from "../connect";
 import { validateQuery } from "../validateQuery";
 import { plugin, ProfilesPluginMethod } from "@grouparoo/core";
 
 export const profiles: ProfilesPluginMethod = async ({
+  connection,
   run,
-  appOptions,
   sourceMapping,
   source,
   limit,
@@ -35,15 +34,11 @@ export const profiles: ProfilesPluginMethod = async ({
         format(`SELECT * FROM %I LIMIT %L OFFSET %L`, table, limit, offset)
       );
 
-  const client = await connect(appOptions);
-
-  const response = await client.query(query);
+  const response = await connection.query(query);
   for (const i in response.rows) {
     await plugin.createImport(sourceMapping, run, response.rows[i]);
     importsCount++;
   }
-
-  await client.end();
 
   const nextHighWaterMark = offset + limit;
   return { importsCount, nextHighWaterMark };

--- a/plugins/@grouparoo/postgres/src/lib/table-import/sourceOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/sourceOptions.ts
@@ -1,12 +1,13 @@
 import format from "pg-format";
-import { connect } from "../connect";
 import { SourceOptionsMethod } from "@grouparoo/core";
 
-export const sourceOptions: SourceOptionsMethod = async ({ appOptions }) => {
+export const sourceOptions: SourceOptionsMethod = async ({
+  appOptions,
+  connection,
+}) => {
   const response = { table: { type: "typeahead", options: [] } };
 
-  const client = await connect(appOptions);
-  const { rows } = await client.query(
+  const { rows } = await connection.query(
     format(
       `SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_catalog = %L AND table_schema = %L`,
       appOptions.database,
@@ -19,6 +20,5 @@ export const sourceOptions: SourceOptionsMethod = async ({ appOptions }) => {
     response.table.options.push(tableName);
   }
 
-  await client.end();
   return response;
 };

--- a/plugins/@grouparoo/postgres/src/lib/table-import/sourcePreview.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/sourcePreview.ts
@@ -1,18 +1,16 @@
 import format from "pg-format";
-import { connect } from "../connect";
 import { SourcePreviewMethod } from "@grouparoo/core";
 
 export const sourcePreview: SourcePreviewMethod = async ({
-  appOptions,
+  connection,
   sourceOptions,
 }) => {
   const response = [];
 
-  const client = await connect(appOptions);
-  const { rows } = await client.query(
+  const { rows } = await connection.query(
     format(`SELECT * FROM %I ORDER BY RANDOM() LIMIT 10`, sourceOptions.table)
   );
   rows.map((row) => response.push(row));
-  await client.end();
+
   return response;
 };

--- a/plugins/@grouparoo/postgres/src/lib/test.ts
+++ b/plugins/@grouparoo/postgres/src/lib/test.ts
@@ -1,12 +1,9 @@
-import { connect } from "./connect";
 import { TestPluginMethod } from "@grouparoo/core";
 
-export const test: TestPluginMethod = async ({ appOptions }) => {
-  const client = await connect(appOptions);
-  const response = await client.query("SELECT $1::text as message", [
+export const test: TestPluginMethod = async ({ connection }) => {
+  const response = await connection.query("SELECT $1::text as message", [
     "grouparoo",
   ]);
-  await client.end();
   const isValid = response.rows[0].message === "grouparoo";
   return isValid;
 };

--- a/plugins/@grouparoo/sailthru/__tests__/export/export-profile.ts
+++ b/plugins/@grouparoo/sailthru/__tests__/export/export-profile.ts
@@ -59,6 +59,7 @@ describe("sailthru/exportProfile", () => {
 
   test("can create profile on Sailthru", async () => {
     await exportProfile({
+      connection: client,
       appOptions,
       oldProfileProperties: {},
       newProfileProperties: { email: email },
@@ -77,6 +78,7 @@ describe("sailthru/exportProfile", () => {
 
   test("can add user variables", async () => {
     await exportProfile({
+      connection: client,
       appOptions,
       oldProfileProperties: { email: email },
       newProfileProperties: { email: email, first_name: "Evan" },
@@ -96,6 +98,7 @@ describe("sailthru/exportProfile", () => {
 
   test("can change user variables", async () => {
     await exportProfile({
+      connection: client,
       appOptions,
       oldProfileProperties: { email: email, first_name: "Evan" },
       newProfileProperties: { email: email, first_name: "Brian" },
@@ -115,6 +118,7 @@ describe("sailthru/exportProfile", () => {
 
   test("can clear user variables", async () => {
     await exportProfile({
+      connection: client,
       appOptions,
       oldProfileProperties: { first_name: "Brian" },
       newProfileProperties: { email: email },
@@ -134,6 +138,7 @@ describe("sailthru/exportProfile", () => {
 
   test("can add to a list", async () => {
     await exportProfile({
+      connection: client,
       appOptions,
       oldProfileProperties: { email: email, first_name: null },
       newProfileProperties: { email: email, first_name: "Brian" },
@@ -155,6 +160,7 @@ describe("sailthru/exportProfile", () => {
 
   test("can remove from a list", async () => {
     await exportProfile({
+      connection: client,
       appOptions,
       oldProfileProperties: { email: email, first_name: "Brian" },
       newProfileProperties: { email: email, first_name: "Brian" },
@@ -176,6 +182,7 @@ describe("sailthru/exportProfile", () => {
 
   test("can delete a user", async () => {
     await exportProfile({
+      connection: client,
       appOptions,
       oldProfileProperties: { email: email, first_name: "Brian" },
       newProfileProperties: { email: email, first_name: "Brian" },


### PR DESCRIPTION
Closes #231
Closes https://github.com/grouparoo/grouparoo/issues/357

For plugins with persistent connections (mySQL, Postgres) or those that need to obtain a long-lived token (BigQuery), this PR adds `connect` and `disconnect` methods to Plugin Apps.  

Grouparoo will try to connect if the plugin#app#connect method exists, and store the resulting object for later use.  The object is either the real MySQL client or an object that contains the keys you want to store.  This will then be passed back to all future methods called on the plugin.

This PR: 
- simplifies plugin logic to not need to connect and disconnect for every query
- speeds up queries as connections do not need to be established
- reduces the number of connections that Grouparoo makes to each source/destination as we are using a shared connection, and not creating a new one for each task/worker/"thread". 

The connection objects are stored per-server.  it's possible that not every server in your grouparoo cluster will connect to all sources/destinations.