### PR TITLE
Store Typeahead value when focus is lost

### DIFF
--- a/core/api/src/actions/events.ts
+++ b/core/api/src/actions/events.ts
@@ -30,9 +30,7 @@ export class EventsList extends AuthenticatedAction {
     const where = {};
     const includeWhere = {};
 
-    if (params.type) {
-      where["type"] = params.type;
-    }
+    if (params.type) where["type"] = { [Op.iLike]: params.type };
 
     if (params.profileGuid) {
       where["profileGuid"] = params.profileGuid;

--- a/core/web/components/events/list.tsx
+++ b/core/web/components/events/list.tsx
@@ -108,7 +108,9 @@ export default function EventsList(props) {
       {hideSearch ? null : (
         <Form id="search" onSubmit={load}>
           <Form.Group>
-            <Form.Label>Event Type</Form.Label>
+            <Form.Label>
+              Event Type (use <code>%</code> for wildcards)
+            </Form.Label>
             <AsyncTypeahead
               key={`typeahead-search-${type}`}
               id={`typeahead-search-${type}`}
@@ -124,6 +126,10 @@ export default function EventsList(props) {
                     ? selected[0].label // when a new custom option is set
                     : selected[0] // when a list option is chosen);
                 );
+              }}
+              onBlur={(e) => {
+                const value = e.target.value;
+                if (value && value.length > 0) setType(value);
               }}
               options={autocompleteResults}
               onSearch={autocompleteProfilePropertySearch}

--- a/core/web/components/profile/list.tsx
+++ b/core/web/components/profile/list.tsx
@@ -170,6 +170,10 @@ export default function ProfilesList(props) {
                         : selected[0] // when a list option is chosen);
                     );
                   }}
+                  onBlur={(e) => {
+                    const value = e.target.value;
+                    if (value && value.length > 0) setSearchValue(value);
+                  }}
                   options={autocompleteResults}
                   onSearch={autocompleteProfilePropertySearch}
                   placeholder={`name@example.com`}

--- a/core/web/components/visualizations/eventsTotals.tsx
+++ b/core/web/components/visualizations/eventsTotals.tsx
@@ -81,7 +81,6 @@ export default function EventsTotals(props) {
         <Accordion>
           <Row>
             <Col>
-              {" "}
               <Form inline>
                 <p>
                   Showing {total} events from{" "}
@@ -104,7 +103,7 @@ export default function EventsTotals(props) {
                     }}
                   >
                     {dateTruncOptions.map((opt) => (
-                      <option>{opt}</option>
+                      <option key={`events-totals-${opt}`}>{opt}</option>
                     ))}
                   </Form.Control>
                 </p>

--- a/core/web/components/visualizations/eventsTotals.tsx
+++ b/core/web/components/visualizations/eventsTotals.tsx
@@ -16,7 +16,7 @@ export default function EventsTotals(props) {
   const [total, setTotal] = useState<number>(props.total);
   const [counts, setCounts] = useState(props.counts);
   const { execApi } = useApi(props, errorHandler);
-  const [dateTrunc, setDateTrunc] = useState(query.dateTrunc);
+  const [dateTrunc, setDateTrunc] = useState(query.dateTrunc || "day");
   const [startDate, setStartDate] = useState<Date>(
     query.startTime
       ? new Date(parseInt(query.startTime))

--- a/core/web/pages/group/[guid]/rules.tsx
+++ b/core/web/pages/group/[guid]/rules.tsx
@@ -365,6 +365,15 @@ export default function Page(props) {
                               _rules[idx] = rule;
                               setLocalRules(_rules);
                             }}
+                            onBlur={(e) => {
+                              const value = e.target.value;
+                              if (value && value.length > 0) {
+                                const _rules = [...localRules];
+                                rule.match = value;
+                                _rules[idx] = rule;
+                                setLocalRules(_rules);
+                              }
+                            }}
                             options={
                               autocompleteResults[rule.key]?.map((v) =>
                                 v.toString()


### PR DESCRIPTION
When the mouse is moved away from the `<AsyncTypeahead />` (using the `onBlur` DOM event), we treat the current value in the form as a valid submission. 
* In the case that the user chose a valid autocomplete value, it will just re-save
* In the case that the user typed a custom value, but hasn't clicked "New Selection..." from the drop down, we'll save the value as if they had. 

![movie](https://user-images.githubusercontent.com/303226/85889072-9ffc0c00-b79f-11ea-8887-a5bfa10a00f2.gif)

This is not a problem with `<Typeahead />` as we do not accept user-provided values.

Closes https://github.com/grouparoo/grouparoo/issues/252