### PR TITLE
Identifying Profile Property

### DIFF
--- a/core/api/__tests__/actions/profiles.ts
+++ b/core/api/__tests__/actions/profiles.ts
@@ -469,9 +469,7 @@ describe("actions/profiles", () => {
         expect(simpleProfileValues(profiles[0].properties).email).toEqual([
           "peach@mushroom-kingdom.gov",
         ]);
-        expect(
-          simpleProfileValues(profiles[0].properties).userId
-        ).toBeUndefined();
+        expect(simpleProfileValues(profiles[0].properties).userId).toEqual([4]);
         expect(total).toBe(1);
       });
 
@@ -490,9 +488,7 @@ describe("actions/profiles", () => {
         expect(simpleProfileValues(profiles[0].properties).email).toEqual([
           "peach@mushroom-kingdom.gov",
         ]);
-        expect(
-          simpleProfileValues(profiles[0].properties).userId
-        ).toBeUndefined();
+        expect(simpleProfileValues(profiles[0].properties).userId).toEqual([4]);
         expect(total).toBe(1);
       });
 

--- a/core/api/__tests__/models/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRule.ts
@@ -141,6 +141,17 @@ describe("models/profilePropertyRule", () => {
         })
       ).rejects.toThrow(/unique profile properties cannot be arrays/);
     });
