### PR TITLE
Require that phoneNumber and email  Profile Properties be valid

### DIFF
--- a/core/api/__tests__/models/group/rules/phoneNumbers.ts
+++ b/core/api/__tests__/models/group/rules/phoneNumbers.ts
@@ -35,7 +35,7 @@ describe("model/group", () => {
     await mario.addOrUpdateProperties({ phoneNumber: ["412 888 0001"] });
     await luigi.addOrUpdateProperties({ phoneNumber: ["412 888 0002"] });
     await peach.addOrUpdateProperties({
-      phoneNumber: ["412 888 0003", "555 001 0001"],
+      phoneNumber: ["412 888 0003", "415 644 0001"],
     });
     await toad.buildNullProperties();
   }, 1000 * 30);

--- a/core/api/__tests__/models/profileProperty.ts
+++ b/core/api/__tests__/models/profileProperty.ts
@@ -233,14 +233,14 @@ describe("models/profileProperty", () => {
       expect(response).toBe("+421 2 312 312 31");
     });
 
-    test("phone numbers which we cannot parse are left as they are provided", async () => {
+    test("phone numbers which we cannot parse throw an error", async () => {
       const profileProperty = new ProfileProperty({
         profileGuid: profile.guid,
         profilePropertyRuleGuid: phoneNumberRule.guid,
       });
-      await profileProperty.setValue("1-800-got-milk");
-      const response = await profileProperty.getValue();
-      expect(response).toBe("1-800-got-milk");
+      await expect(profileProperty.setValue("1-800-got-milk")).rejects.toThrow(
+        /phone number .* is not valid/
+      );
     });
 
     test("integers", async () => {

--- a/core/api/__tests__/models/profileProperty.ts
+++ b/core/api/__tests__/models/profileProperty.ts
@@ -213,6 +213,16 @@ describe("models/profileProperty", () => {
       expect(response).toBe("mario@example.com");
     });
 
+    test("invalid emails throw an error", async () => {
+      const profileProperty = new ProfileProperty({
+        profileGuid: profile.guid,
+        profilePropertyRuleGuid: emailRule.guid,
+      });
+      await expect(
+        profileProperty.setValue("someone.com")
+      ).rejects.toThrowError(/email .* is not valid/);
+    });
+
     test("phone numbers", async () => {
       const profileProperty = new ProfileProperty({
         profileGuid: profile.guid,

--- a/core/api/src/models/ProfileProperty.ts
+++ b/core/api/src/models/ProfileProperty.ts
@@ -14,6 +14,7 @@ import { Profile } from "./Profile";
 import { ProfilePropertyRule } from "./ProfilePropertyRule";
 import { parsePhoneNumberFromString, CountryCode } from "libphonenumber-js/max";
 import { plugin } from "../modules/plugin";
+import isEmail from "validator/lib/isEmail";
 
 @Table({ tableName: "profileProperties", paranoid: false })
 export class ProfileProperty extends LoggedModel<ProfileProperty> {
@@ -97,7 +98,7 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
       case "string":
         return value.toString();
       case "email":
-        return value.toString().toLowerCase();
+        return this.formatEmail(value.toString());
       case "phoneNumber":
         return this.formatPhoneNumber(value.toString());
       case "boolean":
@@ -209,6 +210,14 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
         );
       }
     }
+  }
+
+  async formatEmail(email: string) {
+    if (!isEmail(email)) {
+      throw new Error(`email "${email}" is not valid`);
+    }
+
+    return email.toLocaleLowerCase();
   }
 
   async formatPhoneNumber(number: string) {

--- a/core/api/src/models/ProfileProperty.ts
+++ b/core/api/src/models/ProfileProperty.ts
@@ -221,9 +221,11 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
       defaultCountryCode
     );
 
-    return formattedPhoneNumber && formattedPhoneNumber.isValid()
-      ? formattedPhoneNumber.formatInternational()
-      : number;
+    if (!formattedPhoneNumber || !formattedPhoneNumber.isValid()) {
+      throw new Error(`phone number "${number}" is not valid`);
+    }
+
+    return formattedPhoneNumber.formatInternational();
   }
 
   // --- Class Methods --- //


### PR DESCRIPTION
Throw and error and do not save `phoneNumber` or `email`-type Profile Properties if they are not valid.

Closes T-303
Closes T-304