### PR TITLE
Grouparoo Project Generator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,21 @@ jobs:
           command: mysql -e "create database grouparoo_test" -u root -h 127.0.0.1
       - run:
           name: test
-          command: ./node_modules/.bin/lerna exec jest --stream --concurrency 1 --ignore "@grouparoo/core" --ignore "*/app-*" -- --ci --passWithNoTests --runInBand
+          command: ./node_modules/.bin/lerna exec jest --stream --concurrency 1 --ignore "@grouparoo/core" --ignore "@grouparoo"  --ignore "*/app-*" -- --ci --passWithNoTests --runInBand
+  test-cli:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - checkout
+      - restore_cache:
+          <<: *node-module-cache-options
+      - restore_cache:
+          <<: *dist-cache-options
+      - restore_cache:
+          <<: *core-cache-options
+      - run:
+          name: test
+          command: cd cli && npm test
   complete:
     docker:
       - image: circleci/node:12
@@ -242,6 +256,11 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
+      - test-cli:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
       - complete:
           filters:
             <<: *ignored-branches
@@ -251,6 +270,7 @@ workflows:
             - linter
             - test-core
             - test-plugins
+            - test-cli
       - publish:
           filters:
             branches:
@@ -297,6 +317,11 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
+      - test-cli:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
       - complete:
           filters:
             <<: *ignored-branches
@@ -306,6 +331,7 @@ workflows:
             - linter
             - test-core
             - test-plugins
+            - test-cli
       - publish:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
       - save_cache:
           <<: *dist-cache-options
           paths:
+            - cli/dist
             - clients/@grouparoo/web/dist
             - plugins/@grouparoo/bigquery/dist
             - plugins/@grouparoo/csv/dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
           paths:
             - apps/local-public/node_modules
             - apps/staging-public/node_modules
+            - cli/node_modules
             - clients/@grouparoo/web/node_modules
             - core/node_modules
             - node_modules

--- a/cli/.npmignore
+++ b/cli/.npmignore
@@ -1,0 +1,10 @@
+# General
+node_modules
+.DS_Store
+.vscode
+npm-debug.log
+yarn-error.log
+.env
+dump.rdb
+*.retry
+coverage

--- a/cli/LICENSE.txt
+++ b/cli/LICENSE.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,8 +2,6 @@
 
 _The Grouparoo project generator_
 
----
-
 This package is released as `grouparoo` (no namespace) on NPM. It is used to generate new Grouparoo projects.
 
 ## Installation

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,38 @@
+# Grouparoo
+
+_The Grouparoo project generator_
+
+---
+
+This package is released as `grouparoo` (no namespace) on NPM. It is used to generate new Grouparoo projects.
+
+## Installation
+
+This package does not need to be installed, and can be run ad-hoc with the `npx` command, i.e.: `npx grouparoo generate`
+
+## Usage
+
+_From `npx grouparoo --help`_
+
+```
+Usage: grouparoo [options] [command]
+
+Options:
+  -V, --version    output the version number
+  -h, --help       display help for command
+
+Commands:
+  generate [path]  generate a new Grouparoo project
+  upgrade [path]   upgrade an existing Grouparoo project
+  help [command]   display help for command
+```
+
+- To generate a grouparoo project in the current directory (`process.cwd()`): `npx grouparoo generate`
+- To generate a grouparoo project in another directory: `npx grouparoo generate /path/to/project`
+- `npx grouparoo upgrade` assumes you are tracking the `latest` version of all the Grouparoo dependencies, and will simply run `npm update` under the hood.
+
+## Notes
+
+- We assume `node` and `npm` are installed and available within your `$PATH`
+- We will not override an existing `package.json` or `.env` file if they already exist in the directory
+- We will attempt to run `npm install` in the new directory

--- a/cli/__tests__/test.sh
+++ b/cli/__tests__/test.sh
@@ -7,6 +7,12 @@ WORKDIR="/tmp/grouparoo-$TIME"
 
 echo " >>> testing with WORKDIR=$WORKDIR <<< "
 
