### PR TITLE
Update dependency: @types/jest@26.0.0

### DIFF
--- a/clients/@grouparoo/web/package-lock.json
+++ b/clients/@grouparoo/web/package-lock.json
@@ -700,9 +700,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/clients/@grouparoo/web/package.json
+++ b/clients/@grouparoo/web/package.json
@@ -28,7 +28,7 @@
     "lint": "prettier --check src __tests__"
   },
   "devDependencies": {
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "jest": "^25.4.0",
     "jest-fetch-mock": "^3.0.3",
     "prettier": "^2.0.5",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -3918,9 +3918,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",
@@ -3982,16 +3982,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
-    },
-    "@types/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I="
-    },
-    "@types/strip-json-comments": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ=="
     },
     "@types/uuid": {
       "version": "8.0.0",
@@ -4481,11 +4471,6 @@
           }
         }
       }
-    },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -6524,15 +6509,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.14.0.tgz",
       "integrity": "sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw=="
     },
-    "dateformat": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-      "requires": {
-        "get-stdin": "^4.0.1",
-        "meow": "^3.3.0"
-      }
-    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -6688,11 +6664,6 @@
           "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
         }
       }
-    },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-sequences": {
       "version": "25.2.6",
@@ -6860,14 +6831,6 @@
             "safe-buffer": "~5.1.0"
           }
         }
-      }
-    },
-    "dynamic-dedupe": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
-      "integrity": "sha1-BuRMIj9eTpTXjvnbI6ZRXOL5YqE=",
-      "requires": {
-        "xtend": "^4.0.0"
       }
     },
     "ecc-jsbn": {
@@ -8161,7 +8124,9 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true,
+      "optional": true
     },
     "gud": {
       "version": "1.0.0",
@@ -11475,7 +11440,8 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "make-plural": {
       "version": "6.2.1",
@@ -12410,18 +12376,6 @@
       "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
       "dev": true
-    },
-    "node-notifier": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-      "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
-      "requires": {
-        "growly": "^1.3.0",
-        "is-wsl": "^1.1.0",
-        "semver": "^5.5.0",
-        "shellwords": "^0.1.1",
-        "which": "^1.3.0"
-      }
     },
     "node-pre-gyp": {
       "version": "0.15.0",
@@ -15574,7 +15528,9 @@
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true,
+      "optional": true
     },
     "shimmer": {
       "version": "1.2.1",
@@ -16840,11 +16796,6 @@
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
-    "tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
-    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -16924,110 +16875,10 @@
         }
       }
     },
-    "ts-node": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
-      "requires": {
-        "arg": "^4.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      }
-    },
-    "ts-node-dev": {
-      "version": "1.0.0-pre.48",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.0.0-pre.48.tgz",
-      "integrity": "sha512-Q78zLUfyHqIL+rvMHxP5VdrWch16Xsx8BwpucPx5lcY8fC1DRJbtgHrjpAsXqVFvOrzvanR5qlvoVT0yZGskoA==",
-      "requires": {
-        "chokidar": "^3.4.0",
-        "dateformat": "~1.0.4-1.2.3",
-        "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.5",
-        "mkdirp": "^1.0.4",
-        "node-notifier": "^5.4.0",
-        "resolve": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "source-map-support": "^0.5.12",
-        "tree-kill": "^1.2.2",
-        "ts-node": "^8.10.2",
-        "tsconfig": "^7.0.0"
-      },
-      "dependencies": {
-        "binary-extensions": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
-        },
-        "chokidar": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-          "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
-          "requires": {
-            "anymatch": "~3.1.1",
-            "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
-            "glob-parent": "~5.1.0",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.4.0"
-          }
-        },
-        "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
-        "is-binary-path": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-          "requires": {
-            "binary-extensions": "^2.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-        },
-        "readdirp": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-          "requires": {
-            "picomatch": "^2.2.1"
-          }
-        }
-      }
-    },
     "ts-pnp": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw=="
