### PR TITLE
Use count of imports and exports directly to determine run state

### DIFF
--- a/core/api/src/modules/ops/destination.ts
+++ b/core/api/src/modules/ops/destination.ts
@@ -406,6 +406,11 @@ export namespace DestinationOps {
     let method: ExportProfilePluginMethod;
     const { pluginConnection } = await destination.getPlugin();
     method = pluginConnection.methods.exportProfile;
+    if (!method) {
+      throw new Error(
+        `destination ${destination.name} (${destination.guid}) has no exportProfile method`
+      );
+    }
 
     const parallelismOk = await checkSendExportParallelism(
       app,
@@ -491,6 +496,11 @@ export namespace DestinationOps {
     let method: ExportProfilesPluginMethod;
     const { pluginConnection } = await destination.getPlugin();
     method = pluginConnection.methods.exportProfiles;
+    if (!method) {
+      throw new Error(
+        `destination ${destination.name} (${destination.guid}) has no exportProfiles method`
+      );
+    }
 
     const options = await destination.getOptions();
     const app = await destination.$get("app");

--- a/core/api/src/tasks/run/determineState.ts
+++ b/core/api/src/tasks/run/determineState.ts
@@ -29,7 +29,9 @@ export class RunDetermineState extends Task {
         attempts: attempts + 1,
       });
     } else {
-      const delta = run.completedAt.getTime() - run.createdAt.getTime();
+      const delta = run.completedAt
+        ? run.completedAt.getTime() - run.createdAt.getTime()
+        : 0;
 
       log(
         `[ run ] completed run ${run.guid} for ${


### PR DESCRIPTION
This prevents a bug that can occur when imports or exports for a run have been retried, and the count of imports/exports exceeds that of the actual import/export records.  We want to keep a log on the run of the total /attempts/ for each export, but to determine if the run is complete, we need to look to the exports themselves.