### PR TITLE
Phone Number Profile Property Type

### DIFF
--- a/core/api/__tests__/actions/groups.ts
+++ b/core/api/__tests__/actions/groups.ts
@@ -243,6 +243,7 @@ describe("actions/groups", () => {
           "email",
           "float",
           "integer",
+          "phoneNumber",
           "string",
         ]);
 

--- a/core/api/__tests__/actions/profilePropertyRules.ts
+++ b/core/api/__tests__/actions/profilePropertyRules.ts
@@ -58,12 +58,13 @@ describe("actions/profilePropertyRules", () => {
       );
       expect(error).toBeUndefined();
       expect(types).toEqual([
+        "boolean",
+        "date",
+        "email",
         "float",
         "integer",
-        "date",
+        "phoneNumber",
         "string",
-        "boolean",
-        "email",
       ]);
     });
 

--- a/core/api/__tests__/models/group/rules/booleans.ts
+++ b/core/api/__tests__/models/group/rules/booleans.ts
@@ -24,7 +24,6 @@ describe("model/group", () => {
   describe("rules", () => {
     describe("booleans", () => {
       test("exact matches", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "isVIP", match: true, operation: { op: "eq" } },
         ]);
@@ -32,7 +31,6 @@ describe("model/group", () => {
       });
 
       test("multiple rules with same key", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "isVIP", match: true, operation: { op: "eq" } },
           { key: "isVIP", match: false, operation: { op: "ne" } },
@@ -41,7 +39,6 @@ describe("model/group", () => {
       });
 
       test("multiple matches (ALL)", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "isVIP", match: true, operation: { op: "eq" } },
           { key: "lastName", match: "mario", operation: { op: "iLike" } },
@@ -59,7 +56,6 @@ describe("model/group", () => {
       });
 
       test("null match", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "isVIP", match: "null", operation: { op: "eq" } },
         ]);
@@ -67,7 +63,6 @@ describe("model/group", () => {
       });
 
       test("not null match", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "isVIP", match: "null", operation: { op: "ne" } },
         ]);
@@ -75,13 +70,11 @@ describe("model/group", () => {
       });
 
       test("exists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([{ key: "isVIP", operation: { op: "exists" } }]);
         expect(await group.countPotentialMembers()).toBe(4);
       });
 
       test("notExists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "isVIP", operation: { op: "notExists" } },
         ]);

