### PR TITLE
Destination Plugins can opt into receiving profile property arrays

### DIFF
--- a/core/api/__tests__/actions/destinations.ts
+++ b/core/api/__tests__/actions/destinations.ts
@@ -225,6 +225,34 @@ describe("actions/destinations", () => {
       );
     });
 
+    test("an administrator can see the exportArrayProperties for this destination", async () => {
+      connection.params = {
+        csrfToken,
+        guid,
+      };
+      const { error, exportArrayProperties } = await specHelper.runAction(
+        "destination:exportArrayProperties",
+        connection
+      );
+      expect(error).toBeUndefined();
+      expect(exportArrayProperties).toEqual([]);
+    });
+
+    test("an administrator cannot set a mapping for an array profile property if it is not allowed by the exportArrayProperties", async () => {
+      connection.params = {
+        csrfToken,
+        guid,
+        mapping: { "primary-id": "userId", purchases: "purchases" },
+      };
+      const { error } = await specHelper.runAction(
+        "destination:edit",
+        connection
+      );
+      expect(error.message).toMatch(
+        /purchases is an array profile property that .* cannot support/
+      );
+    });
+
     describe("with group", () => {
       let group: Group;
       let profile: Profile;

--- a/core/api/__tests__/models/destination.ts
+++ b/core/api/__tests__/models/destination.ts
@@ -1197,6 +1197,52 @@ describe("models/destination", () => {
         exportArrayProperties = [];
       });
 
+      test("exportArrayProperties can return single values for profile properties", async () => {
+        const destination = await Destination.create({
+          name: "test plugin destination",
+          type: "export-from-test-template-app",
+          appGuid: app.guid,
+        });
+
+        await destination.setMapping({ purchases: "purchases" });
+
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.guid] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+        const oldProfileProperties = { purchases: ["hat", "mushroom"] };
+        const newProfileProperties = { purchases: ["hat", "mushroom", "star"] };
+        const oldGroups = [group];
+        const newGroups = [];
+
+        const _import = await helper.factories.import();
+
+        await destination.exportProfile(
+          profile,
+          [],
+          [_import],
+          oldProfileProperties,
+          newProfileProperties,
+          oldGroups,
+          newGroups
+        );
+
+        const _exports = await profile.$get("exports");
+        expect(_exports.length).toBe(1);
+        expect(_exports[0].oldProfileProperties).toEqual({
+          purchases: "hat",
+        });
+        expect(_exports[0].newProfileProperties).toEqual({
+          purchases: "hat",
+        });
+
+        await destination.destroy();
+      });
+
       test("exportArrayProperties can ask for an array profile property", async () => {
         exportArrayProperties = ["purchases"];
 

--- a/core/api/__tests__/models/destination.ts
+++ b/core/api/__tests__/models/destination.ts
@@ -784,6 +784,7 @@ describe("models/destination", () => {
                   },
                 };
               },
+              exportArrayProperties: async () => [],
               exportProfile: async ({
                 app,
                 appOptions,

--- a/core/api/__tests__/models/destination.ts
+++ b/core/api/__tests__/models/destination.ts
@@ -713,7 +713,7 @@ describe("models/destination", () => {
       newGroups: null,
       toDelete: null,
     };
-
+    let exportArrayProperties = [];
     let parallelismResponse = Infinity;
     let exportProfileResponse = {
       success: true,
@@ -784,7 +784,7 @@ describe("models/destination", () => {
                   },
                 };
               },
-              exportArrayProperties: async () => [],
+              exportArrayProperties: async () => exportArrayProperties,
               exportProfile: async ({
                 app,
                 appOptions,
@@ -1190,6 +1190,108 @@ describe("models/destination", () => {
         error: undefined,
         retryDelay: undefined,
       };
+    });
+
+    describe("array exports", () => {
+      afterAll(() => {
+        exportArrayProperties = [];
+      });
+
+      test("exportArrayProperties can ask for an array profile property", async () => {
+        exportArrayProperties = ["purchases"];
+
+        const destination = await Destination.create({
+          name: "test plugin destination",
+          type: "export-from-test-template-app",
+          appGuid: app.guid,
+        });
+
+        await destination.setMapping({ purchases: "purchases" });
+
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.guid] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+        const oldProfileProperties = { purchases: ["hat", "mushroom"] };
+        const newProfileProperties = { purchases: ["hat", "mushroom", "star"] };
+        const oldGroups = [group];
+        const newGroups = [];
+
+        const _import = await helper.factories.import();
+
+        await destination.exportProfile(
+          profile,
+          [],
+          [_import],
+          oldProfileProperties,
+          newProfileProperties,
+          oldGroups,
+          newGroups
+        );
+
+        const _exports = await profile.$get("exports");
+        expect(_exports.length).toBe(1);
+        expect(_exports[0].oldProfileProperties).toEqual({
+          purchases: ["hat", "mushroom"],
+        });
+        expect(_exports[0].newProfileProperties).toEqual({
+          purchases: ["hat", "mushroom", "star"],
+        });
+
+        await destination.destroy();
+      });
+
+      test("exportArrayProperties can ask for all properties with *", async () => {
+        exportArrayProperties = ["*"];
+
+        const destination = await Destination.create({
+          name: "test plugin destination",
+          type: "export-from-test-template-app",
+          appGuid: app.guid,
+        });
+
+        await destination.setMapping({ purchases: "purchases" });
+
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.guid] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+        const oldProfileProperties = { purchases: ["hat", "mushroom"] };
+        const newProfileProperties = { purchases: ["hat", "mushroom", "star"] };
+        const oldGroups = [group];
+        const newGroups = [];
+
+        const _import = await helper.factories.import();
+
+        await destination.exportProfile(
+          profile,
+          [],
+          [_import],
+          oldProfileProperties,
+          newProfileProperties,
+          oldGroups,
+          newGroups
+        );
+
+        const _exports = await profile.$get("exports");
+        expect(_exports.length).toBe(1);
+        expect(_exports[0].oldProfileProperties).toEqual({
+          purchases: ["hat", "mushroom"],
+        });
+        expect(_exports[0].newProfileProperties).toEqual({
+          purchases: ["hat", "mushroom", "star"],
+        });
+
+        await destination.destroy();
+      });
     });
   });
 });

