### PR TITLE
use require.resolve to find @grouparoo/client-web

### DIFF
--- a/core/api/src/initializers/clients.ts
+++ b/core/api/src/initializers/clients.ts
@@ -1,4 +1,4 @@
-import { api, Initializer } from "actionhero";
+import { Initializer } from "actionhero";
 import fs from "fs";
 import path from "path";
 
@@ -22,14 +22,8 @@ export class Files extends Initializer {
 
     // copy the web client javascript from the plugin to the public directory
     const source = path.join(
-      __dirname,
+      require.resolve("@grouparoo/client-web"),
       "..",
-      "..",
-      "..",
-      "node_modules",
-      "@grouparoo",
-      "client-web",
-      "dist",
       "grouparooWebClient.js"
     );
 

--- a/tools/license-checker/check
+++ b/tools/license-checker/check
@@ -10,6 +10,7 @@ const excludePackages = [
   // custom exclusions for newrelic
   "newrelic@6.9.0",
   "@newrelic/aws-sdk@1.1.2",
+  "@newrelic/aws-sdk@1.1.3",
   "@newrelic/koa@3.0.0",
   "@newrelic/native-metrics@5.1.0",
   "@newrelic/native-metrics@5.2.0",


### PR DESCRIPTION
This fixes a bug related to the path of the client lib, depending on how Grouparoo is running (client project, monorepo, etc)