--- a/core/api/__tests__/models/group/rules/dates.ts
+++ b/core/api/__tests__/models/group/rules/dates.ts
@@ -27,7 +27,6 @@ describe("model/group", () => {
   describe("rules", () => {
     describe("absolute dates", () => {
       test("exact matches", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           {
             key: "lastLoginAt",
@@ -39,7 +38,6 @@ describe("model/group", () => {
       });
 
       test("comparison matches", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           {
             key: "lastLoginAt",
@@ -51,7 +49,6 @@ describe("model/group", () => {
       });
 
       test("multiple rules with same key", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           {
             key: "lastLoginAt",
@@ -68,7 +65,6 @@ describe("model/group", () => {
       });
 
       test("multiple matches (ALL)", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           {
             key: "lastLoginAt",
@@ -94,7 +90,6 @@ describe("model/group", () => {
       });
 
       test("null match", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "lastLoginAt", match: "null", operation: { op: "eq" } },
         ]);
@@ -102,7 +97,6 @@ describe("model/group", () => {
       });
 
       test("not null match", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "lastLoginAt", match: "null", operation: { op: "ne" } },
         ]);
@@ -110,7 +104,6 @@ describe("model/group", () => {
       });
 
       test("exists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "lastLoginAt", operation: { op: "exists" } },
         ]);
@@ -118,7 +111,6 @@ describe("model/group", () => {
       });
 
       test("notExists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "lastLoginAt", operation: { op: "notExists" } },
         ]);
@@ -128,7 +120,6 @@ describe("model/group", () => {
 
     describe("relative dates", () => {
       test("comparison matches (with matches)", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           {
             key: "lastLoginAt",
@@ -142,7 +133,6 @@ describe("model/group", () => {
       });
 
       test("comparison matches (no matches)", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           {
             key: "lastLoginAt",
@@ -156,7 +146,6 @@ describe("model/group", () => {
       });
 
       test("comparison matches (matches)", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           {
             key: "lastLoginAt",
@@ -170,7 +159,6 @@ describe("model/group", () => {
       });
 
       test("multiple rules with same key", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           {
             key: "lastLoginAt",
@@ -191,7 +179,6 @@ describe("model/group", () => {
       });
 
       test("multiple matches (ALL)", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           {
             key: "lastLoginAt",
@@ -221,7 +208,6 @@ describe("model/group", () => {
       });
 
       test("relative date matchers in the future do not include the past", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           {
             key: "lastLoginAt",
@@ -240,7 +226,6 @@ describe("model/group", () => {
           lastLoginAt: [new Date(now + 1000 * 5)],
         });
 
-        await group.update({ matchType: "all" });
         await group.setRules([
           {
             key: "lastLoginAt",

--- a/core/api/__tests__/models/group/rules/emails.ts
+++ b/core/api/__tests__/models/group/rules/emails.ts
@@ -1,0 +1,141 @@
+import { Group } from "../../../../src/models/Group";
+import { Profile } from "../../../../src/models/Profile";
+import { ProfilePropertyRule } from "../../../../src/models/ProfilePropertyRule";
+import { SharedGroupTests } from "../../../utils/prepareSharedGroupTest";
+
+describe("model/group", () => {
+  let group: Group;
+  let luigi: Profile;
+  let emailRule: ProfilePropertyRule;
+
+  beforeAll(async () => {
+    const response = await SharedGroupTests.beforeAll();
+    luigi = response.luigi;
+
+    emailRule = await ProfilePropertyRule.findOne({
+      where: { key: "email" },
+    });
+  }, 1000 * 30);
+
+  afterAll(async () => {
+    await SharedGroupTests.afterAll();
+  });
+
+  beforeEach(async () => {
+    const response = await SharedGroupTests.beforeEach();
+    group = response.group;
+  });
+
+  afterEach(async () => {
+    await SharedGroupTests.afterEach();
+  });
+
+  describe("rules", () => {
+    describe("emails", () => {
+      test("exact matches", async () => {
+        await group.setRules([
+          { key: "email", match: "mario@example.com", operation: { op: "eq" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(1);
+      });
+
+      test("partial matches", async () => {
+        await group.setRules([
+          { key: "email", match: "%@example.com", operation: { op: "like" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(4);
+      });
+
+      test("multiple rules with same key", async () => {
+        await group.setRules([
+          { key: "email", match: "mario%", operation: { op: "iLike" } },
+          { key: "email", match: "%@example.com", operation: { op: "iLike" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(1);
+      });
+
+      test("null match", async () => {
+        await group.setRules([
+          { key: "email", match: "null", operation: { op: "eq" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(0);
+      });
+
+      test("not null match", async () => {
+        await group.setRules([
+          { key: "email", match: "null", operation: { op: "ne" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(4);
+      });
+
+      test("exists", async () => {
+        await group.setRules([{ key: "email", operation: { op: "exists" } }]);
+        expect(await group.countPotentialMembers()).toBe(4);
+      });
+
+      test("notExists", async () => {
+        await group.setRules([
+          { key: "email", operation: { op: "notExists" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(0);
+      });
+
+      describe("with arrays", () => {
+        beforeAll(async () => {
+          await emailRule.update({ isArray: true, unique: false });
+          await luigi.addOrUpdateProperties({
+            email: ["luigi@example.com", "ghostbuster@example.com"],
+          });
+        });
+
+        test("array property exists", async () => {
+          await group.setRules([{ key: "email", operation: { op: "exists" } }]);
+          expect(await group.countPotentialMembers()).toBe(4);
+        });
+
+        test("array property does not exists", async () => {
+          await group.setRules([
+            { key: "email", operation: { op: "notExists" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(0);
+        });
+
+        test("array property equals", async () => {
+          await group.setRules([
+            {
+              key: "email",
+              match: "luigi@example.com",
+              operation: { op: "eq" },
+            },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(1);
+        });
+
+        test("array property not equals", async () => {
+          await group.setRules([
+            {
+              key: "email",
+              match: "luigi@example.com",
+              operation: { op: "ne" },
+            },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(3);
+        });
+
+        test("array property like", async () => {
+          await group.setRules([
+            { key: "email", match: "%ghost%", operation: { op: "like" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(1);
+        });
+
+        test("array property not like", async () => {
+          await group.setRules([
+            { key: "email", match: "%ghost%", operation: { op: "notLike" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(3);
+        });
+      });
+    });
+  });
+});

--- a/core/api/__tests__/models/group/rules/floats.ts
+++ b/core/api/__tests__/models/group/rules/floats.ts
@@ -24,7 +24,6 @@ describe("model/group", () => {
   describe("rules", () => {
     describe("floats", () => {
       test("exact matches", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "ltv", match: 100, operation: { op: "eq" } },
         ]);
@@ -32,7 +31,6 @@ describe("model/group", () => {
       });
 
       test("comparison matches", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "ltv", match: 1, operation: { op: "gte" } },
         ]);
@@ -40,7 +38,6 @@ describe("model/group", () => {
       });
 
       test("multiple rules with same key", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "ltv", match: 1, operation: { op: "gte" } },
           { key: "ltv", match: 9999, operation: { op: "lt" } },
@@ -49,7 +46,6 @@ describe("model/group", () => {
       });
 
       test("multiple matches (ALL)", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "ltv", match: 1, operation: { op: "gte" } },
           { key: "lastName", match: "mario", operation: { op: "iLike" } },
@@ -67,7 +63,6 @@ describe("model/group", () => {
       });
 
       test("null match", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "ltv", match: "null", operation: { op: "eq" } },
         ]);
@@ -75,7 +70,6 @@ describe("model/group", () => {
       });
 
       test("not null match", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "ltv", match: "null", operation: { op: "ne" } },
         ]);
@@ -83,19 +77,16 @@ describe("model/group", () => {
       });
 
       test("exists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([{ key: "ltv", operation: { op: "exists" } }]);
         expect(await group.countPotentialMembers()).toBe(4);
       });
 
       test("notExists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([{ key: "ltv", operation: { op: "notExists" } }]);
         expect(await group.countPotentialMembers()).toBe(0);
       });
 
       test("array property exists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchaseAmounts", operation: { op: "exists" } },
         ]);
@@ -103,7 +94,6 @@ describe("model/group", () => {
       });
 
       test("array property does not exists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchaseAmounts", operation: { op: "notExists" } },
         ]);
@@ -111,7 +101,6 @@ describe("model/group", () => {
       });
 
       test("array property equals", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchaseAmounts", match: 50, operation: { op: "eq" } },
         ]);
@@ -119,7 +108,6 @@ describe("model/group", () => {
       });
 
       test("array property not equals", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchaseAmounts", match: 50, operation: { op: "ne" } },
         ]);
@@ -127,7 +115,6 @@ describe("model/group", () => {
       });
 
       test("array property comparisons gt", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchaseAmounts", match: 50, operation: { op: "gt" } },
         ]);
@@ -135,7 +122,6 @@ describe("model/group", () => {
       });
 
       test("array property comparisons lte", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchaseAmounts", match: 50, operation: { op: "lte" } },
         ]);

--- a/core/api/__tests__/models/group/rules/integers.ts
+++ b/core/api/__tests__/models/group/rules/integers.ts
@@ -24,7 +24,6 @@ describe("model/group", () => {
   describe("rules", () => {
     describe("integers", () => {
       test("exact matches", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "userId", match: 1, operation: { op: "eq" } },
         ]);
@@ -32,7 +31,6 @@ describe("model/group", () => {
       });
 
       test("comparison matches", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "userId", match: 1, operation: { op: "gt" } },
         ]);
@@ -40,7 +38,6 @@ describe("model/group", () => {
       });
 
       test("multiple rules with same key", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "userId", match: 1, operation: { op: "gt" } },
           { key: "userId", match: 99, operation: { op: "lt" } },
@@ -49,7 +46,6 @@ describe("model/group", () => {
       });
 
       test("multiple matches (ALL)", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "userId", match: 1, operation: { op: "eq" } },
           { key: "lastName", match: "mario", operation: { op: "iLike" } },
@@ -67,7 +63,6 @@ describe("model/group", () => {
       });
 
       test("null match", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "userId", match: "null", operation: { op: "eq" } },
         ]);
@@ -75,7 +70,6 @@ describe("model/group", () => {
       });
 
       test("not null match", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "userId", match: "null", operation: { op: "ne" } },
         ]);
@@ -83,13 +77,11 @@ describe("model/group", () => {
       });
 
       test("exists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([{ key: "userId", operation: { op: "exists" } }]);
         expect(await group.countPotentialMembers()).toBe(4);
       });
 
       test("notExists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "userId", operation: { op: "notExists" } },
         ]);

--- a/core/api/__tests__/models/group/rules/phoneNumbers.ts
+++ b/core/api/__tests__/models/group/rules/phoneNumbers.ts
@@ -1,0 +1,113 @@
+import { Group } from "../../../../src/models/Group";
+import { Profile } from "../../../../src/models/Profile";
+import { ProfilePropertyRule } from "../../../../src/models/ProfilePropertyRule";
+import { SharedGroupTests } from "../../../utils/prepareSharedGroupTest";
+
+describe("model/group", () => {
+  let group: Group;
+  let mario: Profile;
+  let luigi: Profile;
+  let peach: Profile;
+  let toad: Profile;
+  let phoneNumberRule: ProfilePropertyRule;
+
+  beforeAll(async () => {
+    const response = await SharedGroupTests.beforeAll();
+    mario = response.mario;
+    luigi = response.luigi;
+    peach = response.peach;
+    toad = response.toad;
+
+    const emailRule = await ProfilePropertyRule.findOne({
+      where: { key: "email" },
+    });
+
+    phoneNumberRule = await ProfilePropertyRule.create({
+      isArray: true,
+      unique: false,
+      key: "phoneNumber",
+      type: "phoneNumber",
+      sourceGuid: emailRule.sourceGuid,
+    });
+    await phoneNumberRule.setOptions({ column: "phoneNumber" });
+    await phoneNumberRule.update({ state: "ready" });
+
+    await mario.addOrUpdateProperties({ phoneNumber: ["412 888 0001"] });
+    await luigi.addOrUpdateProperties({ phoneNumber: ["412 888 0002"] });
+    await peach.addOrUpdateProperties({
+      phoneNumber: ["412 888 0003", "555 001 0001"],
+    });
+    await toad.buildNullProperties();
+  }, 1000 * 30);
+
+  afterAll(async () => {
+    await SharedGroupTests.afterAll();
+  });
+
+  beforeEach(async () => {
+    const response = await SharedGroupTests.beforeEach();
+    group = response.group;
+  });
+
+  afterEach(async () => {
+    await SharedGroupTests.afterEach();
+  });
+
+  describe("rules", () => {
+    describe("phoneNumbers", () => {
+      test("exact matches", async () => {
+        await group.setRules([
+          {
+            key: "phoneNumber",
+            match: "+1 412 888 0001",
+            operation: { op: "eq" },
+          },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(1);
+      });
+
+      test("partial matches", async () => {
+        await group.setRules([
+          { key: "phoneNumber", match: "+1 412%", operation: { op: "like" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(3);
+      });
+
+      test("multiple rules with same key", async () => {
+        await group.setRules([
+          { key: "phoneNumber", match: "+1 412%", operation: { op: "iLike" } },
+          { key: "phoneNumber", match: "%000%", operation: { op: "iLike" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(3);
+      });
+
+      test("null match", async () => {
+        await group.setRules([
+          { key: "phoneNumber", match: "null", operation: { op: "eq" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(1);
+      });
+
+      test("not null match", async () => {
+        await group.setRules([
+          { key: "phoneNumber", match: "null", operation: { op: "ne" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(3);
+      });
+
+      test("exists", async () => {
+        await group.setRules([
+          { key: "phoneNumber", operation: { op: "exists" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(3);
+      });
+
+      test("notExists", async () => {
+        await group.setRules([
+          { key: "phoneNumber", operation: { op: "notExists" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(1);
+      });
+    });
+  });
+});

--- a/core/api/__tests__/models/group/rules/strings.ts
+++ b/core/api/__tests__/models/group/rules/strings.ts
@@ -24,7 +24,6 @@ describe("model/group", () => {
   describe("rules", () => {
     describe("strings", () => {
       test("exact matches", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "lastName", match: "Mario", operation: { op: "eq" } },
         ]);
@@ -32,7 +31,6 @@ describe("model/group", () => {
       });
 
       test("partial matches", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "lastName", match: "%toad%", operation: { op: "iLike" } },
         ]);
@@ -40,7 +38,6 @@ describe("model/group", () => {
       });
 
       test("multiple rules with same key", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "lastName", match: "Mario", operation: { op: "eq" } },
           { key: "lastName", match: "%a%", operation: { op: "iLike" } },
@@ -49,7 +46,6 @@ describe("model/group", () => {
       });
 
       test("multiple matches (ALL)", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "lastName", match: "%toad%", operation: { op: "iLike" } },
           { key: "firstName", match: "Peach", operation: { op: "eq" } },
@@ -67,7 +63,6 @@ describe("model/group", () => {
       });
 
       test("null match", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "lastName", match: "null", operation: { op: "eq" } },
         ]);
@@ -75,7 +70,6 @@ describe("model/group", () => {
       });
 
       test("not null match", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "lastName", match: "null", operation: { op: "ne" } },
         ]);
@@ -83,7 +77,6 @@ describe("model/group", () => {
       });
 
       test("exists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "lastName", operation: { op: "exists" } },
         ]);
@@ -91,7 +84,6 @@ describe("model/group", () => {
       });
 
       test("notExists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "lastName", operation: { op: "notExists" } },
         ]);
@@ -99,7 +91,6 @@ describe("model/group", () => {
       });
 
       test("array property exists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchases", operation: { op: "exists" } },
         ]);
@@ -107,7 +98,6 @@ describe("model/group", () => {
       });
 
       test("array property does not exists", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchases", operation: { op: "notExists" } },
         ]);
@@ -115,7 +105,6 @@ describe("model/group", () => {
       });
 
       test("array property equals", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchases", match: "mushroom", operation: { op: "eq" } },
         ]);
@@ -123,7 +112,6 @@ describe("model/group", () => {
       });
 
       test("array property not equals", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchases", match: "mushroom", operation: { op: "ne" } },
         ]);
@@ -131,7 +119,6 @@ describe("model/group", () => {
       });
 
       test("array property like", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchases", match: "mush%", operation: { op: "like" } },
         ]);
@@ -139,7 +126,6 @@ describe("model/group", () => {
       });
 
       test("array property not like", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchases", match: "sta%", operation: { op: "notLike" } },
         ]);
@@ -147,7 +133,6 @@ describe("model/group", () => {
       });
 
       test("array property iLike", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchases", match: "MUSH%", operation: { op: "iLike" } },
         ]);
@@ -155,7 +140,6 @@ describe("model/group", () => {
       });
 
       test("array property not iLike", async () => {
-        await group.update({ matchType: "all" });
         await group.setRules([
           { key: "purchases", match: "STA%", operation: { op: "notILike" } },
         ]);

--- a/core/api/__tests__/models/profileProperty.ts
+++ b/core/api/__tests__/models/profileProperty.ts
@@ -21,6 +21,7 @@ describe("models/profileProperty", () => {
   let profile: Profile;
   let firstNameRule: ProfilePropertyRule;
   let emailRule: ProfilePropertyRule;
+  let phoneNumberRule: ProfilePropertyRule;
   let userIdRule: ProfilePropertyRule;
   let lastLoginRule: ProfilePropertyRule;
   let ltvRule: ProfilePropertyRule;
@@ -55,6 +56,14 @@ describe("models/profileProperty", () => {
     });
     await emailRule.setOptions({ column: "email" });
     await emailRule.update({ state: "ready" });
+
+    phoneNumberRule = await ProfilePropertyRule.create({
+      sourceGuid: source.guid,
+      key: "phoneNumber",
+      type: "phoneNumber",
+    });
+    await phoneNumberRule.setOptions({ column: "phoneNumber" });
+    await phoneNumberRule.update({ state: "ready" });
 
     lastLoginRule = await ProfilePropertyRule.create({
       sourceGuid: source.guid,
@@ -202,6 +211,36 @@ describe("models/profileProperty", () => {
       await profileProperty.setValue("MARIO@example.com");
       const response = await profileProperty.getValue();
       expect(response).toBe("mario@example.com");
+    });
+
+    test("phone numbers", async () => {
+      const profileProperty = new ProfileProperty({
+        profileGuid: profile.guid,
+        profilePropertyRuleGuid: phoneNumberRule.guid,
+      });
+      await profileProperty.setValue("4128889999");
+      const response = await profileProperty.getValue();
+      expect(response).toBe("+1 412 888 9999");
+    });
+
+    test("phone numbers with another country code", async () => {
+      const profileProperty = new ProfileProperty({
+        profileGuid: profile.guid,
+        profilePropertyRuleGuid: phoneNumberRule.guid,
+      });
+      await profileProperty.setValue("+42 123 123 1231");
+      const response = await profileProperty.getValue();
+      expect(response).toBe("+421 2 312 312 31");
+    });
+
+    test("phone numbers which we cannot parse are left as they are provided", async () => {
+      const profileProperty = new ProfileProperty({
+        profileGuid: profile.guid,
+        profilePropertyRuleGuid: phoneNumberRule.guid,
+      });
+      await profileProperty.setValue("1-800-got-milk");
+      const response = await profileProperty.getValue();
+      expect(response).toBe("1-800-got-milk");
     });
 
     test("integers", async () => {

--- a/core/api/__tests__/utils/prepareSharedGroupTest.ts
+++ b/core/api/__tests__/utils/prepareSharedGroupTest.ts
@@ -96,6 +96,8 @@ export namespace SharedGroupTests {
       rules: {},
     });
 
+    await group.update({ matchType: "all" });
+
     run = await helper.factories.run();
 
     return { group, run };

--- a/core/api/src/initializers/settings.ts
+++ b/core/api/src/initializers/settings.ts
@@ -35,6 +35,12 @@ export class Plugins extends Initializer {
           "How many profiles should a run try to send at once to destinations which support batch exporting?",
       },
       {
+        key: "default-country-code",
+        defaultValue: "US",
+        description:
+          "The default country code Grouparoo will use to format phone numbers and display data",
+      },
+      {
         key: "sweeper-delete-old-logs-days",
         defaultValue: 31,
         description:

--- a/core/api/src/models/ProfileProperty.ts
+++ b/core/api/src/models/ProfileProperty.ts
@@ -12,6 +12,8 @@ import {
 import { LoggedModel } from "../classes/loggedModel";
 import { Profile } from "./Profile";
 import { ProfilePropertyRule } from "./ProfilePropertyRule";
+import { parsePhoneNumberFromString, CountryCode } from "libphonenumber-js";
+import { plugin } from "../modules/plugin";
 
 @Table({ tableName: "profileProperties", paranoid: false })
 export class ProfileProperty extends LoggedModel<ProfileProperty> {
@@ -96,6 +98,8 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
         return value.toString();
       case "email":
         return value.toString().toLowerCase();
+      case "phoneNumber":
+        return this.formatPhoneNumber(value.toString());
       case "boolean":
         if (![true, false, 0, 1, "true", "false"].includes(value)) {
           throw new Error(
@@ -130,6 +134,8 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
         return this.rawValue;
       case "email":
         return this.rawValue.toLowerCase();
+      case "phoneNumber":
+        return this.rawValue;
       case "boolean":
         if ([true, 1, "true"].includes(this.rawValue)) {
           return true;
@@ -203,6 +209,22 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
         );
       }
     }
+  }
+
+  async formatPhoneNumber(number: string) {
+    // TODO: Cache this
+    const defaultCountryCode = (
+      await plugin.readSetting("core", "default-country-code")
+    ).value as CountryCode;
+
+    const formattedPhoneNumber = parsePhoneNumberFromString(
+      number,
+      defaultCountryCode
+    );
+
+    return formattedPhoneNumber
+      ? formattedPhoneNumber.formatInternational()
+      : number;
   }
 
   // --- Class Methods --- //

--- a/core/api/src/models/ProfileProperty.ts
+++ b/core/api/src/models/ProfileProperty.ts
@@ -12,7 +12,7 @@ import {
 import { LoggedModel } from "../classes/loggedModel";
 import { Profile } from "./Profile";
 import { ProfilePropertyRule } from "./ProfilePropertyRule";
-import { parsePhoneNumberFromString, CountryCode } from "libphonenumber-js";
+import { parsePhoneNumberFromString, CountryCode } from "libphonenumber-js/max";
 import { plugin } from "../modules/plugin";
 
 @Table({ tableName: "profileProperties", paranoid: false })
@@ -212,7 +212,6 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
   }
 
   async formatPhoneNumber(number: string) {
-    // TODO: Cache this
     const defaultCountryCode = (
       await plugin.readSetting("core", "default-country-code")
     ).value as CountryCode;
@@ -222,7 +221,7 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
       defaultCountryCode
     );
 
-    return formattedPhoneNumber
+    return formattedPhoneNumber && formattedPhoneNumber.isValid()
       ? formattedPhoneNumber.formatInternational()
       : number;
   }

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -49,13 +49,13 @@ export function profilePropertyRuleJSToSQLType(jsType: string) {
 }
 
 const TYPES = [
+  "boolean",
+  "date",
+  "email",
   "float",
   "integer",
-  "date",
-  "string",
-  "boolean",
-  "email",
   "phoneNumber",
+  "string",
 ];
 
 const CACHE_TTL = env === "test" ? -1 : 1000 * 30;

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -29,7 +29,6 @@ import { Group } from "./Group";
 import { Run } from "./Run";
 import { GroupRule } from "./GroupRule";
 import { ProfilePropertyRuleFilter } from "./ProfilePropertyRuleFilter";
-import { internalRun } from "../modules/internalRun";
 import { OptionHelper } from "./../modules/optionHelper";
 import { StateMachine } from "./../modules/stateMachine";
 import { Mapping } from "./Mapping";
@@ -41,6 +40,7 @@ export function profilePropertyRuleJSToSQLType(jsType: string) {
     float: "float",
     string: "text",
     email: "text",
+    phoneNumber: "text",
     boolean: "boolean",
     date: "bigint", // we store things via timestamps in the DB
   };
@@ -48,7 +48,15 @@ export function profilePropertyRuleJSToSQLType(jsType: string) {
   return map[jsType];
 }
 
-const TYPES = ["float", "integer", "date", "string", "boolean", "email"];
+const TYPES = [
+  "float",
+  "integer",
+  "date",
+  "string",
+  "boolean",
+  "email",
+  "phoneNumber",
+];
 
 const CACHE_TTL = env === "test" ? -1 : 1000 * 30;
 

--- a/core/api/src/modules/RuleOpsDictionary.ts
+++ b/core/api/src/modules/RuleOpsDictionary.ts
@@ -50,6 +50,7 @@ export const ProfilePropertyRuleOpsDictionary = {
   float: _number_ops,
   boolean: _boolean_ops,
   date: _date_ops,
+  phoneNumber: _string_ops,
   _relativeMatchUnits: ["days", "weeks", "months", "quarters", "years"],
   _convenientRules: {
     exists: { operation: { op: "ne" }, match: "null" },

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1504,9 +1504,9 @@
       }
     },
     "@grouparoo/client-web": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@grouparoo/client-web/-/client-web-0.1.9.tgz",
-      "integrity": "sha512-dcT+u78vJ1FSll/yYoF7OemmjY3i898Zq9QHPKBDiHXwMKJHTEJuvsslylfD0P1tINK3O1k/Wj1OTl/f0I0eBQ=="
+      "version": "0.1.10-alpha.0",
+      "resolved": "https://registry.npmjs.org/@grouparoo/client-web/-/client-web-0.1.10-alpha.0.tgz",
+      "integrity": "sha512-7N6YXYgIaw1toaC+Z4uhIfo8s2boet6xiXw32g7BXltsNA8s0CMeHOqBEuqqLWrtYzQVTWAitDn8d5esbPGJ1A=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -11108,6 +11108,15 @@
         "type-check": "~0.3.2"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.7.56",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.7.56.tgz",
+      "integrity": "sha512-7ArN9sSVs9bzX72+HeryCrmI68w1ry3Sd67+BmbPxbaCU+ZpuB2R9YT/YTsTUFYbxkp933vpQUP5E/1TJ9WvTQ==",
+      "requires": {
+        "minimist": "^1.2.5",
+        "xml2js": "^0.4.17"
+      }
+    },
     "lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -17762,6 +17771,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/core/package.json
+++ b/core/package.json
@@ -59,6 +59,7 @@
     "fs-extra": "9.0.1",
     "ioredis": "4.17.3",
     "isomorphic-fetch": "2.2.1",
+    "libphonenumber-js": "^1.7.56",
     "md5": "2.3.0",
     "moment": "2.27.0",
     "mustache": "4.0.1",


### PR DESCRIPTION
This PR adds a new Profile Property type to Grouparoo - `phoneNumber`. 

* We will attempt to format phone numbers when they are saved according to [libphonenumber-js](https://www.npmjs.com/package/libphonenumber-js).  If the library doesn't think the phone number is valid, rather than throw an error, we will store the phone number as provided by the source.
  * To aid in this formatting, a new setting, `core/default-country-code` is required (default: "US").  When phone numbers are found without a `+#` explicitly setting the country code, we need to guess which country the phone number is from.