### PR TITLE
Identifying Profile Property Settings

### DIFF
--- a/core/web/components/settings/identifyingProfilePropertyRule.tsx
+++ b/core/web/components/settings/identifyingProfilePropertyRule.tsx
@@ -21,7 +21,9 @@ export default function IdentifyingProfilePropertyRule(props) {
 
   async function load() {
     setLoading(true);
-    const response = await execApi("get", `/profilePropertyRules`);
+    const response = await execApi("get", `/profilePropertyRules`, {
+      state: "ready",
+    });
     setLoading(false);
 
     if (response.profilePropertyRules) {

--- a/core/web/pages/settings/[tab].tsx
+++ b/core/web/pages/settings/[tab].tsx
@@ -15,7 +15,7 @@ export default function Page(props) {
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);
   const [settings, setSettings] = useState(props.settings);
-  const [activeTab] = useState(tab || "clusterOperations");
+  const [activeTab] = useState(tab || "core");
 
   async function updateSetting(setting) {
     setLoading(true);
@@ -54,18 +54,25 @@ export default function Page(props) {
         activeKey={activeTab}
         onSelect={(k) => router.push(`/settings/${k}`)}
       >
-        <Tab eventKey="clusterOperations" title="Cluster Operations">
+        <Tab eventKey="actions" title="Actions">
           <br />
-          <h2>Cluster Operations</h2>
-
-          <IdentifyingProfilePropertyRule
-            errorHandler={errorHandler}
-            successHandler={successHandler}
-          />
+          <h2>Cluster Actions</h2>
 
           <br />
 
           <ImportAndUpdateAllProfiles
+            errorHandler={errorHandler}
+            successHandler={successHandler}
+          />
+        </Tab>
+
+        <Tab eventKey="interface" title="Interface">
+          <br />
+          <h2>User Interface</h2>
+
+          <br />
+
+          <IdentifyingProfilePropertyRule
             errorHandler={errorHandler}
             successHandler={successHandler}
           />
@@ -79,6 +86,8 @@ export default function Page(props) {
           >
             <br />
             <h2>{capitalize(pluginName)}</h2>
+
+            {/* Regular Settings organized by Plugin */}
             {settings
               .sort((a, b) => {
                 if (a.key > b.key) return 1;
@@ -116,11 +125,20 @@ function SettingCard({ setting, updateSetting, loading }) {
     updateSetting(setting);
   }
 
+  function capitalize(key: string) {
+    return key
+      .split("-")
+      .map((word) => {
+        return word.charAt(0).toUpperCase() + word.slice(1);
+      })
+      .join(" ");
+  }
+
   return (
     <>
       <Card>
         <Card.Body>
-          <Card.Title>{setting.key}</Card.Title>
+          <Card.Title>{capitalize(setting.key)}</Card.Title>
           <Card.Subtitle className="mb-2 text-muted">
             {setting.description}
           </Card.Subtitle>


### PR DESCRIPTION
* Only show 'ready' Profile Property Rules in the options for Identifying Profile Property
* Rename "Cluster Operations" to "Actions"
* Make a new "Interface" sections to hold Identifying Profile Property 
* Format the titles of the settings (break `-` into` ' '`, capitalize)

<img width="1439" alt="Screen Shot 2020-08-18 at 10 40 56 AM" src="https://user-images.githubusercontent.com/303226/90546713-4da3ef80-e13f-11ea-904e-b38e8a48ff0a.png">

Closes T-299
Closes T-353