### PR TITLE
Navigation should never X overflow

### DIFF
--- a/core/web/components/navigation.tsx
+++ b/core/web/components/navigation.tsx
@@ -100,6 +100,7 @@ export default function Navigation(props) {
         paddingLeft: 20,
         paddingRight: 20,
         overflowY: "auto",
+        overflowX: "hidden",
         height: "100%",
       }}
     >


### PR DESCRIPTION
Closes T-186

There is some wacky pixel match going on if you have displays with non-matching pixel densities (*cough* @andyjih)