### PR TITLE
Always bump groupMember#updatedAt, even when force-syncing a destination

### DIFF
--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -509,6 +509,7 @@ export class Group extends LoggedModel<Group> {
         rules,
         this.matchType
       );
+
       profiles = await ProfileMultipleAssociationShim.findAll({
         attributes: ["guid"],
         where,
@@ -540,10 +541,12 @@ export class Group extends LoggedModel<Group> {
         await run.increment(["importsCreated"], { transaction });
         await _import.save({ transaction });
         await transaction.commit();
-      } else {
-        groupMember.set("updatedAt", new Date());
+      }
+
+      if (groupMember) {
         groupMember.removedAt = null;
-        await groupMember.changed("updatedAt", true);
+        groupMember.set("updatedAt", new Date());
+        groupMember.changed("updatedAt", true);
         await groupMember.save();
       }
 


### PR DESCRIPTION
solves https://github.com/grouparoo/grouparoo/issues/375

When a group was first tracked (or untracked) by a destination, we would force-sync.  We would then not bump  `groupMember#updatedAt`, leading to a second sync of that user. 