### PR TITLE
Telemetry Reporting

### DIFF
--- a/core/api/__tests__/actions/navigation.ts
+++ b/core/api/__tests__/actions/navigation.ts
@@ -28,4 +28,9 @@ describe("actions/navigation", () => {
       { type: "link", title: "Create Team", href: "/team/initialize" },
     ]);
   });
+
+  test("the navigation action includes the clusterName", async () => {
+    const { clusterName } = await specHelper.runAction("navigation:list");
+    expect(clusterName).toBe("My Grouparoo Cluster");
+  });
 });

--- a/core/api/__tests__/fixtures/tasks/telemetry.ts
+++ b/core/api/__tests__/fixtures/tasks/telemetry.ts
@@ -1,0 +1,46 @@
+import nock from "nock";
+
+nock("https://telemetry.grouparoo.com:443", { encodedQueryParams: true })
+  .post("/api/v1/telemetry")
+  .reply(
+    200,
+    [],
+    [
+      "Date",
+      "Wed, 08 Jul 2020 23:19:39 GMT",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "Set-Cookie",
+      "__cfduid=da39af4981a8f27eb35a278d27fb6c9ac1594250379; expires=Fri, 07-Aug-20 23:19:39 GMT; path=/; domain=.grouparoo.com; HttpOnly; SameSite=Lax; Secure",
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+      "Access-Control-Allow-Headers",
+      "Content-Type",
+      "Access-Control-Allow-Methods",
+      "HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS, TRACE",
+      "Access-Control-Allow-Origin",
+      "https://telemetry.grouparoo.com",
+      "X-Powered-By",
+      "@grouparoo/telemetry",
+      "Set-Cookie",
+      "sessionID=49882281586f9064514b269ec9d5977ed7beb852;path=/;expires=Thu, 09 Jul 2020 00:19:39 GMT;",
+      "Via",
+      "1.1 vegur",
+      "CF-Cache-Status",
+      "DYNAMIC",
+      "cf-request-id",
+      "03d25357c20000c9a12f119200000001",
+      "Expect-CT",
+      'max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"',
+      "Server",
+      "cloudflare",
+      "CF-RAY",
+      "5afd88060e69c9a1-SEA",
+      "Content-Encoding",
+      "gzip",
+    ]
+  );

--- a/core/api/__tests__/tasks/telemetry.ts
+++ b/core/api/__tests__/tasks/telemetry.ts
@@ -1,0 +1,88 @@
+import { helper } from "../utils/specHelper";
+import { Log } from "../../src/models/Log";
+import { plugin } from "../../src/modules/plugin";
+import { api, task, specHelper, config } from "actionhero";
+
+let actionhero;
+
+// uncomment to use real HTTP requests
+// import nock from "nock";
+// nock.recorder.rec();
+
+// load the saved nock recordings
+// Note: This fixture has been made generic so it returns 200 regardless of the content sent
+require("./../fixtures/tasks/telemetry");
+
+describe("tasks/telemetry", () => {
+  beforeAll(async () => {
+    const env = await helper.prepareForAPITest();
+    actionhero = env.actionhero;
+    await api.resque.queue.connection.redis.flushdb();
+  }, 1000 * 30);
+
+  afterAll(async () => {
+    await helper.shutdown(actionhero);
+  });
+
+  describe("telemetry", () => {
+    beforeAll(async () => {
+      await helper.factories.profilePropertyRules();
+      await Log.destroy({ truncate: true });
+    });
+
+    test("settings are loaded at boot", async () => {
+      const setting = await plugin.readSetting("telemetry", "customer-guid");
+      expect(setting.value).toMatch(/^tcs_/);
+    });
+
+    test("the telemetry object can be built", async () => {
+      const {
+        customerName,
+        customerGuid,
+        customerLicense,
+        metrics,
+      } = await api.telemetry.build();
+      expect(customerName).toBe("My Grouparoo Cluster");
+      expect(customerGuid).toMatch(/^tcs_/);
+      expect(customerLicense).toBe("");
+
+      expect(metrics[0]).toEqual(
+        expect.objectContaining({
+          collection: "cluster",
+          topic: "workers",
+          aggregation: "count",
+        })
+      );
+
+      expect(metrics[1]).toEqual(
+        expect.objectContaining({
+          collection: "cluster",
+          topic: "os",
+          aggregation: "exact",
+        })
+      );
+
+      expect(metrics[2]).toEqual(
+        expect.objectContaining({
+          collection: "totals",
+          topic: "App",
+          aggregation: "count",
+        })
+      );
+    });
+
+    test("the task can be run", async () => {
+      // does not throw
+      config.telemetry.enabled = true;
+      const ok = await specHelper.runTask("telemetry", {});
+      expect(ok).toBe(true);
+      config.telemetry.enabled = false;
+    });
+
+    test("telemetry can be disabled", async () => {
+      // disabled by default in NODE_ENV=test
+      const response = await specHelper.runTask("telemetry", {});
+      expect(response).toBeUndefined();
+    });
+  });
+});