+## to get around premission issues on CI
+## https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally
+mkdir -p ~/.npm-global
+export NPM_CONFIG_PREFIX=~/.npm-global
+export PATH="$HOME/.npm-global/bin:$PATH"
+
 ## use /this/ version of the "grouparoo" package with NPX
 npm link
 

--- a/cli/__tests__/test.sh
+++ b/cli/__tests__/test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+TIME=`date +%s`
+WORKDIR="/tmp/grouparoo-$TIME"
+
+echo " >>> testing with WORKDIR=$WORKDIR <<< "
+
+## use /this/ version of the "grouparoo" package with NPX
+npm link
+
+echo "--- npm linked ---"
+
+## try the generate command
+npx grouparoo generate $WORKDIR
+
+if [ -f "$WORKDIR/package.json" ]; then
+    echo "✅ package.json exists."
+else
+    echo "🚫 package.json does not exist."
+    exit 1
+fi
+
+if [ -f "$WORKDIR/.env" ]; then
+    echo "✅ .env exists."
+else
+    echo "🚫 .env does not exist."
+    exit 1
+fi
+
+if [ -d "$WORKDIR/node_modules" ]; then
+    echo "✅ node_modules exists."
+else
+    echo "🚫 node_modules does not exist."
+    exit 1
+fi
+
+## try the upgrade command
+npx grouparoo upgrade $WORKDIR
+
+## reset the NPM/NPX link
+npm unlink
+echo "--- npm unlinked ---"
+
+echo ""
+echo "🎉🎉🎉 TESTS PASSED 🎉🎉🎉"

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,124 @@
+{
+  "name": "grouparoo",
+  "version": "0.1.8",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "@types/fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-B42Sxuaz09MhC3DDeW5kubRcQ5by4iuVQ0cRRWM2lggLzAa/KVom0Aft/208NgMvNQQZ86s5rVcqDdn/SH0/mg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "14.0.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.26.tgz",
+      "integrity": "sha512-W+fpe5s91FBGE0pEa0lnqGLL4USgpLgs4nokw16SrBBco/gQxuua7KnArSEOd5iaMqbbSHV10vUDkJYJJqpXKA==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "requires": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      }
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+    },
+    "chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "commander": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.0.0.tgz",
+      "integrity": "sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA=="
+    },
+    "fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "jsonfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
+      }
+    },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "typescript": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "dev": true
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,44 @@
+{
+  "author": "Grouparoo Inc <hello@grouparoo.com>",
+  "name": "grouparoo",
+  "description": "The Grouparoo CLI and Project Generator",
+  "version": "0.1.8",
+  "license": "MPL-2.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "grouparoo": "dist/grouparoo.js"
+  },
+  "homepage": "https://www.grouparoo.com",
+  "bugs": {
+    "url": "https://github.com/grouparoo/grouparoo/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/grouparoo/grouparoo.git",
+    "directory": "cli"
+  },
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "scripts": {
+    "prepare": "rm -rf dist && tsc --declaration && chmod 0766 dist/grouparoo.js",
+    "test": "echo 'no tests'",
+    "pretest": "npm run lint && npm run prepare",
+    "lint": "prettier --check src"
+  },
+  "dependencies": {
+    "chalk": "^4.1.0",
+    "commander": "^6.0.0",
+    "fs-extra": "^9.0.1"
+  },
+  "peerDependencies": {},
+  "devDependencies": {
+    "@types/fs-extra": "^9.0.1",
+    "@types/node": "^14.0.23",
+    "prettier": "^2.0.5",
+    "typescript": "^3.9.6"
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "prepare": "rm -rf dist && tsc --declaration && chmod 0766 dist/grouparoo.js",
-    "test": "echo 'no tests'",
+    "test": "./__tests__/test.sh",
     "pretest": "npm run lint && npm run prepare",
     "lint": "prettier --check src"
   },

