### PR TITLE
Move mutating methods to ModelOps [Refactor]

### DIFF
--- a/core/api/__tests__/models/profile.ts
+++ b/core/api/__tests__/models/profile.ts
@@ -7,6 +7,7 @@ import { GroupMember } from "./../../src/models/GroupMember";
 import { App } from "./../../src/models/App";
 import { Source } from "./../../src/models/Source";
 import { plugin } from "./../../src/modules/plugin";
+import { ProfileOps } from "../../src/modules/ops/profile";
 import { api, specHelper } from "actionhero";
 
 let actionhero;
@@ -134,7 +135,7 @@ describe("models/profile", () => {
       const {
         profile,
         isNew,
-      } = await Profile.findOrCreateByUniqueProfileProperties({
+      } = await ProfileOps.findOrCreateByUniqueProfileProperties({
         email: "toad@example.com",
         color: "orange",
       });
@@ -147,7 +148,7 @@ describe("models/profile", () => {
       const {
         profile,
         isNew,
-      } = await Profile.findOrCreateByUniqueProfileProperties({
+      } = await ProfileOps.findOrCreateByUniqueProfileProperties({
         email: "luigi@example.com",
         color: "green",
       });
@@ -158,7 +159,7 @@ describe("models/profile", () => {
 
     test("it will throw an error if no unique profile properties are included", async () => {
       try {
-        await Profile.findOrCreateByUniqueProfileProperties({
+        await ProfileOps.findOrCreateByUniqueProfileProperties({
           color: "orange",
         });
         throw new Error("should not get here");
@@ -170,12 +171,12 @@ describe("models/profile", () => {
     });
 
     test("it will lock when creating new profiles so duplicate profiles are not created", async () => {
-      const responseA = await Profile.findOrCreateByUniqueProfileProperties({
+      const responseA = await ProfileOps.findOrCreateByUniqueProfileProperties({
         email: "bowser@example.com",
         color: "green",
       });
 
-      const responseB = await Profile.findOrCreateByUniqueProfileProperties({
+      const responseB = await ProfileOps.findOrCreateByUniqueProfileProperties({
         email: "bowser@example.com",
         house: "castle",
       });
@@ -186,12 +187,12 @@ describe("models/profile", () => {
     });
 
     test("it will merge overlapping unique profile properties and not store non-unique properties", async () => {
-      const responseA = await Profile.findOrCreateByUniqueProfileProperties({
+      const responseA = await ProfileOps.findOrCreateByUniqueProfileProperties({
         email: "koopa@example.com",
         userId: 99,
       });
 
-      const responseB = await Profile.findOrCreateByUniqueProfileProperties({
+      const responseB = await ProfileOps.findOrCreateByUniqueProfileProperties({
         userId: 99,
         house: "castle",
       });
@@ -835,7 +836,7 @@ describe("models/profile", () => {
     });
 
     test("merging profiles moved the events & properties", async () => {
-      await Profile.merge(profileA, profileB);
+      await ProfileOps.merge(profileA, profileB);
 
       const propertiesA = await profileA.properties();
       const propertiesB = await profileB.properties();

--- a/core/api/__tests__/tasks/import/associateProfile.ts
+++ b/core/api/__tests__/tasks/import/associateProfile.ts
@@ -80,7 +80,7 @@ describe("tasks/import:associateProfile", () => {
       );
       expect(errorMetadata.step).toBe("import:associateProfile");
       expect(errorMetadata.stack).toMatch(
-        /Function.findOrCreateByUniqueProfileProperties/
+        /findOrCreateByUniqueProfileProperties/
       );
     });
 

--- a/core/api/src/actions/groups.ts
+++ b/core/api/src/actions/groups.ts
@@ -1,7 +1,7 @@
 import { task, api } from "actionhero";
 import { AuthenticatedAction } from "../classes/authenticatedAction";
 import { Group, GROUP_RULE_LIMIT } from "../models/Group";
-import { ProfilePropertyRuleOps } from "../models/ProfilePropertyRule";
+import { ProfilePropertyRuleOpsDictionary } from "../modules/RuleOpsDictionary";
 import { Profile } from "../models/Profile";
 
 export class GroupsList extends AuthenticatedAction {
@@ -56,7 +56,7 @@ export class GroupsRuleOptions extends AuthenticatedAction {
 
   async run({ response }) {
     response.ruleLimit = GROUP_RULE_LIMIT;
-    response.ops = ProfilePropertyRuleOps;
+    response.ops = ProfilePropertyRuleOpsDictionary;
   }
 }
 

--- a/core/api/src/models/ApiKey.ts
+++ b/core/api/src/models/ApiKey.ts
@@ -49,33 +49,6 @@ export class ApiKey extends LoggedModel<ApiKey> {
     }
   }
 
-  @AfterSave
-  static async buildPermissions(instance: ApiKey) {
-    const topics = Permission.topics();
-    for (const i in topics) {
-      const topic = topics[i];
-      const [permission] = await Permission.findOrCreate({
-        where: {
-          topic,
-          ownerGuid: instance.guid,
-          ownerType: "apiKey",
-        },
-      });
-
-      if (instance.permissionAllRead !== null) {
-        await permission.update({ read: instance.permissionAllRead });
-      }
-      if (instance.permissionAllWrite !== null) {
-        await permission.update({ write: instance.permissionAllWrite });
-      }
-    }
-  }
-
-  @AfterDestroy
-  static async deletePermissions(instance: ApiKey) {
-    return Permission.destroy({ where: { ownerGuid: instance.guid } });
-  }
-
   async apiData() {
     const permissions = await this.$get("permissions", {
       order: [["topic", "asc"]],
@@ -129,6 +102,33 @@ export class ApiKey extends LoggedModel<ApiKey> {
   // --- Class Methods --- //
 
   // TODO: Cache these like Profile Property Rules for faster lookup
+
+  @AfterSave
+  static async buildPermissions(instance: ApiKey) {
+    const topics = Permission.topics();
+    for (const i in topics) {
+      const topic = topics[i];
+      const [permission] = await Permission.findOrCreate({
+        where: {
+          topic,
+          ownerGuid: instance.guid,
+          ownerType: "apiKey",
+        },
+      });
+
+      if (instance.permissionAllRead !== null) {
+        await permission.update({ read: instance.permissionAllRead });
+      }
+      if (instance.permissionAllWrite !== null) {
+        await permission.update({ write: instance.permissionAllWrite });
+      }
+    }
+  }
+
+  @AfterDestroy
+  static async deletePermissions(instance: ApiKey) {
+    return Permission.destroy({ where: { ownerGuid: instance.guid } });
+  }
 
   static async findByGuid(guid: string) {
     const instance = await this.scope(null).findOne({ where: { guid } });

--- a/core/api/src/models/DestinationGroup.ts
+++ b/core/api/src/models/DestinationGroup.ts
@@ -33,25 +33,6 @@ export class DestinationGroup extends LoggedModel<DestinationGroup> {
   @BelongsTo(() => Destination)
   destination: Destination;
 
-  @AfterCreate
-  static async updateGroupMembersOnCreate(instance: DestinationGroup) {
-    const group = await Group.findByGuid(instance.groupGuid);
-    await group.run(true, instance.destinationGuid);
-  }
-
-  @AfterDestroy
-  static async updateGroupMembersOnDestroy(instance: DestinationGroup) {
-    try {
-      const group = await Group.findByGuid(instance.groupGuid);
-      await group.run(true, instance.destinationGuid);
-    } catch (error) {
-      // we may be in the after-hook of the group being deleted
-      if (!error.toString().match(/cannot find Group/)) {
-        throw error;
-      }
-    }
-  }
-
   async apiData() {
     return {
       destinationGuid: this.destinationGuid,
@@ -69,5 +50,24 @@ export class DestinationGroup extends LoggedModel<DestinationGroup> {
       throw new Error(`cannot find ${this.name} ${guid}`);
     }
     return instance;
+  }
+
+  @AfterCreate
+  static async updateGroupMembersOnCreate(instance: DestinationGroup) {
+    const group = await Group.findByGuid(instance.groupGuid);
+    await group.run(true, instance.destinationGuid);
+  }
+
+  @AfterDestroy
+  static async updateGroupMembersOnDestroy(instance: DestinationGroup) {
+    try {
+      const group = await Group.findByGuid(instance.groupGuid);
+      await group.run(true, instance.destinationGuid);
+    } catch (error) {
+      // we may be in the after-hook of the group being deleted
+      if (!error.toString().match(/cannot find Group/)) {
+        throw error;
+      }
+    }
   }
 }

--- a/core/api/src/models/ExportImport.ts
+++ b/core/api/src/models/ExportImport.ts
@@ -22,13 +22,6 @@ export class ExportImport extends Model<ExportImport> {
   @Column({ primaryKey: true })
   guid: string;
 
-  @BeforeCreate
-  static generateGuid(instance) {
-    if (!instance.guid) {
-      instance.guid = `${instance.guidPrefix()}_${uuid.v4()}`;
-    }
-  }
-
   @CreatedAt
   createdAt: Date;
 
@@ -68,5 +61,12 @@ export class ExportImport extends Model<ExportImport> {
       throw new Error(`cannot find ${this.name} ${guid}`);
     }
     return instance;
+  }
+
+  @BeforeCreate
+  static generateGuid(instance) {
+    if (!instance.guid) {
+      instance.guid = `${instance.guidPrefix()}_${uuid.v4()}`;
+    }
   }
 }

--- a/core/api/src/models/File.ts
+++ b/core/api/src/models/File.ts
@@ -36,14 +36,6 @@ export class File extends LoggedModel<File> {
   @Column
   sizeBytes: number;
 
-  @BeforeSave
-  static async enureValidType(instance: File) {
-    const validTypes: Array<string> = api.files.types;
-    if (!validTypes.includes(instance.type)) {
-      throw new Error(`${instance.type} is not a valid file type`);
-    }
-  }
-
   async apiData() {
     return {
       guid: this.guid,
@@ -67,5 +59,13 @@ export class File extends LoggedModel<File> {
       throw new Error(`cannot find ${this.name} ${guid}`);
     }
     return instance;
+  }
+
+  @BeforeSave
+  static async enureValidType(instance: File) {
+    const validTypes: Array<string> = api.files.types;
+    if (!validTypes.includes(instance.type)) {
+      throw new Error(`${instance.type} is not a valid file type`);
+    }
   }
 }

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -15,7 +15,7 @@ import {
   DefaultScope,
   Scopes,
 } from "sequelize-typescript";
-import { api, task } from "actionhero";
+import { api } from "actionhero";
 import { Op } from "sequelize";
 import Moment from "moment";
 import { LoggedModel } from "../classes/loggedModel";
@@ -23,9 +23,7 @@ import { GroupMember } from "./GroupMember";
 import { GroupRule } from "./GroupRule";
 import { Run } from "./Run";
 import { Profile } from "./Profile";
-import { Import } from "./Import";
 import { Setting } from "./Setting";
-import { ProfileMultipleAssociationShim } from "./ProfileMultipleAssociationShim";
 import { ProfileProperty } from "./ProfileProperty";
 import { Destination } from "./Destination";
 import { DestinationGroup } from "./DestinationGroup";
@@ -33,9 +31,10 @@ import { DestinationGroupMembership } from "./DestinationGroupMembership";
 import {
   ProfilePropertyRule,
   profilePropertyRuleJSToSQLType,
-  ProfilePropertyRuleOps,
 } from "./ProfilePropertyRule";
+import { ProfilePropertyRuleOpsDictionary } from "../modules/RuleOpsDictionary";
 import { StateMachine } from "./../modules/stateMachine";
+import { GroupOps } from "../modules/ops/group";
 
 export const GROUP_RULE_LIMIT = 10;
 const numbers = [...Array(GROUP_RULE_LIMIT).keys()].map((n) => n + 1).reverse();
@@ -134,112 +133,6 @@ export class Group extends LoggedModel<Group> {
   @BelongsToMany(() => Profile, () => GroupMember)
   profiles: Profile[];
 
-  @BeforeSave
-  static async ensureUniqueName(instance: Group) {
-    const count = await Group.count({
-      where: {
-        guid: { [Op.ne]: instance.guid },
-        name: instance.name,
-        state: { [Op.ne]: "draft" },
-      },
-    });
-    if (count > 0) {
-      throw new Error(`name "${instance.name}" is already in use`);
-    }
-  }
-
-  @BeforeSave
-  static async updateState(instance: Group) {
-    await StateMachine.transition(instance, STATE_TRANSITIONS);
-  }
-
-  @AfterSave
-  static async linkToDestinationsTrackingAllGroups(instance: Group) {
-    if (["draft", "deleted"].includes(instance.state)) return;
-
-    const destinations = await Destination.findAll({
-      where: { trackAllGroups: true },
-    });
-
-    for (const i in destinations) {
-      await DestinationGroup.findOrCreate({
-        where: {
-          groupGuid: instance.guid,
-          destinationGuid: destinations[i].guid,
-        },
-      });
-    }
-  }
-
-  @BeforeDestroy
-  static async checkGroupMembers(instance: Group) {
-    const count = await instance.$count("groupMembers");
-    if (count > 0) {
-      throw new Error(`this group still has ${count} members, cannot delete`);
-    }
-  }
-
-  @BeforeDestroy
-  static async checkDestinationGroups(instance: Group) {
-    const count = await DestinationGroup.count({
-      where: { groupGuid: instance.guid },
-      include: [{ model: Destination, where: { trackAllGroups: false } }],
-    });
-
-    if (count > 0) {
-      throw new Error(
-        `this group still in use by ${count} destinations, cannot delete`
-      );
-    }
-  }
-
-  @BeforeDestroy
-  static async checkDestinationGroupMembership(instance: Group) {
-    const count = await DestinationGroupMembership.count({
-      where: { groupGuid: instance.guid },
-    });
-
-    if (count > 0) {
-      throw new Error(
-        `this group still in use by ${count} destinations, cannot delete`
-      );
-    }
-  }
-
-  @AfterDestroy
-  static async destroyDestinationGroup(instance: Group) {
-    // need to go 1-by-1 for callbacks
-    const destinationGroups = await instance.$get("destinationGroups");
-    for (const i in destinationGroups) {
-      await destinationGroups[i].destroy();
-    }
-  }
-
-  @AfterDestroy
-  static async destroyDestinationGroupMembership(instance: Group) {
-    return DestinationGroupMembership.destroy({
-      where: {
-        groupGuid: instance.guid,
-      },
-    });
-  }
-
-  @AfterDestroy
-  static async destroyGroupRules(instance: Group) {
-    return GroupRule.destroy({
-      where: {
-        groupGuid: instance.guid,
-      },
-    });
-  }
-
-  @AfterDestroy
-  static async destroyRuns(instance: Group) {
-    await Run.destroy({
-      where: { creatorGuid: instance.guid },
-    });
-  }
-
   async profilesCount(options = {}) {
     let search = { where: { groupGuid: this.guid } };
     if (options) {
@@ -267,9 +160,9 @@ export class Group extends LoggedModel<Group> {
         type: profilePropertyRule.type,
         operation: {
           op: rule.op,
-          description: ProfilePropertyRuleOps[profilePropertyRule.type].filter(
-            (operation) => operation.op === rule.op
-          )[0].description,
+          description: ProfilePropertyRuleOpsDictionary[
+            profilePropertyRule.type
+          ].filter((operation) => operation.op === rule.op)[0].description,
         },
         match: rule.match,
         relativeMatchNumber: rule.relativeMatchNumber,
@@ -362,7 +255,7 @@ export class Group extends LoggedModel<Group> {
   }
 
   fromConvenientRules(rules: GroupRuleWithKey[]) {
-    const convenientRules = ProfilePropertyRuleOps._convenientRules;
+    const convenientRules = ProfilePropertyRuleOpsDictionary._convenientRules;
 
     for (const i in rules) {
       if (convenientRules[rules[i].operation.op]) {
@@ -385,7 +278,7 @@ export class Group extends LoggedModel<Group> {
   }
 
   toConvenientRules(rules: GroupRuleWithKey[]) {
-    const convenientRules = ProfilePropertyRuleOps._convenientRules;
+    const convenientRules = ProfilePropertyRuleOpsDictionary._convenientRules;
 
     for (const i in rules) {
       for (const k in convenientRules) {
@@ -403,7 +296,7 @@ export class Group extends LoggedModel<Group> {
         !rules[i].operation.op.match(/^relative_/)
       ) {
         rules[i].operation.op = `relative_${rules[i].operation.op}`;
-        rules[i].operation.description = ProfilePropertyRuleOps[
+        rules[i].operation.description = ProfilePropertyRuleOpsDictionary[
           rules[i].type
         ].filter(
           (operation) => operation.op === rules[i].operation.op
@@ -412,28 +305,6 @@ export class Group extends LoggedModel<Group> {
     }
 
     return rules;
-  }
-
-  async run(force = false, destinationGuid?: string) {
-    await this.stopPreviousRuns();
-    await task.enqueue("group:run", {
-      groupGuid: this.guid,
-      force,
-      destinationGuid,
-    });
-  }
-
-  async stopPreviousRuns() {
-    const previousRuns = await Run.findAll({
-      where: {
-        creatorGuid: this.guid,
-        state: "running",
-      },
-    });
-
-    for (const i in previousRuns) {
-      await previousRuns[i].stop();
-    }
   }
 
   async nextCalculatedAt() {
@@ -448,36 +319,30 @@ export class Group extends LoggedModel<Group> {
     return Moment(this.calculatedAt).add(delayMinutes, "minutes").toDate();
   }
 
-  async _buildProfileImport(
+  async run(force = false, destinationGuid?: string) {
+    return GroupOps.run(this, force, destinationGuid);
+  }
+
+  async stopPreviousRuns() {
+    return GroupOps.stopPreviousRuns(this);
+  }
+
+  async buildProfileImport(
     profileGuid: string,
     creatorType: string,
     creatorGuid: string,
     destinationGuid?: string
   ) {
-    const profile = await Profile.findOne({ where: { guid: profileGuid } });
-
-    const oldProfileProperties = [];
-    const properties = await profile.properties();
-    for (const key in properties) {
-      oldProfileProperties[key] = properties[key].value;
-    }
-
-    const oldGroupGuids = (await profile.$get("groups")).map((g) => g.guid);
-
-    return Import.build({
-      rawData: destinationGuid ? { _meta: { destinationGuid } } : {},
-      data: destinationGuid ? { _meta: { destinationGuid } } : {},
+    return GroupOps.buildProfileImport(
+      profileGuid,
       creatorType,
       creatorGuid,
-      profileGuid: profile.guid,
-      profileAssociatedAt: new Date(),
-      oldProfileProperties,
-      oldGroupGuids,
-    });
+      destinationGuid
+    );
   }
 
   async addProfile(profile: Profile) {
-    const _import = await this._buildProfileImport(
+    const _import = await this.buildProfileImport(
       profile.guid,
       "group",
       this.guid
@@ -500,7 +365,7 @@ export class Group extends LoggedModel<Group> {
       throw new Error("profile is not a member of this group");
     }
 
-    const _import = await this._buildProfileImport(
+    const _import = await this.buildProfileImport(
       profile.guid,
       "group",
       this.guid
@@ -518,74 +383,14 @@ export class Group extends LoggedModel<Group> {
     force = false,
     destinationGuid?: string
   ) {
-    let groupMembersCount = 0;
-    let profiles: ProfileMultipleAssociationShim[];
-
-    if (this.type === "manual") {
-      profiles = await this.$get("profiles", {
-        attributes: ["guid"],
-        limit,
-        offset,
-        order: [["createdAt", "asc"]],
-      });
-    } else {
-      const rules = await this.getRules();
-      if (Object.keys(rules).length === 0) {
-        return 0;
-      }
-
-      const { where, include } = await this._buildGroupMemberQueryParts(
-        rules,
-        this.matchType
-      );
-
-      profiles = await ProfileMultipleAssociationShim.findAll({
-        attributes: ["guid"],
-        where,
-        include,
-        limit,
-        offset,
-        order: [["createdAt", "asc"]],
-        subQuery: false,
-      });
-    }
-
-    for (const i in profiles) {
-      const profile = profiles[i];
-      const groupMember = await GroupMember.findOne({
-        where: {
-          profileGuid: profile.guid,
-          groupGuid: this.guid,
-        },
-      });
-
-      if (!groupMember || force) {
-        const transaction = await api.sequelize.transaction();
-        const _import = await this._buildProfileImport(
-          profile.guid,
-          "run",
-          run.guid,
-          destinationGuid
-        );
-        await run.increment(["importsCreated"], { transaction });
-        await _import.save({ transaction });
-        await transaction.commit();
-      }
-
-      if (groupMember) {
-        groupMember.removedAt = null;
-        groupMember.set("updatedAt", new Date());
-        groupMember.changed("updatedAt", true);
-        await groupMember.save();
-      }
-
-      groupMembersCount++;
-    }
-
-    this.calculatedAt = new Date();
-    await this.save();
-
-    return groupMembersCount;
+    return GroupOps.runAddGroupMembers(
+      this,
+      run,
+      limit,
+      offset,
+      force,
+      destinationGuid
+    );
   }
 
   async runRemoveGroupMembers(
@@ -595,177 +400,36 @@ export class Group extends LoggedModel<Group> {
     force = false,
     destinationGuid?: string
   ) {
-    let groupMembersCount = 0;
-
-    // The offset and order can be ignored as we will keep running this query until the set of results becomes 0.
-    const groupMembersToRemove = await GroupMember.findAll({
-      attributes: ["guid", "profileGuid"],
-      where: {
-        groupGuid: this.guid,
-        updatedAt: { [Op.lt]: run.createdAt },
-        removedAt: null,
-      },
+    return GroupOps.runRemoveGroupMembers(
+      this,
+      run,
       limit,
-    });
-
-    for (const i in groupMembersToRemove) {
-      const member = groupMembersToRemove[i];
-      const transaction = await api.sequelize.transaction();
-      member.removedAt = new Date();
-      await member.save({ transaction });
-      const _import = await this._buildProfileImport(
-        member.profileGuid,
-        "run",
-        run.guid,
-        destinationGuid
-      );
-      await run.increment(["importsCreated"], { transaction });
-      await _import.save({ transaction });
-      await transaction.commit();
-      groupMembersCount++;
-    }
-
-    this.calculatedAt = new Date();
-    await this.save();
-
-    return groupMembersCount;
+      offset,
+      force,
+      destinationGuid
+    );
   }
 
   async removePreviousRunGroupMembers(run: Run, limit = 100) {
-    let groupMembersCount = 0;
-
-    const groupMembersToRemove = await GroupMember.findAll({
-      attributes: ["guid", "profileGuid"],
-      where: {
-        groupGuid: this.guid,
-        removedAt: { [Op.lte]: run.createdAt },
-      },
-      limit,
-    });
-
-    for (const i in groupMembersToRemove) {
-      const member = groupMembersToRemove[i];
-      member.removedAt = new Date();
-      await member.save();
-      const _import = await this._buildProfileImport(
-        member.profileGuid,
-        "run",
-        run.guid
-      );
-      await _import.save();
-      groupMembersCount++;
-    }
-
-    return groupMembersCount;
+    return GroupOps.removePreviousRunGroupMembers(this, run, limit);
   }
 
   async updateProfileMembership(profile: Profile) {
-    const existingMembership = await GroupMember.findOne({
-      where: {
-        groupGuid: this.guid,
-        profileGuid: profile.guid,
-      },
-    });
-
-    if (this.type === "manual") {
-      if (this.state === "deleted") {
-        if (existingMembership) {
-          await existingMembership.destroy();
-        }
-        return false;
-      } else {
-        return existingMembership ? true : false;
-      }
-    } else {
-      const rules = await this.getRules();
-
-      if (Object.keys(rules).length == 0) {
-        if (existingMembership) {
-          await existingMembership.destroy();
-        }
-        return false;
-      } else {
-        const { where, include } = await this._buildGroupMemberQueryParts(
-          rules,
-          this.matchType
-        );
-
-        // and includes this profile
-        if (!where[Op.and]) {
-          where[Op.and] = [];
-        }
-        where[Op.and].push({
-          guid: profile.guid,
-        });
-
-        const matchedProfiles = await ProfileMultipleAssociationShim.findAll({
-          attributes: ["guid"],
-          where,
-          include,
-        });
-
-        const belongs = matchedProfiles.length === 1;
-
-        if (belongs && !existingMembership) {
-          await GroupMember.create({
-            groupGuid: this.guid,
-            profileGuid: profile.guid,
-          });
-        }
-
-        if (!belongs && existingMembership) {
-          await existingMembership.destroy();
-        }
-
-        return belongs;
-      }
-    }
+    return GroupOps.updateProfileMembership(this, profile);
   }
 
   async countPotentialMembers(
     rules?: GroupRuleWithKey[],
     matchType: "any" | "all" = this.matchType
   ) {
-    if (!rules) {
-      rules = await this.getRules();
-    }
-
-    const { where, include } = await this._buildGroupMemberQueryParts(
-      rules,
-      matchType
-    );
-
-    // we use ProfileMultipleAssociationShim as a shim model which has extra associations
-    return ProfileMultipleAssociationShim.count({ where, include });
+    return GroupOps.countPotentialMembers(this, rules, matchType);
   }
 
   /**
    * Take the rules for the group and check how many group members there would have been both individually for each single rule, and then by building up the query step-by-step
    */
   async countComponentMembersFromRules(rules?: GroupRuleWithKey[]) {
-    const componentCounts = [];
-    const funnelCounts = [];
-    let funnelStep = 0;
-
-    if (!rules) {
-      rules = await this.getRules();
-    }
-
-    for (const i in rules) {
-      const localRule = rules[i];
-      componentCounts[i] = await this.countPotentialMembers([localRule]);
-
-      const funnelRules = [];
-      let j = 0;
-      while (j <= funnelStep) {
-        funnelRules.push(rules[j]);
-        j++;
-      }
-      funnelCounts[funnelStep] = await this.countPotentialMembers(funnelRules);
-      funnelStep++;
-    }
-
-    return { componentCounts, funnelCounts };
+    return GroupOps.countComponentMembersFromRules(this, rules);
   }
 
   async _buildGroupMemberQueryParts(
@@ -883,5 +547,111 @@ export class Group extends LoggedModel<Group> {
       throw new Error(`cannot find ${this.name} ${guid}`);
     }
     return instance;
+  }
+
+  @BeforeSave
+  static async ensureUniqueName(instance: Group) {
+    const count = await Group.count({
+      where: {
+        guid: { [Op.ne]: instance.guid },
+        name: instance.name,
+        state: { [Op.ne]: "draft" },
+      },
+    });
+    if (count > 0) {
+      throw new Error(`name "${instance.name}" is already in use`);
+    }
+  }
+
+  @BeforeSave
+  static async updateState(instance: Group) {
+    await StateMachine.transition(instance, STATE_TRANSITIONS);
+  }
+
+  @AfterSave
+  static async linkToDestinationsTrackingAllGroups(instance: Group) {
+    if (["draft", "deleted"].includes(instance.state)) return;
+
+    const destinations = await Destination.findAll({
+      where: { trackAllGroups: true },
+    });
+
+    for (const i in destinations) {
+      await DestinationGroup.findOrCreate({
+        where: {
+          groupGuid: instance.guid,
+          destinationGuid: destinations[i].guid,
+        },
+      });
+    }
+  }
+
+  @BeforeDestroy
+  static async checkGroupMembers(instance: Group) {
+    const count = await instance.$count("groupMembers");
+    if (count > 0) {
+      throw new Error(`this group still has ${count} members, cannot delete`);
+    }
+  }
+
+  @BeforeDestroy
+  static async checkDestinationGroups(instance: Group) {
+    const count = await DestinationGroup.count({
+      where: { groupGuid: instance.guid },
+      include: [{ model: Destination, where: { trackAllGroups: false } }],
+    });
+
+    if (count > 0) {
+      throw new Error(
+        `this group still in use by ${count} destinations, cannot delete`
+      );
+    }
+  }
+
+  @BeforeDestroy
+  static async checkDestinationGroupMembership(instance: Group) {
+    const count = await DestinationGroupMembership.count({
+      where: { groupGuid: instance.guid },
+    });
+
+    if (count > 0) {
+      throw new Error(
+        `this group still in use by ${count} destinations, cannot delete`
+      );
+    }
+  }
+
+  @AfterDestroy
+  static async destroyDestinationGroup(instance: Group) {
+    // need to go 1-by-1 for callbacks
+    const destinationGroups = await instance.$get("destinationGroups");
+    for (const i in destinationGroups) {
+      await destinationGroups[i].destroy();
+    }
+  }
+
+  @AfterDestroy
+  static async destroyDestinationGroupMembership(instance: Group) {
+    return DestinationGroupMembership.destroy({
+      where: {
+        groupGuid: instance.guid,
+      },
+    });
+  }
+
+  @AfterDestroy
+  static async destroyGroupRules(instance: Group) {
+    return GroupRule.destroy({
+      where: {
+        groupGuid: instance.guid,
+      },
+    });
+  }
+
+  @AfterDestroy
+  static async destroyRuns(instance: Group) {
+    await Run.destroy({
+      where: { creatorGuid: instance.guid },
+    });
   }
 }

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -374,8 +374,6 @@ export class Group extends LoggedModel<Group> {
     await _import.save();
   }
 
-  validTypes = ["manual", "calculated"];
-
   async runAddGroupMembers(
     run: Run,
     limit = 1000,

--- a/core/api/src/models/GroupMember.ts
+++ b/core/api/src/models/GroupMember.ts
@@ -25,13 +25,6 @@ export class GroupMember extends Model<GroupMember> {
   @Column({ primaryKey: true })
   guid: string;
 
-  @BeforeCreate
-  static generateGuid(instance) {
-    if (!instance.guid) {
-      instance.guid = `${instance.guidPrefix()}_${uuid.v4()}`;
-    }
-  }
-
   @CreatedAt
   createdAt: Date;
 
@@ -56,6 +49,33 @@ export class GroupMember extends Model<GroupMember> {
 
   @BelongsTo(() => Profile)
   profile: Profile;
+
+  async apiData() {
+    return {
+      profileGuid: this.profileGuid,
+      groupGuid: this.groupGuid,
+      createdAt: this.createdAt ? this.createdAt.getTime() : null,
+      updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,
+      removedAt: this.removedAt ? this.removedAt.getTime() : null,
+    };
+  }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
+
+  @BeforeCreate
+  static generateGuid(instance) {
+    if (!instance.guid) {
+      instance.guid = `${instance.guidPrefix()}_${uuid.v4()}`;
+    }
+  }
 
   @AfterCreate
   static async logCreate(instance: GroupMember) {
@@ -85,25 +105,5 @@ export class GroupMember extends Model<GroupMember> {
         instance.groupGuid
       })`,
     });
-  }
-
-  async apiData() {
-    return {
-      profileGuid: this.profileGuid,
-      groupGuid: this.groupGuid,
-      createdAt: this.createdAt ? this.createdAt.getTime() : null,
-      updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,
-      removedAt: this.removedAt ? this.removedAt.getTime() : null,
-    };
-  }
-
-  // --- Class Methods --- //
-
-  static async findByGuid(guid: string) {
-    const instance = await this.scope(null).findOne({ where: { guid } });
-    if (!instance) {
-      throw new Error(`cannot find ${this.name} ${guid}`);
-    }
-    return instance;
   }
 }

--- a/core/api/src/models/GroupRule.ts
+++ b/core/api/src/models/GroupRule.ts
@@ -22,13 +22,6 @@ export class GroupRule extends Model<GroupRule> {
   @Column({ primaryKey: true })
   guid: string;
 
-  @BeforeCreate
-  static generateGuid(instance) {
-    if (!instance.guid) {
-      instance.guid = `${instance.guidPrefix()}_${uuid.v4()}`;
-    }
-  }
-
   @CreatedAt
   createdAt: Date;
 
@@ -95,5 +88,12 @@ export class GroupRule extends Model<GroupRule> {
       throw new Error(`cannot find ${this.name} ${guid}`);
     }
     return instance;
+  }
+
+  @BeforeCreate
+  static generateGuid(instance) {
+    if (!instance.guid) {
+      instance.guid = `${instance.guidPrefix()}_${uuid.v4()}`;
+    }
   }
 }

--- a/core/api/src/models/Log.ts
+++ b/core/api/src/models/Log.ts
@@ -65,6 +65,29 @@ export class Log extends Model<Log> {
   @UpdatedAt
   updatedAt: Date;
 
+  async apiData() {
+    return {
+      guid: this.guid,
+      ownerGuid: this.ownerGuid,
+      topic: this.topic,
+      verb: this.verb,
+      who: this.who,
+      data: this.data,
+      message: this.message,
+      createdAt: this.createdAt ? this.createdAt.getTime() : null,
+    };
+  }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
+
   @BeforeCreate
   static generateGuid(instance: Log) {
     if (!instance.guid) {
@@ -89,29 +112,6 @@ export class Log extends Model<Log> {
       model: await instance.apiData(),
       verb: "create",
     });
-  }
-
-  async apiData() {
-    return {
-      guid: this.guid,
-      ownerGuid: this.ownerGuid,
-      topic: this.topic,
-      verb: this.verb,
-      who: this.who,
-      data: this.data,
-      message: this.message,
-      createdAt: this.createdAt ? this.createdAt.getTime() : null,
-    };
-  }
-
-  // --- Class Methods --- //
-
-  static async findByGuid(guid: string) {
-    const instance = await this.scope(null).findOne({ where: { guid } });
-    if (!instance) {
-      throw new Error(`cannot find ${this.name} ${guid}`);
-    }
-    return instance;
   }
 
   static async sweep() {

--- a/core/api/src/models/Mapping.ts
+++ b/core/api/src/models/Mapping.ts
@@ -1,8 +1,5 @@
 import {
   Table,
-  CreatedAt,
-  UpdatedAt,
-  BeforeCreate,
   Column,
   AllowNull,
   ForeignKey,
@@ -10,7 +7,6 @@ import {
   Length,
 } from "sequelize-typescript";
 import { LoggedModel } from "../classes/loggedModel";
-import * as uuid from "uuid";
 import { ProfilePropertyRule } from "./ProfilePropertyRule";
 import { Destination } from "./Destination";
 import { Source } from "./Source";

--- a/core/api/src/models/Permission.ts
+++ b/core/api/src/models/Permission.ts
@@ -52,17 +52,6 @@ export class Permission extends LoggedModel<Permission> {
   @BelongsTo(() => ApiKey)
   apiKey: ApiKey;
 
-  @BeforeSave
-  static async checkLocked(instance: Permission) {
-    if (
-      instance.locked &&
-      instance["_previousDataValues"].locked &&
-      (instance.changed("read") || instance.changed("write"))
-    ) {
-      throw new Error("permission is locked");
-    }
-  }
-
   async apiData() {
     return {
       guid: this.guid,
@@ -81,6 +70,17 @@ export class Permission extends LoggedModel<Permission> {
       throw new Error(`cannot find ${this.name} ${guid}`);
     }
     return instance;
+  }
+
+  @BeforeSave
+  static async checkLocked(instance: Permission) {
+    if (
+      instance.locked &&
+      instance["_previousDataValues"].locked &&
+      (instance.changed("read") || instance.changed("write"))
+    ) {
+      throw new Error("permission is locked");
+    }
   }
 
   static async authorizeAction(

--- a/core/api/src/models/Profile.ts
+++ b/core/api/src/models/Profile.ts
@@ -5,19 +5,17 @@ import {
   BelongsToMany,
   AfterDestroy,
 } from "sequelize-typescript";
-import { log, api, task } from "actionhero";
+import { task } from "actionhero";
 import { LoggedModel } from "../classes/loggedModel";
 import { GroupMember } from "./GroupMember";
 import { Group } from "./Group";
 import { Log } from "./Log";
-import { Source } from "./Source";
 import { ProfileProperty } from "./ProfileProperty";
 import { ProfilePropertyRule } from "./ProfilePropertyRule";
 import { Import } from "./Import";
 import { Export } from "./Export";
-import { Destination } from "./Destination";
 import { Event } from "./Event";
-import { waitForLock } from "../modules/locks";
+import { ProfileOps } from "../modules/ops/profile";
 
 @Table({ tableName: "profiles", paranoid: false })
 export class Profile extends LoggedModel<Profile> {
@@ -48,6 +46,104 @@ export class Profile extends LoggedModel<Profile> {
 
   @HasMany(() => Event, "profileGuid")
   events: Event[];
+
+  async apiData() {
+    const properties = await this.properties();
+
+    return {
+      guid: this.guid,
+      anonymousId: this.anonymousId,
+      properties,
+      createdAt: this.createdAt ? this.createdAt.getTime() : null,
+      updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,
+    };
+  }
+
+  async properties() {
+    return ProfileOps.properties(this);
+  }
+
+  async addOrUpdateProperty(properties: { [key: string]: any }) {
+    return ProfileOps.addOrUpdateProperty(this, properties);
+  }
+
+  async addOrUpdateProperties(properties: { [key: string]: any }) {
+    return ProfileOps.addOrUpdateProperties(this, properties);
+  }
+
+  async removeProperty(key: string) {
+    return ProfileOps.removeProperty(this, key);
+  }
+
+  async removeProperties(properties: Array<string>) {
+    return ProfileOps.removeProperties(this, properties);
+  }
+
+  async buildNullProperties() {
+    const properties = await this.properties();
+    const rules = await ProfilePropertyRule.cached();
+    let newPropertiesCount = 0;
+    for (const key in rules) {
+      if (!properties[key]) {
+        await ProfileProperty.create({
+          profileGuid: this.guid,
+          profilePropertyRuleGuid: rules[key].guid,
+        });
+        newPropertiesCount++;
+      }
+    }
+
+    return newPropertiesCount;
+  }
+
+  async updateGroupMembership() {
+    const results = {};
+    const groups = await Group.scope("notDraft").findAll();
+
+    for (const i in groups) {
+      const group = groups[i];
+      const belongs = await group.updateProfileMembership(this);
+      results[group.guid] = belongs;
+    }
+
+    return results;
+  }
+
+  async import(toSave = true, toLock = true) {
+    return ProfileOps._import(this, toSave, toLock);
+  }
+
+  async export(force = false, groupsOverride?: Group[]) {
+    return ProfileOps._export(this, force, groupsOverride);
+  }
+
+  async logMessage(verb: "create" | "update" | "destroy") {
+    let message = "";
+
+    switch (verb) {
+      case "create":
+        message = `profile created`;
+        break;
+      case "update":
+        message = `profile updated`;
+        break;
+      case "destroy":
+        message = `profile destroyed`;
+        break;
+    }
+
+    return message;
+  }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 
   @AfterDestroy
   static async removeFromDestinations(instance: Profile) {
@@ -92,405 +188,13 @@ export class Profile extends LoggedModel<Profile> {
     }
   }
 
-  async apiData() {
-    const properties = await this.properties();
-
-    return {
-      guid: this.guid,
-      anonymousId: this.anonymousId,
-      properties,
-      createdAt: this.createdAt ? this.createdAt.getTime() : null,
-      updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,
-    };
-  }
-
-  async addOrUpdateProperty(hash) {
-    const key = Object.keys(hash)[0];
-    const value = hash[key];
-
-    // ignore reserved property key
-    if (key === "_meta") {
-      return;
-    }
-
-    const profilePropertyRules = await ProfilePropertyRule.cached();
-    const rule = profilePropertyRules[key];
-
-    if (!rule) {
-      throw new Error(`cannot find a profile property rule for key ${key}`);
-    }
-
-    // Note: Lifecycle hooks do not fire on upserts, so we need to manually check if the property exists or not
-    let property = await ProfileProperty.findOne({
-      where: { profileGuid: this.guid, profilePropertyRuleGuid: rule.guid },
-    });
-
-    if (!property) {
-      property = new ProfileProperty({
-        profileGuid: this.guid,
-        profilePropertyRuleGuid: rule.guid,
-      });
-    }
-
-    await property.setValue(value);
-    await property.save();
-    return this;
-  }
-
-  async removeProperty(key: string) {
-    const profilePropertyRules = await ProfilePropertyRule.cached();
-    const rule = profilePropertyRules[key];
-
-    if (!rule) {
-      return;
-    }
-
-    const property = await ProfileProperty.findOne({
-      where: { profileGuid: this.guid, profilePropertyRuleGuid: rule.guid },
-    });
-
-    if (property) {
-      await property.destroy();
-    }
-  }
-
-  async addOrUpdateProperties(properties: { [key: string]: any }) {
-    await this.save();
-
-    const keys = Object.keys(properties);
-    for (const i in keys) {
-      if (keys[i] === "guid") {
-        continue;
-      }
-
-      const h = {};
-      h[keys[i]] = properties[keys[i]];
-      await this.addOrUpdateProperty(h);
-    }
-
-    return this;
-  }
-
-  async removeProperties(properties: Array<string>) {
-    for (const i in properties) {
-      await this.removeProperty(properties[i]);
-    }
-  }
-
-  async properties(): Promise<{
-    [key: string]: {
-      guid: string;
-      value: any;
-      type: string;
-      unique: boolean;
-      createdAt: Date;
-      updatedAt: Date;
-    };
-  }> {
-    const profileProperties =
-      this.profileProperties ||
-      (await ProfileProperty.findAll({ where: { profileGuid: this.guid } }));
-
-    const hash = {};
-    for (const i in profileProperties) {
-      try {
-        const rule = await profileProperties[i].cachedProfilePropertyRule();
-        const key = rule.key;
-        hash[key] = {
-          guid: profileProperties[i].profilePropertyRuleGuid,
-          value: await profileProperties[i].getValue(),
-          type: rule.type,
-          unique: rule.unique,
-          createdAt: profileProperties[i].createdAt,
-          updatedAt: profileProperties[i].updatedAt,
-        };
-      } catch (error) {
-        if (
-          error
-            .toString()
-            .match(
-              /cached profile property rule not found for this profilePropertyRuleGuid/
-            )
-        ) {
-          // it's ok, we are in the middle of creating or destroying a profile property
-          log(error, "info");
-        } else {
-          throw error;
-        }
-      }
-    }
-
-    return hash;
-  }
-
-  async import(toSave = true, toLock = true) {
-    let releaseLock: Function;
-
-    if (toLock) {
-      const lockObject = await waitForLock(`profile:${this.guid}`);
-      releaseLock = lockObject.releaseLock;
-    }
-
-    let hash = {};
-    const sources = await Source.findAll({ where: { state: "ready" } });
-    await Promise.all(
-      sources.map((source) =>
-        source.import(this).then((data) => (hash = Object.assign(hash, data)))
-      )
-    );
-
-    if (toSave) {
-      await this.addOrUpdateProperties(hash);
-      await this.buildNullProperties();
-      await this.save();
-    }
-
-    if (toLock) {
-      releaseLock();
-    }
-
-    return this;
-  }
-
-  async buildNullProperties() {
-    const properties = await this.properties();
-    const rules = await ProfilePropertyRule.cached();
-    let newPropertiesCount = 0;
-    for (const key in rules) {
-      if (!properties[key]) {
-        await ProfileProperty.create({
-          profileGuid: this.guid,
-          profilePropertyRuleGuid: rules[key].guid,
-        });
-        newPropertiesCount++;
-      }
-    }
-
-    return newPropertiesCount;
-  }
-
-  async updateGroupMembership() {
-    const results = {};
-    const groups = await Group.scope("notDraft").findAll();
-
-    for (const i in groups) {
-      const group = groups[i];
-      const belongs = await group.updateProfileMembership(this);
-      results[group.guid] = belongs;
-    }
-
-    return results;
-  }
-
-  async export(force = false, groupsOverride?: Group[]) {
-    let oldSimpleProperties = {};
-    let oldGroups = [];
-
-    const groups = groupsOverride ? groupsOverride : await this.$get("groups");
-
-    const destinations = await Destination.destinationsForGroups(groups);
-    const properties = await this.properties();
-    const simpleProperties = {};
-    for (const i in properties) {
-      simpleProperties[i] = properties[i].value;
-    }
-
-    if (!force) {
-      const oldProperties = await this.properties();
-      oldGroups = groups;
-
-      for (const i in oldProperties) {
-        oldSimpleProperties[i] = oldProperties[i].value;
-      }
-    }
-
-    await Promise.all(
-      destinations.map((destination) =>
-        destination.exportProfile(
-          this,
-          null,
-          [],
-          oldSimpleProperties,
-          simpleProperties,
-          oldGroups,
-          groups,
-          true
-        )
-      )
-    );
-  }
-
-  /**
-   * The method you'll be using to create profiles with arbitrary data.
-   * Hash looks like {email: "person@example.com", id: 123}
-   */
   static async findOrCreateByUniqueProfileProperties(hash: {
     [key: string]: any;
   }) {
-    let profile: Profile;
-    let isNew: boolean;
-    let profileProperty: ProfileProperty;
-    const rules = await ProfilePropertyRule.cached();
-    const uniquePropertiesHash = {};
-
-    Object.keys(rules).forEach((key) => {
-      if (rules[key].unique && hash[key]) {
-        uniquePropertiesHash[key] = hash[key];
-      }
-
-      // and the case when we are sending a profile guid directly
-      if (hash["guid"]) {
-        uniquePropertiesHash["guid"] = hash["guid"];
-      }
-    });
-
-    if (Object.keys(uniquePropertiesHash).length === 0) {
-      throw new Error(
-        `there are no unique profile properties provided in ${JSON.stringify(
-          hash
-        )}`
-      );
-    }
-
-    // special handling when a guid is provided directly
-    // for use with internal runs
-    if (uniquePropertiesHash["guid"]) {
-      profile = await Profile.findOne({
-        where: { guid: uniquePropertiesHash["guid"] },
-      });
-
-      if (profile) {
-        isNew = false;
-        return { profile, isNew };
-      } else {
-        throw new Error(
-          `cannot find profile with guid ${uniquePropertiesHash["guid"]}`
-        );
-      }
-    }
-
-    const keys = Object.keys(uniquePropertiesHash);
-    const lockReleases = [];
-
-    for (const i in keys) {
-      const key = keys[i];
-      const value = uniquePropertiesHash[key];
-      const rule = rules[key];
-
-      const { releaseLock } = await waitForLock(`prp:${key}:${value}`);
-      lockReleases.push(releaseLock);
-
-      profileProperty = await ProfileProperty.findOne({
-        where: {
-          profilePropertyRuleGuid: rule.guid,
-          rawValue: String(value),
-        },
-      });
-
-      if (profileProperty) {
-        break;
-      }
-    }
-
-    if (profileProperty) {
-      profile = await Profile.findOne({
-        where: { guid: profileProperty.profileGuid },
-      });
-      isNew = false;
-    } else {
-      profile = await Profile.create();
-      await profile.addOrUpdateProperties(uniquePropertiesHash);
-      isNew = true;
-    }
-
-    await Promise.all(lockReleases.map((release) => release()));
-
-    return { profile, isNew };
-  }
-
-  async logMessage(verb: "create" | "update" | "destroy") {
-    let message = "";
-
-    switch (verb) {
-      case "create":
-        message = `profile created`;
-        break;
-      case "update":
-        message = `profile updated`;
-        break;
-      case "destroy":
-        message = `profile destroyed`;
-        break;
-    }
-
-    return message;
-  }
-
-  // --- Class Methods --- //
-
-  static async findByGuid(guid: string) {
-    const instance = await this.scope(null).findOne({ where: { guid } });
-    if (!instance) {
-      throw new Error(`cannot find ${this.name} ${guid}`);
-    }
-    return instance;
+    return ProfileOps.findOrCreateByUniqueProfileProperties(hash);
   }
 
   static async merge(profile: Profile, otherProfile: Profile) {
-    const { releaseLock: releaseLockForProfile } = await waitForLock(
-      `profile:${profile.guid}`
-    );
-    const { releaseLock: releaseLockForOtherProfile } = await waitForLock(
-      `profile:${otherProfile.guid}`
-    );
-
-    // transfer events
-    let eventsCount = 1;
-    while (eventsCount > 0) {
-      const events = await otherProfile.$get("events", { limit: 1000 });
-      eventsCount = events.length;
-      await Promise.all(
-        events.map((event) => {
-          event.profileGuid = profile.guid;
-          return event.save();
-        })
-      );
-    }
-
-    // transfer properties, keeping the newest values
-    const properties = await profile.properties();
-    const otherProperties = await otherProfile.properties();
-    const newProperties = {};
-    for (const key in otherProperties) {
-      if (
-        !properties[key] ||
-        (otherProperties[key]?.updatedAt?.getTime() >
-          properties[key]?.updatedAt?.getTime() &&
-          otherProperties[key]?.value !== null &&
-          otherProperties[key]?.value !== undefined)
-      ) {
-        newProperties[key] = otherProperties[key].value;
-      }
-    }
-
-    // delete other profile so unique profile properties will be available
-    await otherProfile.destroy();
-    await profile.addOrUpdateProperties(newProperties);
-
-    // transfer anonymousId
-    if (!profile.anonymousId && otherProfile.anonymousId) {
-      await profile.update({ anonymousId: otherProfile.anonymousId });
-    }
-
-    // re-import and update groups
-    delete profile.profileProperties; // remove any cached values from the instance
-    await profile.import(true, false);
-    await profile.updateGroupMembership();
-
-    // release locks
-    await releaseLockForProfile();
-    await releaseLockForOtherProfile();
-
-    return profile;
+    return ProfileOps.merge(profile, otherProfile);
   }
 }

--- a/core/api/src/models/Profile.ts
+++ b/core/api/src/models/Profile.ts
@@ -187,14 +187,4 @@ export class Profile extends LoggedModel<Profile> {
       _exports = await instance.$get("exports");
     }
   }
-
-  static async findOrCreateByUniqueProfileProperties(hash: {
-    [key: string]: any;
-  }) {
-    return ProfileOps.findOrCreateByUniqueProfileProperties(hash);
-  }
-
-  static async merge(profile: Profile, otherProfile: Profile) {
-    return ProfileOps.merge(profile, otherProfile);
-  }
 }

--- a/core/api/src/models/ProfileProperty.ts
+++ b/core/api/src/models/ProfileProperty.ts
@@ -64,11 +64,11 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
   }
 
   async setValue(value: any) {
-    this.rawValue = await this.buildRawValue(value);
+    this.rawValue = await this._buildRawValue(value);
     await this.validateValue();
   }
 
-  async buildRawValue(value: any) {
+  async _buildRawValue(value: any) {
     const rule = await this.cachedProfilePropertyRule();
 
     if (value === null || value === undefined || value === "") {

--- a/core/api/src/models/ProfileProperty.ts
+++ b/core/api/src/models/ProfileProperty.ts
@@ -3,6 +3,7 @@ import {
   Table,
   Column,
   AllowNull,
+  Default,
   ForeignKey,
   AfterSave,
   AfterDestroy,
@@ -36,31 +37,6 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
 
   @BelongsTo(() => ProfilePropertyRule)
   profilePropertyRule: ProfilePropertyRule;
-
-  @AfterSave
-  static async updateProfileAfterSave(instance: ProfileProperty) {
-    const changed = instance.changed();
-    if (!changed) {
-      return;
-    }
-
-    const profile = await instance.$get("profile");
-    if (profile && changed.indexOf("rawValue") >= 0) {
-      profile.updatedAt = new Date();
-      profile.changed("updatedAt", true);
-      await profile.save();
-    }
-  }
-
-  @AfterDestroy
-  static async updateProfileAfterDestroy(instance: ProfileProperty) {
-    const profile = await instance.$get("profile");
-    if (profile) {
-      profile.updatedAt = new Date();
-      profile.changed("updatedAt", true);
-      await profile.save();
-    }
-  }
 
   async apiData() {
     const rule = await this.cachedProfilePropertyRule();
@@ -231,5 +207,30 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
       throw new Error(`cannot find ${this.name} ${guid}`);
     }
     return instance;
+  }
+
+  @AfterSave
+  static async updateProfileAfterSave(instance: ProfileProperty) {
+    const changed = instance.changed();
+    if (!changed) {
+      return;
+    }
+
+    const profile = await instance.$get("profile");
+    if (profile && changed.indexOf("rawValue") >= 0) {
+      profile.updatedAt = new Date();
+      profile.changed("updatedAt", true);
+      await profile.save();
+    }
+  }
+
+  @AfterDestroy
+  static async updateProfileAfterDestroy(instance: ProfileProperty) {
+    const profile = await instance.$get("profile");
+    if (profile) {
+      profile.updatedAt = new Date();
+      profile.changed("updatedAt", true);
+      await profile.save();
+    }
   }
 }

--- a/core/api/src/models/ProfilePropertyRuleFilter.ts
+++ b/core/api/src/models/ProfilePropertyRuleFilter.ts
@@ -23,13 +23,6 @@ export class ProfilePropertyRuleFilter extends Model<
   @Column({ primaryKey: true })
   guid: string;
 
-  @BeforeCreate
-  static generateGuid(instance) {
-    if (!instance.guid) {
-      instance.guid = `${instance.guidPrefix()}_${uuid.v4()}`;
-    }
-  }
-
   @CreatedAt
   createdAt: Date;
 
@@ -82,5 +75,14 @@ export class ProfilePropertyRuleFilter extends Model<
       createdAt: this.createdAt ? this.createdAt.getTime() : null,
       updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,
     };
+  }
+
+  // --- Class Methods --- //
+
+  @BeforeCreate
+  static generateGuid(instance) {
+    if (!instance.guid) {
+      instance.guid = `${instance.guidPrefix()}_${uuid.v4()}`;
+    }
   }
 }

--- a/core/api/src/models/Schedule.ts
+++ b/core/api/src/models/Schedule.ts
@@ -18,13 +18,13 @@ import {
 } from "sequelize-typescript";
 import { Op } from "sequelize";
 import { LoggedModel } from "../classes/loggedModel";
-import { Source, SimpleSourceOptions, SourceMapping } from "./Source";
+import { Source, SimpleSourceOptions } from "./Source";
 import { App, SimpleAppOptions } from "./App";
-import { Run, HighWaterMark } from "./Run";
+import { Run } from "./Run";
 import { Option } from "./Option";
-import { plugin } from "../modules/plugin";
 import { OptionHelper } from "./../modules/optionHelper";
 import { StateMachine } from "./../modules/stateMachine";
+import { ScheduleOps } from "../modules/ops/schedule";
 
 /**
  * Metadata and methods to return the options a Schedule for this connection/app.
@@ -95,6 +95,89 @@ export class Schedule extends LoggedModel<Schedule> {
 
   @BelongsTo(() => Source)
   source: Source;
+
+  async getOptions() {
+    return OptionHelper.getOptions(this);
+  }
+
+  async setOptions(options: SimpleScheduleOptions) {
+    const existingOptions = await this.getOptions();
+    for (const key in options) {
+      if (existingOptions[key]) {
+        throw new Error(
+          `schedule already has option set for ${key}, cannot update`
+        );
+      }
+    }
+
+    return OptionHelper.setOptions(this, options);
+  }
+
+  async validateOptions(options?: SimpleSourceOptions) {
+    if (!options) {
+      options = await this.getOptions();
+    }
+
+    return OptionHelper.validateOptions(this, options);
+  }
+
+  async getPlugin() {
+    return OptionHelper.getPlugin(this);
+  }
+
+  async pluginOptions() {
+    return ScheduleOps.pluginOptions(this);
+  }
+
+  async apiData() {
+    const source = await this.$get("source");
+    const options = await this.getOptions();
+
+    return {
+      guid: this.guid,
+      name: this.name,
+      state: this.state,
+      source: source ? await source.apiData(false) : undefined,
+      recurring: this.recurring,
+      options,
+      recurringFrequency: this.recurringFrequency,
+      createdAt: this.createdAt ? this.createdAt.getTime() : null,
+      updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,
+    };
+  }
+
+  async enqueueRun() {
+    const run = await Run.create({
+      creatorGuid: this.guid,
+      creatorType: "schedule",
+      state: "running",
+    });
+
+    log(
+      `[ run ] starting run ${run.guid} for schedule ${this.guid}, ${this.name}`,
+      "notice"
+    );
+
+    await task.enqueue(
+      "schedule:run",
+      { scheduleGuid: this.guid, runGuid: run.guid },
+      "schedules"
+    );
+  }
+
+  async run(run: Run) {
+    return ScheduleOps.run(this, run);
+  }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 
   @BeforeSave
   static async ensureSourceOptions(instance: Schedule) {
@@ -195,214 +278,5 @@ export class Schedule extends LoggedModel<Schedule> {
     await Run.destroy({
       where: { creatorGuid: instance.guid },
     });
-  }
-
-  async getOptions() {
-    return OptionHelper.getOptions(this);
-  }
-
-  async setOptions(options: SimpleScheduleOptions) {
-    const existingOptions = await this.getOptions();
-    for (const key in options) {
-      if (existingOptions[key]) {
-        throw new Error(
-          `schedule already has option set for ${key}, cannot update`
-        );
-      }
-    }
-
-    return OptionHelper.setOptions(this, options);
-  }
-
-  async validateOptions(options?: SimpleSourceOptions) {
-    if (!options) {
-      options = await this.getOptions();
-    }
-
-    return OptionHelper.validateOptions(this, options);
-  }
-
-  async getPlugin() {
-    return OptionHelper.getPlugin(this);
-  }
-
-  async pluginOptions() {
-    const source = await Source.findByGuid(this.sourceGuid);
-    const { pluginConnection } = await source.getPlugin();
-
-    const response: Array<{
-      key: string;
-      description: string;
-      required: boolean;
-      type: string;
-      options: Array<{
-        key: string;
-        description?: string;
-        examples?: Array<any>;
-      }>;
-    }> = [];
-
-    if (!pluginConnection) {
-      throw new Error(`cannot find a pluginConnection for type ${source.type}`);
-    }
-    if (!pluginConnection.scheduleOptions) {
-      return response;
-    }
-
-    const app = await source.$get("app");
-    const connection = await app.getConnection();
-    const appOptions = await app.getOptions();
-    const sourceOptions = await source.getOptions();
-    const sourceMapping = await source.getMapping();
-
-    for (const i in pluginConnection.scheduleOptions) {
-      const opt = pluginConnection.scheduleOptions[i];
-      const options = await opt.options({
-        connection,
-        app,
-        appOptions,
-        source,
-        sourceOptions,
-        sourceMapping,
-      });
-
-      response.push({
-        key: opt.key,
-        description: opt.description,
-        required: opt.required,
-        type: opt.type,
-        options,
-      });
-    }
-
-    return response;
-  }
-
-  async apiData() {
-    const source = await this.$get("source");
-    const options = await this.getOptions();
-
-    return {
-      guid: this.guid,
-      name: this.name,
-      state: this.state,
-      source: source ? await source.apiData(false) : undefined,
-      recurring: this.recurring,
-      options,
-      recurringFrequency: this.recurringFrequency,
-      createdAt: this.createdAt ? this.createdAt.getTime() : null,
-      updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,
-    };
-  }
-
-  async enqueueRun() {
-    const run = await Run.create({
-      creatorGuid: this.guid,
-      creatorType: "schedule",
-      state: "running",
-    });
-
-    log(
-      `[ run ] starting run ${run.guid} for schedule ${this.guid}, ${this.name}`,
-      "notice"
-    );
-
-    await task.enqueue(
-      "schedule:run",
-      { scheduleGuid: this.guid, runGuid: run.guid },
-      "schedules"
-    );
-  }
-
-  async run(run: Run) {
-    const options = await this.getOptions();
-    const source = await this.$get("source");
-    const app = await App.findByGuid(source.appGuid);
-    const { pluginConnection } = await source.getPlugin();
-    const method = pluginConnection.methods.profiles;
-
-    if (!method) {
-      throw new Error(`cannot find an import method for app type ${app.type}`);
-    }
-
-    const appOptions = await app.getOptions();
-    const sourceOptions = await source.getOptions();
-    const sourceMapping = await source.getMapping();
-    await app.validateOptions(appOptions);
-    const connection = await app.getConnection();
-    await source.validateOptions(sourceOptions);
-
-    const limit: number = parseInt(
-      (await plugin.readSetting("core", "runs-profile-batch-size")).value
-    );
-
-    let highWaterMark = {};
-    let sourceOffset: number | string = 0;
-
-    if (run.highWaterMark && Object.keys(run.highWaterMark).length > 0) {
-      highWaterMark = run.highWaterMark;
-    } else {
-      const previousRun = await run.previousRun();
-      if (previousRun?.highWaterMark) {
-        highWaterMark = previousRun.highWaterMark;
-      }
-    }
-
-    if (run.sourceOffset) {
-      sourceOffset = run.sourceOffset;
-    }
-
-    let importsCount = 0;
-    let nextHighWaterMark: HighWaterMark;
-    let nextSourceOffset: number | string;
-
-    try {
-      const response = await method({
-        schedule: this,
-        scheduleOptions: options,
-        connection,
-        app,
-        appOptions,
-        source,
-        sourceOptions,
-        sourceMapping,
-        run,
-        limit,
-        highWaterMark,
-        sourceOffset,
-      });
-
-      importsCount = response.importsCount || 0;
-      nextHighWaterMark = response.highWaterMark || {};
-      nextSourceOffset = response.sourceOffset || 0;
-      await run.update({
-        highWaterMark: nextHighWaterMark,
-        sourceOffset: nextSourceOffset,
-      });
-    } catch (error) {
-      log(
-        `failed run ${run.guid} for schedule ${this.guid}: ${error}`,
-        "error",
-        error
-      );
-      run.error = error.stack || error.toString();
-      await run.save();
-    }
-
-    return {
-      importsCount,
-      highWaterMark: nextHighWaterMark,
-      sourceOffset: nextSourceOffset,
-    };
-  }
-
-  // --- Class Methods --- //
-
-  static async findByGuid(guid: string) {
-    const instance = await this.scope(null).findOne({ where: { guid } });
-    if (!instance) {
-      throw new Error(`cannot find ${this.name} ${guid}`);
-    }
-    return instance;
   }
 }

--- a/core/api/src/models/Team.ts
+++ b/core/api/src/models/Team.ts
@@ -4,7 +4,6 @@ import {
   AllowNull,
   Default,
   Length,
-  AfterCreate,
   AfterSave,
   BeforeDestroy,
   HasMany,
@@ -45,6 +44,68 @@ export class Team extends LoggedModel<Team> {
 
   @HasMany(() => Permission)
   permissions: Permission[];
+
+  async apiData() {
+    const membersCount = await this.$count("teamMembers");
+    const permissions = await this.$get("permissions", {
+      order: [["topic", "asc"]],
+    });
+    const permissionsApiData: AsyncReturnType<
+      Permission["apiData"]
+    >[] = await Promise.all(permissions.map((prm) => prm.apiData()));
+
+    return {
+      guid: this.guid,
+      name: this.name,
+      locked: this.locked,
+      permissionAllRead: this.permissionAllRead,
+      permissionAllWrite: this.permissionAllWrite,
+      createdAt: this.createdAt ? this.createdAt.getTime() : null,
+      updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,
+      permissions: permissionsApiData,
+      membersCount,
+    };
+  }
+
+  async authorizeAction(topic: string, mode: "read" | "write") {
+    return Permission.authorizeAction(this.guid, topic, mode);
+  }
+
+  async setPermissions(
+    permissions: Array<{ guid: string; read: boolean; write: boolean }>
+  ) {
+    for (const i in permissions) {
+      const permission = await Permission.findOne({
+        where: { ownerGuid: this.guid, guid: permissions[i].guid },
+      });
+      if (!permission) {
+        throw new Error(
+          `permission ${permissions[i].guid} not found for this team`
+        );
+      }
+      if (!permission.locked) {
+        permission.read =
+          this.permissionAllRead !== null
+            ? this.permissionAllRead
+            : permissions[i].read;
+        permission.write =
+          this.permissionAllWrite !== null
+            ? this.permissionAllWrite
+            : permissions[i].write;
+        await permission.save();
+      }
+    }
+  }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) {
+      throw new Error(`cannot find ${this.name} ${guid}`);
+    }
+    return instance;
+  }
 
   @BeforeSave
   static async checkLockedPermissions(instance: Team) {
@@ -112,67 +173,5 @@ export class Team extends LoggedModel<Team> {
   @AfterDestroy
   static async deletePermissions(instance: Team) {
     return Permission.destroy({ where: { ownerGuid: instance.guid } });
-  }
-
-  async apiData() {
-    const membersCount = await this.$count("teamMembers");
-    const permissions = await this.$get("permissions", {
-      order: [["topic", "asc"]],
-    });
-    const permissionsApiData: AsyncReturnType<
-      Permission["apiData"]
-    >[] = await Promise.all(permissions.map((prm) => prm.apiData()));
-
-    return {
-      guid: this.guid,
-      name: this.name,
-      locked: this.locked,
-      permissionAllRead: this.permissionAllRead,
-      permissionAllWrite: this.permissionAllWrite,
-      createdAt: this.createdAt ? this.createdAt.getTime() : null,
-      updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,
-      permissions: permissionsApiData,
-      membersCount,
-    };
-  }
-
-  async authorizeAction(topic: string, mode: "read" | "write") {
-    return Permission.authorizeAction(this.guid, topic, mode);
-  }
-
-  async setPermissions(
-    permissions: Array<{ guid: string; read: boolean; write: boolean }>
-  ) {
-    for (const i in permissions) {
-      const permission = await Permission.findOne({
-        where: { ownerGuid: this.guid, guid: permissions[i].guid },
-      });
-      if (!permission) {
-        throw new Error(
-          `permission ${permissions[i].guid} not found for this team`
-        );
-      }
-      if (!permission.locked) {
-        permission.read =
-          this.permissionAllRead !== null
-            ? this.permissionAllRead
-            : permissions[i].read;
-        permission.write =
-          this.permissionAllWrite !== null
-            ? this.permissionAllWrite
-            : permissions[i].write;
-        await permission.save();
-      }
-    }
-  }
-
-  // --- Class Methods --- //
-
-  static async findByGuid(guid: string) {
-    const instance = await this.scope(null).findOne({ where: { guid } });
-    if (!instance) {
-      throw new Error(`cannot find ${this.name} ${guid}`);
-    }
-    return instance;
   }
 }

--- a/core/api/src/modules/RuleOpsDictionary.ts
+++ b/core/api/src/modules/RuleOpsDictionary.ts
@@ -1,0 +1,66 @@
+const _boolean_ops = [
+  { op: "exists", description: "exists with any value" },
+  { op: "notExists", description: "does not exist" },
+  { op: "eq", description: "is equal to" },
+  { op: "ne", description: "is not equal to" },
+];
+
+const _number_ops = [
+  { op: "exists", description: "exists with any value" },
+  { op: "notExists", description: "does not exist" },
+  { op: "eq", description: "is equal to" },
+  { op: "ne", description: "is not equal to" },
+  { op: "gt", description: "is greater than" },
+  { op: "lt", description: "is less than" },
+  { op: "gte", description: "is greater than or equal to" },
+  { op: "lte", description: "is less than or equal to" },
+];
+
+const _string_ops = [
+  { op: "exists", description: "exists with any value" },
+  { op: "notExists", description: "does not exist" },
+  { op: "eq", description: "is equal to" },
+  { op: "ne", description: "is not equal to" },
+  { op: "like", description: "is like" },
+  { op: "iLike", description: "is like (case insensitive)" },
+  { op: "notLike", description: "is not like (case insensitive)" },
+  { op: "notILike", description: "is not like (case insensitive)" },
+  { op: "startsWith", description: "starts with" },
+  { op: "endsWith", description: "ends with" },
+  { op: "substring", description: "includes the string" },
+];
+
+const _date_ops = [
+  { op: "exists", description: "exists with any value" },
+  { op: "notExists", description: "does not exist" },
+  { op: "eq", description: "is equal to" },
+  { op: "ne", description: "is not equal to" },
+  { op: "gt", description: "is after" },
+  { op: "lt", description: "is before" },
+  { op: "gte", description: "is on or after" },
+  { op: "lte", description: "is on or before" },
+  { op: "relative_gt", description: "is in the past" },
+  { op: "relative_lt", description: "is in the future" },
+];
+
+export const ProfilePropertyRuleOpsDictionary = {
+  string: _string_ops,
+  email: _string_ops,
+  integer: _number_ops,
+  float: _number_ops,
+  boolean: _boolean_ops,
+  date: _date_ops,
+  _relativeMatchUnits: ["days", "weeks", "months", "quarters", "years"],
+  _convenientRules: {
+    exists: { operation: { op: "ne" }, match: "null" },
+    notExists: { operation: { op: "eq" }, match: "null" },
+    relative_gt: {
+      operation: { op: "gt" },
+      relativeMatchDirection: "subtract",
+    },
+    relative_lt: {
+      operation: { op: "lt" },
+      relativeMatchDirection: "add",
+    },
+  },
+};

--- a/core/api/src/modules/ops/app.ts
+++ b/core/api/src/modules/ops/app.ts
@@ -1,0 +1,95 @@
+import { api, log } from "actionhero";
+import { App, SimpleAppOptions } from "../../models/App";
+import { OptionHelper } from "../optionHelper";
+
+export namespace AppOps {
+  /**
+   * Connect to an App
+   */
+  export async function connect(app: App, options?: SimpleAppOptions) {
+    const appOptions = await app.getOptions();
+    const { pluginApp } = await app.getPlugin();
+    const connection = api.plugins.persistentConnections[app.guid];
+    if (connection) {
+      await app.disconnect();
+    }
+    if (pluginApp.methods.connect) {
+      log(`connecting to app ${app.name} - ${pluginApp.name} (${app.guid})`);
+      const connection = await pluginApp.methods.connect({
+        app,
+        appOptions: options ? options : appOptions,
+      });
+      app.setConnection(connection);
+      return connection;
+    }
+  }
+
+  /**
+   * Disconnect from an App
+   */
+  export async function disconnect(app: App) {
+    const appOptions = await app.getOptions();
+    const { pluginApp } = await app.getPlugin();
+    const connection = api.plugins.persistentConnections[app.guid];
+    if (pluginApp.methods.disconnect && connection) {
+      log(
+        `disconnecting from app ${app.name} - ${pluginApp.name} (${app.guid})`
+      );
+      await pluginApp.methods.disconnect({
+        app,
+        appOptions,
+        connection,
+      });
+      app.setConnection(undefined);
+    }
+  }
+
+  /**
+   * Test an App's Connection
+   */
+  export async function test(app: App, options?: SimpleAppOptions) {
+    let result = false;
+    let error;
+
+    const { pluginApp } = await app.getPlugin();
+    if (!pluginApp) {
+      throw new Error(`cannot find a pluginApp type of ${app.type}`);
+    }
+
+    if (!options) {
+      options = await app.getOptions();
+    } else {
+      options = OptionHelper.sourceEnvironmentVariableOptions(app, options);
+    }
+
+    try {
+      let connection;
+      if (pluginApp.methods.connect) {
+        connection = await pluginApp.methods.connect({
+          app,
+          appOptions: options,
+        });
+      }
+
+      result = await pluginApp.methods.test({
+        app,
+        appOptions: options,
+        connection,
+      });
+
+      if (pluginApp.methods.disconnect) {
+        await pluginApp.methods.disconnect({
+          connection,
+          app,
+          appOptions: options,
+        });
+      }
+    } catch (err) {
+      error = err;
+      result = false;
+      log(`[ app ] testing app threw error: ${error}`);
+    }
+
+    return { result, error };
+  }
+}

--- a/core/api/src/modules/ops/destination.ts
+++ b/core/api/src/modules/ops/destination.ts
@@ -1,0 +1,238 @@
+import { Destination } from "../../models/Destination";
+import { Profile } from "../../models/Profile";
+import { Run } from "../../models/Run";
+import { Import } from "../../models/Import";
+import { Export } from "../../models/Export";
+import { Group } from "../../models/Group";
+import { ExportProfilePluginMethod } from "../../classes/plugin";
+import { task, log, config } from "actionhero";
+
+export namespace DestinationOps {
+  /**
+   * Given a Destination and a Profile (and lots of related data), create all the exports that should be sent
+   */
+  export async function exportProfile(
+    destination: Destination,
+    profile: Profile,
+    runs: Run[],
+    imports: Array<Import>,
+    oldProfileProperties: { [key: string]: any },
+    newProfileProperties: { [key: string]: any },
+    oldGroups: Array<Group>,
+    newGroups: Array<Group>,
+    sync = false
+  ) {
+    const app = await destination.$get("app");
+    let method: ExportProfilePluginMethod;
+    const { pluginConnection } = await destination.getPlugin();
+    method = pluginConnection.methods.exportProfile;
+
+    if (!method) {
+      throw new Error(`cannot find an export method for app type ${app.type}`);
+    }
+
+    const appOptions = await app.getOptions();
+    await app.validateOptions(appOptions);
+    const destinationGroupMemberships = await destination.getDestinationGroupMemberships();
+
+    const mapping = await destination.getMapping();
+    const mappingKeys = Object.keys(mapping);
+    let mappedOldProfileProperties = {};
+    let mappedNewProfileProperties = {};
+    mappingKeys.forEach((k) => {
+      mappedOldProfileProperties[k] = oldProfileProperties[mapping[k]];
+      mappedNewProfileProperties[k] = newProfileProperties[mapping[k]];
+    });
+
+    const oldGroupNames = oldGroups
+      .filter((group) =>
+        destinationGroupMemberships
+          .map((dgm) => dgm.groupGuid)
+          .includes(group.guid)
+      )
+      .map(
+        (group) =>
+          destinationGroupMemberships.filter(
+            (dgm) => dgm.groupGuid === group.guid
+          )[0].remoteKey
+      );
+    const newGroupNames = newGroups
+      .filter((group) =>
+        destinationGroupMemberships
+          .map((dgm) => dgm.groupGuid)
+          .includes(group.guid)
+      )
+      .map(
+        (group) =>
+          destinationGroupMemberships.filter(
+            (dgm) => dgm.groupGuid === group.guid
+          )[0].remoteKey
+      );
+
+    const newGroupGuids = newGroups.map((g) => g.guid);
+    const destinationGroupGuids = (await destination.$get("groups")).map(
+      (g) => g.guid
+    );
+    let toDelete = true;
+    newGroupGuids.forEach((newGroupGuid) => {
+      if (destinationGroupGuids.includes(newGroupGuid)) {
+        toDelete = false;
+      }
+    });
+
+    const mostRecentExport = await Export.findOne({
+      where: {
+        destinationGuid: destination.guid,
+        profileGuid: profile.guid,
+        mostRecent: true,
+      },
+    });
+
+    if (mostRecentExport) {
+      const mostRecentMappedProfilePropertyKeys = Object.keys(
+        mostRecentExport.newProfileProperties
+      );
+      const currentMappedNewProfilePropertyKeys = Object.keys(
+        mappedNewProfileProperties
+      );
+      const currentMappedOldProfilePropertyKeys = Object.keys(
+        mappedNewProfileProperties
+      );
+
+      // since this export was previously mapped, we can assume the previous mapping still makes sense...
+      mostRecentMappedProfilePropertyKeys
+        .filter((k) => !currentMappedNewProfilePropertyKeys.includes(k))
+        .filter((k) => !currentMappedOldProfilePropertyKeys.includes(k))
+        .forEach((k) => (mappedOldProfileProperties[k] = "unknown"));
+    }
+
+    const _export = await Export.create({
+      destinationGuid: destination.guid,
+      profileGuid: profile.guid,
+      runGuids: runs ? runs.map((run) => run.guid) : [],
+      startedAt: sync ? new Date() : undefined,
+      oldProfileProperties: mappedOldProfileProperties,
+      newProfileProperties: mappedNewProfileProperties,
+      oldGroups: oldGroupNames.sort(),
+      newGroups: newGroupNames.sort(),
+      toDelete,
+    });
+
+    if (runs)
+      await Promise.all(runs.map((run) => run.increment("exportsCreated")));
+
+    await _export.associateImports(imports);
+
+    if (sync) {
+      return destination.sendExport(_export, sync);
+    } else {
+      await task.enqueue(
+        "export:send",
+        {
+          destinationGuid: destination.guid,
+          exportGuid: _export.guid,
+        },
+        `exports:${app.type}`
+      );
+    }
+  }
+
+  /**
+   * Send an export previously created to the destination
+   */
+  export async function sendExport(
+    destination: Destination,
+    _export: Export,
+    sync = false
+  ) {
+    await _export.update({ startedAt: new Date() });
+
+    const options = await destination.getOptions();
+    const app = await destination.$get("app");
+    const appOptions = await app.getOptions();
+    const connection = await app.getConnection();
+    const profile = await _export.$get("profile");
+
+    let method: ExportProfilePluginMethod;
+    const { pluginConnection } = await destination.getPlugin();
+    method = pluginConnection.methods.exportProfile;
+
+    const open = await app.checkAndUpdateParallelism("incr");
+    if (!open) {
+      const message = `parallelism limit reached for ${app.type}`;
+      if (sync) {
+        throw new Error(message);
+      } else {
+        log(message + ", re-enqueuing export ${_export.guid}");
+        return task.enqueueIn(
+          config.tasks.timeout + 1,
+          "export:send",
+          {
+            destinationGuid: destination.guid,
+            exportGuid: _export.guid,
+          },
+          `exports:${app.type}`
+        );
+      }
+    }
+
+    try {
+      const { success, retryDelay, error } = await method({
+        connection,
+        app,
+        appOptions,
+        destination,
+        destinationOptions: options,
+        profile,
+        oldProfileProperties: _export.oldProfileProperties,
+        newProfileProperties: _export.newProfileProperties,
+        oldGroups: _export.oldGroups,
+        newGroups: _export.newGroups,
+        toDelete: _export.toDelete,
+      });
+
+      if (!success && retryDelay && !sync) {
+        return task.enqueueIn(
+          retryDelay,
+          "export:send",
+          {
+            destinationGuid: destination.guid,
+            exportGuid: _export.guid,
+          },
+          `exports:${app.type}`
+        );
+      }
+
+      if (!success && retryDelay && sync) {
+        throw error;
+      }
+
+      await _export.update({ completedAt: new Date() });
+      await _export.markMostRecent();
+
+      if (_export.runGuids) {
+        for (const i in _export.runGuids) {
+          const run = await Run.findByGuid(_export.runGuids[i]);
+          await run.increment("profilesExported");
+        }
+      }
+
+      await app.checkAndUpdateParallelism("decr");
+      return { success, retryDelay, error };
+    } catch (error) {
+      _export.errorMessage = error.toString();
+      await _export.save();
+
+      if (_export.runGuids) {
+        for (const i in _export.runGuids) {
+          const run = await Run.findByGuid(_export.runGuids[i]);
+          await run.increment("profilesExported");
+        }
+      }
+
+      await app.checkAndUpdateParallelism("decr");
+      error.message = `error exporting profile ${profile.guid} to destination ${destination.guid}: ${error}`;
+      throw error;
+    }
+  }
+}

--- a/core/api/src/modules/ops/event.ts
+++ b/core/api/src/modules/ops/event.ts
@@ -1,0 +1,126 @@
+import { Event } from "../../models/Event";
+import { Profile } from "../../models/Profile";
+import { ProfileProperty } from "../../models/ProfileProperty";
+import { ProfilePropertyRule } from "../../models/ProfilePropertyRule";
+import { ProfileOps } from "../ops/profile";
+import { Op } from "sequelize";
+
+export namespace EventOps {
+  /**
+   * Associate this Event to a Profile, creating the Profile if needed
+   */
+  export async function associate(
+    event: Event,
+    identifyingProfilePropertyRuleGuid: string
+  ) {
+    // find the cached profile property rule
+    const profilePropertyRules = await ProfilePropertyRule.cached();
+    const profilePropertyRuleCacheKey = Object.keys(
+      profilePropertyRules
+    ).filter(
+      (key) =>
+        profilePropertyRules[key].guid === identifyingProfilePropertyRuleGuid
+    )[0];
+    const profilePropertyRule =
+      profilePropertyRules[profilePropertyRuleCacheKey];
+
+    if (event.profileGuid) {
+      // we are already identified
+      try {
+        const profile = await event.$get("profile");
+        await event.updateProfile(profile);
+        return profile;
+      } catch (error) {
+        // the event may have been moved to another profile
+        const updatedEvent = await event.reload();
+        if (updatedEvent.profileGuid !== event.profileGuid) {
+          return updatedEvent.associate(updatedEvent.profileGuid);
+        } else {
+          throw error;
+        }
+      }
+    } else if (event.userId) {
+      // we have a userId (primaryIdentifyingProfilePropertyRule)
+      let profile = await Profile.findOne({
+        include: [
+          {
+            model: ProfileProperty,
+            where: {
+              rawValue: event.userId,
+              profilePropertyRuleGuid: profilePropertyRule.guid,
+            },
+          },
+        ],
+      });
+
+      if (!profile) {
+        [profile] = await Profile.findOrCreate({
+          where: { anonymousId: event.anonymousId },
+        });
+      }
+
+      const profileProperties = {};
+      profileProperties[profilePropertyRule.key] = event.userId;
+      await profile.addOrUpdateProperties(profileProperties);
+
+      event.profileGuid = profile.guid;
+      event.profileAssociatedAt = new Date();
+      await event.save();
+
+      const otherProfileWithAnonymousId = await Profile.findOne({
+        where: {
+          guid: { [Op.ne]: profile.guid },
+          anonymousId: event.anonymousId,
+        },
+      });
+      if (!otherProfileWithAnonymousId) {
+        await profile.update({ anonymousId: event.anonymousId });
+      } else {
+        await ProfileOps.merge(profile, otherProfileWithAnonymousId);
+      }
+
+      await event.updateProfile(profile);
+      return profile;
+    } else if (event.anonymousId) {
+      // we have an anonymousId
+
+      // can we find the profile by anonymousId?
+      let profile = await Profile.findOne({
+        where: { anonymousId: event.anonymousId },
+      });
+
+      // can we find the profile from other events with the same anonymousId?
+      if (!profile) {
+        const otherEvent = await Event.findOne({
+          where: {
+            anonymousId: event.anonymousId,
+            profileGuid: { [Op.ne]: null },
+          },
+        });
+        if (otherEvent) {
+          profile = await Profile.findOne({
+            where: { guid: otherEvent.profileGuid },
+          });
+        }
+      }
+
+      // if we still don't have a profile, make a new one
+      if (!profile) {
+        [profile] = await Profile.findOrCreate({
+          where: { anonymousId: event.anonymousId },
+        });
+      }
+
+      event.profileGuid = profile.guid;
+      event.profileAssociatedAt = new Date();
+      await event.save();
+      await event.updateProfile(profile);
+      return profile;
+    } else {
+      // we can't identify this event
+      throw new Error(
+        "cannot associate a profile without profileGuid, userId, or anonymousId"
+      );
+    }
+  }
+}

--- a/core/api/src/modules/ops/group.ts
+++ b/core/api/src/modules/ops/group.ts
@@ -1,0 +1,361 @@
+import { Group, GroupRuleWithKey } from "../../models/Group";
+import { GroupMember } from "../../models/GroupMember";
+import { Run } from "../../models/Run";
+import { Profile } from "../../models/Profile";
+import { ProfileMultipleAssociationShim } from "../../models/ProfileMultipleAssociationShim";
+import { Import } from "../../models/Import";
+import { Op } from "sequelize";
+import { api, task } from "actionhero";
+
+export namespace GroupOps {
+  /**
+   * Create a Run for this Group
+   */
+  export async function run(
+    group: Group,
+    force = false,
+    destinationGuid?: string
+  ) {
+    await group.stopPreviousRuns();
+    await task.enqueue("group:run", {
+      groupGuid: group.guid,
+      force,
+      destinationGuid,
+    });
+  }
+
+  /**
+   * Stop previous Runs for this Group
+   */
+  export async function stopPreviousRuns(group: Group) {
+    const previousRuns = await Run.findAll({
+      where: {
+        creatorGuid: group.guid,
+        state: "running",
+      },
+    });
+
+    for (const i in previousRuns) {
+      await previousRuns[i].stop();
+    }
+  }
+
+  /**
+   * Given a Profile, create an import to recalculate its Group Membership
+   */
+  export async function buildProfileImport(
+    profileGuid: string,
+    creatorType: string,
+    creatorGuid: string,
+    destinationGuid?: string
+  ) {
+    const profile = await Profile.findOne({ where: { guid: profileGuid } });
+
+    const oldProfileProperties = [];
+    const properties = await profile.properties();
+    for (const key in properties) {
+      oldProfileProperties[key] = properties[key].value;
+    }
+
+    const oldGroupGuids = (await profile.$get("groups")).map((g) => g.guid);
+
+    return Import.build({
+      rawData: destinationGuid ? { _meta: { destinationGuid } } : {},
+      data: destinationGuid ? { _meta: { destinationGuid } } : {},
+      creatorType,
+      creatorGuid,
+      profileGuid: profile.guid,
+      profileAssociatedAt: new Date(),
+      oldProfileProperties,
+      oldGroupGuids,
+    });
+  }
+
+  /**
+   * Check if the profile should be in this Group
+   */
+  export async function updateProfileMembership(
+    group: Group,
+    profile: Profile
+  ) {
+    const existingMembership = await GroupMember.findOne({
+      where: {
+        groupGuid: group.guid,
+        profileGuid: profile.guid,
+      },
+    });
+
+    if (group.type === "manual") {
+      if (group.state === "deleted") {
+        if (existingMembership) {
+          await existingMembership.destroy();
+        }
+        return false;
+      } else {
+        return existingMembership ? true : false;
+      }
+    } else {
+      const rules = await group.getRules();
+
+      if (Object.keys(rules).length == 0) {
+        if (existingMembership) {
+          await existingMembership.destroy();
+        }
+        return false;
+      } else {
+        const { where, include } = await group._buildGroupMemberQueryParts(
+          rules,
+          group.matchType
+        );
+
+        // and includes this profile
+        if (!where[Op.and]) {
+          where[Op.and] = [];
+        }
+        where[Op.and].push({
+          guid: profile.guid,
+        });
+
+        const matchedProfiles = await ProfileMultipleAssociationShim.findAll({
+          attributes: ["guid"],
+          where,
+          include,
+        });
+
+        const belongs = matchedProfiles.length === 1;
+
+        if (belongs && !existingMembership) {
+          await GroupMember.create({
+            groupGuid: group.guid,
+            profileGuid: profile.guid,
+          });
+        }
+
+        if (!belongs && existingMembership) {
+          await existingMembership.destroy();
+        }
+
+        return belongs;
+      }
+    }
+  }
+
+  /**
+   * Count the members that would be in this group
+   */
+  export async function countPotentialMembers(
+    group: Group,
+    rules?: GroupRuleWithKey[],
+    matchType: "any" | "all" = group.matchType
+  ) {
+    if (!rules) {
+      rules = await group.getRules();
+    }
+
+    const { where, include } = await group._buildGroupMemberQueryParts(
+      rules,
+      matchType
+    );
+
+    // we use ProfileMultipleAssociationShim as a shim model which has extra associations
+    return ProfileMultipleAssociationShim.count({ where, include });
+  }
+
+  /**
+   * Take the rules for the group and check how many group members there would have been both individually for each single rule, and then by building up the query step-by-step
+   */
+  export async function countComponentMembersFromRules(
+    group: Group,
+    rules?: GroupRuleWithKey[]
+  ) {
+    const componentCounts = [];
+    const funnelCounts = [];
+    let funnelStep = 0;
+
+    if (!rules) {
+      rules = await group.getRules();
+    }
+
+    for (const i in rules) {
+      const localRule = rules[i];
+      componentCounts[i] = await group.countPotentialMembers([localRule]);
+
+      const funnelRules = [];
+      let j = 0;
+      while (j <= funnelStep) {
+        funnelRules.push(rules[j]);
+        j++;
+      }
+      funnelCounts[funnelStep] = await group.countPotentialMembers(funnelRules);
+      funnelStep++;
+    }
+
+    return { componentCounts, funnelCounts };
+  }
+
+  /**
+   * Part 1 of the Group Run
+   * Add New Members
+   */
+  export async function runAddGroupMembers(
+    group: Group,
+    run: Run,
+    limit = 1000,
+    offset = 0,
+    force = false,
+    destinationGuid?: string
+  ) {
+    let groupMembersCount = 0;
+    let profiles: ProfileMultipleAssociationShim[];
+
+    if (group.type === "manual") {
+      profiles = await group.$get("profiles", {
+        attributes: ["guid"],
+        limit,
+        offset,
+        order: [["createdAt", "asc"]],
+      });
+    } else {
+      const rules = await group.getRules();
+      if (Object.keys(rules).length === 0) {
+        return 0;
+      }
+
+      const { where, include } = await group._buildGroupMemberQueryParts(
+        rules,
+        group.matchType
+      );
+
+      profiles = await ProfileMultipleAssociationShim.findAll({
+        attributes: ["guid"],
+        where,
+        include,
+        limit,
+        offset,
+        order: [["createdAt", "asc"]],
+        subQuery: false,
+      });
+    }
+
+    for (const i in profiles) {
+      const profile = profiles[i];
+      const groupMember = await GroupMember.findOne({
+        where: {
+          profileGuid: profile.guid,
+          groupGuid: group.guid,
+        },
+      });
+
+      if (!groupMember || force) {
+        const transaction = await api.sequelize.transaction();
+        const _import = await group.buildProfileImport(
+          profile.guid,
+          "run",
+          run.guid,
+          destinationGuid
+        );
+        await run.increment(["importsCreated"], { transaction });
+        await _import.save({ transaction });
+        await transaction.commit();
+      }
+
+      if (groupMember) {
+        groupMember.removedAt = null;
+        groupMember.set("updatedAt", new Date());
+        groupMember.changed("updatedAt", true);
+        await groupMember.save();
+      }
+
+      groupMembersCount++;
+    }
+
+    group.calculatedAt = new Date();
+    await group.save();
+
+    return groupMembersCount;
+  }
+
+  /**
+   * Part 2 of the Group Run
+   * Remove Members
+   */
+  export async function runRemoveGroupMembers(
+    group: Group,
+    run: Run,
+    limit = 1000,
+    offset = 0,
+    force = false,
+    destinationGuid?: string
+  ) {
+    let groupMembersCount = 0;
+
+    // The offset and order can be ignored as we will keep running this query until the set of results becomes 0.
+    const groupMembersToRemove = await GroupMember.findAll({
+      attributes: ["guid", "profileGuid"],
+      where: {
+        groupGuid: group.guid,
+        updatedAt: { [Op.lt]: run.createdAt },
+        removedAt: null,
+      },
+      limit,
+    });
+
+    for (const i in groupMembersToRemove) {
+      const member = groupMembersToRemove[i];
+      const transaction = await api.sequelize.transaction();
+      member.removedAt = new Date();
+      await member.save({ transaction });
+      const _import = await group.buildProfileImport(
+        member.profileGuid,
+        "run",
+        run.guid,
+        destinationGuid
+      );
+      await run.increment(["importsCreated"], { transaction });
+      await _import.save({ transaction });
+      await transaction.commit();
+      groupMembersCount++;
+    }
+
+    group.calculatedAt = new Date();
+    await group.save();
+
+    return groupMembersCount;
+  }
+
+  /**
+   * Part 3 for the Group Run
+   * Check if there was anyone we should have removed from a previous Run that was stopped for this Run
+   */
+  export async function removePreviousRunGroupMembers(
+    group: Group,
+    run: Run,
+    limit = 100
+  ) {
+    let groupMembersCount = 0;
+
+    const groupMembersToRemove = await GroupMember.findAll({
+      attributes: ["guid", "profileGuid"],
+      where: {
+        groupGuid: group.guid,
+        removedAt: { [Op.lte]: run.createdAt },
+      },
+      limit,
+    });
+
+    for (const i in groupMembersToRemove) {
+      const member = groupMembersToRemove[i];
+      member.removedAt = new Date();
+      await member.save();
+      const _import = await group.buildProfileImport(
+        member.profileGuid,
+        "run",
+        run.guid
+      );
+      await _import.save();
+      groupMembersCount++;
+    }
+
+    return groupMembersCount;
+  }
+}

--- a/core/api/src/modules/ops/import.ts
+++ b/core/api/src/modules/ops/import.ts
@@ -1,0 +1,18 @@
+import { Import } from "../../models/Import";
+import { ProfileOps } from "./profile";
+
+export namespace ImportOps {
+  export async function associateProfile(_import: Import) {
+    const {
+      profile,
+      isNew,
+      // will throw if there are no unique profile properties
+    } = await ProfileOps.findOrCreateByUniqueProfileProperties(_import.data);
+
+    _import.profileGuid = profile.guid;
+    _import.profileAssociatedAt = new Date();
+    await _import.save();
+
+    return { profile, isNew };
+  }
+}

--- a/core/api/src/modules/ops/profile.ts
+++ b/core/api/src/modules/ops/profile.ts
@@ -1,0 +1,389 @@
+import { Profile } from "../../models/Profile";
+import { ProfileProperty } from "../../models/ProfileProperty";
+import { ProfilePropertyRule } from "../../models/ProfilePropertyRule";
+import { Source } from "../../models/Source";
+import { Group } from "../../models/Group";
+import { Destination } from "../../models/Destination";
+import { log } from "actionhero";
+import { waitForLock } from "../locks";
+
+export namespace ProfileOps {
+  /**
+   * Get the Properties of this Profile
+   */
+  export async function properties(
+    profile: Profile
+  ): Promise<{
+    [key: string]: {
+      guid: string;
+      value: any;
+      type: string;
+      unique: boolean;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+  }> {
+    const profileProperties =
+      profile.profileProperties ||
+      (await ProfileProperty.findAll({ where: { profileGuid: profile.guid } }));
+
+    const hash = {};
+    for (const i in profileProperties) {
+      try {
+        const rule = await profileProperties[i].cachedProfilePropertyRule();
+        const key = rule.key;
+        hash[key] = {
+          guid: profileProperties[i].profilePropertyRuleGuid,
+          value: await profileProperties[i].getValue(),
+          type: rule.type,
+          unique: rule.unique,
+          createdAt: profileProperties[i].createdAt,
+          updatedAt: profileProperties[i].updatedAt,
+        };
+      } catch (error) {
+        if (
+          error
+            .toString()
+            .match(
+              /cached profile property rule not found for this profilePropertyRuleGuid/
+            )
+        ) {
+          // it's ok, we are in the middle of creating or destroying a profile property
+          log(error, "info");
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    return hash;
+  }
+
+  /**
+   * Add or Update many Properties on this Profile
+   */
+  export async function addOrUpdateProperty(
+    profile: Profile,
+    hash: { [key: string]: any }
+  ) {
+    const key = Object.keys(hash)[0];
+    const value = hash[key];
+
+    // ignore reserved property key
+    if (key === "_meta") {
+      return;
+    }
+
+    const profilePropertyRules = await ProfilePropertyRule.cached();
+    const rule = profilePropertyRules[key];
+
+    if (!rule) {
+      throw new Error(`cannot find a profile property rule for key ${key}`);
+    }
+
+    // Note: Lifecycle hooks do not fire on upserts, so we need to manually check if the property exists or not
+    let property = await ProfileProperty.findOne({
+      where: { profileGuid: profile.guid, profilePropertyRuleGuid: rule.guid },
+    });
+
+    if (!property) {
+      property = new ProfileProperty({
+        profileGuid: profile.guid,
+        profilePropertyRuleGuid: rule.guid,
+      });
+    }
+
+    await property.setValue(value);
+    await property.save();
+    return profile;
+  }
+
+  /**
+   * Remove a Property on this Profile
+   */
+  export async function removeProperty(profile: Profile, key: string) {
+    const profilePropertyRules = await ProfilePropertyRule.cached();
+    const rule = profilePropertyRules[key];
+
+    if (!rule) {
+      return;
+    }
+
+    const property = await ProfileProperty.findOne({
+      where: { profileGuid: profile.guid, profilePropertyRuleGuid: rule.guid },
+    });
+
+    if (property) {
+      await property.destroy();
+    }
+  }
+
+  /**
+   * Add or Update a Property on this Profile
+   */
+  export async function addOrUpdateProperties(
+    profile: Profile,
+    properties: { [key: string]: any }
+  ) {
+    await profile.save();
+
+    const keys = Object.keys(properties);
+    for (const i in keys) {
+      if (keys[i] === "guid") {
+        continue;
+      }
+
+      const h = {};
+      h[keys[i]] = properties[keys[i]];
+      await profile.addOrUpdateProperty(h);
+    }
+
+    return profile;
+  }
+
+  /**
+   * Remove all Properties from this Profile
+   */
+  export async function removeProperties(
+    profile: Profile,
+    properties: Array<string>
+  ) {
+    for (const i in properties) {
+      await profile.removeProperty(properties[i]);
+    }
+  }
+
+  /**
+   * Import the properties of this Profile
+   */
+  export async function _import(
+    profile: Profile,
+    toSave = true,
+    toLock = true
+  ) {
+    let releaseLock: Function;
+
+    if (toLock) {
+      const lockObject = await waitForLock(`profile:${profile.guid}`);
+      releaseLock = lockObject.releaseLock;
+    }
+
+    let hash = {};
+    const sources = await Source.findAll({ where: { state: "ready" } });
+    await Promise.all(
+      sources.map((source) =>
+        source
+          .import(profile)
+          .then((data) => (hash = Object.assign(hash, data)))
+      )
+    );
+
+    if (toSave) {
+      await profile.addOrUpdateProperties(hash);
+      await profile.buildNullProperties();
+      await profile.save();
+    }
+
+    if (toLock) {
+      releaseLock();
+    }
+
+    return profile;
+  }
+
+  /**
+   * Export this Profile to all relevant Sources
+   */
+  export async function _export(
+    profile: Profile,
+    force = false,
+    groupsOverride?: Group[]
+  ) {
+    let oldSimpleProperties = {};
+    let oldGroups = [];
+
+    const groups = groupsOverride
+      ? groupsOverride
+      : await profile.$get("groups");
+
+    const destinations = await Destination.destinationsForGroups(groups);
+    const properties = await profile.properties();
+    const simpleProperties = {};
+    for (const i in properties) {
+      simpleProperties[i] = properties[i].value;
+    }
+
+    if (!force) {
+      const oldProperties = await profile.properties();
+      oldGroups = groups;
+
+      for (const i in oldProperties) {
+        oldSimpleProperties[i] = oldProperties[i].value;
+      }
+    }
+
+    await Promise.all(
+      destinations.map((destination) =>
+        destination.exportProfile(
+          profile,
+          null,
+          [],
+          oldSimpleProperties,
+          simpleProperties,
+          oldGroups,
+          groups,
+          true
+        )
+      )
+    );
+  }
+
+  /**
+   * The method you'll be using to create profiles with arbitrary data.
+   * Hash looks like {email: "person@example.com", id: 123}
+   */
+  export async function findOrCreateByUniqueProfileProperties(hash: {
+    [key: string]: any;
+  }) {
+    let profile: Profile;
+    let isNew: boolean;
+    let profileProperty: ProfileProperty;
+    const rules = await ProfilePropertyRule.cached();
+    const uniquePropertiesHash = {};
+
+    Object.keys(rules).forEach((key) => {
+      if (rules[key].unique && hash[key]) {
+        uniquePropertiesHash[key] = hash[key];
+      }
+
+      // and the case when we are sending a profile guid directly
+      if (hash["guid"]) {
+        uniquePropertiesHash["guid"] = hash["guid"];
+      }
+    });
+
+    if (Object.keys(uniquePropertiesHash).length === 0) {
+      throw new Error(
+        `there are no unique profile properties provided in ${JSON.stringify(
+          hash
+        )}`
+      );
+    }
+
+    // special handling when a guid is provided directly
+    // for use with internal runs
+    if (uniquePropertiesHash["guid"]) {
+      profile = await Profile.findOne({
+        where: { guid: uniquePropertiesHash["guid"] },
+      });
+
+      if (profile) {
+        isNew = false;
+        return { profile, isNew };
+      } else {
+        throw new Error(
+          `cannot find profile with guid ${uniquePropertiesHash["guid"]}`
+        );
+      }
+    }
+
+    const keys = Object.keys(uniquePropertiesHash);
+    const lockReleases = [];
+
+    for (const i in keys) {
+      const key = keys[i];
+      const value = uniquePropertiesHash[key];
+      const rule = rules[key];
+
+      const { releaseLock } = await waitForLock(`prp:${key}:${value}`);
+      lockReleases.push(releaseLock);
+
+      profileProperty = await ProfileProperty.findOne({
+        where: {
+          profilePropertyRuleGuid: rule.guid,
+          rawValue: String(value),
+        },
+      });
+
+      if (profileProperty) {
+        break;
+      }
+    }
+
+    if (profileProperty) {
+      profile = await Profile.findOne({
+        where: { guid: profileProperty.profileGuid },
+      });
+      isNew = false;
+    } else {
+      profile = await Profile.create();
+      await profile.addOrUpdateProperties(uniquePropertiesHash);
+      isNew = true;
+    }
+
+    await Promise.all(lockReleases.map((release) => release()));
+
+    return { profile, isNew };
+  }
+
+  /**
+   * Merge 2 Profiles, favoring the first Profile
+   */
+  export async function merge(profile: Profile, otherProfile: Profile) {
+    const { releaseLock: releaseLockForProfile } = await waitForLock(
+      `profile:${profile.guid}`
+    );
+    const { releaseLock: releaseLockForOtherProfile } = await waitForLock(
+      `profile:${otherProfile.guid}`
+    );
+
+    // transfer events
+    let eventsCount = 1;
+    while (eventsCount > 0) {
+      const events = await otherProfile.$get("events", { limit: 1000 });
+      eventsCount = events.length;
+      await Promise.all(
+        events.map((event) => {
+          event.profileGuid = profile.guid;
+          return event.save();
+        })
+      );
+    }
+
+    // transfer properties, keeping the newest values
+    const properties = await profile.properties();
+    const otherProperties = await otherProfile.properties();
+    const newProperties = {};
+    for (const key in otherProperties) {
+      if (
+        !properties[key] ||
+        (otherProperties[key]?.updatedAt?.getTime() >
+          properties[key]?.updatedAt?.getTime() &&
+          otherProperties[key]?.value !== null &&
+          otherProperties[key]?.value !== undefined)
+      ) {
+        newProperties[key] = otherProperties[key].value;
+      }
+    }
+
+    // delete other profile so unique profile properties will be available
+    await otherProfile.destroy();
+    await profile.addOrUpdateProperties(newProperties);
+
+    // transfer anonymousId
+    if (!profile.anonymousId && otherProfile.anonymousId) {
+      await profile.update({ anonymousId: otherProfile.anonymousId });
+    }
+
+    // re-import and update groups
+    delete profile.profileProperties; // remove any cached values from the instance
+    await profile.import(true, false);
+    await profile.updateGroupMembership();
+
+    // release locks
+    await releaseLockForProfile();
+    await releaseLockForOtherProfile();
+
+    return profile;
+  }
+}

--- a/core/api/src/modules/ops/profilePropertyRule.ts
+++ b/core/api/src/modules/ops/profilePropertyRule.ts
@@ -1,0 +1,123 @@
+import { ProfilePropertyRule } from "../../models/ProfilePropertyRule";
+import { Group } from "../../models/Group";
+import { GroupRule } from "../../models/GroupRule";
+import { App } from "../../models/App";
+import { internalRun } from "../internalRun";
+import { task } from "actionhero";
+
+export namespace ProfilePropertyRuleOps {
+  /**
+   * Enqueue Runs to update all Groups that rely on this Profile Property Rule
+   */
+  export async function enqueueRuns(profilePropertyRule: ProfilePropertyRule) {
+    await internalRun("profilePropertyRule", profilePropertyRule.guid); // update *all* profiles
+
+    const groups = await Group.findAll({
+      include: [
+        {
+          model: GroupRule,
+          where: { profilePropertyRuleGuid: profilePropertyRule.guid },
+        },
+      ],
+    });
+
+    for (const i in groups) {
+      const group = groups[i];
+      await group.update({ state: "initializing" });
+      await task.enqueue("group:run", { groupGuid: group.guid });
+    }
+  }
+
+  /**
+   * Get the options for a Profile Property Rule from its plugin
+   */
+  export async function pluginOptions(
+    profilePropertyRule: ProfilePropertyRule
+  ) {
+    const source = await profilePropertyRule.$get("source");
+    const { pluginConnection } = await source.getPlugin();
+
+    if (!pluginConnection) {
+      throw new Error(`cannot find a pluginConnection for type ${source.type}`);
+    }
+    if (!pluginConnection.profilePropertyRuleOptions) {
+      throw new Error(
+        `cannot find profilePropertyRuleOptions for type ${source.type}`
+      );
+    }
+
+    const response: Array<{
+      key: string;
+      description: string;
+      required: boolean;
+      type: string;
+      options: Array<{
+        key: string;
+        description?: string;
+        examples?: Array<any>;
+      }>;
+    }> = [];
+    const app = await App.findByGuid(source.appGuid);
+    const connection = await app.getConnection();
+    const appOptions = await app.getOptions();
+    const sourceOptions = await source.getOptions();
+    const sourceMapping = await source.getMapping();
+
+    for (const i in pluginConnection.profilePropertyRuleOptions) {
+      const opt = pluginConnection.profilePropertyRuleOptions[i];
+      const options = await opt.options({
+        connection,
+        app,
+        appOptions,
+        source,
+        sourceOptions,
+        sourceMapping,
+        profilePropertyRule,
+      });
+
+      response.push({
+        key: opt.key,
+        description: opt.description,
+        required: opt.required,
+        type: opt.type,
+        options,
+      });
+    }
+
+    return response;
+  }
+
+  /**
+   * Get the options for a Profile Property Rule's Filter from its plugin
+   */
+  export async function pluginFilterOptions(
+    profilePropertyRule: ProfilePropertyRule
+  ) {
+    const { pluginConnection } = await profilePropertyRule.getPlugin();
+    if (!pluginConnection.methods.sourceFilters) {
+      return [];
+    }
+
+    const profilePropertyRuleOptions = await profilePropertyRule.getOptions();
+    const source = await profilePropertyRule.$get("source");
+    const sourceOptions = await source.getOptions();
+    const sourceMapping = await source.getMapping();
+    const app = await App.findByGuid(source.appGuid);
+    const connection = await app.getConnection();
+    const appOptions = await app.getOptions();
+
+    const method = pluginConnection.methods.sourceFilters;
+    const options = await method({
+      connection,
+      app,
+      appOptions,
+      source,
+      sourceOptions,
+      sourceMapping,
+      profilePropertyRule,
+      profilePropertyRuleOptions,
+    });
+
+    return options;
+  }
+}

--- a/core/api/src/modules/ops/runs.ts
+++ b/core/api/src/modules/ops/runs.ts
@@ -1,0 +1,152 @@
+import { Run } from "../../models/Run";
+import { Destination } from "../../models/Destination";
+import { Export } from "../../models/Export";
+import { Profile } from "../../models/Profile";
+import { Group } from "../../models/Group";
+import { Op } from "sequelize";
+import { api } from "actionhero";
+
+export namespace RunOps {
+  /**
+   * Return counts of the states of each import in N chunks over the lifetime of the run
+   * Great for drawing charts!
+   */
+  export async function quantizedTimeline(run: Run, steps = 25) {
+    const data = [];
+    const destinations = await Destination.findAll();
+    const start = run.createdAt.getTime();
+    const end = run.completedAt
+      ? run.completedAt.getTime()
+      : new Date().getTime();
+    const stepSize = Math.floor((end - start) / steps);
+    const boundaries = [start - stepSize * 2];
+    let i = 1;
+    let foundDestinationNames = [];
+    while (i <= steps + 4) {
+      const lastBoundary = boundaries[i - 1];
+      const nextBoundary = lastBoundary + stepSize;
+      boundaries.push(nextBoundary);
+
+      const timeData = {
+        lastBoundary,
+        nextBoundary,
+        steps: {
+          associate: await run.$count("imports", {
+            where: {
+              profileAssociatedAt: {
+                [Op.gte]: lastBoundary,
+                [Op.lt]: nextBoundary,
+              },
+            },
+          }),
+          update: await run.$count("imports", {
+            where: {
+              profileUpdatedAt: {
+                [Op.gte]: lastBoundary,
+                [Op.lt]: nextBoundary,
+              },
+            },
+          }),
+          groups: await run.$count("imports", {
+            where: {
+              groupsUpdatedAt: {
+                [Op.gte]: lastBoundary,
+                [Op.lt]: nextBoundary,
+              },
+            },
+          }),
+          export: await run.$count("imports", {
+            where: {
+              exportedAt: {
+                [Op.gte]: lastBoundary,
+                [Op.lt]: nextBoundary,
+              },
+            },
+          }),
+        },
+      };
+
+      const _exportGroups = await Export.findAll({
+        attributes: [
+          [api.sequelize.fn("COUNT", "*"), "count"],
+          "destinationGuid",
+        ],
+        group: ["destinationGuid"],
+        where: {
+          startedAt: {
+            [Op.gte]: lastBoundary,
+            [Op.lt]: nextBoundary,
+          },
+          runGuids: { [Op.like]: `%${run.guid}%` }, // TODO: this is slow, de-normalize
+        },
+      });
+
+      _exportGroups.forEach((_exportGroup) => {
+        const destination = destinations.filter(
+          (destination) => destination.guid === _exportGroup.destinationGuid
+        )[0];
+        if (destination) {
+          if (!foundDestinationNames.includes(destination.name))
+            foundDestinationNames.push(destination.name);
+          // @ts-ignore
+          timeData.steps[destination.name] = _exportGroup.getDataValue("count");
+        }
+      });
+
+      data.push(timeData);
+      i++;
+    }
+
+    // add back points for destinations that were not found at this interval
+    for (const i in data) {
+      foundDestinationNames.forEach((destinationName) => {
+        if (!data[i].steps[destinationName]) data[i].steps[destinationName] = 0;
+      });
+    }
+
+    return data;
+  }
+
+  /**
+   * Make a guess to what percent complete this Run is
+   */
+  export async function percentComplete(run: Run) {
+    if (run.state === "complete") return 100;
+    if (run.state === "stopped") return 100;
+    if (run.creatorType === "group") {
+      let basePercent = 0;
+      const group = await Group.findByGuid(run.creatorGuid);
+      const groupMembersCount =
+        group.type === "calculated"
+          ? await group.countPotentialMembers()
+          : await group.$count("groupMembers");
+      switch (run.groupMethod) {
+        case "runAddGroupMembers":
+          basePercent = 0;
+          break;
+        case "runRemoveGroupMembers":
+          basePercent = 45;
+          break;
+        case "removePreviousRunGroupMembers":
+          basePercent = 90;
+          break;
+      }
+      return (
+        basePercent +
+        Math.round(
+          (100 * run.groupMemberOffset) /
+            (groupMembersCount > 0 ? groupMembersCount : 1) /
+            3
+        )
+      );
+    }
+    if (run.creatorType === "schedule") {
+      // there's no way to know because we are reading external data
+      return 0;
+    } else {
+      // for profilePropertyRules and for other types of internal run, we can assume we have to check every profile in the system
+      const totalProfiles = await Profile.count();
+      return Math.round((100 * run.profilesImported) / totalProfiles);
+    }
+  }
+}

--- a/core/api/src/modules/ops/schedule.ts
+++ b/core/api/src/modules/ops/schedule.ts
@@ -1,0 +1,145 @@
+import { Schedule } from "../../models/Schedule";
+import { Source } from "../../models/Source";
+import { Run, HighWaterMark } from "../../models/Run";
+import { App } from "../../models/App";
+import { plugin } from "../plugin";
+import { log } from "actionhero";
+
+export namespace ScheduleOps {
+  export async function run(schedule: Schedule, run: Run) {
+    const options = await schedule.getOptions();
+    const source = await schedule.$get("source");
+    const app = await App.findByGuid(source.appGuid);
+    const { pluginConnection } = await source.getPlugin();
+    const method = pluginConnection.methods.profiles;
+
+    if (!method) {
+      throw new Error(`cannot find an import method for app type ${app.type}`);
+    }
+
+    const appOptions = await app.getOptions();
+    const sourceOptions = await source.getOptions();
+    const sourceMapping = await source.getMapping();
+    await app.validateOptions(appOptions);
+    const connection = await app.getConnection();
+    await source.validateOptions(sourceOptions);
+
+    const limit: number = parseInt(
+      (await plugin.readSetting("core", "runs-profile-batch-size")).value
+    );
+
+    let highWaterMark = {};
+    let sourceOffset: number | string = 0;
+
+    if (run.highWaterMark && Object.keys(run.highWaterMark).length > 0) {
+      highWaterMark = run.highWaterMark;
+    } else {
+      const previousRun = await run.previousRun();
+      if (previousRun?.highWaterMark) {
+        highWaterMark = previousRun.highWaterMark;
+      }
+    }
+
+    if (run.sourceOffset) {
+      sourceOffset = run.sourceOffset;
+    }
+
+    let importsCount = 0;
+    let nextHighWaterMark: HighWaterMark;
+    let nextSourceOffset: number | string;
+
+    try {
+      const response = await method({
+        schedule,
+        scheduleOptions: options,
+        connection,
+        app,
+        appOptions,
+        source,
+        sourceOptions,
+        sourceMapping,
+        run,
+        limit,
+        highWaterMark,
+        sourceOffset,
+      });
+
+      importsCount = response.importsCount || 0;
+      nextHighWaterMark = response.highWaterMark || {};
+      nextSourceOffset = response.sourceOffset || 0;
+      await run.update({
+        highWaterMark: nextHighWaterMark,
+        sourceOffset: nextSourceOffset,
+      });
+    } catch (error) {
+      log(
+        `failed run ${run.guid} for schedule ${schedule.guid}: ${error}`,
+        "error",
+        error
+      );
+      run.error = error.stack || error.toString();
+      await run.save();
+    }
+
+    return {
+      importsCount,
+      highWaterMark: nextHighWaterMark,
+      sourceOffset: nextSourceOffset,
+    };
+  }
+
+  /**
+   * Load the options for this schedule from the plugin
+   */
+  export async function pluginOptions(schedule: Schedule) {
+    const source = await Source.findByGuid(schedule.sourceGuid);
+    const { pluginConnection } = await source.getPlugin();
+
+    const response: Array<{
+      key: string;
+      description: string;
+      required: boolean;
+      type: string;
+      options: Array<{
+        key: string;
+        description?: string;
+        examples?: Array<any>;
+      }>;
+    }> = [];
+
+    if (!pluginConnection) {
+      throw new Error(`cannot find a pluginConnection for type ${source.type}`);
+    }
+    if (!pluginConnection.scheduleOptions) {
+      return response;
+    }
+
+    const app = await source.$get("app");
+    const connection = await app.getConnection();
+    const appOptions = await app.getOptions();
+    const sourceOptions = await source.getOptions();
+    const sourceMapping = await source.getMapping();
+
+    for (const i in pluginConnection.scheduleOptions) {
+      const opt = pluginConnection.scheduleOptions[i];
+      const options = await opt.options({
+        connection,
+        app,
+        appOptions,
+        source,
+        sourceOptions,
+        sourceMapping,
+      });
+
+      response.push({
+        key: opt.key,
+        description: opt.description,
+        required: opt.required,
+        type: opt.type,
+        options,
+      });
+    }
+
+    return response;
+  }
+}

--- a/core/api/src/modules/ops/source.ts
+++ b/core/api/src/modules/ops/source.ts
@@ -1,0 +1,266 @@
+import { Source, SimpleSourceOptions } from "../../models/Source";
+import {
+  ProfilePropertyRule,
+  ProfilePropertyRuleFiltersWithKey,
+} from "../../models/ProfilePropertyRule";
+import { Profile } from "../../models/Profile";
+import { App } from "../../models/App";
+import { OptionHelper } from "../optionHelper";
+import { MappingHelper } from "../mappingHelper";
+import { utils } from "actionhero";
+
+export namespace SourceOps {
+  /**
+   * Get the connection options for this source from the plugin
+   */
+  export async function sourceConnectionOptions(
+    source: Source,
+    sourceOptions: SimpleSourceOptions = {}
+  ) {
+    const { pluginConnection } = await source.getPlugin();
+    const app = await source.$get("app");
+    const connection = await app.getConnection();
+    const appOptions = await app.getOptions();
+
+    if (!pluginConnection.methods.sourceOptions) {
+      return {};
+    }
+
+    return pluginConnection.methods.sourceOptions({
+      connection,
+      app,
+      appOptions,
+      sourceOptions,
+    });
+  }
+
+  /**
+   * Load a preview of the data from this Source
+   */
+  export async function sourcePreview(
+    source: Source,
+    sourceOptions?: SimpleSourceOptions
+  ) {
+    if (!sourceOptions) {
+      sourceOptions = await source.getOptions();
+    }
+
+    try {
+      // if the options aren't set yet, return an empty array of rows
+      await source.validateOptions(sourceOptions);
+    } catch {
+      return [];
+    }
+
+    const { pluginConnection } = await source.getPlugin();
+    const app = await source.$get("app");
+    const connection = await app.getConnection();
+    const appOptions = await app.getOptions();
+
+    if (!pluginConnection.methods.sourcePreview) {
+      throw new Error(`cannot return a source preview for ${source.type}`);
+    }
+
+    return pluginConnection.methods.sourcePreview({
+      connection,
+      app,
+      appOptions,
+      source,
+      sourceOptions,
+    });
+  }
+
+  /**
+   * Import a profile property for a Profile from this source
+   */
+  export async function importProfileProperty(
+    source: Source,
+    profile: Profile,
+    profilePropertyRule: ProfilePropertyRule,
+    profilePropertyRuleOptionsOverride?: OptionHelper.SimpleOptions,
+    profilePropertyRuleFiltersOverride?: ProfilePropertyRuleFiltersWithKey[],
+    preloadedArgs: {
+      app?: App;
+      connection?: any;
+      appOptions?: OptionHelper.SimpleOptions;
+      sourceOptions?: OptionHelper.SimpleOptions;
+      sourceMapping?: MappingHelper.Mappings;
+      profileProperties?: {};
+    } = {}
+  ) {
+    if (
+      profilePropertyRule.state !== "ready" &&
+      !profilePropertyRuleOptionsOverride
+    ) {
+      return;
+    }
+
+    await profilePropertyRule.validateOptions(
+      profilePropertyRuleOptionsOverride,
+      false,
+      true
+    );
+
+    const { pluginConnection } = await source.getPlugin();
+    if (!pluginConnection) {
+      throw new Error(
+        `cannot find connection for source ${source.type} (${source.guid})`
+      );
+    }
+
+    const method = pluginConnection.methods.profileProperty;
+
+    if (!method) {
+      return;
+    }
+
+    const app = preloadedArgs.app || (await source.$get("app"));
+    const connection = preloadedArgs.connection || (await app.getConnection());
+    const appOptions = preloadedArgs.appOptions || (await app.getOptions());
+    const sourceOptions =
+      preloadedArgs.sourceOptions || (await source.getOptions());
+    const sourceMapping =
+      preloadedArgs.sourceMapping || (await source.getMapping());
+
+    // we may not have the profile property needed to make the mapping (ie: userId is not set on this anonymous profile)
+    if (Object.values(sourceMapping).length > 0) {
+      const profilePropertyRuleMappingKey = Object.values(sourceMapping)[0];
+      const profileProperties =
+        preloadedArgs.profileProperties || (await profile.properties());
+      if (!profileProperties[profilePropertyRuleMappingKey]) {
+        return;
+      }
+    }
+
+    while ((await app.checkAndUpdateParallelism("incr")) === false) {
+      console.log(`parallelism limit reached for ${app.type}, sleeping...`);
+      utils.sleep(100);
+    }
+
+    const response = await method({
+      connection,
+      app,
+      appOptions,
+      source,
+      sourceOptions,
+      sourceMapping,
+      profilePropertyRule,
+      profilePropertyRuleOptions: profilePropertyRuleOptionsOverride
+        ? profilePropertyRuleOptionsOverride
+        : await profilePropertyRule.getOptions(),
+      profilePropertyRuleFilters: profilePropertyRuleFiltersOverride
+        ? profilePropertyRuleFiltersOverride
+        : await profilePropertyRule.getFilters(),
+      profile,
+    });
+
+    await app.checkAndUpdateParallelism("decr");
+
+    return response;
+  }
+
+  /**
+   * Import all profile properties from a Source for a Profile
+   */
+  export async function _import(source: Source, profile: Profile) {
+    const hash = {};
+    const rules = await source.$get("profilePropertyRules", {
+      where: { state: "ready" },
+    });
+
+    const profileProperties = await profile.properties();
+    const app = await source.$get("app");
+    const appOptions = await app.getOptions();
+    const connection = await app.getConnection();
+    const sourceOptions = await source.getOptions();
+    const sourceMapping = await source.getMapping();
+
+    const preloadedArgs = {
+      app,
+      connection,
+      appOptions,
+      sourceOptions,
+      sourceMapping,
+      profileProperties,
+    };
+
+    await Promise.all(
+      rules.map((rule) =>
+        source
+          .importProfileProperty(profile, rule, null, null, preloadedArgs)
+          .then((response) => (hash[rule.key] = response))
+      )
+    );
+
+    // remove null and undefined as we cannot set that value
+    const hashKeys = Object.keys(hash);
+    for (const i in hashKeys) {
+      const key = hashKeys[i];
+      if (hash[key] === null || hash[key] === undefined) {
+        delete hash[key];
+      }
+    }
+
+    return hash;
+  }
+
+  /**
+   * This method is used to bootstrap a new source which requires a profile property rule for a mapping, but the rule doesn't yet exist.
+   */
+  export async function bootstrapUniqueProfilePropertyRule(
+    source: Source,
+    key: string,
+    type: string,
+    mappedColumn: string
+  ) {
+    const rule = ProfilePropertyRule.build({
+      key,
+      type,
+      state: "ready",
+      unique: true,
+      sourceGuid: source.guid,
+    });
+
+    try {
+      // manually run the hooks we want
+      ProfilePropertyRule.generateGuid(rule);
+      await ProfilePropertyRule.ensureUniqueKey(rule);
+
+      // @ts-ignore
+      // danger zone!
+      await rule.save({ hooks: false });
+      await ProfilePropertyRule.clearCacheAfterSave();
+
+      // build the default options
+      const { pluginConnection } = await source.getPlugin();
+      if (
+        typeof pluginConnection.methods
+          .uniqueProfilePropertyRuleBootstrapOptions === "function"
+      ) {
+        const app = await source.$get("app");
+        const connection = await app.getConnection();
+        const appOptions = await app.getOptions();
+        const options = await source.getOptions();
+        const ruleOptions = await pluginConnection.methods.uniqueProfilePropertyRuleBootstrapOptions(
+          {
+            app,
+            connection,
+            appOptions,
+            source,
+            sourceOptions: options,
+            mappedColumn,
+          }
+        );
+
+        await rule.setOptions(ruleOptions);
+      }
+
+      return rule;
+    } catch (error) {
+      if (rule) {
+        await rule.destroy();
+        throw error;
+      }
+    }
+  }
+}

--- a/core/api/src/modules/ops/teamMember.ts
+++ b/core/api/src/modules/ops/teamMember.ts
@@ -1,0 +1,37 @@
+import bcrypt from "bcrypt";
+import { TeamMember } from "../../models/TeamMember";
+
+export namespace TeamMemberOps {
+  /**
+   * Set a Team Member's Password
+   */
+  export async function updatePassword(
+    teamMember: TeamMember,
+    password: string,
+    transaction = undefined
+  ) {
+    teamMember.passwordHash = await bcrypt.hash(
+      password,
+      teamMember.saltRounds
+    );
+    await teamMember.save({ transaction });
+  }
+
+  /**
+   * Check a Team Member's Password
+   */
+  export async function checkPassword(
+    teamMember: TeamMember,
+    password: string
+  ) {
+    if (!teamMember.passwordHash) {
+      throw new Error("password not set for this team member");
+    }
+
+    const match: boolean = await bcrypt.compare(
+      password,
+      teamMember.passwordHash
+    );
+    return match;
+  }
+}

--- a/documents/development/databases.md
+++ b/documents/development/databases.md
@@ -20,6 +20,7 @@
 - In order to keep models _smaller_, we make the distinction between the Model itself and ModelOps
   - Table/Column definitions, Class methods, Setters, Getters, and Validations belong on the Model
   - Methods that mutate the Model (or more than one Model), or interact with a Plugin, belong in a ModelOp
+  - It is appropriate for convenience to have a Model method call out to a ModelOp (ie: `Profile.import` => `ProfileOpt.import(profile)`)
 
 ## Other Notes
 

--- a/documents/development/databases.md
+++ b/documents/development/databases.md
@@ -17,6 +17,9 @@
   - `Index.ts`
   - `SpecHelper.ts`
   - `modules/plugin.ts`
+- In order to keep models _smaller_, we make the distinction between the Model itself and ModelOps
+  - Table/Column definitions, Class methods, Setters, Getters, and Validations belong on the Model
+  - Methods that mutate the Model (or more than one Model), or interact with a Plugin, belong in a ModelOp
 
 ## Other Notes
 


### PR DESCRIPTION
In order to keep models _smaller_, we make the distinction between the Model itself and ModelOps
  - Table/Column definitions, Class methods, Setters, Getters, and Validations belong on the Model
  - Methods that mutate the Model (or more than one Model), or interact with a Plugin, belong in a ModelOp

For Example, rather than being a class method on the Model, `Profile.merge(profile:Profile, otherProfile:Profile)` is moved to `ProfileOps.merge(profile:Profile, otherProfile:Profile)`.   When appropriate, some model methods still exist as a pass-through to a ModelOp, ie: 

```ts
// from models/Profile.ts

  async import(toSave = true, toLock = true) {
    return ProfileOps._import(this, toSave, toLock);
  }

  async export(force = false, groupsOverride?: Group[]) {
    return ProfileOps._export(this, force, groupsOverride);
  }

```

This PR also cleans up the model files, and collects all the `static` Class methods together at the ends of the file.