### PR TITLE
Runtime fixes for client `npm run dev`

### DIFF
--- a/core/api/bin/dev
+++ b/core/api/bin/dev
@@ -18,5 +18,6 @@ for p in $GROUPAROO_PIDS; do
   kill -9 $p
 done
 
-node --max-old-space-size=4096 "$EXECUTABLE" --notify=false --ignore='node_modules' --ignore='../dist' --ignore='core/web' --ignore-watch='../web' --ignore-watch='../clients' src/server.ts
+# If there are problems, add "--debug" as a flag
+node --max-old-space-size=4096 "$EXECUTABLE" --transpile-only --log-error --notify=false --ignore='node_modules' --ignore='../dist' --ignore='core/web' --ignore-watch='../web' --ignore-watch='../clients' src/server.ts
 

--- a/core/api/src/server.ts
+++ b/core/api/src/server.ts
@@ -38,13 +38,14 @@ for (const i in pluginManifest.plugins) {
   }
 }
 
-import { Process, log } from "actionhero";
-
 async function main() {
+  const { Process, log } = await import("actionhero");
+
   log(
     `Starting Grouparoo ${getCoreVersion()} on node.js ${getNodeVersion()}`,
     "notice"
   );
+
   const app = new Process();
 
   app.registerProcessSignals((exitCode) => {


### PR DESCRIPTION
* await the actionhero import as part of the async main function
* use `--transpile-only` with ts-node-dev

These fixes allow client projects to run `npm run dev` again! 