--- a/cli/src/grouparoo.ts
+++ b/cli/src/grouparoo.ts
@@ -1,0 +1,25 @@
+#! /usr/bin/env node
+
+import { program } from "commander";
+const Package = require("../package.json");
+import Generate from "./lib/generate";
+import Upgrade from "./lib/upgrade";
+
+program.version(Package.version);
+
+program
+  .command("generate [path]")
+  .description("generate a new Grouparoo project")
+  .action(Generate);
+
+program
+  .command("upgrade [path]")
+  .description("upgrade an existing Grouparoo project")
+  .action(Upgrade);
+
+program.parse(process.argv);
+
+process.on("unhandledRejection", (error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/cli/src/lib/generate.ts
+++ b/cli/src/lib/generate.ts
@@ -1,0 +1,52 @@
+import fs from "fs-extra";
+import path from "path";
+import SpawnCommand from "./spawnCommand";
+import Logger from "./logger";
+
+export default async function Generate(workDir: string = process.cwd()) {
+  const log = new Logger();
+
+  log.headline("Generating new Grouparoo Project");
+  log.debug(`path: ${workDir}`);
+
+  if (!fs.existsSync(workDir)) {
+    log.info(`${workDir} does not exist, creating`);
+    fs.mkdirpSync(workDir);
+  }
+
+  const packageJson = path.join(workDir, "package.json");
+  if (!fs.existsSync(packageJson)) {
+    log.info("Creating package.json");
+    fs.copyFileSync(getTemplatePath("package.json"), packageJson);
+  } else {
+    log.warn("package.json already exists, not modifying");
+  }
+
+  const envFile = path.join(workDir, ".env");
+  if (!fs.existsSync(envFile)) {
+    log.info("Creating .env");
+    fs.copyFileSync(getTemplatePath(".env"), envFile);
+    log.info(
+      "Please check the options in .env to ensure that they pertain to your environment"
+    );
+  } else {
+    log.warn(".env already exists, not modifying");
+  }
+
+  log.info("Installing dependencies...");
+  await SpawnCommand("npm", ["install"], workDir, log);
+
+  log.success("Grouparoo project created!");
+  log.info(
+    "- Ensure that Postgres and Redis are running according to the values in .env or your environment"
+  );
+  log.info(
+    `- ${
+      workDir !== process.cwd() ? `Navigate to ${workDir} and ` : ""
+    }type "npm start" to start the Grouparoo application.`
+  );
+}
+
+function getTemplatePath(filename: string) {
+  return path.join(__dirname, "..", "..", "templates", filename);
+}

--- a/cli/src/lib/logger.ts
+++ b/cli/src/lib/logger.ts
@@ -1,0 +1,31 @@
+import Chalk from "chalk";
+
+export default class Logger {
+  debug(message: string) {
+    this.print(Chalk.dim(`- ${message}`));
+  }
+
+  info(message: string) {
+    this.print(Chalk.reset(message));
+  }
+
+  warn(message: string) {
+    this.print(Chalk.yellow(message));
+  }
+
+  error(message: string) {
+    this.print(Chalk.bold.red(message));
+  }
+
+  success(message: string) {
+    this.print(Chalk.bgGreen.bold(message));
+  }
+
+  headline(message: string) {
+    this.print(Chalk.bgBlue(message));
+  }
+
+  private print(formattedMessage: string) {
+    console.log(formattedMessage);
+  }
+}

--- a/cli/src/lib/spawnCommand.ts
+++ b/cli/src/lib/spawnCommand.ts
@@ -1,0 +1,25 @@
+import Logger from "./logger";
+import { spawn } from "child_process";
+
+export default async function spawnCommand(
+  command: string,
+  args: string[],
+  cwd: string,
+  log: Logger
+) {
+  return new Promise((resolve, reject) => {
+    const process = spawn(command, args, { cwd });
+
+    process.stdout.on("data", (message) =>
+      log.debug(message.toString().replace("\n", ""))
+    );
+    process.stderr.on("data", (message) =>
+      log.warn(message.toString().replace("\n", ""))
+    );
+
+    process.on("exit", function (code) {
+      if (code !== 0) return reject(code);
+      return resolve(code);
+    });
+  });
+}

--- a/cli/src/lib/upgrade.ts
+++ b/cli/src/lib/upgrade.ts
@@ -1,0 +1,20 @@
+import fs from "fs-extra";
+import SpawnCommand from "./spawnCommand";
+import Logger from "./logger";
+
+export default async function Generate(workDir: string = process.cwd()) {
+  const log = new Logger();
+
+  log.headline("Upgrading Grouparoo Project");
+  log.debug(`path: ${workDir}`);
+
+  if (!fs.existsSync(workDir)) {
+    log.error(`${workDir} does not exist`);
+    process.exit(1);
+  }
+
+  log.info("Upgrading dependencies...");
+  await SpawnCommand("npm", ["update"], workDir, log);
+
+  log.success("Grouparoo project updated!");
+}

--- a/cli/templates/.env
+++ b/cli/templates/.env
@@ -1,0 +1,23 @@
+#############
+## GENERAL ##
+#############
+
+PORT=3000
+WEB_URL=http://localhost:3000
+
+WEB_SERVER=true
+SCHEDULER=true
+WORKERS=1
+SERVER_TOKEN=my-serer-token
+
+###########
+## REDIS ##
+###########
+
+REDIS_URL="redis://localhost:6379/0"
+
+##############
+## DATABASE ##
+##############
+
+DATABASE_URL="postgresql://localhost:5432/grouparoo_development"

--- a/cli/templates/package.json
+++ b/cli/templates/package.json
@@ -1,0 +1,46 @@
+{
+  "author": "Grouparoo Inc <hello@grouparoo.com>",
+  "name": "@grouparoo/app-example",
+  "description": "An example Grouparoo Deployment",
+  "version": "0.0.1",
+  "license": "MPL-2.0",
+  "private": true,
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "dependencies": {
+    "@grouparoo/core": "latest",
+    "@grouparoo/csv": "latest",
+    "@grouparoo/email-authentication": "latest",
+    "@grouparoo/google-sheets": "latest",
+    "@grouparoo/logger": "latest",
+    "@grouparoo/mailchimp": "latest",
+    "@grouparoo/hubspot": "latest",
+    "@grouparoo/sailthru": "latest",
+    "@grouparoo/mysql": "latest",
+    "@grouparoo/bigquery": "latest",
+    "@grouparoo/postgres": "latest"
+  },
+  "scripts": {
+    "prepare": "cd node_modules/@grouparoo/core && npm run prepare",
+    "start": "cd node_modules/@grouparoo/core && ./api/bin/start",
+    "dev": "cd node_modules/@grouparoo/core && ./api/bin/dev"
+  },
+  "grouparoo": {
+    "plugins": [
+      "@grouparoo/csv",
+      "@grouparoo/email-authentication",
+      "@grouparoo/google-sheets",
+      "@grouparoo/logger",
+      "@grouparoo/mailchimp",
+      "@grouparoo/hubspot",
+      "@grouparoo/sailthru",
+      "@grouparoo/mysql",
+      "@grouparoo/bigquery",
+      "@grouparoo/postgres"
+    ],
+    "includedFiles": [
+      "assets"
+    ]
+  }
+}

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "allowJs": true,
+    "module": "commonjs",
+    "target": "es2018",
+    "esModuleInterop": true
+  },
+  "include": ["./src/**/*"],
+  "exclude": ["./../node_modules"]
+}

