### PR TITLE
URL Profile Property Rule Type

### DIFF
--- a/core/api/__tests__/actions/groups.ts
+++ b/core/api/__tests__/actions/groups.ts
@@ -245,6 +245,7 @@ describe("actions/groups", () => {
           "integer",
           "phoneNumber",
           "string",
+          "url",
         ]);
 
         expect(ops._relativeMatchUnits).toEqual([

--- a/core/api/__tests__/actions/profilePropertyRules.ts
+++ b/core/api/__tests__/actions/profilePropertyRules.ts
@@ -65,6 +65,7 @@ describe("actions/profilePropertyRules", () => {
         "integer",
         "phoneNumber",
         "string",
+        "url",
       ]);
     });
 

--- a/core/api/__tests__/models/group/rules/urls.ts
+++ b/core/api/__tests__/models/group/rules/urls.ts
@@ -1,0 +1,109 @@
+import { Group } from "../../../../src/models/Group";
+import { Profile } from "../../../../src/models/Profile";
+import { ProfilePropertyRule } from "../../../../src/models/ProfilePropertyRule";
+import { SharedGroupTests } from "../../../utils/prepareSharedGroupTest";
+
+describe("model/group", () => {
+  let group: Group;
+  let mario: Profile;
+  let luigi: Profile;
+  let peach: Profile;
+  let toad: Profile;
+  let urlRule: ProfilePropertyRule;
+
+  beforeAll(async () => {
+    const response = await SharedGroupTests.beforeAll();
+    mario = response.mario;
+    luigi = response.luigi;
+    peach = response.peach;
+    toad = response.toad;
+
+    const emailRule = await ProfilePropertyRule.findOne({
+      where: { key: "email" },
+    });
+
+    urlRule = await ProfilePropertyRule.create({
+      isArray: true,
+      unique: false,
+      key: "url",
+      type: "url",
+      sourceGuid: emailRule.sourceGuid,
+    });
+    await urlRule.setOptions({ column: "url" });
+    await urlRule.update({ state: "ready" });
+
+    await mario.addOrUpdateProperties({ url: ["https://nintendo.com"] });
+    await luigi.addOrUpdateProperties({ url: ["https://nintendo.com"] });
+    await peach.addOrUpdateProperties({
+      url: ["https://nintendo.com", "http://mushroom-kingdom.gov"],
+    });
+    await toad.buildNullProperties();
+  }, 1000 * 30);
+
+  afterAll(async () => {
+    await SharedGroupTests.afterAll();
+  });
+
+  beforeEach(async () => {
+    const response = await SharedGroupTests.beforeEach();
+    group = response.group;
+  });
+
+  afterEach(async () => {
+    await SharedGroupTests.afterEach();
+  });
+
+  describe("rules", () => {
+    describe("URLs", () => {
+      test("exact matches", async () => {
+        await group.setRules([
+          {
+            key: "url",
+            match: "https://nintendo.com",
+            operation: { op: "eq" },
+          },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(3);
+      });
+
+      test("partial matches", async () => {
+        await group.setRules([
+          { key: "url", match: "%.com", operation: { op: "like" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(3);
+      });
+
+      test("multiple rules with same key", async () => {
+        await group.setRules([
+          { key: "url", match: "https%", operation: { op: "iLike" } },
+          { key: "url", match: "%.com", operation: { op: "iLike" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(3);
+      });
+
+      test("null match", async () => {
+        await group.setRules([
+          { key: "url", match: "null", operation: { op: "eq" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(1);
+      });
+
+      test("not null match", async () => {
+        await group.setRules([
+          { key: "url", match: "null", operation: { op: "ne" } },
+        ]);
+        expect(await group.countPotentialMembers()).toBe(3);
+      });
+
+      test("exists", async () => {
+        await group.setRules([{ key: "url", operation: { op: "exists" } }]);
+        expect(await group.countPotentialMembers()).toBe(3);
+      });
+
+      test("notExists", async () => {
+        await group.setRules([{ key: "url", operation: { op: "notExists" } }]);
+        expect(await group.countPotentialMembers()).toBe(1);
+      });
+    });
+  });
+});

--- a/core/api/__tests__/models/profileProperty.ts
+++ b/core/api/__tests__/models/profileProperty.ts
@@ -21,6 +21,7 @@ describe("models/profileProperty", () => {
   let profile: Profile;
   let firstNameRule: ProfilePropertyRule;
   let emailRule: ProfilePropertyRule;
+  let urlRule: ProfilePropertyRule;
   let phoneNumberRule: ProfilePropertyRule;
   let userIdRule: ProfilePropertyRule;
   let lastLoginRule: ProfilePropertyRule;
@@ -56,6 +57,14 @@ describe("models/profileProperty", () => {
     });
     await emailRule.setOptions({ column: "email" });
     await emailRule.update({ state: "ready" });
+
+    urlRule = await ProfilePropertyRule.create({
+      sourceGuid: source.guid,
+      key: "url",
+      type: "url",
+    });
+    await urlRule.setOptions({ column: "url" });
+    await urlRule.update({ state: "ready" });
 
     phoneNumberRule = await ProfilePropertyRule.create({
       sourceGuid: source.guid,
@@ -221,6 +230,26 @@ describe("models/profileProperty", () => {
       await expect(
         profileProperty.setValue("someone.com")
       ).rejects.toThrowError(/email .* is not valid/);
+    });
+
+    test("urls", async () => {
+      const profileProperty = new ProfileProperty({
+        profileGuid: profile.guid,
+        profilePropertyRuleGuid: urlRule.guid,
+      });
+      await profileProperty.setValue("HTTPS://grouparoo.com/picture");
+      const response = await profileProperty.getValue();
+      expect(response).toBe("https://grouparoo.com/picture");
+    });
+
+    test("invalid urls throw an error", async () => {
+      const profileProperty = new ProfileProperty({
+        profileGuid: profile.guid,
+        profilePropertyRuleGuid: urlRule.guid,
+      });
+      await expect(profileProperty.setValue("not a url")).rejects.toThrowError(
+        /url .* is not valid/
+      );
     });
 
     test("phone numbers", async () => {

--- a/core/api/src/models/ProfileProperty.ts
+++ b/core/api/src/models/ProfileProperty.ts
@@ -15,6 +15,7 @@ import { ProfilePropertyRule } from "./ProfilePropertyRule";
 import { parsePhoneNumberFromString, CountryCode } from "libphonenumber-js/max";
 import { plugin } from "../modules/plugin";
 import isEmail from "validator/lib/isEmail";
+import isURL from "validator/lib/isURL";
 
 @Table({ tableName: "profileProperties", paranoid: false })
 export class ProfileProperty extends LoggedModel<ProfileProperty> {
@@ -101,6 +102,8 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
         return this.formatEmail(value.toString());
       case "phoneNumber":
         return this.formatPhoneNumber(value.toString());
+      case "url":
+        return this.formatURL(value.toString());
       case "boolean":
         if (![true, false, 0, 1, "true", "false"].includes(value)) {
           throw new Error(
@@ -134,8 +137,10 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
       case "string":
         return this.rawValue;
       case "email":
-        return this.rawValue.toLowerCase();
+        return this.rawValue;
       case "phoneNumber":
+        return this.rawValue;
+      case "url":
         return this.rawValue;
       case "boolean":
         if ([true, 1, "true"].includes(this.rawValue)) {
@@ -210,6 +215,14 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
         );
       }
     }
+  }
+
+  async formatURL(url: string) {
+    if (!isURL(url)) {
+      throw new Error(`url "${url}" is not valid`);
+    }
+
+    return url.toLocaleLowerCase();
   }
 
   async formatEmail(email: string) {

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -36,13 +36,14 @@ import { ProfilePropertyRuleOps } from "../modules/ops/profilePropertyRule";
 
 export function profilePropertyRuleJSToSQLType(jsType: string) {
   const map = {
-    integer: "bigint",
-    float: "float",
-    string: "text",
-    email: "text",
-    phoneNumber: "text",
     boolean: "boolean",
     date: "bigint", // we store things via timestamps in the DB
+    email: "text",
+    float: "float",
+    integer: "bigint",
+    phoneNumber: "text",
+    string: "text",
+    url: "text",
   };
 
   return map[jsType];
@@ -56,6 +57,7 @@ const TYPES = [
   "integer",
   "phoneNumber",
   "string",
+  "url",
 ];
 
 const CACHE_TTL = env === "test" ? -1 : 1000 * 30;

--- a/core/api/src/modules/RuleOpsDictionary.ts
+++ b/core/api/src/modules/RuleOpsDictionary.ts
@@ -44,13 +44,16 @@ const _date_ops = [
 ];
 
 export const ProfilePropertyRuleOpsDictionary = {
-  string: _string_ops,
-  email: _string_ops,
-  integer: _number_ops,
-  float: _number_ops,
+  // types
   boolean: _boolean_ops,
   date: _date_ops,
+  email: _string_ops,
+  float: _number_ops,
+  integer: _number_ops,
   phoneNumber: _string_ops,
+  string: _string_ops,
+  url: _string_ops,
+  // utils
   _relativeMatchUnits: ["days", "weeks", "months", "quarters", "years"],
   _convenientRules: {
     exists: { operation: { op: "ne" }, match: "null" },


### PR DESCRIPTION
This Pull Request adds a Profile Property Rule type of `URL`.  Use this when want to ensure a valid HTTP, HTTPS, FTP, etc URL is used, perhaps for a link to an Avatar Image or Unique profile link.

* Yes, technically this should be `URI`, but that's likely to confuse people.

Closes T-355