### PR TITLE
Show count of failed Resque tasks on Platform Navigation Link(s)

### DIFF
--- a/core/api/__tests__/actions/profilePropertyRules.ts
+++ b/core/api/__tests__/actions/profilePropertyRules.ts
@@ -119,17 +119,29 @@ describe("actions/profilePropertyRules", () => {
         csrfToken,
         guid,
       };
-      const {
-        error,
-        profilePropertyRule,
-        pluginOptions,
-      } = await specHelper.runAction("profilePropertyRule:view", connection);
+      const { error, profilePropertyRule } = await specHelper.runAction(
+        "profilePropertyRule:view",
+        connection
+      );
 
       expect(error).toBeUndefined();
       expect(profilePropertyRule.key).toBe("email");
       expect(profilePropertyRule.isArray).toBe(false);
       expect(profilePropertyRule.unique).toBe(true);
       expect(profilePropertyRule.source.guid).toBe(source.guid);
+    });
+
+    test("an administrator can view a profilePropertyRule's plugin options", async () => {
+      connection.params = {
+        csrfToken,
+        guid,
+      };
+      const { error, pluginOptions } = await specHelper.runAction(
+        "profilePropertyRule:pluginOptions",
+        connection
+      );
+
+      expect(error).toBeUndefined();
       expect(pluginOptions[0].key).toBe("column");
     });
 

--- a/core/api/src/actions/profilePropertyRules.ts
+++ b/core/api/src/actions/profilePropertyRules.ts
@@ -225,6 +225,26 @@ export class ProfilePropertyRuleView extends AuthenticatedAction {
     );
 
     response.profilePropertyRule = await profilePropertyRule.apiData();
+  }
+}
+
+export class ProfilePropertyRulePluginOptions extends AuthenticatedAction {
+  constructor() {
+    super();
+    this.name = "profilePropertyRule:pluginOptions";
+    this.description = "view the plugin options for a profile property rule";
+    this.outputExample = {};
+    this.permission = { topic: "profilePropertyRule", mode: "read" };
+    this.inputs = {
+      guid: { required: true },
+    };
+  }
+
+  async run({ params, response }) {
+    const profilePropertyRule = await ProfilePropertyRule.findByGuid(
+      params.guid
+    );
+
     response.pluginOptions = await profilePropertyRule.pluginOptions();
   }
 }

