### PR TITLE
Display UI Errors in custom error component

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -6085,6 +6085,14 @@
         }
       }
     },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "es-abstract": {
       "version": "1.17.6",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
@@ -15518,6 +15526,14 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
+    "stack-generator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -15538,6 +15554,37 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
+      }
+    },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+    },
+    "stacktrace-gps": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+      "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.1.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "requires": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
       }
     },
     "stacktrace-parser": {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1503,11 +1503,6 @@
         "prop-types": "^15.7.2"
       }
     },
-    "@grouparoo/client-web": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@grouparoo/client-web/-/client-web-0.1.8.tgz",
-      "integrity": "sha512-78WCrTbsEviID1TRp4PiOg74S7OjO1CY3TiQ9DlYMJhul/Tzpaa/soa+SHgxhHOiM6ZQeq0xoehGYMVenHa/DA=="
-    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -3090,6 +3085,11 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+    },
+    "@zeit/next-source-maps": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@zeit/next-source-maps/-/next-source-maps-0.0.3.tgz",
+      "integrity": "sha512-gFDf7yQI8r/fdzTKJG9cp0rhKscRJWs/uebhScj8nZINT16kPTVm23JAi5EivO5pAJmHGzT1A8dwxAhTX0liNw=="
     },
     "abab": {
       "version": "2.0.3",

--- a/core/package.json
+++ b/core/package.json
@@ -45,6 +45,7 @@
     "@fortawesome/react-fontawesome": "0.1.11",
     "@grouparoo/client-web": "^0.1.9-alpha.0",
     "@nivo/line": "0.62.0",
+    "@zeit/next-source-maps": "0.0.3",
     "actionhero": "23.0.5",
     "ah-next-plugin": "0.3.0",
     "ah-sequelize-plugin": "2.2.2",

--- a/core/package.json
+++ b/core/package.json
@@ -81,6 +81,7 @@
     "reflect-metadata": "0.1.13",
     "sequelize": "5.22.3",
     "sequelize-typescript": "1.1.0",
+    "stacktrace-js": "^2.0.2",
     "swagger-ui": "3.31.1",
     "ts-node-dev": "1.0.0-pre.56",
     "type-fest": "0.16.0",

--- a/core/web/next.config.js
+++ b/core/web/next.config.js
@@ -6,6 +6,8 @@ const {
 } = require("../api/src/utils/pluginDetails");
 require("./plugins"); // prepare plugins
 
+const withSourceMaps = require("@zeit/next-source-maps");
+
 const nodeModulesPath = path.join(
   path.dirname(require.resolve("react/package.json")),
   ".."
@@ -36,7 +38,7 @@ pluginManifest.plugins.forEach((plugin) => {
   }
 });
 
-module.exports = {
+module.exports = withSourceMaps({
   env,
 
   webpack: (config, options) => {
@@ -62,7 +64,7 @@ module.exports = {
 
     return config;
   },
-};
+});
 
 /**
  * This method exits to allow next.js/babel to transpile files within node_modules... which is how Grouparoo is deployed!

--- a/core/web/pages/_app.tsx
+++ b/core/web/pages/_app.tsx
@@ -43,7 +43,7 @@ const profilePropertyRulesHandler = new ProfilePropertyRulesHandler();
 require("../components/icons");
 
 export default function GrouparooWebApp(props) {
-  const { Component } = props;
+  const { Component, pageProps, err } = props;
   const [routerReady, setRouterReady] = useState(false);
   const [previousPath, setPreviousPath] = useState("");
   const router = useRouter();
@@ -68,7 +68,7 @@ export default function GrouparooWebApp(props) {
     };
   }, [pathname, query]);
 
-  const combinedProps = Object.assign({}, props.pageProps || {}, {
+  const combinedProps = Object.assign({}, pageProps || {}, {
     currentTeamMember: props.currentTeamMember,
     navigation: props.navigation,
     navigationMode: props.navigationMode,
@@ -96,7 +96,7 @@ export default function GrouparooWebApp(props) {
   return (
     <Injection {...combinedProps}>
       <Layout display={routerReady} {...combinedProps}>
-        <Component {...combinedProps} />
+        <Component {...combinedProps} err={err} />
       </Layout>
     </Injection>
   );

--- a/core/web/pages/_error.tsx
+++ b/core/web/pages/_error.tsx
@@ -1,0 +1,65 @@
+import { Alert } from "react-bootstrap";
+import { Fragment, useState, useEffect } from "react";
+import StackTrace from "stacktrace-js";
+
+export default function ErrorPage({ err, statusCode }) {
+  const [stringifiedStack, setStringifiedStack] = useState(
+    "Loading source map..."
+  );
+
+  useEffect(() => {
+    parseError();
+  }, []);
+
+  function parseError() {
+    StackTrace.fromError(err)
+      .then((stackFrames) => {
+        const _stringifiedStack = stackFrames
+          .map((sf) => sf.toString().replace(/webpack:\/\/_\w_\w/g, "")) // this would match a prefix like "webpack://_N_E"
+          .join("\n");
+        setStringifiedStack(_stringifiedStack);
+      })
+      .catch(console.error);
+  }
+
+  return (
+    <>
+      <Alert variant="danger">
+        <Alert.Heading>
+          {err.message} {statusCode ? `, status code: ${statusCode}` : null}
+        </Alert.Heading>
+
+        <strong>An error has occurred at:</strong>
+
+        <pre
+          style={{
+            color: "white",
+            backgroundColor: "black",
+            borderRadius: 5,
+            padding: 10,
+          }}
+        >
+          {stringifiedStack.split("\n").map((line, idx) => {
+            return (
+              <Fragment key={`error-stack-${idx}`}>
+                <span
+                  className={
+                    line.includes("node_modules") ? "text-muted" : null
+                  }
+                >
+                  {line}
+                </span>
+                <br />
+              </Fragment>
+            );
+          })}
+        </pre>
+      </Alert>
+    </>
+  );
+}
+
+ErrorPage.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  return { statusCode };
+};

--- a/core/web/pages/_error.tsx
+++ b/core/web/pages/_error.tsx
@@ -24,12 +24,14 @@ export default function ErrorPage({ err, statusCode }) {
 
   return (
     <>
+      <h1>An Error has Occurred</h1>
+
       <Alert variant="danger">
         <Alert.Heading>
           {err.message} {statusCode ? `, status code: ${statusCode}` : null}
         </Alert.Heading>
 
-        <strong>An error has occurred at:</strong>
+        <strong>Error Details:</strong>
 
         <pre
           style={{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1154,9 +1154,9 @@
 			}
 		},
 		"@npmcli/run-script": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.3.1.tgz",
-			"integrity": "sha512-9Ea57XJjNLtBFRAaiKqqdoqRrL2QkM0vvCbMjPecljhog5IHupStPtZULbl0CoGN00N3lhLWJ4PaIEC0MGjqJw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.4.0.tgz",
+			"integrity": "sha512-evlD0Ur2ILGyTP7FfMYi90x80bto9+nEbGjoWzdF+gmIX3HuA1nW0Ghj91JFaTJAHiXnDEEduZS24oAve/aeOA==",
 			"dev": true,
 			"requires": {
 				"@npmcli/promise-spawn": "^1.2.0",
@@ -2595,9 +2595,9 @@
 			}
 		},
 		"commander": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.0.0.tgz",
+			"integrity": "sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA==",
 			"dev": true
 		},
 		"compare-func": {
@@ -6453,12 +6453,6 @@
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
 		},
-		"nested-error-stacks": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz",
-			"integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
-			"dev": true
-		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -6561,26 +6555,25 @@
 			}
 		},
 		"npm-check-updates": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-7.0.2.tgz",
-			"integrity": "sha512-MyH17fUCFbYShuIyxZj6yqB6YZ47+AjPCgXQiH1oqNe3vElBoJ0toY7nwy88qJbfXnFqjTFigzs9lsoKSK0iUw==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-7.0.3.tgz",
+			"integrity": "sha512-20R5Zp5H/3Uw3VAeYAwuEECtA4ML5QxaMVCsKviFZtN5p2ONDeXQT18+31vughQEDexDyNWRDU7JwwPeao2apA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0",
 				"cint": "^8.2.1",
 				"cli-table": "^0.3.1",
-				"commander": "^5.1.0",
+				"commander": "^6.0.0",
 				"find-up": "4.1.0",
 				"get-stdin": "^8.0.0",
 				"json-parse-helpfulerror": "^1.0.3",
 				"libnpmconfig": "^1.2.1",
 				"lodash": "^4.17.19",
 				"p-map": "^4.0.0",
-				"pacote": "^11.1.10",
+				"pacote": "^11.1.11",
 				"progress": "^2.0.3",
 				"prompts": "^2.3.2",
 				"rc-config-loader": "^3.0.0",
-				"requireg": "^0.2.2",
 				"semver": "^7.3.2",
 				"semver-utils": "^1.1.4",
 				"spawn-please": "^0.3.0",
@@ -8223,28 +8216,6 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
-		},
-		"requireg": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/requireg/-/requireg-0.2.2.tgz",
-			"integrity": "sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==",
-			"dev": true,
-			"requires": {
-				"nested-error-stacks": "~2.0.1",
-				"rc": "~1.2.7",
-				"resolve": "~1.7.1"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.7.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-					"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.5"
-					}
-				}
-			}
 		},
 		"resolve": {
 			"version": "1.16.1",


### PR DESCRIPTION
This Pull Request adds the ability to render UI errors in a custom component, complete with SourceMap resolution back to the original file names and line numbers when running the minified "production" version of the codebase.  

![Screen Shot 2020-08-07 at 5 03 42 PM](https://user-images.githubusercontent.com/303226/89697211-052f3b00-d8d0-11ea-88f4-b222908212ee.png)

* React/Next already use [React Error Boundaries](https://reactjs.org/docs/error-boundaries.html), so errors are able to be trapped without crashing the application.  
* This Pull Request enables SourceMap generation in "production" mode via `@zeit/next-source-maps`.  Normally, it might be a risk to expose sourcemaps to a production application, but since Grouparoo is already open-source, the risk here is low
* We then use [stacktrace-js](http://www.stacktracejs.com/) which is able to take JS error object and asynchronously resolve it's SourceMap and original line numbers. 
* Finally, we render everything in a new `_error.tsx` page, bypassing the default `_error` page provided by next

Note, the new `_error` page does not change the more helpful default behavior in `npm run dev` mode... it is only used in "production" mode (https://nextjs.org/docs/advanced-features/custom-error-page#customizing-the-error-page). 