### PR TITLE
ts-node-dev v1.0.0-pre.50

### DIFF
--- a/core/api/bin/dev
+++ b/core/api/bin/dev
@@ -19,14 +19,5 @@ for p in $GROUPAROO_PIDS; do
   kill -9 $p
 done
 
+node --max-old-space-size=4096 "$EXECUTABLE" --notify=false --ignore='node_modules' --ignore='../dist' --ignore='core/web' --ignore-watch='../web' --ignore-watch='../plugins' --ignore-watch='../clients' --debug src/server.ts
 
-node \
-  --max-old-space-size=4096 \
-  -- "$EXECUTABLE" \
-    --transpile-only \
-    --ignore-watch=web \
-    --ignore-watch='../web' \
-    --no-deps \
-    --notify=false \
-      -- \
-      src/server.ts

--- a/core/package.json
+++ b/core/package.json
@@ -67,7 +67,7 @@
     "pg-hstore": "^2.3.3",
     "raw-loader": "^4.0.1",
     "react": "^16.13.1",
-    "react-bootstrap": "^1.0.1",
+    "react-bootstrap": "1.0.1",
     "react-bootstrap-typeahead": "^5.1.0",
     "react-date-range": "^1.0.3",
     "react-datepicker": "^3.0.0",

--- a/core/package.json
+++ b/core/package.json
@@ -81,7 +81,7 @@
     "sequelize": "^5.21.6",
     "sequelize-typescript": "^1.1.0",
     "swagger-ui": "^3.28.0",
-    "ts-node-dev": "1.0.0-pre.44",
+    "ts-node-dev": "1.0.0-pre.50",
     "type-fest": "^0.16.0",
     "typescript": "^3.9.5",
     "umzug": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6808,9 +6808,9 @@
 			}
 		},
 		"npm-registry-fetch": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-8.1.0.tgz",
-			"integrity": "sha512-RkcugRDye2j6yEiHGMyAdKQoipgp8VToSIjm+TFLhVraXOkC/WU2kjE2URcYBpcJ4hs++VFBKo6+Zg4wmrS+Qw==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-8.1.1.tgz",
+			"integrity": "sha512-3FCYb/YO6k9vfPMSU6H1CbixQAzoLuBqTTpjcks2PHlN59c0ENTYrDF8lCRvgLm1iAhwhwZg7pRq2VOTw3Yfaw==",
 			"dev": true,
 			"requires": {
 				"@npmcli/ci-detect": "^1.0.0",
@@ -6824,9 +6824,9 @@
 			},
 			"dependencies": {
 				"agent-base": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-					"integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+					"integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
 					"dev": true,
 					"requires": {
 						"debug": "4"

--- a/plugins/@grouparoo/email-authentication/package.json
+++ b/plugins/@grouparoo/email-authentication/package.json
@@ -27,7 +27,7 @@
     "lint": "prettier --check src __tests__"
   },
   "dependencies": {
-    "react-bootstrap": "^1.0.1"
+    "react-bootstrap": "1.0.1"
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",


### PR DESCRIPTION
This PR also should speed up page rendering in development mode, as we won't be double-compiling each page (once via ts-dev-node, and once for next/webpack)