--- a/core/api/__tests__/tasks/telemetry.ts
+++ b/core/api/__tests__/tasks/telemetry.ts
@@ -36,15 +36,10 @@ describe("tasks/telemetry", () => {
     });
 
     test("the telemetry object can be built", async () => {
-      const {
-        customerName,
-        customerGuid,
-        customerLicense,
-        metrics,
-      } = await api.telemetry.build();
-      expect(customerName).toBe("My Grouparoo Cluster");
-      expect(customerGuid).toMatch(/^tcs_/);
-      expect(customerLicense).toBe("");
+      const { name, guid, license, metrics } = await api.telemetry.build();
+      expect(name).toBe("My Grouparoo Cluster");
+      expect(guid).toMatch(/^tcs_/);
+      expect(license).toBe("");
 
       expect(metrics[0]).toEqual(
         expect.objectContaining({

--- a/core/api/jest.config.js
+++ b/core/api/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   testPathIgnorePatterns: [
     "<rootDir>/__tests__/utils",
     "<rootDir>/__tests__/factories",
+    "<rootDir>/__tests__/fixtures",
     "<rootDir>/src/.*/*.ts",
     "<rootDir>/dist/.*/*.ts",
     "<rootDir>/dist/.*/*.js",

--- a/core/api/src/actions/navigation.ts
+++ b/core/api/src/actions/navigation.ts
@@ -1,5 +1,6 @@
 import { OptionallyAuthenticatedAction } from "../classes/optionallyAuthenticatedAction";
 import { Team } from "../models/Team";
+import { Setting } from "../models/Setting";
 
 export class NavigationList extends OptionallyAuthenticatedAction {
   constructor() {
@@ -166,7 +167,12 @@ export class NavigationList extends OptionallyAuthenticatedAction {
       });
     }
 
+    const clusterNameSetting = await Setting.findOne({
+      where: { pluginName: "core", key: "cluster-name" },
+    });
+
     response.navigationMode = navigationMode;
+    response.clusterName = clusterNameSetting.value;
     response.navigation = {
       navigationItems,
       platformItems,

--- a/core/api/src/config/telemetry.ts
+++ b/core/api/src/config/telemetry.ts
@@ -1,11 +1,12 @@
 export const DEFAULT = {
   telemetry: () => {
     return {
-      enabled: ["false", "FALSE", "0", "off"].includes(
-        process.env.GROUPAROO_TELEMETRY_ENABLED
-      )
-        ? false
-        : true,
+      enabled:
+        ["false", "FALSE", "0", "off"].includes(
+          process.env.GROUPAROO_TELEMETRY_ENABLED
+        ) || process.env.NODE_ENV === "test"
+          ? false
+          : true,
       url:
         process.env.GROUPAROO_TELEMETRY_URL ||
         "https://telemetry.grouparoo.com/api/v1/telemetry",

--- a/core/api/src/config/telemetry.ts
+++ b/core/api/src/config/telemetry.ts
@@ -1,0 +1,14 @@
+export const DEFAULT = {
+  telemetry: () => {
+    return {
+      enabled: ["false", "FALSE", "0", "off"].includes(
+        process.env.GROUPAROO_TELEMETRY_ENABLED
+      )
+        ? false
+        : true,
+      url:
+        process.env.GROUPAROO_TELEMETRY_URL ||
+        "https://telemetry.grouparoo.com/api/v1/telemetry",
+    };
+  },
+};

--- a/core/api/src/initializers/settings.ts
+++ b/core/api/src/initializers/settings.ts
@@ -11,6 +11,12 @@ export class Plugins extends Initializer {
     // The core API configurable settings
     const coreSettings = [
       {
+        key: "cluster-name",
+        defaultValue: "My Grouparoo Cluster",
+        description:
+          "A way to identify this Grouparoo cluster.  Will be displayed in the web interface and sent with Telemetry.",
+      },
+      {
         key: "groups-calculation-delay-minutes",
         defaultValue: 60,
         description:

--- a/core/api/src/initializers/telemetry.ts
+++ b/core/api/src/initializers/telemetry.ts
@@ -1,0 +1,27 @@
+// const fetch = require("isomorphic-fetch");
+import { Initializer } from "actionhero";
+import { plugin } from "../modules/plugin";
+import * as UUID from "uuid";
+
+export class Plugins extends Initializer {
+  constructor() {
+    super();
+    this.name = "telemetry";
+  }
+
+  async start() {
+    await plugin.registerSetting(
+      "telemetry",
+      "customer-guid",
+      `tcs_${UUID.v4()}`,
+      "A unique, anonymous ID for this Grouparoo cluster."
+    );
+
+    await plugin.registerSetting(
+      "telemetry",
+      "customer-license",
+      "",
+      "Your Grouparoo License Key (for paid features)."
+    );
+  }
+}

--- a/core/api/src/initializers/telemetry.ts
+++ b/core/api/src/initializers/telemetry.ts
@@ -48,9 +48,9 @@ declare module "actionhero" {
   export interface Api {
     telemetry: {
       build: () => Promise<{
-        customerGuid: string;
-        customerName: string;
-        customerLicense: string;
+        guid: string;
+        name: string;
+        license: string;
         metrics: TelemetryMetric[];
       }>;
     };
@@ -97,9 +97,9 @@ export class Plugins extends Initializer {
         pluginManifest.plugins.forEach((plugin) => {
           metrics.push({
             collection: "cluster",
-            topic: "plugin",
+            topic: plugin.name,
             aggregation: "exact",
-            key: plugin.name,
+            key: "version",
             value: plugin.version,
           });
         });
@@ -190,9 +190,9 @@ export class Plugins extends Initializer {
         });
 
         return {
-          customerName: clusterNameSetting.value,
-          customerGuid: clusterGuidSetting.value,
-          customerLicense: clusterLicenseSetting.value,
+          name: clusterNameSetting.value,
+          guid: clusterGuidSetting.value,
+          license: clusterLicenseSetting.value,
           metrics: mergedMetrics,
         };
       },

--- a/core/api/src/initializers/telemetry.ts
+++ b/core/api/src/initializers/telemetry.ts
@@ -1,12 +1,202 @@
 // const fetch = require("isomorphic-fetch");
-import { Initializer } from "actionhero";
+import { Initializer, api } from "actionhero";
 import { plugin } from "../modules/plugin";
+import { Setting } from "../models/Setting";
 import * as UUID from "uuid";
+import os from "os";
+import PluginDetails from "./../utils/pluginDetails";
+const pluginManifest = PluginDetails.getPluginManifest();
+
+import {
+  App,
+  ApiKey,
+  Source,
+  Schedule,
+  Destination,
+  Import,
+  File,
+  Group,
+  GroupRule,
+  Export,
+  Event,
+  Profile,
+  ProfileProperty,
+  ProfilePropertyRule,
+  Run,
+  Team,
+  TeamMember,
+} from "../index";
+
+interface TelemetryMetric {
+  // the possible attributes for a metric are:
+  // { collection, topic, aggregation, key, value, count, min, max, avg, imports, exports, runs, errors }
+  collection: string;
+  topic: string;
+  aggregation: string;
+  key?: string;
+  value?: string;
+  count?: number;
+  min?: number;
+  max?: number;
+  avg?: number;
+  imports?: number;
+  exports?: number;
+  runs?: number;
+  errors?: number;
+}
+declare module "actionhero" {
+  export interface Api {
+    telemetry: {
+      build: () => Promise<{
+        customerGuid: string;
+        customerName: string;
+        customerLicense: string;
+        metrics: TelemetryMetric[];
+      }>;
+    };
+  }
+}
 
 export class Plugins extends Initializer {
   constructor() {
     super();
     this.name = "telemetry";
+  }
+
+  async initialize() {
+    api.telemetry = {
+      build: async () => {
+        const metrics: TelemetryMetric[] = [];
+
+        // load settings
+        const clusterNameSetting = await Setting.findOne({
+          where: { pluginName: "core", key: "cluster-name" },
+        });
+        const clusterGuidSetting = await Setting.findOne({
+          where: { pluginName: "telemetry", key: "customer-guid" },
+        });
+        const clusterLicenseSetting = await Setting.findOne({
+          where: { pluginName: "telemetry", key: "customer-license" },
+        });
+
+        // information about how Grouparoo is being operated
+        metrics.push({
+          collection: "cluster",
+          topic: "workers",
+          aggregation: "count",
+          count: Object.keys(await api.resque.queue.workers()).length,
+        });
+        metrics.push({
+          collection: "cluster",
+          topic: "os",
+          aggregation: "exact",
+          value: `${process.platform}/${os.release()}`,
+        });
+
+        // versions of the plugins installed
+        pluginManifest.plugins.forEach((plugin) => {
+          metrics.push({
+            collection: "cluster",
+            topic: "plugin",
+            aggregation: "exact",
+            key: plugin.name,
+            value: plugin.version,
+          });
+        });
+
+        // usage counts
+        const Models = [
+          App,
+          ApiKey,
+          Source,
+          Schedule,
+          Destination,
+          Import,
+          File,
+          Group,
+          GroupRule,
+          Export,
+          Event,
+          Profile,
+          ProfileProperty,
+          ProfilePropertyRule,
+          Run,
+          Team,
+          TeamMember,
+        ];
+        for (const i in Models) {
+          metrics.push({
+            collection: "totals",
+            topic: Models[i].name,
+            aggregation: "count",
+            count: await Models[i].count(),
+          });
+        }
+
+        // usage by source
+        const sources = await Source.findAll();
+        for (const i in sources) {
+          const source = sources[i];
+          const schedule = await source.$get("schedule");
+          const { plugin } = await source.getPlugin();
+          metrics.push({
+            collection: "sourceTotals",
+            topic: plugin.name,
+            aggregation: "count",
+            // imports: 0, // TODO?
+            // exports: 0,
+            runs: schedule
+              ? await Run.count({ where: { creatorGuid: schedule.guid } })
+              : 0,
+          });
+        }
+
+        // usage by destination
+        const destinations = await Destination.findAll();
+        for (const i in destinations) {
+          const destination = destinations[i];
+          const { pluginApp } = await destination.getPlugin();
+          metrics.push({
+            collection: "destinationTotals",
+            topic: pluginApp.name,
+            aggregation: "count",
+            // imports: 0, // TODO?
+            exports: await Export.count({
+              where: { destinationGuid: destination.guid },
+            }),
+            runs: await Run.count({ where: { creatorGuid: destination.guid } }), // TODO: the group is actually the run owner
+          });
+        }
+
+        var mergedMetrics = [];
+        metrics.forEach((item, idx) => {
+          const found = mergedMetrics.some((el, i) => {
+            if (i === idx) return false;
+            return (
+              el.collection === item.collection &&
+              el.topic === item.topic &&
+              el.aggregation === item.aggregation
+            );
+          });
+          if (!found) {
+            mergedMetrics.push(item);
+          } else if (idx !== null) {
+            for (const k in Object.keys(item)) {
+              if (item.hasOwnProperty(k)) {
+                mergedMetrics[idx].count = +item.count;
+              }
+            }
+          }
+        });
+
+        return {
+          customerName: clusterNameSetting.value,
+          customerGuid: clusterGuidSetting.value,
+          customerLicense: clusterLicenseSetting.value,
+          metrics: mergedMetrics,
+        };
+      },
+    };
   }
 
   async start() {

--- a/core/api/src/initializers/telemetry.ts
+++ b/core/api/src/initializers/telemetry.ts
@@ -155,10 +155,10 @@ export class Plugins extends Initializer {
         const destinations = await Destination.findAll();
         for (const i in destinations) {
           const destination = destinations[i];
-          const { pluginApp } = await destination.getPlugin();
+          const { plugin } = await destination.getPlugin();
           metrics.push({
             collection: "destinationTotals",
-            topic: pluginApp.name,
+            topic: plugin.name,
             aggregation: "count",
             // imports: 0, // TODO?
             exports: await Export.count({

--- a/core/api/src/tasks/telemetry.ts
+++ b/core/api/src/tasks/telemetry.ts
@@ -1,0 +1,26 @@
+import { Task, api, config } from "actionhero";
+import fetch from "isomorphic-fetch";
+
+export class Sweeper extends Task {
+  constructor() {
+    super();
+    this.name = "telemetry";
+    this.description = "send telemetry information about this cluster";
+    this.frequency = 1000 * 60 * 60 * 24; // every 24 hours
+    this.queue = "default";
+  }
+
+  async run() {
+    if (!config.telemetry.enabled) return;
+
+    const payload = await api.telemetry.build();
+
+    const response = await fetch(config.telemetry.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    return response.status === 200;
+  }
+}

--- a/core/web/components/layouts/main.tsx
+++ b/core/web/components/layouts/main.tsx
@@ -17,6 +17,7 @@ export default function ({
   sessionHandler,
   currentTeamMember,
   navigation,
+  clusterName,
   navigationMode,
 }) {
   const [navExpanded, setNavExpanded] = useState(true);
@@ -148,6 +149,7 @@ export default function ({
           pathname={pathname}
           currentTeamMember={currentTeamMember}
           navigation={navigation}
+          clusterName={clusterName}
           navigationMode={navigationMode}
           sessionHandler={sessionHandler}
           navExpanded={navExpanded}

--- a/core/web/components/navigation.tsx
+++ b/core/web/components/navigation.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Image, Accordion, Button } from "react-bootstrap";
+import { Image, Accordion, Button, Badge } from "react-bootstrap";
 import Link from "next/link";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -22,6 +22,7 @@ export default function Navigation(props) {
     pathname,
     navigationMode,
     navigation,
+    clusterName,
     sessionHandler,
     navExpanded,
     toggleNavExpanded,
@@ -124,6 +125,8 @@ export default function Navigation(props) {
             />
           </a>
         </Link>
+        <br />
+        <Badge variant="secondary">{clusterName}</Badge>
 
         <ul style={{ padding: 0, margin: 0 }}>
           {navigation.navigationItems.map((nav, idx) => {

--- a/core/web/pages/_app.tsx
+++ b/core/web/pages/_app.tsx
@@ -72,6 +72,7 @@ export default function GrouparooWebApp(props) {
     currentTeamMember: props.currentTeamMember,
     navigation: props.navigation,
     navigationMode: props.navigationMode,
+    clusterName: props.clusterName,
     previousPath,
     successHandler,
     errorHandler,
@@ -103,7 +104,10 @@ export default function GrouparooWebApp(props) {
 
 GrouparooWebApp.getInitialProps = async (appContext) => {
   const { execApi } = useApi(appContext.ctx);
-  const { navigationMode, navigation } = await execApi("get", `/navigation`);
+  const { navigationMode, navigation, clusterName } = await execApi(
+    "get",
+    `/navigation`
+  );
   let currentTeamMember = {
     firstName: "",
     guid: null,
@@ -115,5 +119,11 @@ GrouparooWebApp.getInitialProps = async (appContext) => {
   // render page-specific getInitialProps
   const appProps = await App.getInitialProps(appContext);
 
-  return { ...appProps, currentTeamMember, navigationMode, navigation };
+  return {
+    ...appProps,
+    currentTeamMember,
+    navigationMode,
+    navigation,
+    clusterName,
+  };
 };

--- a/core/web/pages/settings.tsx
+++ b/core/web/pages/settings.tsx
@@ -36,7 +36,7 @@ export default function Page(props) {
 
       <h1>Settings</h1>
 
-      {pluginNames.map((pluginName) => {
+      {pluginNames.sort().map((pluginName) => {
         return (
           <div key={`plugin-${pluginName}`}>
             <h2>{pluginName}</h2>
@@ -51,16 +51,21 @@ export default function Page(props) {
                 </tr>
               </thead>
               <tbody>
-                {settings.map((setting) =>
-                  setting.pluginName === pluginName ? (
-                    <SettingRow
-                      key={`team-${setting.guid}`}
-                      setting={setting}
-                      loading={loading}
-                      updateSetting={updateSetting}
-                    />
-                  ) : null
-                )}
+                {settings
+                  .sort((a, b) => {
+                    if (a.key > b.key) return 1;
+                    if (a.key < b.key) return -1;
+                  })
+                  .map((setting) =>
+                    setting.pluginName === pluginName ? (
+                      <SettingRow
+                        key={`team-${setting.guid}`}
+                        setting={setting}
+                        loading={loading}
+                        updateSetting={updateSetting}
+                      />
+                    ) : null
+                  )}
               </tbody>
             </LoadingTable>
           </div>


### PR DESCRIPTION
The Grouparoo application will report anonymized telemetry data to our servers.  This will help us learn how Grouparoo is being used, what apps/sources/destinations are popular, provide insight into performance, and other related data.

You can opt-out of telemetry by setting the environment variable `GROUPAROO_TELEMETRY_ENABLED` to "false" or "0".

Telemetry is reported to `https://telemetry.grouparoo.com` 