### PR TITLE
Store previous page as global prop; never user Router.back

### DIFF
--- a/core/web/pages/_app.tsx
+++ b/core/web/pages/_app.tsx
@@ -1,6 +1,6 @@
 import App from "next/app";
 import { useState, useEffect } from "react";
-import { useRouter } from "next/router";
+import Router, { useRouter } from "next/router";
 import { useApi } from "../hooks/useApi";
 
 import "../scss/grouparoo.scss";
@@ -45,6 +45,7 @@ require("../components/icons");
 export default function GrouparooWebApp(props) {
   const { Component } = props;
   const [routerReady, setRouterReady] = useState(false);
+  const [previousPath, setPreviousPath] = useState("");
   const router = useRouter();
   const { query, pathname } = router;
 
@@ -52,12 +53,26 @@ export default function GrouparooWebApp(props) {
   // See https://github.com/zeit/next.js/issues/8259
   useEffect(() => {
     setRouterReady(true);
+    if (previousPath === "")
+      setPreviousPath(
+        window?.document?.referrer.replace(window?.location?.origin, "")
+      );
+
+    Router.events.on("routeChangeStart", (newRoute) => {
+      if (window?.location?.pathname !== newRoute)
+        setPreviousPath(window?.location?.pathname);
+    });
+
+    return () => {
+      Router.events.off("routeChangeStart", setPreviousPath);
+    };
   }, [pathname, query]);
 
   const combinedProps = Object.assign({}, props.pageProps || {}, {
     currentTeamMember: props.currentTeamMember,
     navigation: props.navigation,
     navigationMode: props.navigationMode,
+    previousPath,
     successHandler,
     errorHandler,
     uploadHandler,

--- a/core/web/pages/profilePropertyRule/[guid]/edit.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/edit.tsx
@@ -17,6 +17,7 @@ import { ProfilePropertyRuleAPIData } from "../../../utils/apiData";
 
 export default function Page(props) {
   const {
+    previousPath,
     errorHandler,
     successHandler,
     profilePropertyRulesHandler,
@@ -65,7 +66,7 @@ export default function Page(props) {
           response.profilePropertyRule.state === "ready" &&
           profilePropertyRule.state === "draft"
         ) {
-          Router.back();
+          Router.push(previousPath);
         } else {
           successHandler.set({ message: "Profile Property Rule Updated" });
         }
@@ -83,7 +84,7 @@ export default function Page(props) {
       const response = await execApi("delete", `/profilePropertyRule/${guid}`);
       setLoading(false);
       if (response) {
-        Router.back();
+        Router.push(previousPath);
       }
     }
   }


### PR DESCRIPTION
closes https://github.com/grouparoo/grouparoo/issues/349

We now provide the `intitialPageProp` of `previousRoute` to all pages.  This contains the previous page's URL.  This should be used with `Router.push(previousPage)` vs `Router.back()`.  This will really re-hydrate pages and load new data, and won't mess with the back button's behavior.