--- a/lerna.json
+++ b/lerna.json
@@ -1,20 +1,12 @@
 {
-  "packages": [
-    "apps/*",
-    "core",
-    "clients/*/*",
-    "plugins/*/*"
-  ],
+  "packages": ["cli", "apps/*", "core", "clients/*/*", "plugins/*/*"],
   "version": "0.1.8",
   "command": {
     "bootstrap": {
       "ignore": "@grouparoo/app-local*"
     },
     "version": {
-      "allowBranch": [
-        "master",
-        "stable"
-      ],
+      "allowBranch": ["master", "stable"],
       "message": "chore(release): publish %s [ci skip]"
     }
   }

--- a/tools/merger/data/ci/cli/job.yml.template
+++ b/tools/merger/data/ci/cli/job.yml.template
@@ -1,0 +1,17 @@
+  {{{job_name}}}:
+    docker:
+      - image: circleci/node:12
+{{{custom_docker}}}
+    steps:
+      - checkout
+      - restore_cache:
+          <<: *node-module-cache-options
+      - restore_cache:
+          <<: *dist-cache-options
+      - restore_cache:
+          <<: *core-cache-options
+{{{custom_steps}}}
+      - run:
+          name: test
+          command: cd cli && npm test
+{{custom_test}}

--- a/tools/merger/data/ci/cli/workflow.yml.template
+++ b/tools/merger/data/ci/cli/workflow.yml.template
@@ -1,0 +1,5 @@
+      - {{{job_name}}}:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build

--- a/tools/merger/data/ci/plugin/job.yml.template
+++ b/tools/merger/data/ci/plugin/job.yml.template
@@ -33,5 +33,5 @@
 {{{custom_steps}}}
       - run:
           name: test
-          command: ./node_modules/.bin/lerna exec jest --stream --concurrency 1 --ignore "@grouparoo/core" --ignore "*/app-*" -- --ci --passWithNoTests --runInBand
+          command: ./node_modules/.bin/lerna exec jest --stream --concurrency 1 --ignore "@grouparoo/core" --ignore "@grouparoo"  --ignore "*/app-*" -- --ci --passWithNoTests --runInBand
 {{custom_test}}

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -184,8 +184,6 @@ class Generator {
       .sort()
       .join("\n");
 
-    console.log(combinedDistDirs);
-
     return combinedDistDirs;
   }
 

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -174,12 +174,19 @@ class Generator {
     const pluginPaths = allPluginPaths(glob)
       .map((p) => path.relative(this.rootPath, p))
       .filter(filterPlugins);
+    const pluginDistDirs = pluginPaths;
+    const cliDistDir = ["cli"];
 
     const prefix = " ".repeat(12) + "- ";
-    return pluginPaths
+    const combinedDistDirs = []
+      .concat(pluginDistDirs, cliDistDir)
       .map((p) => `${prefix}${p}/dist`)
       .sort()
       .join("\n");
+
+    console.log(combinedDistDirs);
+
+    return combinedDistDirs;
   }
 
   core_cache() {

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -54,6 +54,7 @@ class Generator {
     this.addCommands();
     this.addCore();
     this.addPlugins();
+    this.addCLI();
 
     this.bindJobMethods();
   }
@@ -78,6 +79,15 @@ class Generator {
       job_name: `test-core`,
       relative_path: `core`,
       name: "core",
+    });
+  }
+
+  addCLI() {
+    this.jobList.push({
+      type: "cli",
+      job_name: `test-cli`,
+      relative_path: `cli`,
+      name: "cli",
     });
   }
 


### PR DESCRIPTION
# Grouparoo

_The Grouparoo project generator_

This package is released as `grouparoo` (no namespace) on NPM. It is used to generate new Grouparoo projects.

## Installation

This package does not need to be installed, and can be run ad-hoc with the `npx` command, i.e.: `npx grouparoo generate`

## Usage

_From `npx grouparoo --help`_

```
Usage: grouparoo [options] [command]

Options:
  -V, --version    output the version number
  -h, --help       display help for command

Commands:
  generate [path]  generate a new Grouparoo project
  upgrade [path]   upgrade an existing Grouparoo project
  help [command]   display help for command
```

- To generate a grouparoo project in the current directory (`process.cwd()`): `npx grouparoo generate`
- To generate a grouparoo project in another directory: `npx grouparoo generate /path/to/project`
- `npx grouparoo upgrade` assumes you are tracking the `latest` version of all the Grouparoo dependencies, and will simply run `npm update` under the hood.

## Notes

- We assume `node` and `npm` are installed and available within your `$PATH`
- We will not override an existing `package.json` or `.env` file if they already exist in the directory
- We will attempt to run `npm install` in the new directory
