### PR TITLE
Show Active Run count in Navigation and Dashboard

### DIFF
--- a/core/api/src/actions/navigation.ts
+++ b/core/api/src/actions/navigation.ts
@@ -96,12 +96,17 @@ export class NavigationList extends OptionallyAuthenticatedAction {
           href: "/destinations",
           icon: "file-export",
         },
+        {
+          type: "link",
+          title: "Runs",
+          href: "/runs",
+          icon: "exchange-alt",
+        },
         { type: "subNavMenu", title: "Platform", icon: "terminal" },
       ];
 
       platformItems.push(
         { type: "link", title: "Apps", href: "/apps" },
-        { type: "link", title: "Runs", href: "/runs" },
         { type: "link", title: "Imports", href: "/imports" },
         { type: "link", title: "Exports", href: "/exports" }
       );

--- a/core/api/src/config/api.ts
+++ b/core/api/src/config/api.ts
@@ -63,6 +63,7 @@ export const DEFAULT = {
       },
 
       startingChatRooms: {
+        "model:run": {},
         "model:log": {},
         "model:event": {},
         "model:profile": {},

--- a/core/api/src/models/Permission.ts
+++ b/core/api/src/models/Permission.ts
@@ -120,6 +120,7 @@ export class Permission extends LoggedModel<Permission> {
       "profile",
       "profilePropertyRule",
       "resque",
+      "run",
       "system",
       "source",
       "team",

--- a/core/web/components/icons.ts
+++ b/core/web/components/icons.ts
@@ -12,6 +12,7 @@ import {
   faFileExport,
   faTerminal,
   faStream,
+  faExchangeAlt,
 } from "@fortawesome/free-solid-svg-icons";
 
 library.add(
@@ -24,5 +25,6 @@ library.add(
   faFileImport,
   faFileExport,
   faTerminal,
-  faStream
+  faStream,
+  faExchangeAlt
 );

--- a/core/web/hooks/useRealtimeModelStream.ts
+++ b/core/web/hooks/useRealtimeModelStream.ts
@@ -4,8 +4,8 @@ export const useRealtimeModelStream = (
   modelName: string,
   messageCallback: Function
 ) => {
-  // @ts-ignore
-  const [client] = useState(new ActionheroWebsocketClient());
+  if (!globalThis.ActionheroWebsocketClient) return null;
+  const [client] = useState(new globalThis.ActionheroWebsocketClient());
   const [room] = useState(`model:${modelName}`);
   const [enabled, setEnabled] = useState(true);
 


### PR DESCRIPTION
When there are Active Runs in the Grouparoo Cluster, we show a badge next to the "Runs" link in the navigation.   The "Runs" link in the Navigation is moved up from Platform.  

<img width="1327" alt="Screen Shot 2020-07-14 at 3 18 03 PM" src="https://user-images.githubusercontent.com/303226/87483331-58231480-c5e8-11ea-958f-6dbda8b2279b.png">

This PR also uses the same `runs` websocket room to display Active Runs on the dashboard.

<img width="1427" alt="Screen Shot 2020-07-14 at 3 28 39 PM" src="https://user-images.githubusercontent.com/303226/87483382-725cf280-c5e8-11ea-91ff-6bdd9a33c044.png"> 

This PR required a new permission scope, "runs".  To add it to an existing project, please run `cd /core/api && SERVER_TOKEN=abc ./bin/updateTeamPermissions`

Closes T-168