### PR TITLE
Destination draining

### DIFF
--- a/core/api/src/migrations/000036-createExportRuns.ts
+++ b/core/api/src/migrations/000036-createExportRuns.ts
@@ -1,0 +1,46 @@
+module.exports = {
+  up: async function (migration, DataTypes) {
+    await migration.createTable("exportRuns", {
+      guid: {
+        type: DataTypes.STRING(40),
+        primaryKey: true,
+      },
+
+      exportGuid: {
+        type: DataTypes.STRING(40),
+        allowNull: false,
+      },
+
+      runGuid: {
+        type: DataTypes.STRING(40),
+        allowNull: false,
+      },
+
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+    });
+
+    await migration.addIndex("exportRuns", ["exportGuid", "runGuid"], {
+      unique: true,
+      fields: ["exportGuid", "runGuid"],
+    });
+
+    await migration.removeColumn("exports", "runGuids");
+  },
+
+  down: async function (migration, DataTypes) {
+    await migration.dropTable("exportRuns");
+
+    await migration.addColumn("exports", "runGuids", {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    });
+  },
+};

--- a/core/api/src/models/Export.ts
+++ b/core/api/src/models/Export.ts
@@ -17,9 +17,9 @@ import {
 import * as uuid from "uuid";
 import { Import } from "./Import";
 import { ExportImport } from "./ExportImport";
+import { ExportRun } from "./ExportRun";
 import { Destination } from "./Destination";
 import { Profile } from "./Profile";
-import { Run } from "./Run";
 import { plugin } from "../modules/plugin";
 import Moment from "moment";
 import { Op } from "sequelize";
@@ -52,22 +52,6 @@ export class Export extends Model<Export> {
   @ForeignKey(() => Profile)
   @Column
   profileGuid: string;
-
-  @AllowNull(true)
-  @ForeignKey(() => Run)
-  @Column(DataType.TEXT)
-  get runGuids(): string[] {
-    try {
-      //@ts-ignore
-      return JSON.parse(this.getDataValue("runGuids"));
-    } catch (e) {
-      return [];
-    }
-  }
-  set runGuids(value: string[]) {
-    //@ts-ignore
-    this.setDataValue("runGuids", JSON.stringify(value));
-  }
 
   @Column
   startedAt: Date;
@@ -151,6 +135,9 @@ export class Export extends Model<Export> {
   @BelongsToMany(() => Import, () => ExportImport)
   imports: Import[];
 
+  @HasMany(() => ExportRun)
+  exportRuns: ExportRun[];
+
   @BelongsTo(() => Profile)
   profile: Profile;
 
@@ -212,9 +199,14 @@ export class Export extends Model<Export> {
   @AfterDestroy
   static async destroyExportImports(instance: Export) {
     return ExportImport.destroy({
-      where: {
-        exportGuid: instance.guid,
-      },
+      where: { exportGuid: instance.guid },
+    });
+  }
+
+  @AfterDestroy
+  static async destroyExportRuns(instance: Export) {
+    return ExportRun.destroy({
+      where: { exportGuid: instance.guid },
     });
   }
 

--- a/core/api/src/models/ExportRun.ts
+++ b/core/api/src/models/ExportRun.ts
@@ -1,0 +1,70 @@
+import {
+  Model,
+  Table,
+  Column,
+  CreatedAt,
+  UpdatedAt,
+  AllowNull,
+  BeforeCreate,
+  BelongsTo,
+  ForeignKey,
+} from "sequelize-typescript";
+import * as uuid from "uuid";
+import { Run } from "./Run";
+import { Export } from "./Export";
+
+@Table({ tableName: "exportRuns", paranoid: false })
+export class ExportRun extends Model<ExportRun> {
+  guidPrefix() {
+    return "exr";
+  }
+
+  @Column({ primaryKey: true })
+  guid: string;
+
+  @CreatedAt
+  createdAt: Date;
+
+  @UpdatedAt
+  updatedAt: Date;
+
+  @AllowNull(false)
+  @ForeignKey(() => Export)
+  @Column
+  exportGuid: string;
+
+  @AllowNull(false)
+  @ForeignKey(() => Run)
+  @Column
+  runGuid: string;
+
+  @BelongsTo(() => Export)
+  export: Export;
+
+  @BelongsTo(() => Run)
+  run: Run;
+
+  async apiData() {
+    return {
+      exportGuid: this.exportGuid,
+      runGuid: this.runGuid,
+      createdAt: this.createdAt ? this.createdAt.getTime() : null,
+      updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,
+    };
+  }
+
+  // --- Class Methods --- //
+
+  static async findByGuid(guid: string) {
+    const instance = await this.scope(null).findOne({ where: { guid } });
+    if (!instance) throw new Error(`cannot find ${this.name} ${guid}`);
+    return instance;
+  }
+
+  @BeforeCreate
+  static generateGuid(instance) {
+    if (!instance.guid) {
+      instance.guid = `${instance.guidPrefix()}_${uuid.v4()}`;
+    }
+  }
+}

--- a/core/api/src/modules/telemetryReporters.ts
+++ b/core/api/src/modules/telemetryReporters.ts
@@ -20,6 +20,7 @@ import {
   Team,
   TeamMember,
 } from "../index";
+import { ExportRun } from "../models/ExportRun";
 
 export interface TelemetryMetric {
   // the possible attributes for a metric are:
@@ -157,10 +158,18 @@ export namespace TelemetryReporters {
           exports: await Export.count({
             where: { destinationGuid: destination.guid },
           }),
-          runs: await Export.count({
+          runs: await ExportRun.count({
             distinct: true,
-            col: "Export.runGuids",
-            where: { destinationGuid: destination.guid },
+            col: "runGuid",
+            include: [
+              {
+                model: Export,
+                where: { destinationGuid: destination.guid },
+                required: true,
+                attributes: [],
+              },
+            ],
+            logging: true,
           }),
         });
       }

--- a/core/web/components/tabs/destination.tsx
+++ b/core/web/components/tabs/destination.tsx
@@ -6,7 +6,7 @@ export default function DestinationTabs({
 }: {
   destination: DestinationAPIData;
 }) {
-  const tabs = ["edit", "data", "exports"];
+  const tabs = ["edit", "data", "runs", "exports"];
   return (
     <Tabs name={destination.name} draftType={destination.type} tabs={tabs} />
   );

--- a/core/web/pages/destination/[guid]/data.tsx
+++ b/core/web/pages/destination/[guid]/data.tsx
@@ -48,7 +48,7 @@ export default function Page(props) {
       await execApi("post", `/destination/${guid}/track`, {
         groupGuid: trackedGroupGuid,
       });
-    } else if (trackedGroupGuid === "_none") {
+    } else if (trackedGroupGuid === "_none" && !destination.trackAllGroups) {
       await execApi("post", `/destination/${guid}/untrack`);
     }
 

--- a/core/web/pages/destination/[guid]/runs.tsx
+++ b/core/web/pages/destination/[guid]/runs.tsx
@@ -1,0 +1,28 @@
+import Head from "next/head";
+import { useApi } from "../../../hooks/useApi";
+import DestinationTabs from "../../../components/tabs/destination";
+import RunsList from "../../../components/runs/list";
+
+export default function Page(props) {
+  const { destination } = props;
+
+  return (
+    <>
+      <Head>
+        <title>Grouparoo: Destination Runs</title>
+      </Head>
+
+      <DestinationTabs destination={destination} />
+
+      <RunsList {...props} />
+    </>
+  );
+}
+
+Page.getInitialProps = async (ctx) => {
+  const { execApi } = useApi(ctx);
+  const { guid } = ctx.query;
+  const { destination } = await execApi("get", `/destination/${guid}`);
+  const runsListInitialProps = await RunsList.hydrate(ctx);
+  return { destination, ...runsListInitialProps };
+};


### PR DESCRIPTION
This PR Links Destinations to Runs though a new `ExportRun` model.  `Group` -> `Run` -> `ExportRun` -> `Export` -> `Destination`.

In this way, we can now get a more direct link to the Runs that have exported a profile to a given destination.   This allows a few new features:

1. We can display a Destination's runs in the UI.  The "Creator" of the Runs remain the Group, but we can show which runs have exported a profile to this Destination.
 <img width="1641" alt="Screen Shot 2020-08-11 at 11 24 56 AM" src="https://user-images.githubusercontent.com/303226/89934359-4f146b80-dbc5-11ea-8079-0ec95abd463a.png">

2. We can prevent a Destination from being deleted if any run is still using it for a run
<img width="1662" alt="Screen Shot 2020-08-11 at 10 31 26 AM" src="https://user-images.githubusercontent.com/303226/89934409-5f2c4b00-dbc5-11ea-85c4-98ccc5469649.png">

3. We can prevent a Destination from being deleted if a Group which used to be tracked by this destination is updating.  This is the case when you've  _just_ told a Destination to track no Groups, but we are in the early phases of a Run for that group which still needs to tell the Destination to remove the Profiles it used to Track.  Once there are exports created, we are in condition `#2` above
<img width="1662" alt="Screen Shot 2020-08-11 at 10 40 16 AM" src="https://user-images.githubusercontent.com/303226/89934592-aadef480-dbc5-11ea-9e47-d2619b3685f8.png">


Closes T-54
Closes T-263