### PR TITLE
Display and import updates for manual profile properties

### DIFF
--- a/core/api/__tests__/models/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRule.ts
@@ -143,33 +143,6 @@ describe("models/profilePropertyRule", () => {
     });
   });
 
-  test("creating a profile property rule for a manual app did enqueue an internalRun", async () => {
-    await api.resque.queue.connection.redis.flushdb();
-
-    const app = await helper.factories.app();
-    await app.update({ type: "manual" });
-    const source = await helper.factories.source(app);
-    await source.setOptions({ table: "some table" });
-    await source.setMapping({ id: "userId" });
-    await source.update({ state: "ready" });
-
-    const profilePropertyRule = await ProfilePropertyRule.create({
-      sourceGuid: source.guid,
-      key: "thing",
-      type: "string",
-      unique: false,
-    });
-
-    const foundTasks = await specHelper.findEnqueuedTasks("run:internalRun");
-    expect(foundTasks.length).toBe(1);
-
-    await profilePropertyRule.destroy();
-    await specHelper.deleteEnqueuedTasks(
-      "run:internalRun",
-      foundTasks[0].args[0]
-    );
-  });
-
   test("updating a profile property rule with new options enqueued an internalRun and update groups relying on it", async () => {
     await api.resque.queue.connection.redis.flushdb();
     const rule = await ProfilePropertyRule.findOne({ where: { key: "email" } });

--- a/core/api/src/initializers/plugins.ts
+++ b/core/api/src/initializers/plugins.ts
@@ -51,6 +51,12 @@ export class Plugins extends Initializer {
           app: "manual",
           description: "manually update the properties of a profile",
           options: [],
+          profilePropertyRuleOptions: [],
+          methods: {
+            sourceOptions: async () => {
+              return {};
+            },
+          },
         },
       ],
     });

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -400,15 +400,6 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
     return this.clearCache();
   }
 
-  @AfterCreate
-  static async buildManualProfileProperties(instance: ProfilePropertyRule) {
-    const source = await instance.$get("source");
-    const app = await source.$get("app");
-    if (app.type === "manual") {
-      await internalRun("profilePropertyRule", instance.guid);
-    }
-  }
-
   @BeforeDestroy
   static async ensureNotInUse(instance: ProfilePropertyRule) {
     const groupRule = await GroupRule.findOne({

--- a/core/web/components/profile/arrayProfilePropertyList.tsx
+++ b/core/web/components/profile/arrayProfilePropertyList.tsx
@@ -13,7 +13,8 @@ export default function ArrayProfilePropertyList({
 
   const formattedValues = values.map((value) => {
     if (value === true || value === false) {
-      return <input type="checkbox" checked={value} readOnly />;
+      // return <input type="checkbox" checked={value} readOnly />;
+      return value.toString();
     } else if (type === "date") {
       return value ? new Date(value).toLocaleString() : value;
     } else {
@@ -21,8 +22,9 @@ export default function ArrayProfilePropertyList({
     }
   });
 
-  if (formattedValues.length <= 10)
+  if (formattedValues.length <= 10) {
     return <span>{formattedValues.join(", ")}</span>;
+  }
 
   const firstChunk = formattedValues.slice(0, 10);
   const lastChunk = formattedValues.slice(9);

--- a/core/web/pages/profile/[guid]/edit.tsx
+++ b/core/web/pages/profile/[guid]/edit.tsx
@@ -134,7 +134,7 @@ export default function Page(props) {
     .map((app) => app.guid);
 
   profilePropertyRules.forEach((rule) => {
-    if (manualAppGuids.indexOf(rule.appGuid) >= 0) {
+    if (manualAppGuids.includes(rule.source.app.guid)) {
       manualProperties.push(rule.key);
     }
   });
@@ -301,14 +301,14 @@ export default function Page(props) {
                       <span style={{ fontWeight: "bold" }}>{key}</span>
                     </td>
                     <td>
-                      {manualProperties.indexOf(key) >= 0 ? (
+                      {manualProperties.includes(key) ? (
                         <Form>
                           <Form.Group controlId={key}>
                             <Form.Control
                               required
                               type="text"
                               value={
-                                properties[key].values.length > 0
+                                properties[key].values.length === 0
                                   ? ""
                                   : properties[key].values.join(", ")
                               }
@@ -330,10 +330,6 @@ export default function Page(props) {
                       ) : (
                         <span>
                           <strong>
-                            {/* {renderProperty(
-                              properties[key].values,
-                              properties[key].type
-                            )} */}
                             <ArrayProfilePropertyList
                               type={properties[key].type}
                               values={properties[key].values}


### PR DESCRIPTION
This PR fixes a few bugs related to the manual App and related Profile Property Rules that were introduced when Array Profile Properties were added.   It is once again possible to add/edit manual Profile Properties

<img width="1427" alt="Screen Shot 2020-08-06 at 10 57 53 AM" src="https://user-images.githubusercontent.com/303226/89565658-ba2ffd80-d7d3-11ea-9b9d-12f9eb596620.png">
