### PR TITLE
Render Source, Destination and Profile Property pages if the App is unreachable

### DIFF
--- a/core/api/__tests__/actions/profilePropertyRules.ts
+++ b/core/api/__tests__/actions/profilePropertyRules.ts
@@ -119,17 +119,29 @@ describe("actions/profilePropertyRules", () => {
         csrfToken,
         guid,
       };
-      const {
-        error,
-        profilePropertyRule,
-        pluginOptions,
-      } = await specHelper.runAction("profilePropertyRule:view", connection);
+      const { error, profilePropertyRule } = await specHelper.runAction(
+        "profilePropertyRule:view",
+        connection
+      );
 
       expect(error).toBeUndefined();
       expect(profilePropertyRule.key).toBe("email");
       expect(profilePropertyRule.isArray).toBe(false);
       expect(profilePropertyRule.unique).toBe(true);
       expect(profilePropertyRule.source.guid).toBe(source.guid);
+    });
+
+    test("an administrator can view a profilePropertyRule's plugin options", async () => {
+      connection.params = {
+        csrfToken,
+        guid,
+      };
+      const { error, pluginOptions } = await specHelper.runAction(
+        "profilePropertyRule:pluginOptions",
+        connection
+      );
+
+      expect(error).toBeUndefined();
       expect(pluginOptions[0].key).toBe("column");
     });
 

--- a/core/api/src/actions/profilePropertyRules.ts
+++ b/core/api/src/actions/profilePropertyRules.ts
@@ -225,6 +225,26 @@ export class ProfilePropertyRuleView extends AuthenticatedAction {
     );
 
     response.profilePropertyRule = await profilePropertyRule.apiData();
+  }
+}
+
+export class ProfilePropertyRulePluginOptions extends AuthenticatedAction {
+  constructor() {
+    super();
+    this.name = "profilePropertyRule:pluginOptions";
+    this.description = "view the plugin options for a profile property rule";
+    this.outputExample = {};
+    this.permission = { topic: "profilePropertyRule", mode: "read" };
+    this.inputs = {
+      guid: { required: true },
+    };
+  }
+
+  async run({ params, response }) {
+    const profilePropertyRule = await ProfilePropertyRule.findByGuid(
+      params.guid
+    );
+
     response.pluginOptions = await profilePropertyRule.pluginOptions();
   }
 }

--- a/core/api/src/config/routes.ts
+++ b/core/api/src/config/routes.ts
@@ -31,6 +31,7 @@ export const DEFAULT = {
         { path: "/v:apiVersion/profilePropertyRules", action: "profilePropertyRules:list" },
         { path: "/v:apiVersion/profilePropertyRuleOptions", action: "profilePropertyRules:options" },
         { path: "/v:apiVersion/profilePropertyRule/:guid", action: "profilePropertyRule:view" },
+        { path: "/v:apiVersion/profilePropertyRule/:guid/pluginOptions", action: "profilePropertyRule:pluginOptions" },
         { path: "/v:apiVersion/profilePropertyRule/:guid/filterOptions", action: "profilePropertyRule:filterOptions" },
         { path: "/v:apiVersion/profilePropertyRule/:guid/groups", action: "profilePropertyRule:groups" },
         { path: "/v:apiVersion/profilePropertyRule/:guid/profilePreview", action: "profilePropertyRule:profilePreview" },

--- a/core/web/components/destination/profilePreview.tsx
+++ b/core/web/components/destination/profilePreview.tsx
@@ -139,7 +139,9 @@ export default function ProfilePreview(props) {
       {sleeping ? null : (
         <>
           <Card.Body style={{ textAlign: "center" }}>
-            <strong>{mappingOptions.labels.profilePropertyRule.plural}</strong>
+            <strong>
+              {mappingOptions?.labels?.profilePropertyRule.plural}
+            </strong>
           </Card.Body>
 
           <ListGroup variant="flush">
@@ -158,7 +160,7 @@ export default function ProfilePreview(props) {
           </ListGroup>
 
           <Card.Body style={{ textAlign: "center" }}>
-            <strong>{mappingOptions.labels.group.plural}</strong>
+            <strong>{mappingOptions?.labels?.group.plural}</strong>
           </Card.Body>
 
           <ListGroup variant="flush">

--- a/core/web/components/navigation.tsx
+++ b/core/web/components/navigation.tsx
@@ -95,9 +95,10 @@ export default function Navigation(props) {
     return () => {
       clearTimeout(resqueTimer);
     };
-  }, []);
+  }, [navigationMode]);
 
   async function load() {
+    if (navigationMode === "unauthenticated") return;
     const { failedCount } = await execApi("get", `/resque/resqueFailedCount`);
     setResqueFailedCount(failedCount);
     resqueTimer = setTimeout(() => {
@@ -209,6 +210,7 @@ export default function Navigation(props) {
                         {nav.title}{" "}
                         {!expandPlatformMenu ? (
                           <ResqueFailedCountBadge
+                            navigationMode={navigationMode}
                             resqueFailedCount={resqueFailedCount}
                           />
                         ) : null}
@@ -230,6 +232,7 @@ export default function Navigation(props) {
                                 {expandPlatformMenu &&
                                 nav.title === "Resque" ? (
                                   <ResqueFailedCountBadge
+                                    navigationMode={navigationMode}
                                     resqueFailedCount={resqueFailedCount}
                                   />
                                 ) : null}
@@ -380,9 +383,12 @@ function RunningRunsBadge({ execApi }) {
 
 function ResqueFailedCountBadge({
   resqueFailedCount,
+  navigationMode,
 }: {
   resqueFailedCount: number;
+  navigationMode: string;
 }) {
+  if (navigationMode === "unauthenticated") return null;
   if (resqueFailedCount === 0) return null;
 
   return (


### PR DESCRIPTION
This PR provides some safety around rendering pages which require hydration data (`getInitialProps`) from an App.  Before this PR, if the app was unreachable for whatever reason, the page would 500.  Now we can render the page with a `hydrationError` shown.

This makes it so that it is possible to remove Sources, Destinations and Profile Properties for an app which no longer works.

For parts of hydration that rely only on internal data (in the Grouparoo database), we do still want the page to error.

<img width="1518" alt="Screen Shot 2020-07-31 at 10 19 03 AM" src="https://user-images.githubusercontent.com/303226/89060807-7b540080-d318-11ea-8391-a202d42fcf76.png">
