### PR TITLE
The options for AsyncTypeahead need to always be strings

### DIFF
--- a/core/web/pages/group/[guid]/rules.tsx
+++ b/core/web/pages/group/[guid]/rules.tsx
@@ -392,7 +392,7 @@ export default function Page(props) {
                               setLocalRules(_rules);
                             }}
                             options={
-                              autocompleteResults[rule.key].map((v) =>
+                              autocompleteResults[rule.key]?.map((v) =>
                                 v.toString()
                               ) || []
                             }

--- a/core/web/pages/group/[guid]/rules.tsx
+++ b/core/web/pages/group/[guid]/rules.tsx
@@ -391,7 +391,11 @@ export default function Page(props) {
                               _rules[idx] = rule;
                               setLocalRules(_rules);
                             }}
-                            options={autocompleteResults[rule.key] || []}
+                            options={
+                              autocompleteResults[rule.key].map((v) =>
+                                v.toString()
+                              ) || []
+                            }
                             onSearch={(_match) => {
                               autocompleteProfilePropertySearch(rule, _match);
                             }}


### PR DESCRIPTION
closes https://github.com/grouparoo/grouparoo/issues/369