### PR TITLE
UI Updates & Bugfixes

### DIFF
--- a/core/api/__tests__/models/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRule.ts
@@ -64,7 +64,7 @@ describe("models/profilePropertyRule", () => {
     await source.destroy();
   });
 
-  describe("key", () => {
+  describe("keys and types", () => {
     let source: Source;
 
     beforeAll(async () => {
@@ -109,6 +109,18 @@ describe("models/profilePropertyRule", () => {
 
       await ruleOne.destroy();
       await ruleTwo.destroy();
+    });
+
+    test("types must be of a known type", async () => {
+      const rule = await ProfilePropertyRule.create({
+        sourceGuid: source.guid,
+      });
+
+      await expect(rule.update({ type: "something" })).rejects.toThrow(
+        /something is not an allowed type/
+      );
+
+      await rule.destroy();
     });
   });
 

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -310,7 +310,7 @@ export class Group extends LoggedModel<Group> {
         );
       }
 
-      if (this.state !== "deleted") {
+      if (this.state !== "deleted" && rules.length > 0) {
         this.state = "initializing";
         this.changed("updatedAt", true);
         await this.save({ transaction });

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -101,6 +101,8 @@ export const PROFILE_PROPERTY_RULE_OPS = {
   },
 };
 
+const TYPES = ["float", "integer", "date", "string", "boolean", "email"];
+
 const CACHE_TTL = env === "test" ? -1 : 1000 * 30;
 
 interface ProfilePropertyRulesCache {
@@ -181,9 +183,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
 
   @AllowNull(false)
   @Default("string")
-  @Column(
-    DataType.ENUM("float", "integer", "date", "string", "boolean", "email")
-  )
+  @Column(DataType.ENUM(...TYPES))
   type: string;
 
   @AllowNull(false)
@@ -233,6 +233,13 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
   @BeforeSave
   static async updateState(instance: ProfilePropertyRule) {
     await StateMachine.transition(instance, STATE_TRANSITIONS);
+  }
+
+  @BeforeSave
+  static async ensureType(instance: ProfilePropertyRule) {
+    if (!TYPES.includes(instance.type)) {
+      throw new Error(`${instance.type} is not an allowed type`);
+    }
   }
 
   @BeforeCreate

--- a/core/web/pages/destination/[guid]/data.tsx
+++ b/core/web/pages/destination/[guid]/data.tsx
@@ -20,7 +20,9 @@ export default function Page(props) {
     groups,
   } = props;
   const { execApi } = useApi(props, errorHandler);
-  const [trackedGroupGuid, setTrackedGroupGuid] = useState("_none");
+  const [trackedGroupGuid, setTrackedGroupGuid] = useState(
+    props.trackedGroupGuid || "_none"
+  );
   const [destination, setDestination] = useState<DestinationAPIData>(
     props.destination
   );
@@ -654,6 +656,9 @@ Page.getInitialProps = async (ctx) => {
     destination,
     profilePropertyRules,
     mappingOptions: options,
+    trackedGroupGuid: destination.trackAllGroups
+      ? "_all"
+      : destination.destinationGroups[0]?.guid,
     groups: groups.filter((group) => group.state !== "draft"),
   };
 };

--- a/core/web/pages/group/new.tsx
+++ b/core/web/pages/group/new.tsx
@@ -21,7 +21,11 @@ export default function (props) {
     );
     setLoading(false);
     if (response?.group) {
-      Router.push("/group/[guid]/edit", `/group/${response.group.guid}/edit`);
+      const path = response.group.type === "calculated" ? "rules" : "edit";
+      Router.push(
+        `/group/[guid]/${path}`,
+        `/group/${response.group.guid}/${path}`
+      );
     }
   }
 

--- a/core/web/pages/profilePropertyRule/[guid]/edit.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/edit.tsx
@@ -1,4 +1,4 @@
-import { useState, Fragment } from "react";
+import { useState, useEffect, Fragment } from "react";
 import { useApi } from "../../../hooks/useApi";
 import { Row, Col, Button, Form, Table, Badge } from "react-bootstrap";
 import Router from "next/router";
@@ -35,6 +35,10 @@ export default function Page(props) {
   );
 
   const { guid } = query;
+
+  useEffect(() => {
+    newRuleDefaults();
+  }, []);
 
   async function onSubmit(event) {
     event.preventDefault();
@@ -80,6 +84,20 @@ export default function Page(props) {
       if (response) {
         Router.back();
       }
+    }
+  }
+
+  function newRuleDefaults() {
+    if (
+      profilePropertyRule.state === "draft" &&
+      profilePropertyRule.key === ""
+    ) {
+      const _profilePropertyRule = Object.assign({}, profilePropertyRule);
+
+      // make the user explicitly choose a type
+      _profilePropertyRule.type = "";
+
+      setProfilePropertyRule(_profilePropertyRule);
     }
   }
 
@@ -181,6 +199,9 @@ export default function Page(props) {
                 value={profilePropertyRule.type}
                 onChange={(e) => update(e)}
               >
+                <option value="" disabled>
+                  Choose a Type
+                </option>
                 {types.map((type) => (
                   <option key={`type-${type}`}>{type}</option>
                 ))}

--- a/core/web/pages/profilePropertyRule/[guid]/edit.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/edit.tsx
@@ -78,7 +78,7 @@ export default function Page(props) {
       const response = await execApi("delete", `/profilePropertyRule/${guid}`);
       setLoading(false);
       if (response) {
-        Router.push("/profilePropertyRules");
+        Router.back();
       }
     }
   }

--- a/core/web/pages/source/[guid]/mapping.tsx
+++ b/core/web/pages/source/[guid]/mapping.tsx
@@ -1,7 +1,7 @@
 import { useApi } from "../../../hooks/useApi";
 import SourceTabs from "../../../components/tabs/source";
 import Head from "next/head";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Row, Col, Table, Form, Button } from "react-bootstrap";
 import { createSchedule } from "../../../components/schedule/add";
 import Router from "next/router";
@@ -72,7 +72,7 @@ export default function Page(props) {
 
       // this source can have a schedule, and we have no schedules yet
       if (scheduleCount === 0 && response.source.scheduleAvailable) {
-        createSchedule({
+        await createSchedule({
           sourceGuid: response.source.guid,
           setLoading: () => {},
           successHandler,

--- a/core/web/pages/source/[guid]/mapping.tsx
+++ b/core/web/pages/source/[guid]/mapping.tsx
@@ -41,6 +41,7 @@ export default function Page(props) {
 
         const prrResponse = await execApi("get", `/profilePropertyRules`, {
           unique: true,
+          state: "ready",
         });
         if (prrResponse?.profilePropertyRules) {
           setProfilePropertyRules(prrResponse.profilePropertyRules);
@@ -312,7 +313,10 @@ Page.getInitialProps = async (ctx) => {
   const {
     profilePropertyRules,
     examples: profilePropertyRuleExamples,
-  } = await execApi("get", `/profilePropertyRules`);
+  } = await execApi("get", `/profilePropertyRules`, {
+    state: "ready",
+    unique: true,
+  });
   const { types } = await execApi("get", `/profilePropertyRuleOptions`);
   const { total: scheduleCount } = await execApi("get", `/schedules`);
 

--- a/core/web/pages/source/[guid]/schedule.tsx
+++ b/core/web/pages/source/[guid]/schedule.tsx
@@ -28,7 +28,7 @@ export default function Page(props) {
       delete _schedule.options; // they are immutable and cannot be changed once set; server will return an error
     }
     if (recurringFrequencyMinutes) {
-      schedule.recurringFrequency = recurringFrequencyMinutes * (60 * 1000);
+      _schedule.recurringFrequency = recurringFrequencyMinutes * (60 * 1000);
     }
 
     setLoading(true);


### PR DESCRIPTION
* closes https://github.com/grouparoo/grouparoo/issues/358 Calculated groups should stay in `draft` mode until a rule has been added
* closes https://github.com/grouparoo/grouparoo/issues/331 When going to a Destination `data` tab, the Group dropdown defaults to "No Group" even if it is currently sending a group.
* closes https://github.com/grouparoo/grouparoo/issues/348 When creating a schedule with a valid recurring time, the form throws an error saying the frequency should be an integer.
* closes #350 In the Source Mapping page, only show `ready` Unique Profile Property Rules 
* closes #347 When bootstrapping a source, after making the first mapping, I should go to the "Make a new Schedule" page 
* closes #355 After making a new group, would expect to be on the Rules tab by default 
* closes #351 When deleting a profile property rule from the Source, it does not do the “back” thing and always goes to /profilePropertyRules
* closes  #352 Don't default profile property type to String. Default is "Choose a type" placeholder.