### PR TITLE
Runs UI Updates

### DIFF
--- a/core/api/__tests__/actions/runs.ts
+++ b/core/api/__tests__/actions/runs.ts
@@ -114,4 +114,22 @@ describe("actions/runs", () => {
     expect(run.guid).toBe(runA.guid);
     expect(quantizedTimeline.length).toBe(25 + 4); // 25 for times, 4
   });
+
+  test("a run can be edited", async () => {
+    const _run = await helper.factories.run(scheduleA, { state: "running" });
+    expect(_run.state).toBe("running");
+
+    connection.params = {
+      csrfToken,
+      guid: _run.guid,
+      state: "stopped",
+    };
+
+    const { error, run } = await specHelper.runAction("run:edit", connection);
+    expect(error).toBeUndefined();
+    expect(run.guid).toBe(_run.guid);
+    expect(run.state).toBe("stopped");
+
+    await _run.destroy();
+  });
 });

--- a/core/api/__tests__/models/run.ts
+++ b/core/api/__tests__/models/run.ts
@@ -124,7 +124,8 @@ describe("models/run", () => {
           creatorGuid: group.guid,
           creatorType: "group",
         });
-        expect(await run.percentComplete()).toBe(100);
+        await run.determinePercentComplete();
+        expect(run.percentComplete).toBe(100);
       });
 
       test("stopped", async () => {
@@ -133,7 +134,8 @@ describe("models/run", () => {
           creatorGuid: group.guid,
           creatorType: "group",
         });
-        expect(await run.percentComplete()).toBe(100);
+        await run.determinePercentComplete();
+        expect(run.percentComplete).toBe(100);
       });
 
       test("running - schedule", async () => {
@@ -142,7 +144,8 @@ describe("models/run", () => {
           creatorGuid: schedule.guid,
           creatorType: "schedule",
         });
-        expect(await run.percentComplete()).toBe(0);
+        await run.determinePercentComplete();
+        expect(run.percentComplete).toBe(0);
       });
 
       test("running - group - runAddGroupMembers", async () => {
@@ -152,7 +155,8 @@ describe("models/run", () => {
           creatorType: "group",
           groupMethod: "runAddGroupMembers",
         });
-        expect(await run.percentComplete()).toBe(0);
+        await run.determinePercentComplete();
+        expect(run.percentComplete).toBe(0);
       });
 
       test("running - group - runRemoveGroupMembers", async () => {
@@ -162,7 +166,8 @@ describe("models/run", () => {
           creatorType: "group",
           groupMethod: "runRemoveGroupMembers",
         });
-        expect(await run.percentComplete()).toBe(45);
+        await run.determinePercentComplete();
+        expect(run.percentComplete).toBe(45);
       });
 
       test("running - teamMember", async () => {
@@ -174,7 +179,8 @@ describe("models/run", () => {
           creatorType: "teamMember",
           profilesImported: 1,
         });
-        expect(await run.percentComplete()).toBe(50);
+        await run.determinePercentComplete();
+        expect(run.percentComplete).toBe(50);
         await profileA.destroy();
         await profileB.destroy();
       });

--- a/core/api/src/actions/runs.ts
+++ b/core/api/src/actions/runs.ts
@@ -56,6 +56,26 @@ export class ListRuns extends AuthenticatedAction {
   }
 }
 
