### PR TITLE
Destination UI Fixes

### DIFF
--- a/core/web/pages/destination/[guid]/data.tsx
+++ b/core/web/pages/destination/[guid]/data.tsx
@@ -44,14 +44,6 @@ export default function Page(props) {
   const update = async (event) => {
     event.preventDefault();
 
-    if (trackedGroupGuid.match(/^grp_/)) {
-      await execApi("post", `/destination/${guid}/track`, {
-        groupGuid: trackedGroupGuid,
-      });
-    } else if (trackedGroupGuid === "_none" && !destination.trackAllGroups) {
-      await execApi("post", `/destination/${guid}/untrack`);
-    }
-
     // handle destination group membership & mapping
     const filteredMapping = {};
     for (const k in destination.mapping) {
@@ -69,6 +61,15 @@ export default function Page(props) {
       destinationGroupMemberships: destinationGroupMembershipsObject,
       trackAllGroups: trackedGroupGuid === "_all" ? true : false,
     });
+
+    // update group being tracked after the edit (as trackAllGroups may have changed)
+    if (trackedGroupGuid.match(/^grp_/)) {
+      await execApi("post", `/destination/${guid}/track`, {
+        groupGuid: trackedGroupGuid,
+      });
+    } else if (trackedGroupGuid === "_none" && !destination.trackAllGroups) {
+      await execApi("post", `/destination/${guid}/untrack`);
+    }
 
     successHandler.set({ message: "Destination Updated" });
   };

--- a/core/web/pages/destination/[guid]/data.tsx
+++ b/core/web/pages/destination/[guid]/data.tsx
@@ -439,15 +439,17 @@ export default function Page(props) {
                                   <span className="text-muted">({type})</span>
                                 </td>
                                 <td>
-                                  <Button
-                                    size="sm"
-                                    variant="danger"
-                                    onClick={() => {
-                                      updateMapping(key, "", key);
-                                    }}
-                                  >
-                                    X
-                                  </Button>
+                                  {destination.mapping[key] ? (
+                                    <Button
+                                      size="sm"
+                                      variant="danger"
+                                      onClick={() => {
+                                        updateMapping(key, "", key);
+                                      }}
+                                    >
+                                      X
+                                    </Button>
+                                  ) : null}
                                 </td>
                               </tr>
                             ) : null

--- a/core/web/pages/destination/[guid]/data.tsx
+++ b/core/web/pages/destination/[guid]/data.tsx
@@ -808,7 +808,9 @@ Page.getInitialProps = async (ctx) => {
     trackedGroupGuid: destination.trackAllGroups
       ? "_all"
       : destination.destinationGroups[0]?.guid,
-    groups: groups.filter((group) => group.state !== "draft"),
+    groups: groups
+      .filter((group) => group.state !== "draft")
+      .filter((group) => group.state !== "deleted"),
     hydrationError,
   };
 };

--- a/plugins/@grouparoo/mysql/src/lib/connect.ts
+++ b/plugins/@grouparoo/mysql/src/lib/connect.ts
@@ -20,7 +20,9 @@ export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
         replacementValues,
         (error: Error, rows: Array<QueryResultObject>) => {
           if (error) {
-            return reject(`error with mysql query: "${q.sql}" - ${error}`);
+            return reject(
+              new Error(`error with mysql query: "${q.sql}" - ${error}`)
+            );
           }
 
           const cleanedRows = [];

--- a/plugins/@grouparoo/mysql/src/lib/export/exportProfile.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/exportProfile.ts
@@ -3,9 +3,9 @@ import { ExportProfilePluginMethod } from "@grouparoo/core";
 export const exportProfile: ExportProfilePluginMethod = async ({
   connection,
   newProfileProperties,
+  oldProfileProperties,
   newGroups,
   toDelete,
-  appOptions,
   destination,
 }) => {
   let success = false;
@@ -55,8 +55,10 @@ export const exportProfile: ExportProfilePluginMethod = async ({
         // erase old columns
         const columnsToErase = Object.keys(existingRecords[0]).filter(
           (k) =>
-            newProfileProperties[k] === null ||
-            newProfileProperties[k] === undefined
+            (newProfileProperties[k] === null ||
+              newProfileProperties[k] === undefined) &&
+            oldProfileProperties[k] !== null &&
+            oldProfileProperties[k] !== undefined
         );
 
         if (columnsToErase.length > 0) {

--- a/plugins/@grouparoo/postgres/src/lib/export/exportProfile.ts
+++ b/plugins/@grouparoo/postgres/src/lib/export/exportProfile.ts
@@ -6,6 +6,7 @@ export const exportProfile: ExportProfilePluginMethod = async ({
   connection,
   destination,
   newProfileProperties,
+  oldProfileProperties,
   newGroups,
   toDelete,
 }) => {
@@ -77,8 +78,10 @@ export const exportProfile: ExportProfilePluginMethod = async ({
         // erase old columns
         const columnsToErase = Object.keys(existingRecords.rows[0]).filter(
           (k) =>
-            newProfileProperties[k] === null ||
-            newProfileProperties[k] === undefined
+            (newProfileProperties[k] === null ||
+              newProfileProperties[k] === undefined) &&
+            oldProfileProperties[k] !== null &&
+            oldProfileProperties[k] !== undefined
         );
 
         if (columnsToErase.length > 0) {


### PR DESCRIPTION
* When the MYSQL and Postgres are exporting a user who has already been exported, don't use null for columns that are unmapped 
* Resque error when appending message to a destination error 
* When removing a destination mapping for MySQL (and others?), a different mapping was reset 
* Error appears when switching a destination from 'track all groups' to a single group 