--- a/core/api/src/config/routes.ts
+++ b/core/api/src/config/routes.ts
@@ -31,6 +31,7 @@ export const DEFAULT = {
         { path: "/v:apiVersion/profilePropertyRules", action: "profilePropertyRules:list" },
         { path: "/v:apiVersion/profilePropertyRuleOptions", action: "profilePropertyRules:options" },
         { path: "/v:apiVersion/profilePropertyRule/:guid", action: "profilePropertyRule:view" },
+        { path: "/v:apiVersion/profilePropertyRule/:guid/pluginOptions", action: "profilePropertyRule:pluginOptions" },
         { path: "/v:apiVersion/profilePropertyRule/:guid/filterOptions", action: "profilePropertyRule:filterOptions" },
         { path: "/v:apiVersion/profilePropertyRule/:guid/groups", action: "profilePropertyRule:groups" },
         { path: "/v:apiVersion/profilePropertyRule/:guid/profilePreview", action: "profilePropertyRule:profilePreview" },

--- a/core/web/components/destination/profilePreview.tsx
+++ b/core/web/components/destination/profilePreview.tsx
@@ -139,7 +139,9 @@ export default function ProfilePreview(props) {
       {sleeping ? null : (
         <>
           <Card.Body style={{ textAlign: "center" }}>
-            <strong>{mappingOptions.labels.profilePropertyRule.plural}</strong>
+            <strong>
+              {mappingOptions?.labels?.profilePropertyRule.plural}
+            </strong>
           </Card.Body>
 
           <ListGroup variant="flush">
@@ -158,7 +160,7 @@ export default function ProfilePreview(props) {
           </ListGroup>
 
           <Card.Body style={{ textAlign: "center" }}>
-            <strong>{mappingOptions.labels.group.plural}</strong>
+            <strong>{mappingOptions?.labels?.group.plural}</strong>
           </Card.Body>
 
           <ListGroup variant="flush">

--- a/core/web/components/navigation.tsx
+++ b/core/web/components/navigation.tsx
@@ -95,9 +95,10 @@ export default function Navigation(props) {
     return () => {
       clearTimeout(resqueTimer);
     };
-  }, []);
+  }, [navigationMode]);
 
   async function load() {
+    if (navigationMode === "unauthenticated") return;
     const { failedCount } = await execApi("get", `/resque/resqueFailedCount`);
     setResqueFailedCount(failedCount);
     resqueTimer = setTimeout(() => {
@@ -209,6 +210,7 @@ export default function Navigation(props) {
                         {nav.title}{" "}
                         {!expandPlatformMenu ? (
                           <ResqueFailedCountBadge
+                            navigationMode={navigationMode}
                             resqueFailedCount={resqueFailedCount}
                           />
                         ) : null}
@@ -230,6 +232,7 @@ export default function Navigation(props) {
                                 {expandPlatformMenu &&
                                 nav.title === "Resque" ? (
                                   <ResqueFailedCountBadge
+                                    navigationMode={navigationMode}
                                     resqueFailedCount={resqueFailedCount}
                                   />
                                 ) : null}
@@ -380,9 +383,12 @@ function RunningRunsBadge({ execApi }) {
 
 function ResqueFailedCountBadge({
   resqueFailedCount,
+  navigationMode,
 }: {
   resqueFailedCount: number;
+  navigationMode: string;
 }) {
+  if (navigationMode === "unauthenticated") return null;
   if (resqueFailedCount === 0) return null;
 
   return (

--- a/core/web/components/navigation.tsx
+++ b/core/web/components/navigation.tsx
@@ -85,6 +85,26 @@ export default function Navigation(props) {
 
   if (!navExpanded && !hasBeenCollapsed) setHasBeenCollapsed(true);
 
+  // resque failure counts
+  const resqueSleep = 10 * 1000 + 1;
+  let resqueTimer: NodeJS.Timeout;
+  const [resqueFailedCount, setResqueFailedCount] = useState(0);
+
+  useEffect(() => {
+    load();
+    return () => {
+      clearTimeout(resqueTimer);
+    };
+  }, []);
+
+  async function load() {
+    const { failedCount } = await execApi("get", `/resque/resqueFailedCount`);
+    setResqueFailedCount(failedCount);
+    resqueTimer = setTimeout(() => {
+      load();
+    }, resqueSleep);
+  }
+
   return (
     <div
       id="navigation"
@@ -186,7 +206,12 @@ export default function Navigation(props) {
                           color: "white",
                         }}
                       >
-                        {nav.title}
+                        {nav.title}{" "}
+                        {!expandPlatformMenu ? (
+                          <ResqueFailedCountBadge
+                            resqueFailedCount={resqueFailedCount}
+                          />
+                        ) : null}
                       </span>
                       <div style={{ padding: 6 }} />
                     </Accordion.Toggle>
@@ -202,6 +227,12 @@ export default function Navigation(props) {
                                 <Link href={nav.href}>
                                   <a style={{ color: "white" }}>{nav.title}</a>
                                 </Link>
+                                {expandPlatformMenu &&
+                                nav.title === "Resque" ? (
+                                  <ResqueFailedCountBadge
+                                    resqueFailedCount={resqueFailedCount}
+                                  />
+                                ) : null}
                               </p>
                             );
                           } else if (nav.type === "divider") {
@@ -336,14 +367,28 @@ function RunningRunsBadge({ execApi }) {
     setRuns(runs);
   }
 
-  if (runs.length === 0) {
-    return null;
-  }
+  if (runs.length === 0) return null;
 
   return (
     <span style={{ paddingLeft: 5 }}>
       <Badge pill variant="info">
         {runs.length}
+      </Badge>
+    </span>
+  );
+}
+
+function ResqueFailedCountBadge({
+  resqueFailedCount,
+}: {
+  resqueFailedCount: number;
+}) {
+  if (resqueFailedCount === 0) return null;
+
+  return (
+    <span style={{ paddingLeft: 5 }}>
+      <Badge pill variant="warning">
+        {resqueFailedCount}
       </Badge>
     </span>
   );


### PR DESCRIPTION
It's hard to know if you have failed Resque tasks.

If there are failed Resque tasks in your cluster, show a badge on the `Platform` link.  If the `Platform` menu is expanded, show the count on the `Resque` link.

<img width="1518" alt="Screen Shot 2020-07-30 at 5 09 00 PM" src="https://user-images.githubusercontent.com/303226/88986412-bb1ed780-d287-11ea-9283-e47bbbd919fb.png">

<img width="1518" alt="Screen Shot 2020-07-30 at 5 08 55 PM" src="https://user-images.githubusercontent.com/303226/88986405-b528f680-d287-11ea-9401-5e8a93566707.png">

Closes T-246
