### PR TITLE
Create Hubspot lists within a global lock

### DIFF
--- a/core/api/src/index.ts
+++ b/core/api/src/index.ts
@@ -30,3 +30,5 @@ export { Setting } from "./models/Setting";
 export { Source } from "./models/Source";
 export { Team } from "./models/Team";
 export { TeamMember } from "./models/TeamMember";
+
+export { waitForLock } from "./modules/locks";

--- a/plugins/@grouparoo/hubspot/src/lib/export/listMethods.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/export/listMethods.ts
@@ -1,25 +1,32 @@
 import { cache } from "actionhero";
+import { waitForLock } from "@grouparoo/core";
 import Axios, { AxiosError } from "axios";
 
 const cacheKey = "grouparoo:hubspot:lists";
 const cacheDuration = 1000 * 60; // 1 minute
+const lockKey = "grouparoo:hubspot:getLists";
 
 export async function getLists(appOptions, force = false) {
   // TODO: This is not paginated, it will need to be
   // https://legacydocs.hubspot.com/docs/methods/lists/get_static_lists
   const url = `https://api.hubapi.com/contacts/v1/lists/static?hapikey=${appOptions.hapikey}&count=999`;
 
+  const { releaseLock } = await waitForLock(lockKey);
+
   if (force) await cache.destroy(cacheKey);
 
   try {
     const cachedLists = await cache.load(cacheKey);
+    releaseLock();
     return cachedLists.value;
   } catch (error) {
     if (
       error.message.toString() !== "Object not found" &&
       error.message.toString() !== "Object expired"
-    )
+    ) {
+      releaseLock();
       throw error;
+    }
 
     try {
       const { data } = await Axios({
@@ -28,22 +35,29 @@ export async function getLists(appOptions, force = false) {
         headers: { "Content-Type": "application/json" },
       });
       await cache.save(cacheKey, data.lists, cacheDuration);
+      releaseLock();
       return data.lists;
     } catch (error) {
+      releaseLock();
       throwBetterAxiosError(error);
     }
   }
 }
 
-export async function ensureGroupContactListExists(appOptions, groupName) {
-  const url = `https://api.hubapi.com/contacts/v1/lists?hapikey=${appOptions.hapikey}`;
+export async function ensureGroupContactListExists(
+  appOptions,
+  groupName
+): Promise<string> {
   const hubspotLists = await getLists(appOptions);
 
-  const found =
-    hubspotLists.filter((list) => list.name === groupName).length === 1;
-  if (found) return;
+  const matchingList = hubspotLists.filter(
+    (list) => list.name === groupName
+  )[0];
+  if (matchingList) return matchingList.listId;
 
   try {
+    const url = `https://api.hubapi.com/contacts/v1/lists?hapikey=${appOptions.hapikey}`;
+
     await Axios({
       method: "POST",
       url,
@@ -53,17 +67,15 @@ export async function ensureGroupContactListExists(appOptions, groupName) {
       },
     });
     await getLists(appOptions, true);
+    return ensureGroupContactListExists(appOptions, groupName);
   } catch (error) {
     throwBetterAxiosError(error);
   }
 }
 
 export async function addToList(appOptions, email, groupName) {
-  await ensureGroupContactListExists(appOptions, groupName);
-
-  const hubspotLists = await getLists(appOptions);
-  const list = hubspotLists.filter((list) => list.name === groupName)[0];
-  const url = `https://api.hubapi.com/contacts/v1/lists/${list.listId}/add?hapikey=${appOptions.hapikey}`;
+  const listId = await ensureGroupContactListExists(appOptions, groupName);
+  const url = `https://api.hubapi.com/contacts/v1/lists/${listId}/add?hapikey=${appOptions.hapikey}`;
 
   try {
     await Axios({
@@ -107,7 +119,7 @@ export async function removeFromList(appOptions, email, groupName) {
 function throwBetterAxiosError(error: AxiosError) {
   if (error?.response?.data)
     throw new Error(
-      `Hubspot API ERror: ${JSON.stringify(error?.response?.data)}`
+      `Hubspot API Error: ${JSON.stringify(error?.response?.data)}`
     );
 
   throw error;


### PR DESCRIPTION
closes T-131

Use a global lock (`waitForLock`) when creating Hubspot Lists to prevent double-list creation