### PR TITLE
Compare Destination group membership with previous export

### DIFF
--- a/core/api/__tests__/models/destination.ts
+++ b/core/api/__tests__/models/destination.ts
@@ -981,6 +981,134 @@ describe("models/destination", () => {
       await destination.destroy();
     });
 
+    test("newly tracked groups will appear new in next export", async () => {
+      const destination = await Destination.create({
+        name: "test plugin destination",
+        type: "export-from-test-template-app",
+        appGuid: app.guid,
+      });
+
+      await destination.setMapping({
+        uid: "userId",
+        customer_email: "email",
+      });
+
+      const group = await helper.factories.group();
+      await destination.trackGroup(group);
+
+      const profile = await helper.factories.profile();
+      group.addProfile(profile);
+
+      const oldProfileProperties = {};
+      const newProfileProperties = {};
+      const oldGroups = [];
+      const newGroups = [group];
+
+      // create a previous export
+      const _export = await Export.create({
+        profileGuid: profile.guid,
+        destinationGuid: destination.guid,
+        newProfileProperties: {},
+        oldProfileProperties: {},
+        oldGroups: [],
+        newGroups: [],
+        mostRecent: true,
+      });
+
+      const destinationGroupMemberships = {};
+      destinationGroupMemberships[group.guid] = group.name;
+      await destination.setDestinationGroupMemberships(
+        destinationGroupMemberships
+      );
+
+      const _import = await helper.factories.import();
+
+      await destination.exportProfile(
+        profile,
+        [],
+        [_import],
+        oldProfileProperties,
+        newProfileProperties,
+        oldGroups,
+        newGroups
+      );
+
+      const foundTasks = await specHelper.findEnqueuedTasks("export:send");
+      expect(foundTasks.length).toBe(1);
+      await specHelper.runTask("export:send", foundTasks[0].args[0]);
+
+      expect(exportArgs.oldGroups).toEqual([]);
+      expect(exportArgs.newGroups).toEqual([group.name]);
+
+      await destination.unTrackGroups();
+      await destination.destroy();
+    });
+
+    test("newly un-tracked groups will be removed from the next export", async () => {
+      const destination = await Destination.create({
+        name: "test plugin destination",
+        type: "export-from-test-template-app",
+        appGuid: app.guid,
+      });
+
+      await destination.setMapping({
+        uid: "userId",
+        customer_email: "email",
+      });
+
+      const group = await helper.factories.group();
+      await destination.trackGroup(group);
+
+      const profile = await helper.factories.profile();
+      group.addProfile(profile);
+
+      const oldProfileProperties = {};
+      const newProfileProperties = {};
+      const oldGroups = [];
+      const newGroups = [group];
+
+      const destinationGroupMemberships = {};
+      destinationGroupMemberships[group.guid] = group.name;
+      await destination.setDestinationGroupMemberships(
+        destinationGroupMemberships
+      );
+
+      // create a previous export
+      const _export = await Export.create({
+        profileGuid: profile.guid,
+        destinationGuid: destination.guid,
+        newProfileProperties: {},
+        oldProfileProperties: {},
+        oldGroups: [group.name],
+        newGroups: [group.name],
+        mostRecent: true,
+      });
+
+      const _import = await helper.factories.import();
+
+      await destination.setDestinationGroupMemberships({});
+
+      await destination.exportProfile(
+        profile,
+        [],
+        [_import],
+        oldProfileProperties,
+        newProfileProperties,
+        oldGroups,
+        newGroups
+      );
+
+      const foundTasks = await specHelper.findEnqueuedTasks("export:send");
+      expect(foundTasks.length).toBe(1);
+      await specHelper.runTask("export:send", foundTasks[0].args[0]);
+
+      expect(exportArgs.oldGroups).toEqual([group.name]);
+      expect(exportArgs.newGroups).toEqual([]);
+
+      await destination.unTrackGroups();
+      await destination.destroy();
+    });
+
     test("if a profile is removed from all groups tracked by this destination, toDelete is true", async () => {
       const destination = await Destination.create({
         name: "test plugin destination",

--- a/core/api/__tests__/models/destination.ts
+++ b/core/api/__tests__/models/destination.ts
@@ -981,7 +981,7 @@ describe("models/destination", () => {
       await destination.destroy();
     });
 
-    test("newly tracked groups will appear new in next export", async () => {
+    test("newly tagged groups will appear new in next export", async () => {
       const destination = await Destination.create({
         name: "test plugin destination",
         type: "export-from-test-template-app",
@@ -1044,7 +1044,7 @@ describe("models/destination", () => {
       await destination.destroy();
     });
 
-    test("newly un-tracked groups will be removed from the next export", async () => {
+    test("newly un-tagged groups will be removed from the next export", async () => {
       const destination = await Destination.create({
         name: "test plugin destination",
         type: "export-from-test-template-app",

--- a/core/api/src/modules/ops/destination.ts
+++ b/core/api/src/modules/ops/destination.ts
@@ -287,6 +287,18 @@ export namespace DestinationOps {
         .filter((k) => !currentMappedNewProfilePropertyKeys.includes(k))
         .filter((k) => !currentMappedOldProfilePropertyKeys.includes(k))
         .forEach((k) => (mappedOldProfileProperties[k] = ["unknown"]));
+
+      // we also want to check for groups we previously sent but are no longer sending
+      // the profile may have not changed membership in the group, but the destination may have just started tracking it
+      mostRecentExport.newGroups
+        .filter((groupName) => !oldGroupNames.includes(groupName))
+        .forEach((groupName) => oldGroupNames.push(groupName));
+
+      newGroupNames
+        .filter((groupName) => !mostRecentExport.newGroups.includes(groupName))
+        .forEach((groupName) => {
+          oldGroupNames.splice(oldGroupNames.indexOf(groupName), 1);
+        });
     }
 
     // Send only the properties form the array that should be sent to the Destination, otherwise send the first entry in the array of profile properties


### PR DESCRIPTION
When building the New and Old Groups for a Profile Export, there are 2 things that need to be considered 
1. The actual Groups the profile is a part of - did the Profile enter or exit any Groups due to the related Imports?
2. Did the Destination decide to follow or un-follow any Group Memberships (tags) since the last export.

Until this PR, `#2` was naively assuming that the Groups Memberships being tracked as tags doesn't change between exports.  But, now that we can readily access the `mostRecentExport` (the most-recent previous export between this Profile and Destination), we can see if the Destination previously was tracking these "tags" or not.

Closes T-298