### PR TITLE
Support Postgres schemas other than 'public'

### DIFF
--- a/plugins/@grouparoo/postgres/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/postgres/src/initializers/plugin.ts
@@ -45,6 +45,11 @@ export class Plugins extends Initializer {
               required: true,
               description: "the postgres database",
             },
+            {
+              key: "schema",
+              required: false,
+              description: "the postgres schema (default: public)",
+            },
             { key: "user", required: false, description: "the postgres user" },
             {
               key: "password",

--- a/plugins/@grouparoo/postgres/src/lib/connect.ts
+++ b/plugins/@grouparoo/postgres/src/lib/connect.ts
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import format from "pg-format";
 import { ConnectPluginAppMethod } from "@grouparoo/core";
 
 export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
@@ -6,7 +7,7 @@ export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
   await client.connect();
 
   if (appOptions.schema) {
-    await client.query(`SET search_path TO '${appOptions.schema}';`);
+    await client.query(format(`SET search_path TO %L;`, appOptions.schema));
   }
 
   return client;

--- a/plugins/@grouparoo/postgres/src/lib/connect.ts
+++ b/plugins/@grouparoo/postgres/src/lib/connect.ts
@@ -2,7 +2,6 @@ import { Client } from "pg";
 import { ConnectPluginAppMethod } from "@grouparoo/core";
 
 export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
-  console.log({ appOptions });
   const client = new Client(appOptions);
   await client.connect();
 

--- a/plugins/@grouparoo/postgres/src/lib/connect.ts
+++ b/plugins/@grouparoo/postgres/src/lib/connect.ts
@@ -2,7 +2,13 @@ import { Client } from "pg";
 import { ConnectPluginAppMethod } from "@grouparoo/core";
 
 export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
+  console.log({ appOptions });
   const client = new Client(appOptions);
   await client.connect();
+
+  if (appOptions.schema) {
+    await client.query(`SET search_path TO '${appOptions.schema}';`);
+  }
+
   return client;
 };

--- a/plugins/@grouparoo/postgres/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/export/destinationMappingOptions.ts
@@ -10,7 +10,7 @@ export const destinationMappingOptions: DestinationMappingOptionsMethod = async 
     format(
       `SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_catalog = %L AND table_schema = %L AND table_name = %L`,
       appOptions.database,
-      "public",
+      appOptions.schema || "public",
       destinationOptions.table
     )
   );

--- a/plugins/@grouparoo/postgres/src/lib/export/destinationOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/export/destinationOptions.ts
@@ -11,7 +11,7 @@ export const destinationOptions: DestinationOptionsMethod = async ({
       format(
         `SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_catalog = %L AND table_schema = %L AND table_name = %L`,
         appOptions.database,
-        "public",
+        appOptions.schema || "public",
         tableName
       )
     );
@@ -33,7 +33,7 @@ export const destinationOptions: DestinationOptionsMethod = async ({
     format(
       `SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_catalog = %L AND table_schema = %L`,
       appOptions.database,
-      "public"
+      appOptions.schema || "public"
     )
   );
 

--- a/plugins/@grouparoo/postgres/src/lib/table-import/sourceOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/sourceOptions.ts
@@ -11,7 +11,7 @@ export const sourceOptions: SourceOptionsMethod = async ({
     format(
       `SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_catalog = %L AND table_schema = %L`,
       appOptions.database,
-      "public"
+      appOptions.schema || "public"
     )
   );
 


### PR DESCRIPTION
Allows the `@grouparoo/postgres` plugin to work with schemas other than `public` (both sources and destinations)

<img width="1493" alt="Screen Shot 2020-07-28 at 11 20 16 AM" src="https://user-images.githubusercontent.com/303226/88705391-51a29b80-d0c4-11ea-8ed4-7f80fcb553f3.png">

Closes https://github.com/grouparoo/grouparoo/issues/510
Closes T-226