--- a/core/api/__tests__/models/destination.ts
+++ b/core/api/__tests__/models/destination.ts
@@ -1197,48 +1197,18 @@ describe("models/destination", () => {
         exportArrayProperties = [];
       });
 
-      test("exportArrayProperties can return single values for profile properties", async () => {
+      test("mappings cannot use array profile properties if they are not allowed by exportArrayProperties", async () => {
         const destination = await Destination.create({
           name: "test plugin destination",
           type: "export-from-test-template-app",
           appGuid: app.guid,
         });
 
-        await destination.setMapping({ purchases: "purchases" });
-
-        const group = await helper.factories.group();
-        const destinationGroupMemberships = {};
-        destinationGroupMemberships[group.guid] = group.name;
-        await destination.setDestinationGroupMemberships(
-          destinationGroupMemberships
+        await expect(
+          destination.setMapping({ purchases: "purchases" })
+        ).rejects.toThrow(
+          /purchases is an array profile property that .* cannot support/
         );
-
-        const profile = await helper.factories.profile();
-        const oldProfileProperties = { purchases: ["hat", "mushroom"] };
-        const newProfileProperties = { purchases: ["hat", "mushroom", "star"] };
-        const oldGroups = [group];
-        const newGroups = [];
-
-        const _import = await helper.factories.import();
-
-        await destination.exportProfile(
-          profile,
-          [],
-          [_import],
-          oldProfileProperties,
-          newProfileProperties,
-          oldGroups,
-          newGroups
-        );
-
-        const _exports = await profile.$get("exports");
-        expect(_exports.length).toBe(1);
-        expect(_exports[0].oldProfileProperties).toEqual({
-          purchases: "hat",
-        });
-        expect(_exports[0].newProfileProperties).toEqual({
-          purchases: "hat",
-        });
 
         await destination.destroy();
       });

--- a/core/api/__tests__/tasks/profiles/export.ts
+++ b/core/api/__tests__/tasks/profiles/export.ts
@@ -89,6 +89,7 @@ describe("tasks/profile:export", () => {
                 exportProfile: async () => {
                   return { success: true };
                 },
+                exportArrayProperties: async () => [],
                 destinationMappingOptions: async () => {
                   return {
                     labels: {

--- a/core/api/__tests__/utils/specHelper.ts
+++ b/core/api/__tests__/utils/specHelper.ts
@@ -290,6 +290,7 @@ export namespace helper {
                 response["receivedOptions"] = destinationOptions.options;
               return response;
             },
+            exportArrayProperties: async () => [],
             destinationMappingOptions: async () => {
               return {
                 labels: {

--- a/core/api/src/actions/destinations.ts
+++ b/core/api/src/actions/destinations.ts
@@ -209,6 +209,25 @@ export class DestinationMappingOptions extends AuthenticatedAction {
   }
 }
 
+export class DestinationExportArrayProperties extends AuthenticatedAction {
+  constructor() {
+    super();
+    this.name = "destination:exportArrayProperties";
+    this.description =
+      "get the list of profile properties this destination can handle as arrays";
+    this.outputExample = {};
+    this.permission = { topic: "destination", mode: "read" };
+    this.inputs = {
+      guid: { required: true },
+    };
+  }
+
+  async run({ params, response }) {
+    const destination = await Destination.findByGuid(params.guid);
+    response.exportArrayProperties = await destination.getExportArrayProperties();
+  }
+}
+
 export class DestinationTrackGroup extends AuthenticatedAction {
   constructor() {
     super();

--- a/core/api/src/classes/plugin.ts
+++ b/core/api/src/classes/plugin.ts
@@ -74,6 +74,7 @@ export interface PluginConnection {
     destinationOptions?: DestinationOptionsMethod;
     destinationMappingOptions?: DestinationMappingOptionsMethod;
     exportProfile?: ExportProfilePluginMethod;
+    exportArrayProperties?: ExportArrayPropertiesMethod;
   };
 }
 
@@ -331,3 +332,19 @@ export interface DestinationMappingOptionsMethodResponse {
     };
   };
 }
+
+/**
+ * Method to return the list of destination profile properties which can accept array values.
+ * '*' can be used as a wildcard to accept all properties as arrays
+ */
+export interface ExportArrayPropertiesMethod {
+  (argument: {
+    connection: any;
+    app: App;
+    appOptions: SimpleAppOptions;
+    destination: Destination;
+    destinationOptions: SimpleDestinationOptions;
+  }): Promise<ExportArrayPropertiesMethodResponse>;
+}
+
+export type ExportArrayPropertiesMethodResponse = Array<string>;

--- a/core/api/src/config/routes.ts
+++ b/core/api/src/config/routes.ts
@@ -64,6 +64,7 @@ export const DEFAULT = {
         { path: "/v:apiVersion/destination/:guid/connectionOptions", action: "destination:connectionOptions" },
         { path: "/v:apiVersion/destination/:guid/mappingOptions", action: "destination:mappingOptions" },
         { path: "/v:apiVersion/destination/:guid/profilePreview", action: "destination:profilePreview" },
+        { path: "/v:apiVersion/destination/:guid/exportArrayProperties", action: "destination:exportArrayProperties" },
         { path: "/v:apiVersion/files", action: "files:list" },
         { path: "/v:apiVersion/files/options", action: "files:options" },
         { path: "/v:apiVersion/file/:guid/details", action: "file:details" },

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -153,6 +153,10 @@ export class Destination extends LoggedModel<Destination> {
     return OptionHelper.setOptions(this, options);
   }
 
+  async getExportArrayProperties() {
+    return DestinationOps.getExportArrayProperties(this);
+  }
+
   async getDestinationGroupMemberships(): Promise<
     SimpleDestinationGroupMembership[]
   > {

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -232,12 +232,26 @@ export class Destination extends LoggedModel<Destination> {
   }
 
   async validateMappings(mappings: { [groupGuid: string]: string }) {
-    if (Object.keys(mappings).length === 0) {
-      return;
-    }
+    if (Object.keys(mappings).length === 0) return;
 
     const destinationMappingOptions = await this.destinationMappingOptions();
     const cachedProfilePropertyRules = await ProfilePropertyRule.cached();
+    const exportArrayProperties = await this.getExportArrayProperties();
+
+    // check for array properties
+    Object.values(mappings).forEach((k) => {
+      const profilePropertyRule = cachedProfilePropertyRules[k];
+      if (
+        profilePropertyRule &&
+        profilePropertyRule.isArray &&
+        !exportArrayProperties.includes(k) &&
+        !exportArrayProperties.includes("*")
+      ) {
+        throw new Error(
+          `${k} is an array profile property that ${this.name} cannot support`
+        );
+      }
+    });
 
     // required
     for (const i in destinationMappingOptions.profilePropertyRules.required) {

--- a/core/api/src/modules/ops/destination.ts
+++ b/core/api/src/modules/ops/destination.ts
@@ -280,8 +280,8 @@ export namespace DestinationOps {
     for (const k in mappedOldProfileProperties) {
       if (
         mappedOldProfileProperties[k] &&
-        (!exportArrayProperties.includes(k) ||
-          exportArrayProperties.includes("*"))
+        !exportArrayProperties.includes(k) &&
+        !exportArrayProperties.includes("*")
       ) {
         mappedOldProfileProperties[k] = mappedOldProfileProperties[k][0];
       }
@@ -289,8 +289,8 @@ export namespace DestinationOps {
     for (const k in mappedNewProfileProperties) {
       if (
         mappedNewProfileProperties[k] &&
-        (!exportArrayProperties.includes(k) ||
-          exportArrayProperties.includes("*"))
+        !exportArrayProperties.includes(k) &&
+        !exportArrayProperties.includes("*")
       ) {
         mappedNewProfileProperties[k] = mappedNewProfileProperties[k][0];
       }

--- a/core/api/src/modules/ops/destination.ts
+++ b/core/api/src/modules/ops/destination.ts
@@ -154,6 +154,28 @@ export namespace DestinationOps {
     });
   }
 
+  export async function getExportArrayProperties(destination: Destination) {
+    const { pluginConnection } = await destination.getPlugin();
+    const app = await destination.$get("app");
+    const connection = await app.getConnection();
+    const appOptions = await app.getOptions();
+    const destinationOptions = await destination.getOptions();
+
+    if (!pluginConnection.methods.exportArrayProperties) {
+      throw new Error(
+        `cannot determine export array properties for ${destination.type}`
+      );
+    }
+
+    return pluginConnection.methods.exportArrayProperties({
+      connection,
+      app,
+      appOptions,
+      destination,
+      destinationOptions,
+    });
+  }
+
   /**
    * Given a Destination and a Profile (and lots of related data), create all the exports that should be sent
    */
@@ -252,14 +274,24 @@ export namespace DestinationOps {
         .forEach((k) => (mappedOldProfileProperties[k] = ["unknown"]));
     }
 
-    // Send only the properties form the array that should be sent to the Destination
+    // Send only the properties form the array that should be sent to the Destination, otherwise send the first entry in the array of profile properties
+    const exportArrayProperties = await getExportArrayProperties(destination);
+
     for (const k in mappedOldProfileProperties) {
-      if (mappedOldProfileProperties[k]) {
+      if (
+        mappedOldProfileProperties[k] &&
+        (!exportArrayProperties.includes(k) ||
+          exportArrayProperties.includes("*"))
+      ) {
         mappedOldProfileProperties[k] = mappedOldProfileProperties[k][0];
       }
     }
     for (const k in mappedNewProfileProperties) {
-      if (mappedNewProfileProperties[k]) {
+      if (
+        mappedNewProfileProperties[k] &&
+        (!exportArrayProperties.includes(k) ||
+          exportArrayProperties.includes("*"))
+      ) {
         mappedNewProfileProperties[k] = mappedNewProfileProperties[k][0];
       }
     }

--- a/plugins/@grouparoo/hubspot/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/hubspot/src/initializers/plugin.ts
@@ -7,6 +7,7 @@ import { connect } from "./../lib/connect";
 import { exportProfile } from "../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
 import { destinationMappingOptions } from "../lib/export/destinationMappingOptions";
+import { exportArrayProperties } from "../lib/export/exportArrayProperties";
 
 const packageJSON = require("./../../package.json");
 
@@ -44,6 +45,7 @@ export class Plugins extends Initializer {
             exportProfile,
             destinationOptions,
             destinationMappingOptions,
+            exportArrayProperties,
           },
         },
       ],

--- a/plugins/@grouparoo/hubspot/src/lib/export/exportArrayProperties.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/export/exportArrayProperties.ts
@@ -1,0 +1,5 @@
+import { ExportArrayPropertiesMethod } from "@grouparoo/core";
+
+export const exportArrayProperties: ExportArrayPropertiesMethod = async () => {
+  return ["*"];
+};

--- a/plugins/@grouparoo/hubspot/src/lib/export/exportArrayProperties.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/export/exportArrayProperties.ts
@@ -1,5 +1,5 @@
 import { ExportArrayPropertiesMethod } from "@grouparoo/core";
 
 export const exportArrayProperties: ExportArrayPropertiesMethod = async () => {
-  return ["*"];
+  return [];
 };

--- a/plugins/@grouparoo/logger/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/logger/src/initializers/plugin.ts
@@ -6,6 +6,7 @@ import { appOptions } from "./../lib/appOptions";
 import { exportProfile } from "./../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
 import { destinationMappingOptions } from "../lib/export/destinationMappingOptions";
+import { exportArrayProperties } from "../lib/export/exportArrayProperties";
 
 const packageJSON = require("./../../package.json");
 
@@ -49,6 +50,7 @@ export class Plugins extends Initializer {
             exportProfile,
             destinationOptions,
             destinationMappingOptions,
+            exportArrayProperties,
           },
         },
       ],

--- a/plugins/@grouparoo/logger/src/lib/export/exportArrayProperties.ts
+++ b/plugins/@grouparoo/logger/src/lib/export/exportArrayProperties.ts
@@ -1,0 +1,5 @@
+import { ExportArrayPropertiesMethod } from "@grouparoo/core";
+
+export const exportArrayProperties: ExportArrayPropertiesMethod = async () => {
+  return [];
+};

--- a/plugins/@grouparoo/logger/src/lib/export/exportArrayProperties.ts
+++ b/plugins/@grouparoo/logger/src/lib/export/exportArrayProperties.ts
@@ -1,5 +1,5 @@
 import { ExportArrayPropertiesMethod } from "@grouparoo/core";
 
 export const exportArrayProperties: ExportArrayPropertiesMethod = async () => {
-  return [];
+  return ["*"];
 };

--- a/plugins/@grouparoo/mailchimp/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mailchimp/src/initializers/plugin.ts
@@ -7,6 +7,7 @@ import { parallelism } from "./../lib/parallelism";
 import { exportProfile } from "../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
 import { destinationMappingOptions } from "../lib/export/destinationMappingOptions";
+import { exportArrayProperties } from "../lib/export/exportArrayProperties";
 
 const packageJSON = require("./../../package.json");
 
@@ -50,6 +51,7 @@ export class Plugins extends Initializer {
             exportProfile,
             destinationOptions,
             destinationMappingOptions,
+            exportArrayProperties,
           },
         },
       ],

--- a/plugins/@grouparoo/mailchimp/src/lib/export/exportArrayProperties.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/export/exportArrayProperties.ts
@@ -1,0 +1,5 @@
+import { ExportArrayPropertiesMethod } from "@grouparoo/core";
+
+export const exportArrayProperties: ExportArrayPropertiesMethod = async () => {
+  return [];
+};

--- a/plugins/@grouparoo/mysql/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mysql/src/initializers/plugin.ts
@@ -5,6 +5,7 @@ import { test } from "./../lib/test";
 import { connect } from "./../lib/connect";
 import { disconnect } from "./../lib/disconnect";
 import { exportProfile } from "./../lib/export/exportProfile";
+import { exportArrayProperties } from "./../lib/export/exportArrayProperties";
 
 import { sourcePreview as tableSourcePreview } from "../lib/table-import/sourcePreview";
 import { sourceOptions as tableSourceOptions } from "../lib/table-import/sourceOptions";
@@ -129,6 +130,7 @@ export class Plugins extends Initializer {
             exportProfile,
             destinationOptions,
             destinationMappingOptions,
+            exportArrayProperties,
           },
         },
       ],

--- a/plugins/@grouparoo/mysql/src/lib/export/exportArrayProperties.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/exportArrayProperties.ts
@@ -1,0 +1,5 @@
+import { ExportArrayPropertiesMethod } from "@grouparoo/core";
+
+export const exportArrayProperties: ExportArrayPropertiesMethod = async () => {
+  return ["*"];
+};

--- a/plugins/@grouparoo/mysql/src/lib/export/exportArrayProperties.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/exportArrayProperties.ts
@@ -1,5 +1,5 @@
 import { ExportArrayPropertiesMethod } from "@grouparoo/core";
 
 export const exportArrayProperties: ExportArrayPropertiesMethod = async () => {
-  return ["*"];
+  return [];
 };

--- a/plugins/@grouparoo/postgres/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/postgres/src/initializers/plugin.ts
@@ -5,6 +5,7 @@ import { test } from "./../lib/test";
 import { connect } from "./../lib/connect";
 import { disconnect } from "./../lib/disconnect";
 import { exportProfile } from "../lib/export/exportProfile";
+import { exportArrayProperties } from "../lib/export/exportArrayProperties";
 
 import { sourcePreview as tableSourcePreview } from "../lib/table-import/sourcePreview";
 import { sourceOptions as tableSourceOptions } from "../lib/table-import/sourceOptions";
@@ -130,6 +131,7 @@ export class Plugins extends Initializer {
             exportProfile,
             destinationOptions,
             destinationMappingOptions,
+            exportArrayProperties,
           },
         },
       ],

--- a/plugins/@grouparoo/postgres/src/lib/export/exportArrayProperties.ts
+++ b/plugins/@grouparoo/postgres/src/lib/export/exportArrayProperties.ts
@@ -1,0 +1,5 @@
+import { ExportArrayPropertiesMethod } from "@grouparoo/core";
+
+export const exportArrayProperties: ExportArrayPropertiesMethod = async () => {
+  return ["*"];
+};

--- a/plugins/@grouparoo/postgres/src/lib/export/exportArrayProperties.ts
+++ b/plugins/@grouparoo/postgres/src/lib/export/exportArrayProperties.ts
@@ -1,5 +1,5 @@
 import { ExportArrayPropertiesMethod } from "@grouparoo/core";
 
 export const exportArrayProperties: ExportArrayPropertiesMethod = async () => {
-  return ["*"];
+  return [];
 };

--- a/plugins/@grouparoo/sailthru/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/sailthru/src/initializers/plugin.ts
@@ -6,6 +6,7 @@ import { test } from "./../lib/test";
 import { exportProfile } from "../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
 import { destinationMappingOptions } from "../lib/export/destinationMappingOptions";
+import { exportArrayProperties } from "../lib/export/exportArrayProperties";
 
 const packageJSON = require("./../../package.json");
 
@@ -48,6 +49,7 @@ export class Plugins extends Initializer {
             exportProfile,
             destinationOptions,
             destinationMappingOptions,
+            exportArrayProperties,
           },
         },
       ],

--- a/plugins/@grouparoo/sailthru/src/lib/export/exportArrayProperties.ts
+++ b/plugins/@grouparoo/sailthru/src/lib/export/exportArrayProperties.ts
@@ -1,0 +1,5 @@
+import { ExportArrayPropertiesMethod } from "@grouparoo/core";
+
+export const exportArrayProperties: ExportArrayPropertiesMethod = async () => {
+  return [];
+};


### PR DESCRIPTION
Plugin Connections gain a new method, `exportArrayProperties` which allows them to define if they want arrays of profile properties, or just the one value to their `exportProfile` method.  In the case where some fields are returned (`['purchases']`) or all (`[*]`) `newProfileProperties` and `oldProfileProperties` will be arrays of values... otherwise the previous behavior of getting single strings/numbers/booleans/dates will remain.

This is an aync method, as the plugin may need to check an API or database to know if arrays are acceptable or not.