### PR TITLE
Disable next.js when testing api server

### DIFF
--- a/core/api/jest.setup.js
+++ b/core/api/jest.setup.js
@@ -1,4 +1,4 @@
-process.env.NEXT_DISABLED = true;
+process.env.NEXT_DISABLED = "true";
 
 if (!process.env.SERVER_TOKEN) {
   process.env.SERVER_TOKEN = "test-server-token";

--- a/core/api/jest.setup.js
+++ b/core/api/jest.setup.js
@@ -1,3 +1,5 @@
+process.env.NEXT_DISABLED = true;
+
 if (!process.env.SERVER_TOKEN) {
   process.env.SERVER_TOKEN = "test-server-token";
 }

--- a/core/api/src/config/next.ts
+++ b/core/api/src/config/next.ts
@@ -1,10 +1,11 @@
 // learn more about the next.js app options here https://nextjs.org/docs/advanced-features/custom-server
 
 export const DEFAULT = {
-  next: (config) => {
+  next: () => {
     const env = process.env.NODE_ENV ? process.env.NODE_ENV : "development";
 
     return {
+      enabled: process.env.NEXT_DISABLED === "true" ? false : true,
       dev: process.env.NEXT_DEVELOPMENT_MODE
         ? process.env.NEXT_DEVELOPMENT_MODE === "false"
           ? false

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -4928,9 +4928,9 @@
       }
     },
     "ah-next-plugin": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ah-next-plugin/-/ah-next-plugin-0.2.1.tgz",
-      "integrity": "sha512-LOTiYXSoKEM88VZXK0Y42G/RaLiCKbaVJJ4Spe67KXVbm3Nw8CaQrpv5dYlY+O41sqDZXDSvSxUfPKSdNe4oDg=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ah-next-plugin/-/ah-next-plugin-0.3.0.tgz",
+      "integrity": "sha512-pAm98wnoL27hz631xPQTS0fjQ0R85yDk5H4jpemfcsBDnDXj8zVROeVPmfizHexoEI0trWU/Uhh4vJ1eLQpMcA=="
     },
     "ah-sequelize-plugin": {
       "version": "2.2.1",

--- a/core/package.json
+++ b/core/package.json
@@ -46,7 +46,7 @@
     "@grouparoo/client-web": "^0.1.6-alpha.0",
     "@nivo/line": "^0.62.0",
     "actionhero": "^23.0.4",
-    "ah-next-plugin": "^0.2.1",
+    "ah-next-plugin": "^0.3.0",
     "ah-sequelize-plugin": "^2.2.1",
     "axios": "^0.19.2",
     "bcrypt": "^5.0.0",

--- a/core/web/jest.setup.js
+++ b/core/web/jest.setup.js
@@ -6,3 +6,5 @@ configure({ adapter: new Adapter() });
 if (!process.env.SERVER_TOKEN) {
   process.env.SERVER_TOKEN = "test-server-token";
 }
+
+require("./plugins");


### PR DESCRIPTION
This will not only speed up the API tests, but also also us to keep a `dev` server running in another process while running API tests.

Closes T-185