-    },
-    "tsconfig": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-      "requires": {
-        "@types/strip-bom": "^3.0.0",
-        "@types/strip-json-comments": "0.0.30",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "^2.0.0"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-        }
-      }
     },
     "tslib": {
       "version": "1.13.0",
@@ -18103,11 +17954,6 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "zenscroll": {
       "version": "4.0.2",

--- a/core/package.json
+++ b/core/package.json
@@ -91,7 +91,7 @@
     "@types/faker": "^4.1.11",
     "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
-    "@types/react": "^16.9.35",
+    "@types/react": "^16.9.36",
     "@types/react-dom": "^16.9.8",
     "@types/validator": "^13.0.0",
     "csv-parse": "^4.8.9",

--- a/core/package.json
+++ b/core/package.json
@@ -89,7 +89,7 @@
   "devDependencies": {
     "@types/bluebird": "^3.5.30",
     "@types/faker": "^4.1.11",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1433,9 +1433,9 @@
 			}
 		},
 		"@types/istanbul-lib-coverage": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.2.tgz",
-			"integrity": "sha512-rsZg7eL+Xcxsxk2XlBt9KcG8nOp9iYdKCOikY9x2RFJCyOdNj4MKPQty0e8oZr29vVAzKXr1BmR+kZauti3o1w==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+			"integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
 			"dev": true
 		},
 		"@types/istanbul-lib-report": {
@@ -1458,9 +1458,9 @@
 			}
 		},
 		"@types/jest": {
-			"version": "25.2.3",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-			"integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+			"integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
 			"dev": true,
 			"requires": {
 				"jest-diff": "^25.2.1",
@@ -6833,9 +6833,9 @@
 					}
 				},
 				"agentkeepalive": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.2.tgz",
