### PR TITLE
Plugin Validation

### DIFF
--- a/core/api/__tests__/models/destination.ts
+++ b/core/api/__tests__/models/destination.ts
@@ -652,30 +652,33 @@ describe("models/destination", () => {
     };
 
     beforeAll(async () => {
-      plugin.registerPlugin({
-        name: "test-import-only-plugin",
-        apps: [
-          {
-            name: "test-template-app",
-            options: [],
-            methods: {
-              test: async () => {
-                return { success: true };
+      plugin.registerPlugin(
+        {
+          name: "test-import-only-plugin",
+          apps: [
+            {
+              name: "test-template-app",
+              options: [],
+              methods: {
+                test: async () => {
+                  return { success: true };
+                },
               },
             },
-          },
-        ],
-        connections: [
-          {
-            name: "import-from-test-template-app",
-            description: "a test app connection",
-            app: "test-template-app",
-            direction: "export",
-            options: [],
-            methods: {},
-          },
-        ],
-      });
+          ],
+          connections: [
+            {
+              name: "import-from-test-template-app",
+              description: "a test app connection",
+              app: "test-template-app",
+              direction: "export",
+              options: [],
+              methods: {},
+            },
+          ],
+        },
+        false // skip validation as we need an invalid plugin here
+      );
 
       app = await App.create({
         name: "test app with temp methods",
@@ -744,7 +747,7 @@ describe("models/destination", () => {
 
     beforeAll(async () => {
       plugin.registerPlugin({
-        name: "test-plugin",
+        name: "test-export-plugin",
         apps: [
           {
             name: "test-template-app",
@@ -761,7 +764,7 @@ describe("models/destination", () => {
         ],
         connections: [
           {
-            name: "export-from-test-template-app",
+            name: "export-from-test-app",
             description: "a test app connection",
             app: "test-template-app",
             direction: "export",
@@ -831,7 +834,7 @@ describe("models/destination", () => {
     test("the app exportProfiles method can be called by the destination and exports will be created and mappings followed", async () => {
       const destination = await Destination.create({
         name: "test plugin destination",
-        type: "export-from-test-template-app",
+        type: "export-from-test-app",
         appGuid: app.guid,
       });
 
@@ -923,7 +926,7 @@ describe("models/destination", () => {
     test("profile properties previously mapped but now removed will be included as oldProfileProperties in the export", async () => {
       const destination = await Destination.create({
         name: "test plugin destination",
-        type: "export-from-test-template-app",
+        type: "export-from-test-app",
         appGuid: app.guid,
       });
 
@@ -984,7 +987,7 @@ describe("models/destination", () => {
     test("newly tagged groups will appear new in next export", async () => {
       const destination = await Destination.create({
         name: "test plugin destination",
-        type: "export-from-test-template-app",
+        type: "export-from-test-app",
         appGuid: app.guid,
       });
 
@@ -1047,7 +1050,7 @@ describe("models/destination", () => {
     test("newly un-tagged groups will be removed from the next export", async () => {
       const destination = await Destination.create({
         name: "test plugin destination",
-        type: "export-from-test-template-app",
+        type: "export-from-test-app",
         appGuid: app.guid,
       });
 
@@ -1112,7 +1115,7 @@ describe("models/destination", () => {
     test("if a profile is removed from all groups tracked by this destination, toDelete is true", async () => {
       const destination = await Destination.create({
         name: "test plugin destination",
-        type: "export-from-test-template-app",
+        type: "export-from-test-app",
         appGuid: app.guid,
       });
 
@@ -1164,7 +1167,7 @@ describe("models/destination", () => {
     test("if an export has the same data as the previous export, and force=false, it will not be sent to the destination", async () => {
       const destination = await Destination.create({
         name: "test plugin destination",
-        type: "export-from-test-template-app",
+        type: "export-from-test-app",
         appGuid: app.guid,
       });
       const profile = await helper.factories.profile();
@@ -1215,7 +1218,7 @@ describe("models/destination", () => {
     test("if an export has the same data as the previous export, and force=true, it will be sent to the destination", async () => {
       const destination = await Destination.create({
         name: "test plugin destination",
-        type: "export-from-test-template-app",
+        type: "export-from-test-app",
         appGuid: app.guid,
       });
       const profile = await helper.factories.profile();
@@ -1268,7 +1271,7 @@ describe("models/destination", () => {
     test("if there is no previous export, it will be sent to the destination", async () => {
       const destination = await Destination.create({
         name: "test plugin destination",
-        type: "export-from-test-template-app",
+        type: "export-from-test-app",
         appGuid: app.guid,
       });
       const profile = await helper.factories.profile();
@@ -1304,7 +1307,7 @@ describe("models/destination", () => {
 
       const destination = await Destination.create({
         name: "test plugin destination",
-        type: "export-from-test-template-app",
+        type: "export-from-test-app",
         appGuid: app.guid,
       });
       const group = await helper.factories.group();
@@ -1347,7 +1350,7 @@ describe("models/destination", () => {
 
       const destination = await Destination.create({
         name: "test plugin destination",
-        type: "export-from-test-template-app",
+        type: "export-from-test-app",
         appGuid: app.guid,
       });
       const group = await helper.factories.group();
@@ -1375,7 +1378,7 @@ describe("models/destination", () => {
 
       const destination = await Destination.create({
         name: "test plugin destination",
-        type: "export-from-test-template-app",
+        type: "export-from-test-app",
         appGuid: app.guid,
       });
       const group = await helper.factories.group();
@@ -1427,7 +1430,7 @@ describe("models/destination", () => {
 
       const destination = await Destination.create({
         name: "test plugin destination",
-        type: "export-from-test-template-app",
+        type: "export-from-test-app",
         appGuid: app.guid,
       });
       const group = await helper.factories.group();
@@ -1458,7 +1461,7 @@ describe("models/destination", () => {
       beforeAll(async () => {
         destination = await Destination.create({
           name: "test plugin destination",
-          type: "export-from-test-template-app",
+          type: "export-from-test-app",
           appGuid: app.guid,
         });
 
@@ -1534,7 +1537,7 @@ describe("models/destination", () => {
       test("mappings cannot use array profile properties if they are not allowed by exportArrayProperties", async () => {
         const destination = await Destination.create({
           name: "test plugin destination",
-          type: "export-from-test-template-app",
+          type: "export-from-test-app",
           appGuid: app.guid,
         });
 
@@ -1552,7 +1555,7 @@ describe("models/destination", () => {
 
         const destination = await Destination.create({
           name: "test plugin destination",
-          type: "export-from-test-template-app",
+          type: "export-from-test-app",
           appGuid: app.guid,
         });
 
@@ -1600,7 +1603,7 @@ describe("models/destination", () => {
 
         const destination = await Destination.create({
           name: "test plugin destination",
-          type: "export-from-test-template-app",
+          type: "export-from-test-app",
           appGuid: app.guid,
         });
 

--- a/core/api/src/initializers/plugins.ts
+++ b/core/api/src/initializers/plugins.ts
@@ -1,4 +1,4 @@
-import { Initializer, api } from "actionhero";
+import { Initializer, api, log } from "actionhero";
 import { GrouparooPlugin } from "../classes/plugin";
 import { plugin } from "../modules/plugin";
 import { App } from "../models/App";
@@ -7,6 +7,8 @@ declare module "actionhero" {
   export interface Api {
     plugins: {
       plugins: Array<GrouparooPlugin>;
+      validate: (plugin: GrouparooPlugin) => boolean;
+      register: (plugin: GrouparooPlugin) => void;
       persistentConnections: {
         [guid: string]: any;
       };
@@ -26,6 +28,8 @@ export class Plugins extends Initializer {
     api.plugins = {
       plugins: [],
       persistentConnections: {},
+      validate: this.validatePlugin,
+      register: this.registerPlugin,
     };
 
     // --- Add the core plugin --- //
@@ -67,5 +71,118 @@ export class Plugins extends Initializer {
       const app = await App.findByGuid(guid);
       await app.disconnect();
     }
+  }
+
+  validatePlugin(plugin: GrouparooPlugin) {
+    let errors: string[] = [];
+
+    if (!plugin.name) {
+      errors.push(`name is required for a Grouparoo Plugin`);
+    }
+    if (api.plugins.plugins.map((p) => p.name).includes(plugin.name)) {
+      errors.push(`a plugin named ${plugin.name} is already registered`);
+    }
+
+    if (plugin.apps) {
+      plugin?.apps.forEach((app) => {
+        if (!app.name) {
+          errors.push(`app.name is required for a Grouparoo Plugin App`);
+        }
+        if (
+          api.plugins.plugins
+            .map((p) => p.apps?.map((app) => app.name))
+            .flat()
+            .includes(plugin.name)
+        ) {
+          errors.push(`a plugin app named ${app.name} is already registered`);
+        }
+        if (!app.options) {
+          errors.push(`app.options is required for a Grouparoo Plugin App`);
+        }
+        if (!app.methods.test) {
+          errors.push(
+            `app.methods.test is required for a Grouparoo Plugin App`
+          );
+        }
+        if (
+          (app.methods.connect && !app.methods.disconnect) ||
+          (!app.methods.connect && app.methods.disconnect)
+        ) {
+          errors.push(
+            `both app.methods.connect and app.methods.disconnect are required for a Grouparoo Plugin App`
+          );
+        }
+      });
+    }
+
+    if (plugin.connections) {
+      plugin.connections.forEach((connection) => {
+        if (!connection.name) {
+          errors.push(
+            `connection.name is required for a Grouparoo Plugin Connection`
+          );
+        }
+        if (
+          api.plugins.plugins
+            .map((p) => p.connections?.map((conn) => conn.name))
+            .flat()
+            .includes(connection.name)
+        ) {
+          errors.push(
+            `a plugin connection named ${connection.name} is already registered`
+          );
+        }
+        if (!connection.app) {
+          errors.push(
+            `connection.app is required for a Grouparoo Plugin Connection`
+          );
+        }
+        if (!connection.description) {
+          errors.push(
+            `connection.description is required for a Grouparoo Plugin Connection`
+          );
+        }
+        if (!connection.direction) {
+          errors.push(
+            `connection.direction is required for a Grouparoo Plugin Connection`
+          );
+        }
+        if (!connection.options) {
+          errors.push(
+            `connection.options is required for a Grouparoo Plugin Connection`
+          );
+        }
+        if (!["import", "export"].includes(connection.direction)) {
+          errors.push(
+            `connection.direction must be either import or export for a Grouparoo Plugin Connection`
+          );
+        }
+        if (
+          connection.direction === "export" &&
+          !connection.methods.exportProfile &&
+          !connection.methods.exportProfiles
+        ) {
+          errors.push(
+            `export connections must provide either connection.methods.exportProfile or connection.methods.exportProfiles`
+          );
+        }
+      });
+    }
+
+    if (errors.length > 0) {
+      throw new Error(
+        `Plugin validation failure for ${
+          plugin.name ? `"${plugin.name}"` : "plugin"
+        }: ${errors.join(", ")}`
+      );
+    }
+
+    return true;
+  }
+
+  registerPlugin(plugin: GrouparooPlugin) {
+    api.plugins.validate(plugin);
+    api.plugins.plugins.push(plugin);
+    log(`registered grouparoo plugin: ${plugin.name}`);
   }
 }

--- a/core/api/src/initializers/plugins.ts
+++ b/core/api/src/initializers/plugins.ts
@@ -8,7 +8,7 @@ declare module "actionhero" {
     plugins: {
       plugins: Array<GrouparooPlugin>;
       validate: (plugin: GrouparooPlugin) => boolean;
-      register: (plugin: GrouparooPlugin) => void;
+      register: (plugin: GrouparooPlugin, validate: boolean) => void;
       persistentConnections: {
         [guid: string]: any;
       };
@@ -180,8 +180,8 @@ export class Plugins extends Initializer {
     return true;
   }
 
-  registerPlugin(plugin: GrouparooPlugin) {
-    api.plugins.validate(plugin);
+  registerPlugin(plugin: GrouparooPlugin, validate = true) {
+    if (validate) api.plugins.validate(plugin);
     api.plugins.plugins.push(plugin);
     log(`registered grouparoo plugin: ${plugin.name}`);
   }

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -448,8 +448,8 @@ export class Destination extends LoggedModel<Destination> {
     }
 
     if (
-      !pluginConnection.methods.exportProfile &&
-      !pluginConnection.methods.exportProfiles
+      !pluginConnection?.methods.exportProfile &&
+      !pluginConnection?.methods.exportProfiles
     ) {
       throw new Error(
         `a destination of type ${instance.type} cannot be created as there are no profile export methods`

--- a/core/api/src/modules/plugin.ts
+++ b/core/api/src/modules/plugin.ts
@@ -77,8 +77,8 @@ export namespace plugin {
   /**
    * Register a Grouparoo Plugin
    */
-  export function registerPlugin(plugin: GrouparooPlugin) {
-    api.plugins.register(plugin);
+  export function registerPlugin(plugin: GrouparooPlugin, validate?: boolean) {
+    api.plugins.register(plugin, validate);
   }
 
   /**

--- a/core/api/src/modules/plugin.ts
+++ b/core/api/src/modules/plugin.ts
@@ -78,8 +78,7 @@ export namespace plugin {
    * Register a Grouparoo Plugin
    */
   export function registerPlugin(plugin: GrouparooPlugin) {
-    log(`registering grouparoo plugin: ${plugin.name}`);
-    api.plugins.plugins.push(plugin);
+    api.plugins.register(plugin);
   }
 
   /**

--- a/plugins/@grouparoo/hubspot/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/hubspot/src/initializers/plugin.ts
@@ -3,6 +3,7 @@ import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
 import { connect } from "./../lib/connect";
+import { disconnect } from "./../lib/disconnect";
 
 import { exportProfile } from "../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
@@ -31,7 +32,7 @@ export class Plugins extends Initializer {
               description: "your hubspot hapikey (api) key",
             },
           ],
-          methods: { connect, test },
+          methods: { connect, disconnect, test },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/hubspot/src/lib/disconnect.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/disconnect.ts
@@ -1,0 +1,5 @@
+import { DisconnectPluginAppMethod } from "@grouparoo/core";
+
+export const disconnect: DisconnectPluginAppMethod = async () => {
+  // nothing to do
+};


### PR DESCRIPTION
Validate plugins as they are added via `plugin.registerPlugin()`.  We can check for required properties, ensure there are no duplicates, etc. 

Errors crash the server at boot:

```
2020-08-19T17:59:46.290Z - notice: Starting Grouparoo 0.1.10-alpha.0 on node.js v12.18.2
2020-08-19T17:59:55.312Z - info: registered grouparoo plugin: @grouparoo/core/manual
2020-08-19T17:59:55.316Z - info: registered grouparoo plugin: @grouparoo/core/events
2020-08-19T17:59:55.317Z - info: registered grouparoo plugin: @grouparoo/bigquery
2020-08-19T17:59:55.318Z - info: registered grouparoo plugin: @grouparoo/csv
2020-08-19T17:59:55.318Z - info: registered grouparoo plugin: @grouparoo/email-authentication
2020-08-19T17:59:55.318Z - info: registered grouparoo plugin: @grouparoo/files-s3
2020-08-19T17:59:55.610Z - info: registered grouparoo plugin: @grouparoo/google-sheets
2020-08-19T17:59:55.610Z - emerg: Exception occurred in initializer `@grouparoo/hubspot` during load
2020-08-19T17:59:55.610Z - emerg: Error with initializer step: "initialize"
2020-08-19T17:59:55.616Z - emerg: Error: Plugin validation failure for "@grouparoo/hubspot": both app.methods.connect and app.methods.disconnect are required for a Grouparoo Plugin App
```

Closes T-361