### PR TITLE
Check the Grouparoo project for banned words

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,20 @@ jobs:
       - run:
           name: license-checker
           command: ./tools/license-checker/check
+  spell-checker:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - checkout
+      - restore_cache:
+          <<: *node-module-cache-options
+      - restore_cache:
+          <<: *dist-cache-options
+      - restore_cache:
+          <<: *core-cache-options
+      - run:
+          name: spell-checker
+          command: ./tools/spell-checker/check
   linter:
     docker:
       - image: circleci/node:12
@@ -207,6 +221,11 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
+      - spell-checker:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
       - linter:
           filters:
             <<: *ignored-branches
@@ -227,6 +246,7 @@ workflows:
             <<: *ignored-branches
           requires:
             - license-checker
+            - spell-checker
             - linter
             - test-core
             - test-plugins
@@ -256,6 +276,11 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
+      - spell-checker:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
       - linter:
           filters:
             <<: *ignored-branches
@@ -276,6 +301,7 @@ workflows:
             <<: *ignored-branches
           requires:
             - license-checker
+            - spell-checker
             - linter
             - test-core
             - test-plugins

--- a/core/api/src/config/api.ts
+++ b/core/api/src/config/api.ts
@@ -23,7 +23,7 @@ export const DEFAULT = {
       simultaneousActions: 5,
       // allow connections to be created without remoteIp and remotePort (they will be set to 0)
       enforceConnectionProperties: true,
-      // disables the whitelisting of client params
+      // disables the allowing/filtering of client params
       disableParamScrubbing: false,
       // enable action response to logger
       enableResponseLogging: false,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bootstrap-flat": "lerna bootstrap --strict",
     "bootstrap-hoist": "lerna bootstrap --strict --hoist",
     "license-checker": "./tools/license-checker/check",
+    "spell-checker": "./tools/spell-checker/check",
     "version-alpha": "lerna version prerelease --preid alpha --force-publish --yes",
     "version-stable": "lerna version patch --force-publish --yes",
     "clean": "lerna clean",

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -68,6 +68,7 @@ class Generator {
   }
   addCommands() {
     this.addCommand("license-checker", "./tools/license-checker/check");
+    this.addCommand("spell-checker", "./tools/spell-checker/check");
     this.addCommand("linter", "npm run lint");
   }
 

--- a/tools/spell-checker/check
+++ b/tools/spell-checker/check
@@ -6,7 +6,12 @@ set -e
 cd "$(dirname "$0")"
 cd ../..
 
-BAD_WORDS=("thing" "blacklist" "whitelist" "slave")
+BAD_WORDS=()
+# Typos
+BAD_WORDS+=("gropuaroo" "groparoo")
+# Offensive CS Terms
+BAD_WORDS+=("blacklist" "whitelist" "slave")
+
 MATCHES=""
 
 echo "🦘 Checking Grouparoo for bad words"
@@ -33,4 +38,5 @@ for word in "${BAD_WORDS[@]}"; do
   fi
 done
 
+echo "All Good!"
 exit 0

--- a/tools/spell-checker/check
+++ b/tools/spell-checker/check
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+# set -x
+
+cd "$(dirname "$0")"
+cd ../..
+
+BAD_WORDS=("gropuraoo" "blacklist" "whitelist" "slave")
+MATCHES=""
+
+echo "🦘 Checking Grouparoo for bad words"
+
+for word in "${BAD_WORDS[@]}"; do
+  printf "checking for instances of \`$word\`... "
+  MATCHES=`grep -inR \
+    --exclude-dir=node_modules \
+    --exclude-dir=log \
+    --exclude-dir=.git \
+    --exclude-dir=dist \
+    --exclude-dir=.next \
+    --exclude-dir=spell-checker \
+    "${word}" .` || true
+  if [ -z "$MATCHES" ]; then
+    printf " ✅\n"
+  else
+    printf "🚫\n"
+    echo "> instnces of $word found:"
+    echo "---------------"
+    echo $MATCHES
+    echo "---------------"
+    exit 1
+  fi
+done
+
+exit 0

--- a/tools/spell-checker/check
+++ b/tools/spell-checker/check
@@ -6,7 +6,7 @@ set -e
 cd "$(dirname "$0")"
 cd ../..
 
-BAD_WORDS=("gropuraoo" "blacklist" "whitelist" "slave")
+BAD_WORDS=("thing" "blacklist" "whitelist" "slave")
 MATCHES=""
 
 echo "🦘 Checking Grouparoo for bad words"
@@ -27,7 +27,7 @@ for word in "${BAD_WORDS[@]}"; do
     printf "🚫\n"
     echo "> instnces of $word found:"
     echo "---------------"
-    echo $MATCHES
+    echo "$MATCHES"
     echo "---------------"
     exit 1
   fi


### PR DESCRIPTION
This PR adds a new CI tool, `spell-checker`.  We use `grep` to scan our project for words we don't want to appear.  This can include typos or words which may cause offense.

<img width="614" alt="Screen Shot 2020-07-23 at 11 33 39 AM" src="https://user-images.githubusercontent.com/303226/88324927-41ac4580-ccd9-11ea-8f08-0cd01e0a60bd.png">

CI will not pass if these words are present in the codebase.  Offending lines will be displayed.