### PR TITLE
Draft breadcrumbs include the topic name

### DIFF
--- a/core/web/components/tabs.tsx
+++ b/core/web/components/tabs.tsx
@@ -39,7 +39,11 @@ export default function GrouparooTabs({
           {capitalize(pluralize(topic))}
         </Breadcrumb.Item>
         <Breadcrumb.Item>
-          {name !== "" ? name : draftType ? `${draftType} Draft` : "Draft"}
+          {name !== ""
+            ? name
+            : draftType
+            ? `${capitalize(draftType)} Draft`
+            : "Draft"}
         </Breadcrumb.Item>
         <Breadcrumb.Item>{capitalize(verb)}</Breadcrumb.Item>
       </Breadcrumb>

--- a/core/web/components/tabs.tsx
+++ b/core/web/components/tabs.tsx
@@ -31,7 +31,9 @@ export default function GrouparooTabs({
         <Breadcrumb.Item href={`/${pluralize(topic)}`}>
           {capitalize(pluralize(topic))}
         </Breadcrumb.Item>
-        <Breadcrumb.Item>{name !== "" ? name : "Draft"}</Breadcrumb.Item>
+        <Breadcrumb.Item>
+          {name !== "" ? name : `${capitalize(topic)} Draft`}
+        </Breadcrumb.Item>
         <Breadcrumb.Item>{capitalize(verb)}</Breadcrumb.Item>
       </Breadcrumb>
 

--- a/core/web/components/tabs.tsx
+++ b/core/web/components/tabs.tsx
@@ -3,9 +3,11 @@ import Router from "next/router";
 
 export default function GrouparooTabs({
   name,
+  draftType,
   tabs,
 }: {
   name: string;
+  draftType?: string;
   tabs: string[];
 }) {
   if (!globalThis.location) {
@@ -18,7 +20,12 @@ export default function GrouparooTabs({
   const verb = parts[5].split("?")[0];
 
   function capitalize(s: string) {
-    return s.charAt(0).toUpperCase() + s.slice(1);
+    return s
+      .split(" ")
+      .map((word) => {
+        return word.charAt(0).toUpperCase() + word.slice(1);
+      })
+      .join(" ");
   }
 
   function pluralize(s: string) {
@@ -32,7 +39,7 @@ export default function GrouparooTabs({
           {capitalize(pluralize(topic))}
         </Breadcrumb.Item>
         <Breadcrumb.Item>
-          {name !== "" ? name : `${capitalize(topic)} Draft`}
+          {name !== "" ? name : draftType ? `${draftType} Draft` : "Draft"}
         </Breadcrumb.Item>
         <Breadcrumb.Item>{capitalize(verb)}</Breadcrumb.Item>
       </Breadcrumb>

--- a/core/web/components/tabs/app.tsx
+++ b/core/web/components/tabs/app.tsx
@@ -3,5 +3,5 @@ import { AppAPIData } from "../../utils/apiData";
 
 export default function ({ app }: { app: AppAPIData }) {
   const tabs = ["edit"];
-  return <Tabs name={app.name} tabs={tabs} />;
+  return <Tabs name={app.name} draftType={app.type} tabs={tabs} />;
 }

--- a/core/web/components/tabs/destination.tsx
+++ b/core/web/components/tabs/destination.tsx
@@ -3,5 +3,7 @@ import { DestinationAPIData } from "../../utils/apiData";
 
 export default function ({ destination }: { destination: DestinationAPIData }) {
   const tabs = ["edit", "data", "exports"];
-  return <Tabs name={destination.name} tabs={tabs} />;
+  return (
+    <Tabs name={destination.name} draftType={destination.type} tabs={tabs} />
+  );
 }

--- a/core/web/components/tabs/profilePropertyRule.tsx
+++ b/core/web/components/tabs/profilePropertyRule.tsx
@@ -15,7 +15,11 @@ export default function ({
 
   return (
     <>
-      <Tabs name={profilePropertyRule.key} tabs={tabs} />
+      <Tabs
+        name={profilePropertyRule.key}
+        draftType={profilePropertyRule.source.name}
+        tabs={tabs}
+      />
     </>
   );
 }

--- a/core/web/components/tabs/source.tsx
+++ b/core/web/components/tabs/source.tsx
@@ -13,5 +13,5 @@ export default function ({ source }: { source: SourceAPIData }) {
     tabs.push("runs");
   }
 
-  return <Tabs name={source.name} tabs={tabs} />;
+  return <Tabs name={source.name} draftType={source.type} tabs={tabs} />;
 }


### PR DESCRIPTION
closes https://github.com/grouparoo/grouparoo/issues/385.  

Draft objects now include the name of the topic in the breadcrumb, like `Postgres Draft` (app) or `Mysql-table Draft` (source)

<img width="1473" alt="Screen Shot 2020-06-23 at 11 17 11 AM" src="https://user-images.githubusercontent.com/303226/85440612-16e89900-b543-11ea-9dfc-6964070d54e8.png">