+export class RunEdit extends AuthenticatedAction {
+  constructor() {
+    super();
+    this.name = "run:edit";
+    this.description = "edit a run";
+    this.outputExample = {};
+    this.permission = { topic: "system", mode: "write" };
+    this.inputs = {
+      guid: { required: true },
+      state: { required: true },
+    };
+  }
+
+  async run({ params, response }) {
+    const run = await Run.findByGuid(params.guid);
+    await run.update({ state: params.state });
+    response.run = await run.apiData();
+  }
+}
+
 export class RunView extends AuthenticatedAction {
   constructor() {
     super();

--- a/core/api/src/classes/plugin.ts
+++ b/core/api/src/classes/plugin.ts
@@ -68,6 +68,7 @@ export interface PluginConnection {
     sourceOptions?: SourceOptionsMethod;
     sourcePreview?: SourcePreviewMethod;
     sourceFilters?: SourceFilterMethod;
+    sourceRunPercentComplete?: SourceRunPercentCompleteMethod;
     uniqueProfilePropertyRuleBootstrapOptions?: UniqueProfilePropertyRuleBootstrapOptions;
     profiles?: ProfilesPluginMethod;
     profileProperty?: ProfilePropertyPluginMethod;
@@ -265,6 +266,24 @@ export interface SourceFilterMethodResponseRow {
   key: string;
   ops: Array<string>;
   canHaveRelativeMatch: boolean;
+}
+
+/**
+ * Return a percentage (0-100) for the completion status of this run
+ */
+export interface SourceRunPercentCompleteMethod {
+  (argument: {
+    connection: any;
+    app: App;
+    appOptions: SimpleAppOptions;
+    source: Source;
+    sourceOptions: SimpleSourceOptions;
+    sourceMapping: SourceMapping;
+    schedule: Schedule;
+    scheduleOptions: SimpleScheduleOptions;
+    highWaterMark: HighWaterMark;
+    run: Run;
+  }): Promise<number>;
 }
 
 /**

--- a/core/api/src/config/routes.ts
+++ b/core/api/src/config/routes.ts
@@ -114,6 +114,7 @@ export const DEFAULT = {
         { path: "/v:apiVersion/app/:guid/test", action: "app:test" },
         { path: "/v:apiVersion/profilePropertyRule/:guid/test", action: "profilePropertyRule:test" },
         { path: "/v:apiVersion/app/:guid", action: "app:edit" },
+        { path: "/v:apiVersion/run/:guid", action: "run:edit" },
         { path: "/v:apiVersion/source/:guid", action: "source:edit" },
         { path: "/v:apiVersion/schedule/:guid", action: "schedule:edit" },
         { path: "/v:apiVersion/destination/:guid", action: "destination:edit" }

--- a/core/api/src/migrations/000034-runPercentComplete.ts
+++ b/core/api/src/migrations/000034-runPercentComplete.ts
@@ -1,0 +1,17 @@
+module.exports = {
+  up: async function (migration, DataTypes) {
+    await migration.addColumn("runs", "percentComplete", {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 100,
+    });
+    await migration.changeColumn("runs", "percentComplete", {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    });
+  },
+
+  down: async function (migration) {
+    await migration.removeColumn("runs", "percentComplete");
+  },
+};

--- a/core/api/src/models/Schedule.ts
+++ b/core/api/src/models/Schedule.ts
@@ -129,6 +129,10 @@ export class Schedule extends LoggedModel<Schedule> {
     return ScheduleOps.pluginOptions(this);
   }
 
+  async runPercentComplete(run: Run) {
+    return ScheduleOps.runPercentComplete(this, run);
+  }
+
   async apiData() {
     const source = await this.$get("source");
     const options = await this.getOptions();

--- a/core/api/src/modules/ops/runs.ts
+++ b/core/api/src/modules/ops/runs.ts
@@ -112,6 +112,8 @@ export namespace RunOps {
    * Make a guess to what percent complete this Run is
    */
   export async function determinePercentComplete(run: Run) {
+    await run.reload(); // the loaded instance's counts may have changed after it was loaded
+
     if (run.state === "complete") return 100;
     if (run.state === "stopped") return 100;
 

--- a/core/api/src/modules/ops/runs.ts
+++ b/core/api/src/modules/ops/runs.ts
@@ -111,7 +111,7 @@ export namespace RunOps {
   /**
    * Make a guess to what percent complete this Run is
    */
-  export async function percentComplete(run: Run) {
+  export async function determinePercentComplete(run: Run) {
     if (run.state === "complete") return 100;
     if (run.state === "stopped") return 100;
 

--- a/core/api/src/tasks/group/destroy.ts
+++ b/core/api/src/tasks/group/destroy.ts
@@ -61,6 +61,8 @@ export class GroupDestroy extends Task {
     );
     const remainingMembers = await group.$count("groupMembers");
 
+    await run.determinePercentComplete();
+
     if (importsCounts > 0 || previousRunMembers > 0 || remainingMembers > 0) {
       await task.enqueueIn(config.tasks.timeout + 1, "group:destroy", {
         runGuid: run.guid,

--- a/core/api/src/tasks/group/run.ts
+++ b/core/api/src/tasks/group/run.ts
@@ -101,6 +101,8 @@ export class RunGroup extends Task {
       throw new Error(`${method} is not now a known method`);
     }
 
+    await run.determinePercentComplete();
+
     if (memberCount === 0 && method === "runAddGroupMembers") {
       await task.enqueueIn(config.tasks.timeout + 1, "group:run", {
         runGuid: run.guid,

--- a/core/api/src/tasks/runs/determineState.ts
+++ b/core/api/src/tasks/runs/determineState.ts
@@ -21,6 +21,7 @@ export class RunDetermineState extends Task {
     const run = await Run.findByGuid(runGuid);
 
     await run.determineState();
+    await run.determinePercentComplete();
     await run.reload();
 
     if (run.state === "running") {

--- a/core/api/src/tasks/runs/internalRun.ts
+++ b/core/api/src/tasks/runs/internalRun.ts
@@ -74,6 +74,8 @@ export class RunInternalRun extends Task {
       await transaction.commit();
     }
 
+    await run.determinePercentComplete();
+
     if (profiles.length > 0) {
       await task.enqueueIn(config.tasks.timeout + 1, "run:internalRun", {
         runGuid: run.guid,

--- a/core/api/src/tasks/schedule/run.ts
+++ b/core/api/src/tasks/schedule/run.ts
@@ -25,6 +25,8 @@ export class ScheduleRun extends Task {
 
     const { importsCount } = await schedule.run(run);
 
+    await run.determinePercentComplete();
+
     if (importsCount > 0) {
       await task.enqueueIn(config.tasks.timeout + 1, "schedule:run", params);
     } else {

--- a/core/web/components/events/list.tsx
+++ b/core/web/components/events/list.tsx
@@ -72,12 +72,8 @@ export default function EventsList(props) {
 
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
-    if (type && type !== "") {
-      url += `type=${escape(type)}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
+    if (type && type !== "") url += `type=${escape(type)}&`;
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/core/web/components/events/types.tsx
+++ b/core/web/components/events/types.tsx
@@ -51,9 +51,7 @@ export default function EventsList(props) {
 
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/core/web/components/export/list.tsx
+++ b/core/web/components/export/list.tsx
@@ -77,9 +77,8 @@ export default function ExportsList(props) {
 
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
+
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";
     Router[routerMethod](Router.route, url, { shallow: true });

--- a/core/web/components/import/list.tsx
+++ b/core/web/components/import/list.tsx
@@ -56,9 +56,7 @@ export default function ImportList(props) {
 
   async function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/core/web/components/log/list.tsx
+++ b/core/web/components/log/list.tsx
@@ -62,10 +62,6 @@ export default function LogsList(props) {
     if (response?.logs) {
       setLogs(response.logs);
       setTotal(response.total);
-
-      if (response.logs.length === 0 && offset > 0) {
-        setOffset(0);
-      }
     }
   }
 
@@ -120,7 +116,10 @@ export default function LogsList(props) {
         <Button
           size="sm"
           variant={topic ? "info" : "secondary"}
-          onClick={() => setTopic(null)}
+          onClick={() => {
+            setTopic(null);
+            setOffset(0);
+          }}
         >
           All
         </Button>
@@ -131,7 +130,10 @@ export default function LogsList(props) {
               key={`topic-${t}`}
               size="sm"
               variant={variant}
-              onClick={() => setTopic(t)}
+              onClick={() => {
+                setTopic(t);
+                setOffset(0);
+              }}
             >
               {t}
             </Button>

--- a/core/web/components/log/list.tsx
+++ b/core/web/components/log/list.tsx
@@ -96,12 +96,8 @@ export default function LogsList(props) {
 
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
-    if (topic) {
-      url += `topic=${topic}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
+    if (topic) url += `topic=${topic}&`;
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/core/web/components/navigation.tsx
+++ b/core/web/components/navigation.tsx
@@ -99,11 +99,16 @@ export default function Navigation(props) {
 
   async function load() {
     if (navigationMode === "unauthenticated") return;
-    const { failedCount } = await execApi("get", `/resque/resqueFailedCount`);
-    setResqueFailedCount(failedCount);
-    resqueTimer = setTimeout(() => {
-      load();
-    }, resqueSleep);
+
+    try {
+      const { failedCount } = await execApi("get", `/resque/resqueFailedCount`);
+      setResqueFailedCount(failedCount);
+      resqueTimer = setTimeout(() => {
+        load();
+      }, resqueSleep);
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   return (

--- a/core/web/components/profile/list.tsx
+++ b/core/web/components/profile/list.tsx
@@ -71,15 +71,10 @@ export default function ProfilesList(props) {
 
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
-    if (searchKey && searchKey !== "") {
-      url += `searchKey=${searchKey}&`;
-    }
-    if (searchValue && searchValue !== "") {
+    if (offset && offset !== 0) url += `offset=${offset}&`;
+    if (searchKey && searchKey !== "") url += `searchKey=${searchKey}&`;
+    if (searchValue && searchValue !== "")
       url += `searchValue=${escape(searchValue)}&`;
-    }
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/core/web/components/resque/delayed.tsx
+++ b/core/web/components/resque/delayed.tsx
@@ -73,9 +73,8 @@ export default function ResqueDelayedList(props) {
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
     url += `tab=delayed&`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
+
     Router.push(Router.route, url, { shallow: true });
   }
 

--- a/core/web/components/resque/failed.tsx
+++ b/core/web/components/resque/failed.tsx
@@ -72,9 +72,8 @@ export default function ResqueFailedList(props) {
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
     url += `tab=failed&`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
+
     Router.push(Router.route, url, { shallow: true });
   }
 

--- a/core/web/components/resque/locks.tsx
+++ b/core/web/components/resque/locks.tsx
@@ -47,9 +47,8 @@ export default function ResqueLocksList(props) {
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
     url += `tab=locks&`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
+
     Router.push(Router.route, url, { shallow: true });
   }
 

--- a/core/web/components/resque/queue.tsx
+++ b/core/web/components/resque/queue.tsx
@@ -49,9 +49,8 @@ export default function ResqueQueue(props) {
     let url = `${window.location.pathname}?`;
     url += `tab=queue&`;
     url += `queue=${queue}&`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
+
     Router.push(Router.route, url, { shallow: true });
   }
 

--- a/core/web/components/runs/list.tsx
+++ b/core/web/components/runs/list.tsx
@@ -78,6 +78,18 @@ export default function RunsList(props) {
     Router[routerMethod](Router.route, url, { shallow: true });
   }
 
+  function setFilter({
+    errorFilter,
+    stateFilter,
+  }: {
+    errorFilter?: string;
+    stateFilter?: string;
+  }) {
+    if (errorFilter !== undefined) setErrorFilter(errorFilter);
+    if (stateFilter !== undefined) setStateFilter(stateFilter);
+    setOffset(0);
+  }
+
   return (
     <>
       <h1>Runs</h1>
@@ -92,28 +104,28 @@ export default function RunsList(props) {
             <Button
               size="sm"
               variant={stateFilter === "" ? "secondary" : "info"}
-              onClick={() => setStateFilter("")}
+              onClick={() => setFilter({ stateFilter: "" })}
             >
               All
             </Button>
             <Button
               size="sm"
               variant={stateFilter === "running" ? "secondary" : "info"}
-              onClick={() => setStateFilter("running")}
+              onClick={() => setFilter({ stateFilter: "running" })}
             >
               Running
             </Button>
             <Button
               size="sm"
               variant={stateFilter === "complete" ? "secondary" : "info"}
-              onClick={() => setStateFilter("complete")}
+              onClick={() => setFilter({ stateFilter: "complete" })}
             >
               Complete
             </Button>
             <Button
               size="sm"
               variant={stateFilter === "stopped" ? "secondary" : "info"}
-              onClick={() => setStateFilter("stopped")}
+              onClick={() => setFilter({ stateFilter: "stopped" })}
             >
               Stopped
             </Button>
@@ -125,21 +137,21 @@ export default function RunsList(props) {
             <Button
               size="sm"
               variant={errorFilter === "" ? "secondary" : "info"}
-              onClick={() => setErrorFilter("")}
+              onClick={() => setFilter({ errorFilter: "" })}
             >
               All
             </Button>
             <Button
               size="sm"
               variant={errorFilter === "true" ? "secondary" : "info"}
-              onClick={() => setErrorFilter("true")}
+              onClick={() => setFilter({ errorFilter: "true" })}
             >
               True
             </Button>
             <Button
               size="sm"
               variant={errorFilter === "false" ? "secondary" : "info"}
-              onClick={() => setErrorFilter("false")}
+              onClick={() => setFilter({ errorFilter: "false" })}
             >
               False
             </Button>

--- a/core/web/components/runs/list.tsx
+++ b/core/web/components/runs/list.tsx
@@ -38,18 +38,9 @@ export default function RunsList(props) {
 
   async function load() {
     const params = { limit, offset };
-
-    if (query.guid) {
-      params["guid"] = query.guid;
-    }
-
-    if (stateFilter !== "") {
-      params["state"] = stateFilter;
-    }
-
-    if (errorFilter !== "") {
-      params["hasError"] = errorFilter;
-    }
+    if (query.guid) params["guid"] = query.guid;
+    if (stateFilter !== "") params["state"] = stateFilter;
+    if (errorFilter !== "") params["hasError"] = errorFilter;
 
     updateURLParams();
     setLoading(true);
@@ -63,15 +54,9 @@ export default function RunsList(props) {
 
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
-    if (stateFilter !== "") {
-      url += `state=${stateFilter}&`;
-    }
-    if (errorFilter != "") {
-      url += `error=${errorFilter}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
+    if (stateFilter !== "") url += `state=${stateFilter}&`;
+    if (errorFilter != "") url += `error=${errorFilter}&`;
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/core/web/pages/apiKeys.tsx
+++ b/core/web/pages/apiKeys.tsx
@@ -44,9 +44,7 @@ export default function Page(props) {
 
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/core/web/pages/apps.tsx
+++ b/core/web/pages/apps.tsx
@@ -50,9 +50,7 @@ export default function Page(props) {
 
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/core/web/pages/destinations.tsx
+++ b/core/web/pages/destinations.tsx
@@ -52,9 +52,7 @@ export default function Page(props) {
 
   async function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/core/web/pages/files.tsx
+++ b/core/web/pages/files.tsx
@@ -65,9 +65,7 @@ export default function Page(props) {
 
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/core/web/pages/groups.tsx
+++ b/core/web/pages/groups.tsx
@@ -45,9 +45,7 @@ export default function Page(props) {
 
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/core/web/pages/profilePropertyRules.tsx
+++ b/core/web/pages/profilePropertyRules.tsx
@@ -79,9 +79,7 @@ export default function Page(props) {
 
   function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/core/web/pages/sources.tsx
+++ b/core/web/pages/sources.tsx
@@ -49,9 +49,7 @@ export default function Page(props) {
 
   async function updateURLParams() {
     let url = `${window.location.pathname}?`;
-    if (offset && offset !== 0) {
-      url += `offset=${offset}&`;
-    }
+    if (offset && offset !== 0) url += `offset=${offset}&`;
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";

--- a/plugins/@grouparoo/bigquery/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/bigquery/src/initializers/plugin.ts
@@ -13,6 +13,7 @@ import { profiles as tableProfiles } from "../lib/table-import/profiles";
 import { profileProperty as tableProfileProperty } from "../lib/table-import/profileProperty";
 import { profilePropertyRuleOptions as tableProfilePropertyRuleOptions } from "../lib/table-import/profilePropertyRuleOptions";
 import { scheduleOptions as tableScheduleOptions } from "../lib/table-import/scheduleOptions";
+import { sourceRunPercentComplete as tableSourceRunPercentComplete } from "../lib/table-import/sourceRunPercentComplete";
 
 import { sourceOptions as querySourceOptions } from "../lib/query-import/sourceOptions";
 import { profileProperty as queryProfileProperty } from "../lib/query-import/profileProperty";
@@ -86,6 +87,7 @@ export class Plugins extends Initializer {
             uniqueProfilePropertyRuleBootstrapOptions: tableUniqueProfilePropertyRuleBootstrapOptions,
             profiles: tableProfiles,
             profileProperty: tableProfileProperty,
+            sourceRunPercentComplete: tableSourceRunPercentComplete,
           },
         },
         {

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/sourceRunPercentComplete.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/sourceRunPercentComplete.ts
@@ -1,0 +1,41 @@
+import { SourceRunPercentCompleteMethod } from "@grouparoo/core";
+import { makeWhereClause, getColumns, castRow } from "../util";
+
+export const sourceRunPercentComplete: SourceRunPercentCompleteMethod = async ({
+  source,
+  highWaterMark,
+  connection,
+  run,
+}) => {
+  const { table } = await source.parameterizedOptions(run);
+  const hasHighWaterMark = Object.keys(highWaterMark).length === 1;
+  const filterCol = hasHighWaterMark ? Object.keys(highWaterMark)[0] : null;
+  const filterVal = hasHighWaterMark ? Object.values(highWaterMark)[0] : null;
+  const columns = await getColumns(connection, table);
+  const params = [];
+  const types = [];
+
+  let query = `SELECT COUNT (*) AS __count FROM \`${table}\``;
+  if (filterCol) {
+    query += " WHERE";
+    query += makeWhereClause(
+      columns,
+      filterCol,
+      null,
+      ">=",
+      filterVal,
+      params,
+      types
+    );
+  }
+
+  const options = { query, params, types };
+  const [rows] = await connection.query(options);
+  const result = castRow(rows[0]);
+  const total = parseInt(result["__count"]);
+
+  const percentComplete =
+    total > 0 ? Math.floor((run.profilesImported / total) * 100) : 100;
+
+  return percentComplete;
+};

--- a/plugins/@grouparoo/csv/__tests__/integration/csv.ts
+++ b/plugins/@grouparoo/csv/__tests__/integration/csv.ts
@@ -306,6 +306,10 @@ describe("integration/runs/csv", () => {
           )
         );
 
+        // check the run's completion percentage (before the run is complete)
+        await run.determinePercentComplete();
+        expect(run.percentComplete).toBe(90);
+
         // check if the run is done
         const foundRunDetermineStateTasks = await specHelper.findEnqueuedTasks(
           "run:determineState"
@@ -328,6 +332,7 @@ describe("integration/runs/csv", () => {
         expect(run.profilesImported).toBe(10);
         expect(run.exportsCreated).toBe(0);
         expect(run.profilesExported).toBe(0);
+        expect(run.percentComplete).toBe(100);
       },
       1000 * 60
     );
@@ -420,6 +425,10 @@ describe("integration/runs/csv", () => {
           )
         );
 
+        // check the run's completion percentage (before the run is complete)
+        await run.determinePercentComplete();
+        expect(run.percentComplete).toBe(90);
+
         // check if the run is done
         const foundRunDetermineStateTasks = await specHelper.findEnqueuedTasks(
           "run:determineState"
@@ -442,6 +451,7 @@ describe("integration/runs/csv", () => {
         expect(run.profilesImported).toBe(10);
         expect(run.exportsCreated).toBe(0);
         expect(run.profilesExported).toBe(0);
+        expect(run.percentComplete).toBe(100);
       },
       1000 * 60
     );

--- a/plugins/@grouparoo/csv/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/csv/src/initializers/plugin.ts
@@ -7,6 +7,7 @@ import { sourcePreview } from "../lib/file-import/sourcePreview";
 import { profiles } from "../lib/file-import/profiles";
 import { profileProperty } from "../lib/file-import/profileProperty";
 import { profilePropertyRuleOptions } from "../lib/file-import/profilePropertyRuleOptions";
+import { sourceRunPercentComplete } from "../lib/file-import/sourceRunPercentComplete";
 
 const packageJSON = require("./../../package.json");
 
@@ -48,6 +49,7 @@ export class Plugins extends Initializer {
             sourcePreview,
             profiles,
             profileProperty,
+            sourceRunPercentComplete,
           },
         },
       ],

--- a/plugins/@grouparoo/csv/src/lib/file-import/sourceRunPercentComplete.ts
+++ b/plugins/@grouparoo/csv/src/lib/file-import/sourceRunPercentComplete.ts
@@ -1,0 +1,27 @@
+import { createReadStream } from "fs";
+import { plugin, SourceRunPercentCompleteMethod } from "@grouparoo/core";
+
+export const sourceRunPercentComplete: SourceRunPercentCompleteMethod = async ({
+  run,
+  sourceOptions,
+}) => {
+  const localPath = await plugin.getLocalFilePath(sourceOptions.fileGuid);
+
+  const total: number = await new Promise((resolve, reject) => {
+    let i: number;
+    let count = 0;
+
+    // http://stackoverflow.com/questions/12453057/node-js-count-the-number-of-lines-in-a-file
+    createReadStream(localPath)
+      .once("error", (error) => reject(error))
+      .on("data", (chunk) => {
+        for (i = 0; i < chunk.length; ++i) if (chunk[i] == 10) count++;
+      })
+      .on("end", () => resolve(count));
+  });
+
+  const percentComplete =
+    total > 0 ? Math.floor((run.profilesImported / total) * 100) : 100;
+
+  return percentComplete;
+};

--- a/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
+++ b/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
@@ -315,6 +315,10 @@ describe("integration/runs/google-sheets", () => {
           )
         );
 
+        // check the run's completion percentage (before the run is complete)
+        await run.determinePercentComplete();
+        expect(run.percentComplete).toBe(0); // we can't actually tell :(
+
         // check if the run is done
         const foundRunDetermineStateTasks = await specHelper.findEnqueuedTasks(
           "run:determineState"
@@ -337,6 +341,7 @@ describe("integration/runs/google-sheets", () => {
         expect(run.profilesImported).toBe(10);
         expect(run.exportsCreated).toBe(0);
         expect(run.profilesExported).toBe(0);
+        expect(run.percentComplete).toBe(100);
       },
       1000 * 60
     );
@@ -429,6 +434,10 @@ describe("integration/runs/google-sheets", () => {
           )
         );
 
+        // check the run's completion percentage (before the run is complete)
+        await run.determinePercentComplete();
+        expect(run.percentComplete).toBe(0);
+
         // check if the run is done
         const foundRunDetermineStateTasks = await specHelper.findEnqueuedTasks(
           "run:determineState"
@@ -451,6 +460,7 @@ describe("integration/runs/google-sheets", () => {
         expect(run.profilesImported).toBe(10);
         expect(run.exportsCreated).toBe(0);
         expect(run.profilesExported).toBe(0);
+        expect(run.percentComplete).toBe(100);
       },
       1000 * 60
     );

--- a/plugins/@grouparoo/google-sheets/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/google-sheets/src/initializers/plugin.ts
@@ -6,6 +6,7 @@ import { sourcePreview } from "../lib/sheet-import/sourcePreview";
 import { profiles } from "../lib/sheet-import/profiles";
 import { profileProperty } from "../lib/sheet-import/profileProperty";
 import { profilePropertyRuleOptions } from "../lib/sheet-import/profilePropertyRuleOptions";
+import { sourceRunPercentComplete } from "../lib/sheet-import/sourceRunPercentComplete";
 
 const packageJSON = require("./../../package.json");
 
@@ -58,6 +59,7 @@ export class Plugins extends Initializer {
             sourcePreview,
             profiles,
             profileProperty,
+            sourceRunPercentComplete,
           },
         },
       ],

--- a/plugins/@grouparoo/google-sheets/src/lib/sheet-import/sourceRunPercentComplete.ts
+++ b/plugins/@grouparoo/google-sheets/src/lib/sheet-import/sourceRunPercentComplete.ts
@@ -1,0 +1,6 @@
+import { SourceRunPercentCompleteMethod } from "@grouparoo/core";
+
+export const sourceRunPercentComplete: SourceRunPercentCompleteMethod = async ({}) => {
+  // there is no method to get the number of rows in the sheet
+  return 0;
+};

--- a/plugins/@grouparoo/google-sheets/src/lib/sheet-import/sourceRunPercentComplete.ts
+++ b/plugins/@grouparoo/google-sheets/src/lib/sheet-import/sourceRunPercentComplete.ts
@@ -1,6 +1,6 @@
 import { SourceRunPercentCompleteMethod } from "@grouparoo/core";
 
 export const sourceRunPercentComplete: SourceRunPercentCompleteMethod = async ({}) => {
-  // there is no method to get the number of rows in the sheet
+  // there is no method to get the number of rows in the sheet...
   return 0;
 };

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -486,6 +486,10 @@ describe("integration/runs/mysql", () => {
         )
       );
 
+      // check the run's completion percentage (before the run is complete)
+      await run.determinePercentComplete();
+      expect(run.percentComplete).toBe(100);
+
       // check if the run is done
       const foundRunDetermineStateTasks = await specHelper.findEnqueuedTasks(
         "run:determineState"
@@ -510,6 +514,7 @@ describe("integration/runs/mysql", () => {
       expect(run.highWaterMark).toEqual({ id: "10" });
       expect(run.sourceOffset).toBe("0");
       expect(run.error).toBeFalsy();
+      expect(run.percentComplete).toBe(100);
 
       // check the destination
       const userRows = await client.asyncQuery("SELECT * FROM output_users");
@@ -617,6 +622,10 @@ describe("integration/runs/mysql", () => {
         )
       );
 
+      // check the run's completion percentage (before the run is complete)
+      await run.determinePercentComplete();
+      expect(run.percentComplete).toBe(100);
+
       // check if the run is done
       const foundRunDetermineStateTasks = await specHelper.findEnqueuedTasks(
         "run:determineState"
@@ -641,6 +650,7 @@ describe("integration/runs/mysql", () => {
       expect(run.highWaterMark).toEqual({ id: "10" });
       expect(run.sourceOffset).toBe("0");
       expect(run.error).toBeFalsy();
+      expect(run.percentComplete).toBe(100);
 
       // check the destination
       const userRows = await client.asyncQuery("SELECT * FROM output_users");

--- a/plugins/@grouparoo/mysql/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mysql/src/initializers/plugin.ts
@@ -15,6 +15,7 @@ import { profiles as tableProfiles } from "../lib/table-import/profiles";
 import { profileProperty as tableProfileProperty } from "../lib/table-import/profileProperty";
 import { profilePropertyRuleOptions as tableProfilePropertyRuleOptions } from "../lib/table-import/profilePropertyRuleOptions";
 import { scheduleOptions as tableScheduleOptions } from "../lib/table-import/scheduleOptions";
+import { sourceRunPercentComplete as tableSourceRunPercentComplete } from "../lib/table-import/sourceRunPercentComplete";
 
 import { sourceOptions as querySourceOptions } from "../lib/query-import/sourceOptions";
 import { profileProperty as queryProfileProperty } from "../lib/query-import/profileProperty";
@@ -78,6 +79,7 @@ export class Plugins extends Initializer {
             uniqueProfilePropertyRuleBootstrapOptions: tableUniqueProfilePropertyRuleBootstrapOptions,
             profiles: tableProfiles,
             profileProperty: tableProfileProperty,
+            sourceRunPercentComplete: tableSourceRunPercentComplete,
           },
         },
         {

--- a/plugins/@grouparoo/mysql/src/lib/connect.ts
+++ b/plugins/@grouparoo/mysql/src/lib/connect.ts
@@ -34,7 +34,16 @@ export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
     });
   };
 
-  const asyncEnd = promisify(client.end).bind(client);
+  const asyncEnd = async function () {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        client.end((error) => {
+          if (error) return reject(error);
+          return resolve();
+        });
+      }, 1000);
+    });
+  };
 
   return Object.assign(client, { asyncQuery, asyncEnd });
 };

--- a/plugins/@grouparoo/mysql/src/lib/table-import/sourceRunPercentComplete.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/sourceRunPercentComplete.ts
@@ -1,0 +1,26 @@
+import { SourceRunPercentCompleteMethod } from "@grouparoo/core";
+
+export const sourceRunPercentComplete: SourceRunPercentCompleteMethod = async ({
+  source,
+  scheduleOptions,
+  highWaterMark,
+  connection,
+  run,
+}) => {
+  const { table } = await source.parameterizedOptions(run);
+  const sortColumn = scheduleOptions.column;
+  const where = highWaterMark[sortColumn]
+    ? `\`${sortColumn}\` >= "${highWaterMark[sortColumn]}"`
+    : null;
+
+  const rows = await connection.asyncQuery(
+    `SELECT COUNT (*) AS __count FROM ?? ${where ? `WHERE ${where}` : ""}`,
+    [table]
+  );
+  const total = parseInt(rows[0].__count);
+
+  const percentComplete =
+    total > 0 ? Math.floor((run.profilesImported / total) * 100) : 100;
+
+  return percentComplete;
+};

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
@@ -476,6 +476,10 @@ describe("integration/runs/postgres", () => {
         )
       );
 
+      // check the run's completion percentage (before the run is complete)
+      await run.determinePercentComplete();
+      expect(run.percentComplete).toBe(100);
+
       // check if the run is done
       const foundRunDetermineStateTasks = await specHelper.findEnqueuedTasks(
         "run:determineState"
@@ -500,6 +504,7 @@ describe("integration/runs/postgres", () => {
       expect(run.highWaterMark).toEqual({ id: "10" });
       expect(run.sourceOffset).toBe("0");
       expect(run.error).toBeFalsy();
+      expect(run.percentComplete).toBe(100);
 
       // check the destination
       const userRows = await api.sequelize.query(
@@ -611,6 +616,10 @@ describe("integration/runs/postgres", () => {
         )
       );
 
+      // check the run's completion percentage (before the run is complete)
+      await run.determinePercentComplete();
+      expect(run.percentComplete).toBe(100);
+
       // check if the run is done
       const foundRunDetermineStateTasks = await specHelper.findEnqueuedTasks(
         "run:determineState"
@@ -635,6 +644,7 @@ describe("integration/runs/postgres", () => {
       expect(run.highWaterMark).toEqual({ id: "10" });
       expect(run.sourceOffset).toBe("0");
       expect(run.error).toBeFalsy();
+      expect(run.percentComplete).toBe(100);
 
       // check the destination
       const userRows = await api.sequelize.query(

--- a/plugins/@grouparoo/postgres/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/postgres/src/initializers/plugin.ts
@@ -15,6 +15,7 @@ import { profiles as tableProfiles } from "../lib/table-import/profiles";
 import { profileProperty as tableProfileProperty } from "../lib/table-import/profileProperty";
 import { profilePropertyRuleOptions as tableProfilePropertyRuleOptions } from "../lib/table-import/profilePropertyRuleOptions";
 import { scheduleOptions as tableScheduleOptions } from "../lib/table-import/scheduleOptions";
+import { sourceRunPercentComplete as tableSourceRunPercentComplete } from "../lib/table-import/sourceRunPercentComplete";
 
 import { sourceOptions as querySourceOptions } from "../lib/query-import/sourceOptions";
 import { profileProperty as queryProfileProperty } from "../lib/query-import/profileProperty";
@@ -84,6 +85,7 @@ export class Plugins extends Initializer {
             uniqueProfilePropertyRuleBootstrapOptions: tableUniqueProfilePropertyRuleBootstrapOptions,
             profiles: tableProfiles,
             profileProperty: tableProfileProperty,
+            sourceRunPercentComplete: tableSourceRunPercentComplete,
           },
         },
         {

--- a/plugins/@grouparoo/postgres/src/lib/table-import/sourceRunPercentComplete.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/sourceRunPercentComplete.ts
@@ -1,0 +1,31 @@
+import { validateQuery } from "../validateQuery";
+import format from "pg-format";
+import { SourceRunPercentCompleteMethod } from "@grouparoo/core";
+
+export const sourceRunPercentComplete: SourceRunPercentCompleteMethod = async ({
+  source,
+  scheduleOptions,
+  highWaterMark,
+  connection,
+  run,
+}) => {
+  const { table } = await source.parameterizedOptions(run);
+  const sortColumn = scheduleOptions.column;
+  const where = highWaterMark[sortColumn]
+    ? format("%I >= %L", sortColumn, highWaterMark[sortColumn])
+    : null;
+
+  const totalResult = await connection.query(
+    validateQuery(
+      where
+        ? format(`SELECT COUNT (*) AS __count FROM %I WHERE %s`, table, where)
+        : format(`SELECT COUNT (*) AS __count FROM %I`, table)
+    )
+  );
+  const total = parseInt(totalResult.rows[0].__count);
+
+  const percentComplete =
+    total > 0 ? Math.floor((run.profilesImported / total) * 100) : 100;
+
+  return percentComplete;
+};


### PR DESCRIPTION
* When changing the filter for Runs#list, reset the offest (pagination) to 0 
* Runs can be stopped manually
* Runs for a Schedule can set their own percent completion

TODO:
- [x] Move on-demand % complete calculations to Run Status task (and store in DB)
- [x] Tests for `sourceRunPercentComplete`