### PR TITLE
Do not export Profiles to Destinations if there are no changes (unless we are forcing the run)

### DIFF
--- a/core/api/__tests__/models/export.ts
+++ b/core/api/__tests__/models/export.ts
@@ -3,6 +3,8 @@ import { Destination } from "../../src/models/Destination";
 import { Profile } from "../../src/models/Profile";
 import { Export } from "../../src/models/Export";
 import { ExportImport } from "../../src/models/ExportImport";
+import { ExportRun } from "../../src/models/ExportRun";
+import { Op } from "sequelize";
 let actionhero;
 
 describe("models/export", () => {
@@ -100,11 +102,86 @@ describe("models/export", () => {
     await unrelatedExport.destroy();
   });
 
-  test("deleting the export should have deleted the exportImports", async () => {
-    await _export.destroy();
+  test("runs can be associated by ExportRuns", async () => {
+    const run = await helper.factories.run();
+    await destination.exportProfile(profile, [run], [], {}, {}, [], []);
 
-    const exportedImports = await ExportImport.findAll();
-    expect(exportedImports.length).toBe(0);
+    const exportRuns = await ExportRun.findAll({
+      where: { runGuid: run.guid },
+    });
+    expect(exportRuns.length).toBe(1);
+    expect(exportRuns[0].guid).not.toEqual(_export.guid);
+
+    const newExport = await Export.findByGuid(exportRuns[0].exportGuid);
+    await newExport.destroy();
+    await run.destroy();
+  });
+
+  test("exports can be marked as having changes or not", async () => {
+    const group = await helper.factories.group();
+    await group.addProfile(profile);
+    await destination.trackGroup(group);
+
+    const run = await helper.factories.run();
+    await run.update({ creatorType: "group", creatorGuid: group.guid });
+
+    const oldExport = await Export.create({
+      destinationGuid: destination.guid,
+      profileGuid: profile.guid,
+      startedAt: new Date(),
+      oldProfileProperties: {},
+      newProfileProperties: {},
+      oldGroups: [],
+      newGroups: [],
+      mostRecent: true,
+    });
+
+    await destination.exportProfile(
+      profile,
+      [run],
+      [],
+      {},
+      {},
+      [group],
+      [group]
+    );
+
+    const exportRuns = await ExportRun.findAll({
+      where: { runGuid: run.guid },
+    });
+    const newExport = await Export.findOne({
+      where: {
+        guid: {
+          [Op.and]: [
+            { [Op.in]: exportRuns.map((er) => er.exportGuid) },
+            { [Op.ne]: oldExport.guid },
+          ],
+        },
+      },
+    });
+
+    expect(newExport.hasChanges).toBe(false);
+    expect(newExport.toDelete).toBe(false);
+
+    await oldExport.destroy();
+    await newExport.destroy();
+    await run.destroy();
+  });
+
+  describe("deletion", () => {
+    beforeAll(async () => {
+      await _export.destroy();
+    });
+
+    test("deleting the export should have deleted the exportImports", async () => {
+      const exportedImports = await ExportImport.findAll();
+      expect(exportedImports.length).toBe(0);
+    });
+
+    test("deleting the export should have deleted the exportRuns", async () => {
+      const exportRuns = await ExportRun.findAll();
+      expect(exportRuns.length).toBe(0);
+    });
   });
 
   test("old entries can be swept away, not the newest one for each profile + destination", async () => {

--- a/core/api/__tests__/tasks/exports/send.ts
+++ b/core/api/__tests__/tasks/exports/send.ts
@@ -5,6 +5,7 @@ import { Group } from "./../../../src/models/Group";
 import { Destination } from "./../../../src/models/Destination";
 import { Export } from "./../../../src/models/Export";
 import { Run } from "./../../../src/models/Run";
+import { Json } from "sequelize/types/lib/utils";
 
 let actionhero;
 
@@ -29,7 +30,7 @@ describe("tasks/export:send", () => {
       expect(found.length).toEqual(1);
     });
 
-    describe("withing an export workflow", () => {
+    describe("within an export workflow", () => {
       let destination: Destination, group: Group, profile: Profile, run: Run;
 
       beforeAll(async () => {
@@ -50,7 +51,7 @@ describe("tasks/export:send", () => {
         );
         await destination.update({ state: "ready" });
 
-        await destination.exportGroupMembers();
+        await destination.exportGroupMembers(true);
         const foundGroupRunTasks = await specHelper.findEnqueuedTasks(
           "group:run"
         );

--- a/core/api/__tests__/tasks/groups/run.ts
+++ b/core/api/__tests__/tasks/groups/run.ts
@@ -288,5 +288,15 @@ describe("tasks/group:run", () => {
       expect((await group.$get("groupMembers")).length).toBe(0);
       await bowser.destroy();
     });
+
+    it("will set run.force if that option is provided to the task", async () => {
+      const group = await helper.factories.group();
+      await task.enqueue("group:run", { groupGuid: group.guid, force: true });
+      const foundTasks = await specHelper.findEnqueuedTasks("group:run");
+      await specHelper.runTask("group:run", foundTasks[0].args[0]);
+      const run = await Run.findOne({ where: { creatorGuid: group.guid } });
+      expect(run.state).toBe("running");
+      expect(run.force).toBe(true);
+    });
   });
 });

--- a/core/api/__tests__/utils/specHelper.ts
+++ b/core/api/__tests__/utils/specHelper.ts
@@ -28,6 +28,7 @@ import { Export } from "../../src/models/Export";
 import { Event } from "../../src/models/Event";
 import { EventData } from "../../src/models/EventData";
 import { ExportImport } from "../../src/models/ExportImport";
+import { ExportRun } from "../../src/models/ExportRun";
 import { Group } from "../../src/models/Group";
 import { GroupMember } from "../../src/models/GroupMember";
 import { GroupRule } from "../../src/models/GroupRule";
@@ -68,6 +69,7 @@ const models = [
   Event,
   EventData,
   ExportImport,
+  ExportRun,
   Log,
   Permission,
   Profile,

--- a/core/api/src/actions/destinations.ts
+++ b/core/api/src/actions/destinations.ts
@@ -294,13 +294,14 @@ export class DestinationExport extends AuthenticatedAction {
     this.permission = { topic: "destination", mode: "write" };
     this.inputs = {
       guid: { required: true },
+      force: { required: false, default: true },
     };
   }
 
   async run({ params, response }) {
     response.success = false;
     const destination = await Destination.findByGuid(params.guid);
-    await destination.exportGroupMembers();
+    await destination.exportGroupMembers(params.force);
     response.success = true;
   }
 }

--- a/core/api/src/migrations/000037-exportHasChanges.ts
+++ b/core/api/src/migrations/000037-exportHasChanges.ts
@@ -1,0 +1,28 @@
+module.exports = {
+  up: async function (migration, DataTypes) {
+    await migration.addColumn("exports", "hasChanges", {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    });
+    await migration.changeColumn("exports", "hasChanges", {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+    });
+
+    await migration.addColumn("runs", "force", {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    await migration.changeColumn("runs", "force", {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+    });
+  },
+
+  down: async function (migration) {
+    await migration.removeColumn("exports", "hasChanges");
+    await migration.removeColumn("runs", "force");
+  },
+};

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -220,8 +220,8 @@ export class Destination extends LoggedModel<Destination> {
     return OptionHelper.getPlugin(this);
   }
 
-  async exportGroupMembers() {
-    return DestinationOps.exportGroupMembers(this);
+  async exportGroupMembers(force = false) {
+    return DestinationOps.exportGroupMembers(this, force);
   }
 
   async trackGroup(group: Group) {
@@ -389,7 +389,8 @@ export class Destination extends LoggedModel<Destination> {
     newProfileProperties: { [key: string]: any[] },
     oldGroups: Array<Group>,
     newGroups: Array<Group>,
-    sync = false
+    sync = false,
+    force = false
   ) {
     return DestinationOps.exportProfile(
       this,
@@ -400,7 +401,8 @@ export class Destination extends LoggedModel<Destination> {
       newProfileProperties,
       oldGroups,
       newGroups,
-      sync
+      sync,
+      force
     );
   }
 

--- a/core/api/src/models/Export.ts
+++ b/core/api/src/models/Export.ts
@@ -119,10 +119,17 @@ export class Export extends Model<Export> {
   }
 
   @Default(false)
+  @AllowNull(false)
   @Column
   toDelete: boolean;
 
   @Default(false)
+  @AllowNull(false)
+  @Column
+  hasChanges: boolean;
+
+  @Default(false)
+  @AllowNull(false)
   @Column
   mostRecent: boolean;
 
@@ -183,6 +190,7 @@ export class Export extends Model<Export> {
       oldGroups: this.oldGroups,
       newGroups: this.newGroups,
       toDelete: this.toDelete,
+      hasChanges: this.hasChanges,
       mostRecent: this.mostRecent,
       errorMessage: this.errorMessage,
     };

--- a/core/api/src/models/Run.ts
+++ b/core/api/src/models/Run.ts
@@ -128,6 +128,11 @@ export class Run extends Model<Run> {
   @Column
   percentComplete: number;
 
+  @Default(false)
+  @AllowNull(false)
+  @Column
+  force: boolean;
+
   @BelongsTo(() => Schedule)
   schedule: Schedule;
 
@@ -260,6 +265,7 @@ export class Run extends Model<Run> {
       groupMemberLimit: this.groupMemberLimit,
       groupMemberOffset: this.groupMemberOffset,
       groupMethod: this.groupMethod,
+      force: this.force,
       completedAt: this.completedAt ? this.completedAt.getTime() : null,
       createdAt: this.createdAt ? this.createdAt.getTime() : null,
       updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,

--- a/core/api/src/modules/ops/profile.ts
+++ b/core/api/src/modules/ops/profile.ts
@@ -303,7 +303,8 @@ export namespace ProfileOps {
           simpleProperties,
           oldGroups,
           groups,
-          true
+          true, // sync = true -> do the export in-line
+          true // force = true -> do the export even if it looks like the data hasn't changed
         )
       )
     );

--- a/core/api/src/tasks/group/run.ts
+++ b/core/api/src/tasks/group/run.ts
@@ -46,14 +46,13 @@ export class RunGroup extends Task {
     let run: Run;
     if (params.runGuid) {
       run = await Run.findByGuid(params.runGuid);
-      if (run.state === "stopped") {
-        return;
-      }
+      if (run.state === "stopped") return;
     } else {
       run = await Run.create({
         creatorGuid: group.guid,
         creatorType: "group",
         state: "running",
+        force,
       });
       await group.update({ state: "updating" });
       log(
@@ -111,6 +110,7 @@ export class RunGroup extends Task {
         offset: 0,
         limit,
         force,
+        destinationGuid,
       });
     } else if (memberCount === 0 && method === "runRemoveGroupMembers") {
       await task.enqueueIn(config.tasks.timeout + 1, "group:run", {
@@ -120,6 +120,7 @@ export class RunGroup extends Task {
         offset: 0,
         limit,
         force,
+        destinationGuid,
       });
     } else if (memberCount > 0) {
       await task.enqueueIn(config.tasks.timeout + 1, "group:run", {
@@ -129,6 +130,7 @@ export class RunGroup extends Task {
         offset: offset + limit,
         limit,
         force,
+        destinationGuid,
       });
     } else {
       await group.countComponentMembersFromRules(null);
@@ -137,5 +139,7 @@ export class RunGroup extends Task {
         runGuid: run.guid,
       });
     }
+
+    return memberCount;
   }
 }

--- a/core/api/src/tasks/profile/export.ts
+++ b/core/api/src/tasks/profile/export.ts
@@ -16,6 +16,7 @@ export class ProfileExport extends RetryableTask {
     this.queue = "exports";
     this.inputs = {
       guid: { required: true },
+      force: { required: false },
     };
   }
 
@@ -98,7 +99,9 @@ export class ProfileExport extends RetryableTask {
           oldProfileProperties,
           newProfileProperties,
           oldGroups,
-          newGroups
+          newGroups,
+          false,
+          params.force ? params.force : undefined
         );
       }
 

--- a/core/api/src/tasks/profile/importAndUpdate.ts
+++ b/core/api/src/tasks/profile/importAndUpdate.ts
@@ -100,13 +100,16 @@ export class ProfileImportAndUpdate extends RetryableTask {
         },
       });
 
+      let force = false;
       for (const i in runs) {
         const run = runs[i];
         await run.increment("profilesImported", {});
+        if (run.force) force = true;
       }
 
       await task.enqueue("profile:export", {
         guid: profile.guid,
+        force,
       });
     } catch (error) {
       await Promise.all(imports.map((e) => e.setError(error, this.name)));

--- a/core/web/components/export/list.tsx
+++ b/core/web/components/export/list.tsx
@@ -142,6 +142,10 @@ export default function ExportsList(props) {
                     ) : (
                       "false"
                     )}
+                    <br />
+                    Most Recent? {_export.mostRecent.toString()}
+                    <br />
+                    Has Changes? {_export.hasChanges.toString()}
                   </td>
                   <td>
                     Start: {formatCreatedAt(_export.startedAt)}

--- a/core/web/components/runs/list.tsx
+++ b/core/web/components/runs/list.tsx
@@ -159,9 +159,8 @@ export default function RunsList(props) {
         <thead>
           <tr>
             <th>Guid</th>
-            <th>Created At</th>
+            <th>Times</th>
             <th>Creator</th>
-            <th>Completed At</th>
             <th>State</th>
             <th>Filters</th>
             <th>Stats</th>
@@ -179,19 +178,11 @@ export default function RunsList(props) {
                     </Link>
                   </td>
                   <td>
-                    <Moment fromNow>{run.createdAt}</Moment>
-                  </td>
-                  <td>
-                    <Link prefetch={false} href={`/object/${run.creatorGuid}`}>
-                      <a>
-                        {run.creatorType}: {run.creatorName}
-                      </a>
-                    </Link>
-                  </td>
-                  <td>
+                    Created: <Moment fromNow>{run.createdAt}</Moment>
                     {run.completedAt ? (
                       <>
-                        <Moment fromNow>{run.completedAt}</Moment>
+                        <br />
+                        Completed: <Moment fromNow>{run.completedAt}</Moment>
                         <br />
                         <small>
                           Duration:{" "}
@@ -204,6 +195,13 @@ export default function RunsList(props) {
                     ) : null}
                   </td>
                   <td>
+                    <Link prefetch={false} href={`/object/${run.creatorGuid}`}>
+                      <a>
+                        {run.creatorType}: {run.creatorName}
+                      </a>
+                    </Link>
+                  </td>
+                  <td>
                     {run.state} <br />
                     {run.percentComplete}%
                   </td>
@@ -212,7 +210,8 @@ export default function RunsList(props) {
                     <>
                       groupMemberLimit: {run.groupMemberLimit} <br />
                       groupMemberOffset: {run.groupMemberOffset} <br />
-                      sourceOffset: {run.sourceOffset}
+                      sourceOffset: {run.sourceOffset} <br />
+                      force: {run.force.toString()}
                     </>
                     {run.highWaterMark ? (
                       <>

--- a/core/web/pages/profile/[guid]/edit.tsx
+++ b/core/web/pages/profile/[guid]/edit.tsx
@@ -61,7 +61,7 @@ export default function Page(props) {
     );
     setLoading(false);
     if (response?.profile) {
-      successHandler.set({ message: "Import Complete!" });
+      successHandler.set({ message: "Import and Export Complete!" });
       load();
     }
   }


### PR DESCRIPTION
If there is no change to the Profile's Properties or Group Memberships, don't waste time (and money!) exporting the Profile again. Provided:
* That there has been a previous, non-error Export to this Profile
* The Mappings have not changed for either the Properties or Group Names
* The Profile should not be deleted
Then we'll skip doing the export.

If a Grouparoo User taps either the `Import + Export` button on a profile, or the `Export Profiles` button on a Destination, this is no considered a "force" Export or Run, and we will send all profiles regardless of their equality to the most recent Export to this same Destination. 

We are still counting the Export on the Runs's `profilesExported`, even if it was skipped - we do this to know when the Run is complete.

Also in this PR:
* Model Changes: `Export#hasChanges` and `Run#force`
* Minor UI tweaks to the Run's/list page


Closes T-270