+
+    test("only one profile property rule can be identifying", async () => {
+      // the bootstrapped rule is already identifying
+
+      await expect(
+        ProfilePropertyRule.create({
+          sourceGuid: source.guid,
+          identifying: true,
+        })
+      ).rejects.toThrow(/only one profile property rule can be identifying/);
+    });
   });
 
   test("updating a profile property rule with new options enqueued an internalRun and update groups relying on it", async () => {

--- a/core/api/__tests__/models/source.ts
+++ b/core/api/__tests__/models/source.ts
@@ -425,6 +425,14 @@ describe("models/source", () => {
       await source.destroy();
     });
 
+    test("it can remove identifying from other profile property rules", async () => {
+      const rule = await ProfilePropertyRule.findOne({
+        where: { identifying: true },
+      });
+      rule.identifying = false;
+      await rule.save();
+    });
+
     test("bootstrapUniqueProfilePropertyRule will create a new profile property rule", async () => {
       const rule = await source.bootstrapUniqueProfilePropertyRule(
         "uniqueId",
@@ -434,6 +442,8 @@ describe("models/source", () => {
 
       expect(rule.key).toBe("uniqueId");
       expect(rule.type).toBe("integer");
+      expect(rule.isArray).toBe(false);
+      expect(rule.identifying).toBe(true);
       expect(rule.state).toBe("ready");
       expect(rule.unique).toBe(true);
 

--- a/core/api/src/actions/profilePropertyRules.ts
+++ b/core/api/src/actions/profilePropertyRules.ts
@@ -127,6 +127,7 @@ export class ProfilePropertyRuleCreate extends AuthenticatedAction {
       type: { required: true },
       unique: { required: false },
       isArray: { required: false },
+      identifying: { required: false },
       state: { required: false },
       sourceGuid: { required: false },
       options: { required: false },
@@ -140,6 +141,7 @@ export class ProfilePropertyRuleCreate extends AuthenticatedAction {
       type: params.type,
       unique: params.unique,
       isArray: params.isArray,
+      identifying: params.identifying,
       sourceGuid: params.sourceGuid,
     });
 
@@ -165,6 +167,7 @@ export class ProfilePropertyRuleEdit extends AuthenticatedAction {
       type: { required: false },
       unique: { required: false },
       isArray: { required: false },
+      identifying: { required: false },
       state: { required: false },
       sourceGuid: { required: false },
       options: { required: false },
@@ -319,6 +322,8 @@ export class ProfilePropertyRuleProfilePreview extends AuthenticatedAction {
       values: newPropertyValues,
       type: profilePropertyRule.type,
       unique: profilePropertyRule.unique,
+      isArray: profilePropertyRule.isArray,
+      identifying: profilePropertyRule.identifying,
       createdAt: new Date(),
       updatedAt: new Date(),
     };

--- a/core/api/src/actions/profiles.ts
+++ b/core/api/src/actions/profiles.ts
@@ -111,7 +111,10 @@ export class ProfilesList extends AuthenticatedAction {
 
       response.total = total;
       response.profiles = await Promise.all(
-        profiles.map(async (p) => p.apiData())
+        profiles.map(async (p) => {
+          const profile = await Profile.findByGuid(p.guid);
+          return profile.apiData();
+        })
       );
     }
   }

--- a/core/api/src/migrations/000035-identifyingProfilePropertyRule.ts
+++ b/core/api/src/migrations/000035-identifyingProfilePropertyRule.ts
@@ -1,0 +1,17 @@
+module.exports = {
+  up: async function (migration, DataTypes) {
+    await migration.addColumn("profilePropertyRules", "identifying", {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await migration.changeColumn("profilePropertyRules", "identifying", {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+    });
+  },
+
+  down: async function (migration) {
+    await migration.removeColumn("profilePropertyRules", "identifying");
+  },
+};

--- a/core/api/src/modules/ops/profile.ts
+++ b/core/api/src/modules/ops/profile.ts
@@ -13,6 +13,8 @@ export interface ProfilePropertyType {
     values: Array<string | number | boolean | Date>;
     type: string;
     unique: boolean;
+    isArray: boolean;
+    identifying: boolean;
     createdAt: Date;
     updatedAt: Date;
   };
@@ -41,6 +43,8 @@ export namespace ProfileOps {
             values: [],
             type: rule.type,
             unique: rule.unique,
+            isArray: rule.isArray,
+            identifying: rule.identifying,
             createdAt: profileProperties[i].createdAt,
             updatedAt: profileProperties[i].updatedAt,
           };

--- a/core/api/src/modules/ops/source.ts
+++ b/core/api/src/modules/ops/source.ts
@@ -219,12 +219,17 @@ export namespace SourceOps {
       state: "ready",
       unique: true,
       sourceGuid: source.guid,
+      isArray: false,
+      identifying: true,
     });
 
     try {
       // manually run the hooks we want
       ProfilePropertyRule.generateGuid(rule);
+      await ProfilePropertyRule.ensureType(rule);
       await ProfilePropertyRule.ensureUniqueKey(rule);
+      await ProfilePropertyRule.ensureNonArrayAndUnique(rule);
+      await ProfilePropertyRule.ensureOneIdentifyingProperty(rule);
 
       // @ts-ignore
       // danger zone!

--- a/core/web/components/profile/getProfileDisplayName.ts
+++ b/core/web/components/profile/getProfileDisplayName.ts
@@ -2,27 +2,11 @@ import { ProfileAPIData } from "../../utils/apiData";
 
 export default function getProfileDisplayName(profile: ProfileAPIData) {
   const propertiesArray = [];
-  for (const k in profile.properties) {
-    const hash = profile.properties[k];
-    hash["key"] = k;
-    propertiesArray.push(hash);
-  }
-
   let displayName = profile.guid;
 
-  const uniqueProperties = propertiesArray
-    .filter((prp) => prp.unique)
-    .filter((prp) => prp.values.length > 0);
-
-  if (uniqueProperties.length > 0) {
-    const emailProperties = uniqueProperties.filter(
-      (prp) => prp.type === "email"
-    );
-
-    if (emailProperties.length > 0) {
-      displayName = emailProperties[0].values[0] || "Anonymous Profile";
-    } else {
-      displayName = uniqueProperties[0].values[0] || "Anonymous Profile";
+  for (const key in profile.properties) {
+    if (profile.properties[key].identifying) {
+      displayName = profile.properties[key].values.join(", ");
     }
   }
 

--- a/core/web/components/profile/getProfileDisplayName.ts
+++ b/core/web/components/profile/getProfileDisplayName.ts
@@ -8,18 +8,23 @@ export default function getProfileDisplayName(profile: ProfileAPIData) {
     propertiesArray.push(hash);
   }
 
-  let name = profile.guid;
-  const uniqueProperties = propertiesArray.filter((prp) => prp.unique);
+  let displayName = profile.guid;
+
+  const uniqueProperties = propertiesArray
+    .filter((prp) => prp.unique)
+    .filter((prp) => prp.values.length > 0);
+
   if (uniqueProperties.length > 0) {
     const emailProperties = uniqueProperties.filter(
       (prp) => prp.type === "email"
     );
-    if (emailProperties) {
-      name = emailProperties[0].values[0] || "Anonymous Profile";
+
+    if (emailProperties.length > 0) {
+      displayName = emailProperties[0].values[0] || "Anonymous Profile";
     } else {
-      name = uniqueProperties[0].values[0] || "Anonymous Profile";
+      displayName = uniqueProperties[0].values[0] || "Anonymous Profile";
     }
   }
 
-  return name;
+  return displayName;
 }

--- a/core/web/components/profile/list.tsx
+++ b/core/web/components/profile/list.tsx
@@ -81,13 +81,6 @@ export default function ProfilesList(props) {
     Router[routerMethod](Router.route, url, { shallow: true });
   }
 
-  const uniqueProfileProperties = [];
-  profilePropertyRules.forEach((rule) => {
-    if (rule.unique) {
-      uniqueProfileProperties.push(rule.key);
-    }
-  });
-
   async function autocompleteProfilePropertySearch(
     match,
     _searchKey = searchKey
@@ -113,6 +106,15 @@ export default function ProfilesList(props) {
     }
     setSearchLoading(false);
   }
+
+  const identifyingProfileProperty = profilePropertyRules.filter(
+    (rule) => rule.identifying
+  )[0];
+
+  const uniqueProfilePropertyKeys = profilePropertyRules
+    .filter((rule) => rule.guid !== identifyingProfileProperty.guid)
+    .filter((rule) => rule.unique)
+    .map((rule) => rule.key);
 
   return (
     <>
@@ -223,45 +225,52 @@ export default function ProfilesList(props) {
                     href="/profile/[guid]/edit"
                     as={`/profile/${profile.guid}/edit`}
                   >
-                    <a>
-                      {uniqueProfileProperties.map((key) => {
-                        if (!profile.properties[key]) {
-                          return null;
-                        }
-
-                        return (
-                          <div key={`key-${profile.guid}-${key}`}>
-                            <span className="text-muted">
-                              {key}:{" "}
-                              <ArrayProfilePropertyList
-                                type={profile.properties[key].type}
-                                values={profile.properties[key].values}
-                              />
-                            </span>
-                            <br />
-                          </div>
-                        );
-                      })}
-                      {searchKey === "" ? null : (
-                        <div key={`key-${profile.guid}-${searchKey}`}>
-                          <span className="text-muted">
-                            {searchKey}:{" "}
-                            {profile.properties[searchKey] ? (
-                              <ArrayProfilePropertyList
-                                type={profile.properties[searchKey].type}
-                                values={profile.properties[searchKey].values}
-                              />
-                            ) : null}
-                          </span>
+                    <a className="text-muted">
+                      {identifyingProfileProperty.key &&
+                      profile.properties[identifyingProfileProperty.key] ? (
+                        <>
+                          {identifyingProfileProperty.key}:{" "}
+                          {profile.properties[
+                            identifyingProfileProperty.key
+                          ].values.join(", ")}{" "}
                           <br />
-                        </div>
-                      )}
-
-                      <span className="text-muted">
-                        Grouparoo Guid: {profile.guid}
-                      </span>
+                        </>
+                      ) : null}
+                      <span>Grouparoo Guid: {profile.guid}</span>
                     </a>
                   </Link>
+                  {uniqueProfilePropertyKeys.map((key) => {
+                    if (!profile.properties[key]) {
+                      return null;
+                    }
+
+                    return (
+                      <div key={`key-${profile.guid}-${key}`}>
+                        <span className="text-muted">
+                          {key}:{" "}
+                          <ArrayProfilePropertyList
+                            type={profile.properties[key].type}
+                            values={profile.properties[key].values}
+                          />
+                        </span>
+                        <br />
+                      </div>
+                    );
+                  })}
+                  {searchKey === "" ? null : (
+                    <div key={`key-${profile.guid}-${searchKey}`}>
+                      <span className="text-muted">
+                        {searchKey}:{" "}
+                        {profile.properties[searchKey] ? (
+                          <ArrayProfilePropertyList
+                            type={profile.properties[searchKey].type}
+                            values={profile.properties[searchKey].values}
+                          />
+                        ) : null}
+                      </span>
+                      <br />
+                    </div>
+                  )}
                 </td>
                 <td>
                   <Moment fromNow>{profile.createdAt}</Moment>

--- a/core/web/pages/profilePropertyRule/[guid]/edit.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/edit.tsx
@@ -228,6 +228,14 @@ export default function Page(props) {
                 onChange={(e) => update(e)}
               />
             </Form.Group>
+            <Form.Group controlId="identifying">
+              <Form.Check
+                type="checkbox"
+                label="Identifying?"
+                checked={profilePropertyRule.identifying}
+                onChange={(e) => update(e)}
+              />
+            </Form.Group>
             <Form.Group controlId="sourceGuid">
               <Form.Label>Profile Property Rule Source</Form.Label>
               <Form.Control

--- a/core/web/pages/profilePropertyRules.tsx
+++ b/core/web/pages/profilePropertyRules.tsx
@@ -11,6 +11,8 @@ import Pagination from "../components/pagination";
 import LoadingTable from "../components/loadingTable";
 import StateBadge from "../components/stateBadge";
 
+import { ProfilePropertyRuleAPIData } from "../utils/apiData";
+
 export default function Page(props) {
   const { errorHandler, successHandler, query } = props;
   const { execApi } = useApi(props, errorHandler);
@@ -21,9 +23,9 @@ export default function Page(props) {
   const [newRuleSourceGuid, setNewRuleSourceGuid] = useState(
     props.sources[0]?.guid || ""
   );
-  const [profilePropertyRules, setProfilePropertyRules] = useState(
-    props.profilePropertyRules
-  );
+  const [profilePropertyRules, setProfilePropertyRules] = useState<
+    ProfilePropertyRuleAPIData[]
+  >(props.profilePropertyRules);
 
   // pagination
   const limit = 100;
@@ -110,6 +112,7 @@ export default function Page(props) {
             <th>Type</th>
             <th>Unique</th>
             <th>Is Array</th>
+            <th>Identifying</th>
             <th>Source</th>
             <th>State</th>
             <th>Example Values</th>
@@ -140,6 +143,7 @@ export default function Page(props) {
                 <td>{rule.type}</td>
                 <td>{rule.unique ? "✅" : null}</td>
                 <td>{rule.isArray ? "✅" : null}</td>
+                <td>{rule.identifying ? "✅" : null}</td>
                 <td>
                   <Link
                     href="/source/[guid]/overview"


### PR DESCRIPTION
One Profile Property Rule can be marked `identifying`, which will then be used throughout the UI as the main way to display the 'name' of the profile.  By default, the first Profile Property Rule Bootstrapped will be `identifying` (ie "User ID"), but this can be changed to be something else (like "Email Address") later on, as those Profile Property Rules are created and populated.

<img width="1449" alt="Screen Shot 2020-08-10 at 2 45 38 PM" src="https://user-images.githubusercontent.com/303226/89834705-35691a80-db18-11ea-81c8-958658944af7.png">
<img width="1449" alt="Screen Shot 2020-08-10 at 2 45 43 PM" src="https://user-images.githubusercontent.com/303226/89834717-3ac66500-db18-11ea-9b8a-ceba066b6aa7.png">
<img width="1449" alt="Screen Shot 2020-08-10 at 2 45 48 PM" src="https://user-images.githubusercontent.com/303226/89834722-3c902880-db18-11ea-8da7-691da20dc442.png">


Closes https://github.com/grouparoo/grouparoo/issues/586

- [x] Don't assume that all email-type properties have values (and are unique)
- [x] Allow for configuration to choose which property is used as the 'name' for the Profile 