### PR TITLE
SourceOptionsMethod and DestinationOptionsMethod can be refreshed with partial option values as they are filled in

### DIFF
--- a/core/api/__tests__/models/destination.ts
+++ b/core/api/__tests__/models/destination.ts
@@ -212,9 +212,19 @@ describe("models/destination", () => {
     });
 
     test("a destination can get options from a connection", async () => {
-      const options = await destination.destinationConnectionOptions();
-      expect(options).toEqual({
+      const connectionOptions = await destination.destinationConnectionOptions();
+      expect(connectionOptions).toEqual({
         table: { type: "list", options: ["users_out"] },
+      });
+    });
+
+    test("partial options will be passed to destinationConnectionOptions", async () => {
+      const connectionOptions = await destination.destinationConnectionOptions({
+        options: true,
+      });
+      expect(connectionOptions).toEqual({
+        table: { type: "list", options: ["users_out"] },
+        receivedOptions: true,
       });
     });
 

--- a/core/api/__tests__/models/source.ts
+++ b/core/api/__tests__/models/source.ts
@@ -329,6 +329,16 @@ describe("models/source", () => {
       });
     });
 
+    test("partial options will be passed to sourceConnectionOptions", async () => {
+      const connectionOptions = await source.sourceConnectionOptions({
+        options: true,
+      });
+      expect(connectionOptions).toEqual({
+        table: { options: ["users"], type: "list" },
+        receivedOptions: true,
+      });
+    });
+
     test("a plugin with a profiles method can have a schedule", async () => {
       const scheduleAvailable = await source.scheduleAvailable();
       expect(scheduleAvailable).toBe(true);

--- a/core/api/__tests__/utils/specHelper.ts
+++ b/core/api/__tests__/utils/specHelper.ts
@@ -222,8 +222,11 @@ export namespace helper {
             },
           ],
           methods: {
-            sourceOptions: async () => {
-              return { table: { type: "list", options: ["users"] } };
+            sourceOptions: async ({ sourceOptions }) => {
+              const response = { table: { type: "list", options: ["users"] } };
+              if (sourceOptions.options)
+                response["receivedOptions"] = sourceOptions.options;
+              return response;
             },
             sourcePreview: async () => {
               return [
@@ -275,8 +278,13 @@ export namespace helper {
             exportProfile: async () => {
               return true;
             },
-            destinationOptions: async () => {
-              return { table: { type: "list", options: ["users_out"] } };
+            destinationOptions: async ({ destinationOptions }) => {
+              const response = {
+                table: { type: "list", options: ["users_out"] },
+              };
+              if (destinationOptions.options)
+                response["receivedOptions"] = destinationOptions.options;
+              return response;
             },
             destinationMappingOptions: async () => {
               return {

--- a/core/api/src/actions/destinations.ts
+++ b/core/api/src/actions/destinations.ts
@@ -218,12 +218,19 @@ export class DestinationConnectionOptions extends AuthenticatedAction {
     this.permission = { topic: "destination", mode: "read" };
     this.inputs = {
       guid: { required: true },
+      options: { required: false },
     };
   }
 
   async run({ params, response }) {
     const destination = await Destination.findByGuid(params.guid);
-    response.options = await destination.destinationConnectionOptions();
+
+    const options =
+      typeof params.options === "string"
+        ? JSON.parse(params.options)
+        : params.options;
+
+    response.options = await destination.destinationConnectionOptions(options);
   }
 }
 

--- a/core/api/src/actions/sources.ts
+++ b/core/api/src/actions/sources.ts
@@ -213,12 +213,19 @@ export class sourceConnectionOptions extends AuthenticatedAction {
     this.permission = { topic: "source", mode: "read" };
     this.inputs = {
       guid: { required: true },
+      options: { required: false },
     };
   }
 
   async run({ params, response }) {
     const source = await Source.findByGuid(params.guid);
-    response.options = await source.sourceConnectionOptions();
+
+    const options =
+      typeof params.options === "string"
+        ? JSON.parse(params.options)
+        : params.options;
+
+    response.options = await source.sourceConnectionOptions(options);
   }
 }
 

--- a/core/api/src/classes/plugin.ts
+++ b/core/api/src/classes/plugin.ts
@@ -224,6 +224,7 @@ export interface SourceOptionsMethod {
     connection: any;
     app: App;
     appOptions: SimpleAppOptions;
+    sourceOptions: SimpleSourceOptions;
   }): Promise<SourceOptionsMethodResponse>;
 }
 
@@ -300,6 +301,7 @@ export interface DestinationOptionsMethod {
     connection: any;
     app: App;
     appOptions: SimpleAppOptions;
+    destinationOptions: SimpleDestinationOptions;
   }): Promise<DestinationOptionsMethodResponse>;
 }
 

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -447,7 +447,9 @@ export class Destination extends LoggedModel<Destination> {
     return parameterizedOptions;
   }
 
-  async destinationConnectionOptions() {
+  async destinationConnectionOptions(
+    destinationOptions: SimpleDestinationOptions = {}
+  ) {
     const { pluginConnection } = await this.getPlugin();
     const app = await this.$get("app");
     const connection = await app.getConnection();
@@ -461,6 +463,7 @@ export class Destination extends LoggedModel<Destination> {
       connection,
       app,
       appOptions,
+      destinationOptions,
     });
   }
 

--- a/core/api/src/models/Profile.ts
+++ b/core/api/src/models/Profile.ts
@@ -213,7 +213,7 @@ export class Profile extends LoggedModel<Profile> {
             )
         ) {
           // it's ok, we are in the middle of creating or destroying a profile property
-          log(error, "alert");
+          log(error, "info");
         } else {
           throw error;
         }

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -222,7 +222,7 @@ export class Source extends LoggedModel<Source> {
     }
   }
 
-  async sourceConnectionOptions() {
+  async sourceConnectionOptions(sourceOptions: SimpleSourceOptions = {}) {
     const { pluginConnection } = await this.getPlugin();
     const app = await this.$get("app");
     const connection = await app.getConnection();
@@ -236,6 +236,7 @@ export class Source extends LoggedModel<Source> {
       connection,
       app,
       appOptions,
+      sourceOptions,
     });
   }
 

--- a/core/web/pages/source/[guid]/edit.tsx
+++ b/core/web/pages/source/[guid]/edit.tsx
@@ -263,6 +263,17 @@ export default function Page(props) {
                           </Form.Text>
                         </>
                       );
+                    } else if (connectionOptions[opt.key]?.type === "pending") {
+                      return (
+                        <>
+                          <Form.Control
+                            size="sm"
+                            disabled
+                            type="text"
+                            value="pending another selection"
+                          ></Form.Control>
+                        </>
+                      );
                     } else {
                       return (
                         <>

--- a/core/web/pages/source/[guid]/edit.tsx
+++ b/core/web/pages/source/[guid]/edit.tsx
@@ -10,16 +10,13 @@ import { Typeahead } from "react-bootstrap-typeahead";
 import { SourceAPIData } from "../../../utils/apiData";
 
 export default function Page(props) {
-  const {
-    errorHandler,
-    successHandler,
-    sourceHandler,
-    connectionOptions,
-    query,
-  } = props;
+  const { errorHandler, successHandler, sourceHandler, query } = props;
   const { execApi } = useApi(props, errorHandler);
   const [preview, setPreview] = useState([]);
   const [source, setSource] = useState<SourceAPIData>(props.source);
+  const [connectionOptions, setConnectionOptions] = useState(
+    props.connectionOptions
+  );
   const { guid } = query;
 
   useEffect(() => {
@@ -76,6 +73,18 @@ export default function Page(props) {
       }
     }
   };
+
+  async function refreshOptions() {
+    const response = await execApi(
+      "get",
+      `/source/${guid}/connectionOptions`,
+      source,
+      null,
+      null,
+      false
+    );
+    if (response?.options) setConnectionOptions(response.options);
+  }
 
   async function handleDelete() {
     if (window.confirm("are you sure?")) {
@@ -197,12 +206,12 @@ export default function Page(props) {
                                   key={`opt-${idx}-descriptions`}
                                   className="text-small"
                                 >
-                                  <em>
-                                    Descriptions:{" "}
-                                    {opt.descriptions
-                                      ? opt.descriptions.join(", ")
-                                      : "None"}
-                                  </em>
+                                  {opt.descriptions ? (
+                                    <em>
+                                      Descriptions:{" "}
+                                      {opt.descriptions.join(", ")}
+                                    </em>
+                                  ) : null}
                                 </small>,
                               ];
                             }}
@@ -345,7 +354,8 @@ Page.getInitialProps = async (ctx) => {
   const { source } = await execApi("get", `/source/${guid}`);
   const { options: connectionOptions } = await execApi(
     "get",
-    `/source/${guid}/connectionOptions`
+    `/source/${guid}/connectionOptions`,
+    { options: source.options }
   );
 
   return { source, connectionOptions };

--- a/plugins/@grouparoo/mysql/src/lib/export/destinationOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/destinationOptions.ts
@@ -3,17 +3,26 @@ import { DestinationOptionsMethod } from "@grouparoo/core";
 export const destinationOptions: DestinationOptionsMethod = async ({
   connection,
   appOptions,
+  destinationOptions,
 }) => {
+  async function getColumns(tableName: string) {
+    const colRows = await connection.asyncQuery(
+      `SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = ? AND table_name = ?`,
+      [appOptions.database, tableName]
+    );
+
+    return colRows.map((row) => row.column_name).sort();
+  }
+
   const response = {
     table: { type: "typeahead", options: [] },
     groupsTable: { type: "typeahead", options: [] },
-    primaryKey: { type: "typeahead", options: [] },
-    groupForeignKey: { type: "typeahead", options: [] },
-    groupColumnName: { type: "typeahead", options: [] },
+    primaryKey: { type: "pending", options: [] },
+    groupForeignKey: { type: "pending", options: [] },
+    groupColumnName: { type: "pending", options: [] },
   };
 
   const tables = [];
-  const columns = [];
 
   const rows = await connection.asyncQuery(
     `SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = ?`,
@@ -23,25 +32,28 @@ export const destinationOptions: DestinationOptionsMethod = async ({
   for (const i in rows) {
     const tableName: string = rows[i].table_name;
     tables.push(tableName);
-    const colRows = await connection.asyncQuery(
-      `SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = ? AND table_name = ?`,
-      [appOptions.database, tableName]
-    );
-    colRows.map((r) => {
-      if (!columns.includes(r.column_name)) {
-        columns.push(r.column_name);
-      }
-    });
   }
 
   tables.sort();
-  columns.sort();
 
   response.table.options = tables;
   response.groupsTable.options = tables;
-  response.primaryKey.options = columns;
-  response.groupForeignKey.options = columns;
-  response.groupColumnName.options = columns;
+
+  if (destinationOptions.table) {
+    response.primaryKey.type = "typeahead";
+    response.primaryKey.options = await getColumns(destinationOptions.table);
+  }
+
+  if (destinationOptions.groupsTable) {
+    response.groupForeignKey.type = "typeahead";
+    response.groupColumnName.type = "typeahead";
+    response.groupForeignKey.options = await getColumns(
+      destinationOptions.groupsTable
+    );
+    response.groupColumnName.options = await getColumns(
+      destinationOptions.groupsTable
+    );
+  }
 
   return response;
 };


### PR DESCRIPTION
This PR re-sends source and destination options back to the plugin methods as they are filled in.  In this way, the source/destination can modify the options returned to the user to select.  A new type of option, `pending` can be used to indicate that an option depends on another, ie: choosing a table before a list of columns is returned.  This dependency logic is up to the plugin. 

![output](https://user-images.githubusercontent.com/303226/84958753-e4f2b500-b0b2-11ea-9164-a1cdfc42cd74.gif)

closes https://github.com/grouparoo/grouparoo/issues/363