### PR TITLE
Choose oldest unique profile property rule to be identifying

### DIFF
--- a/core/api/src/migrations/000035-identifyingProfilePropertyRule.ts
+++ b/core/api/src/migrations/000035-identifyingProfilePropertyRule.ts
@@ -9,6 +9,17 @@ module.exports = {
       type: DataTypes.BOOLEAN,
       allowNull: false,
     });
+
+    // we need to pick one of the existing rules to be identifying - prefer the oldest unique rule.
+    const [results] = await migration.sequelize.query(
+      'select * from "profilePropertyRules" order by "unique" desc, "createdAt" desc limit 1'
+    );
+    if (results.length === 1) {
+      const rule = results[0];
+      await migration.sequelize.query(
+        `update "profilePropertyRules" set identifying=true where guid='${rule.guid}'`
+      );
+    }
   },
 
   down: async function (migration) {


### PR DESCRIPTION
Closes T-288

```ts
    // we need to pick one of the existing rules to be identifying - prefer the oldest unique rule.
    const [results] = await migration.sequelize.query(
      'select * from "profilePropertyRules" order by "unique" desc, "createdAt" desc limit 1'
    );
    if (results.length === 1) {
      const rule = results[0];
      await migration.sequelize.query(
        `update "profilePropertyRules" set identifying=true where guid='${rule.guid}'`
      );
    }
```