-					"integrity": "sha512-waNHE7tQBBn+2qXucI8HY0o2Y0OBPWldWOWsZwY71JcCm4SvrPnWdceFfB5NIXSqE8Ewq6VR/Qt5b1i69P6KCQ==",
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.3.tgz",
+					"integrity": "sha512-wn8fw19xKZwdGPO47jivonaHRTd+nGOMP1z11sgGeQzDy2xd5FG0R67dIMcKHDE2cJ5y+YXV30XVGUBPRSY7Hg==",
 					"dev": true,
 					"requires": {
 						"debug": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/grouparoo/grouparoo.git"
   },
   "devDependencies": {
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "glob": "^7.1.6",
     "lerna": "^3.20.2",
     "lerna-changelog": "^1.0.1",

--- a/plugins/@grouparoo/bigquery/package-lock.json
+++ b/plugins/@grouparoo/bigquery/package-lock.json
@@ -796,9 +796,9 @@
 			}
 		},
 		"@types/jest": {
-			"version": "25.2.3",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-			"integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+			"integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
 			"dev": true,
 			"requires": {
 				"jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/bigquery/package.json
+++ b/plugins/@grouparoo/bigquery/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "actionhero": "^22.1.1",
     "dotenv": "^8.2.0",

--- a/plugins/@grouparoo/csv/package-lock.json
+++ b/plugins/@grouparoo/csv/package-lock.json
@@ -750,9 +750,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/csv/package.json
+++ b/plugins/@grouparoo/csv/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "actionhero": "^22.1.1",
     "jest": "^25.4.0",

--- a/plugins/@grouparoo/email-authentication/package-lock.json
+++ b/plugins/@grouparoo/email-authentication/package-lock.json
@@ -737,9 +737,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/email-authentication/package-lock.json
+++ b/plugins/@grouparoo/email-authentication/package-lock.json
@@ -776,9 +776,9 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.9.35",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.35.tgz",
-      "integrity": "sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==",
+      "version": "16.9.36",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.36.tgz",
+      "integrity": "sha512-mGgUb/Rk/vGx4NCvquRuSH0GHBQKb1OqpGS9cT9lFxlTLHZgkksgI60TuIxubmn7JuCb+sENHhQciqa0npm0AQ==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"

--- a/plugins/@grouparoo/email-authentication/package.json
+++ b/plugins/@grouparoo/email-authentication/package.json
@@ -39,7 +39,7 @@
     "@grouparoo/core": "^0.1.4",
     "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
-    "@types/react": "^16.9.35",
+    "@types/react": "^16.9.36",
     "actionhero": "^22.1.1",
     "jest": "^25.4.0",
     "prettier": "^2.0.5",

--- a/plugins/@grouparoo/email-authentication/package.json
+++ b/plugins/@grouparoo/email-authentication/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "@types/react": "^16.9.35",
     "actionhero": "^22.1.1",

--- a/plugins/@grouparoo/files-local/package-lock.json
+++ b/plugins/@grouparoo/files-local/package-lock.json
@@ -710,9 +710,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/files-local/package.json
+++ b/plugins/@grouparoo/files-local/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "actionhero": "^22.1.1",
     "jest": "^25.4.0",

--- a/plugins/@grouparoo/files-s3/package-lock.json
+++ b/plugins/@grouparoo/files-s3/package-lock.json
@@ -775,9 +775,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/files-s3/package.json
+++ b/plugins/@grouparoo/files-s3/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "actionhero": "^22.1.1",
     "jest": "^25.4.0",

--- a/plugins/@grouparoo/google-sheets/package-lock.json
+++ b/plugins/@grouparoo/google-sheets/package-lock.json
@@ -710,9 +710,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/google-sheets/package.json
+++ b/plugins/@grouparoo/google-sheets/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "actionhero": "^22.1.1",
     "dotenv": "^8.2.0",

--- a/plugins/@grouparoo/logger/package-lock.json
+++ b/plugins/@grouparoo/logger/package-lock.json
@@ -710,9 +710,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/logger/package.json
+++ b/plugins/@grouparoo/logger/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "actionhero": "^22.1.1",
     "jest": "^25.4.0",

--- a/plugins/@grouparoo/mailchimp/package-lock.json
+++ b/plugins/@grouparoo/mailchimp/package-lock.json
@@ -710,9 +710,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/mailchimp/package.json
+++ b/plugins/@grouparoo/mailchimp/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "actionhero": "^22.1.1",
     "jest": "^25.4.0",

--- a/plugins/@grouparoo/mysql/package-lock.json
+++ b/plugins/@grouparoo/mysql/package-lock.json
@@ -710,9 +710,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/mysql/package.json
+++ b/plugins/@grouparoo/mysql/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/mysql": "^2.15.10",
     "@types/node": "^14.0.5",
     "actionhero": "^22.1.1",

--- a/plugins/@grouparoo/newrelic/package-lock.json
+++ b/plugins/@grouparoo/newrelic/package-lock.json
@@ -813,9 +813,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/newrelic/package.json
+++ b/plugins/@grouparoo/newrelic/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "actionhero": "^22.1.1",
     "jest": "^25.4.0",

--- a/plugins/@grouparoo/postgres/package-lock.json
+++ b/plugins/@grouparoo/postgres/package-lock.json
@@ -710,9 +710,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/postgres/package.json
+++ b/plugins/@grouparoo/postgres/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "@types/pg": "^7.14.3",
     "actionhero": "^22.1.1",

--- a/plugins/@grouparoo/sailthru/package-lock.json
+++ b/plugins/@grouparoo/sailthru/package-lock.json
@@ -808,9 +808,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/sailthru/package.json
+++ b/plugins/@grouparoo/sailthru/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "actionhero": "^22.1.1",
     "dotenv": "^8.2.0",

--- a/plugins/@grouparoo/sample-ui-plugin/package-lock.json
+++ b/plugins/@grouparoo/sample-ui-plugin/package-lock.json
@@ -726,9 +726,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
-      "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",

--- a/plugins/@grouparoo/sample-ui-plugin/package-lock.json
+++ b/plugins/@grouparoo/sample-ui-plugin/package-lock.json
@@ -766,9 +766,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.9.35",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.35.tgz",
-      "integrity": "sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==",
+      "version": "16.9.36",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.36.tgz",
+      "integrity": "sha512-mGgUb/Rk/vGx4NCvquRuSH0GHBQKb1OqpGS9cT9lFxlTLHZgkksgI60TuIxubmn7JuCb+sENHhQciqa0npm0AQ==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",

--- a/plugins/@grouparoo/sample-ui-plugin/package.json
+++ b/plugins/@grouparoo/sample-ui-plugin/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.4",
-    "@types/jest": "^25.2.3",
+    "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
     "@types/react": "^16.9.35",
     "actionhero": "^22.1.1",

--- a/plugins/@grouparoo/sample-ui-plugin/package.json
+++ b/plugins/@grouparoo/sample-ui-plugin/package.json
@@ -33,7 +33,7 @@
     "@grouparoo/core": "^0.1.4",
     "@types/jest": "^26.0.0",
     "@types/node": "^14.0.5",
-    "@types/react": "^16.9.35",
+    "@types/react": "^16.9.36",
     "actionhero": "^22.1.1",
     "jest": "^25.4.0",
     "prettier": "^2.0.5",


### PR DESCRIPTION
closes https://github.com/grouparoo/grouparoo/pull/346

@types/jest
  * @grouparoo/bigquery: ^25.2.3 → 26.0.0
  * @grouparoo/client-web: ^25.2.3 → 26.0.0
  * @grouparoo/core: ^25.2.3 → 26.0.0
  * @grouparoo/csv: ^25.2.3 → 26.0.0
  * @grouparoo/email-authentication: ^25.2.3 → 26.0.0
  * @grouparoo/files-local: ^25.2.3 → 26.0.0
  * @grouparoo/files-s3: ^25.2.3 → 26.0.0
  * @grouparoo/google-sheets: ^25.2.3 → 26.0.0
  * @grouparoo/logger: ^25.2.3 → 26.0.0
  * @grouparoo/mailchimp: ^25.2.3 → 26.0.0
  * @grouparoo/mysql: ^25.2.3 → 26.0.0
  * @grouparoo/newrelic: ^25.2.3 → 26.0.0
  * @grouparoo/postgres: ^25.2.3 → 26.0.0
  * @grouparoo/sailthru: ^25.2.3 → 26.0.0
  * @grouparoo/sample-ui-plugin: ^25.2.3 → 26.0.0