### PR TITLE
Don't clobber mailchimp properties that Grouparoo didn't set

### DIFF
--- a/plugins/@grouparoo/mailchimp/__tests__/fixtures/nock.ts
+++ b/plugins/@grouparoo/mailchimp/__tests__/fixtures/nock.ts
@@ -2,212 +2,3009 @@ import nock from "nock";
 
 // --- paste nock output below ---
 
-// prettier-ignore
+nock("https://us4.api.mailchimp.com:443", { encodedQueryParams: true })
+  .get("/3.0/lists/a42c031026/merge-fields", {})
+  .reply(
+    200,
+    {
+      merge_fields: [
+        {
+          merge_id: 3,
+          tag: "ADDRESS",
+          name: "Address",
+          type: "address",
+          required: false,
+          default_value: "",
+          public: false,
+          display_order: 4,
+          options: { default_country: 164 },
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/3",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/3",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/3",
+              method: "DELETE",
+            },
+          ],
+        },
+        {
+          merge_id: 1,
+          tag: "FNAME",
+          name: "First Name",
+          type: "text",
+          required: false,
+          default_value: "",
+          public: true,
+          display_order: 2,
+          options: { size: 25 },
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/1",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/1",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/1",
+              method: "DELETE",
+            },
+          ],
+        },
+        {
+          merge_id: 7,
+          tag: "LANGUAGE",
+          name: "Language",
+          type: "text",
+          required: false,
+          default_value: "",
+          public: true,
+          display_order: 8,
+          options: { size: 25 },
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/7",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/7",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/7",
+              method: "DELETE",
+            },
+          ],
+        },
+        {
+          merge_id: 2,
+          tag: "LNAME",
+          name: "Last Name",
+          type: "text",
+          required: false,
+          default_value: "",
+          public: true,
+          display_order: 3,
+          options: { size: 25 },
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/2",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/2",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/2",
+              method: "DELETE",
+            },
+          ],
+        },
+        {
+          merge_id: 6,
+          tag: "LTV",
+          name: "LTV",
+          type: "number",
+          required: false,
+          default_value: "",
+          public: true,
+          display_order: 7,
+          options: {},
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/6",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/6",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/6",
+              method: "DELETE",
+            },
+          ],
+        },
+        {
+          merge_id: 4,
+          tag: "PHONE",
+          name: "Phone Number",
+          type: "phone",
+          required: false,
+          default_value: "",
+          public: false,
+          display_order: 5,
+          options: { phone_format: "none" },
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/4",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/4",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/4",
+              method: "DELETE",
+            },
+          ],
+        },
+        {
+          merge_id: 5,
+          tag: "USERID",
+          name: "UserID",
+          type: "number",
+          required: false,
+          default_value: "",
+          public: true,
+          display_order: 6,
+          options: {},
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/5",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/5",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/5",
+              method: "DELETE",
+            },
+          ],
+        },
+      ],
+      list_id: "a42c031026",
+      total_items: 7,
+      _links: [
+        {
+          rel: "self",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+        },
+        {
+          rel: "create",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+          method: "POST",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/POST.json",
+        },
+        {
+          rel: "parent",
+          href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+        },
+      ],
+    },
+    [
+      "Server",
+      "openresty",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Vary",
+      "Accept-Encoding",
+      "X-Request-Id",
+      "2bc328ff-b2e1-46a3-b0e4-f07ea5e46128",
+      "Link",
+      '<https://us4.api.mailchimp.com/schema/3.0/Lists/MergeFields/Collection.json>; rel="describedBy"',
+      "Date",
+      "Wed, 19 Aug 2020 21:27:59 GMT",
+      "Content-Length",
+      "8778",
+      "Connection",
+      "close",
+    ]
+  );
+nock("https://us4.api.mailchimp.com:443", { encodedQueryParams: true })
+  .get("/3.0/lists", {})
+  .reply(
+    200,
+    {
+      lists: [
+        {
+          id: "1b724bb934",
+          web_id: 382062,
+          name: "Demo (Evan)",
+          contact: {
+            company: "Grouparoo",
+            address1: "1001 University Dr",
+            address2: "",
+            city: "Menlo Park",
+            state: "CA",
+            zip: "94025-4614",
+            country: "US",
+            phone: "8602639544",
+          },
+          permission_reminder: "You aren't a real person - this is a demo.",
+          use_archive_bar: true,
+          campaign_defaults: {
+            from_name: "Grouparoo",
+            from_email: "fake-evan@grouparoo.com",
+            subject: "",
+            language: "en",
+          },
+          notify_on_subscribe: "",
+          notify_on_unsubscribe: "",
+          date_created: "2020-08-12T16:21:04+00:00",
+          list_rating: 0,
+          email_type_option: false,
+          subscribe_url_short: "http://eepurl.com/haJ6YH",
+          subscribe_url_long:
+            "https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=1b724bb934",
+          beamer_address: "us4-0c2a01eabd-992b9e38fb@inbound.mailchimp.com",
+          visibility: "prv",
+          double_optin: false,
+          has_welcome: false,
+          marketing_permissions: false,
+          modules: [],
+          stats: {
+            member_count: 0,
+            unsubscribe_count: 0,
+            cleaned_count: 0,
+            member_count_since_send: 70,
+            unsubscribe_count_since_send: 0,
+            cleaned_count_since_send: 0,
+            campaign_count: 0,
+            campaign_last_sent: "",
+            merge_field_count: 6,
+            avg_sub_rate: 262,
+            avg_unsub_rate: 0,
+            target_sub_rate: 0,
+            open_rate: 0,
+            click_rate: 0,
+            last_sub_date: "",
+            last_unsub_date: "",
+          },
+          _links: [
+            {
+              rel: "self",
+              href: "https://us4.api.mailchimp.com/3.0/lists/1b724bb934",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+            },
+            {
+              rel: "parent",
+              href: "https://us4.api.mailchimp.com/3.0/lists",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json",
+            },
+            {
+              rel: "update",
+              href: "https://us4.api.mailchimp.com/3.0/lists/1b724bb934",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json",
+            },
+            {
+              rel: "batch-sub-unsub-members",
+              href: "https://us4.api.mailchimp.com/3.0/lists/1b724bb934",
+              method: "POST",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json",
+            },
+            {
+              rel: "delete",
+              href: "https://us4.api.mailchimp.com/3.0/lists/1b724bb934",
+              method: "DELETE",
+            },
+            {
+              rel: "abuse-reports",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/abuse-reports",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json",
+            },
+            {
+              rel: "activity",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/activity",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json",
+            },
+            {
+              rel: "clients",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/clients",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json",
+            },
+            {
+              rel: "growth-history",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/growth-history",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json",
+            },
+            {
+              rel: "interest-categories",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/interest-categories",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json",
+            },
+            {
+              rel: "members",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/members",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json",
+            },
+            {
+              rel: "merge-fields",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "segments",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/segments",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json",
+            },
+            {
+              rel: "webhooks",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/webhooks",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json",
+            },
+            {
+              rel: "signup-forms",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/signup-forms",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json",
+            },
+            {
+              rel: "locations",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/locations",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json",
+            },
+          ],
+        },
+        {
+          id: "23d8e9cb6e",
+          web_id: 363213,
+          name: "Grouparoo",
+          contact: {
+            company: "Grouparoo",
+            address1: "1001 University Dr",
+            address2: "",
+            city: "Menlo Park",
+            state: "CA",
+            zip: "94025-4614",
+            country: "US",
+            phone: "",
+          },
+          permission_reminder:
+            "You are receiving this email because you opted in via our website.",
+          use_archive_bar: true,
+          campaign_defaults: {
+            from_name: "Evan",
+            from_email: "evan.tahler@grouparoo.com",
+            subject: "",
+            language: "en",
+          },
+          notify_on_subscribe: "",
+          notify_on_unsubscribe: "",
+          date_created: "2020-02-06T21:02:33+00:00",
+          list_rating: 0,
+          email_type_option: false,
+          subscribe_url_short: "http://eepurl.com/gShnbH",
+          subscribe_url_long:
+            "https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=23d8e9cb6e",
+          beamer_address: "us4-0c2a01eabd-840733a81d@inbound.mailchimp.com",
+          visibility: "pub",
+          double_optin: false,
+          has_welcome: false,
+          marketing_permissions: false,
+          modules: [],
+          stats: {
+            member_count: 1,
+            unsubscribe_count: 0,
+            cleaned_count: 0,
+            member_count_since_send: 1,
+            unsubscribe_count_since_send: 0,
+            cleaned_count_since_send: 0,
+            campaign_count: 0,
+            campaign_last_sent: "",
+            merge_field_count: 5,
+            avg_sub_rate: 0,
+            avg_unsub_rate: 0,
+            target_sub_rate: 0,
+            open_rate: 0,
+            click_rate: 0,
+            last_sub_date: "2020-02-06T21:02:34+00:00",
+            last_unsub_date: "",
+          },
+          _links: [
+            {
+              rel: "self",
+              href: "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+            },
+            {
+              rel: "parent",
+              href: "https://us4.api.mailchimp.com/3.0/lists",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json",
+            },
+            {
+              rel: "update",
+              href: "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json",
+            },
+            {
+              rel: "batch-sub-unsub-members",
+              href: "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e",
+              method: "POST",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json",
+            },
+            {
+              rel: "delete",
+              href: "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e",
+              method: "DELETE",
+            },
+            {
+              rel: "abuse-reports",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/abuse-reports",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json",
+            },
+            {
+              rel: "activity",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/activity",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json",
+            },
+            {
+              rel: "clients",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/clients",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json",
+            },
+            {
+              rel: "growth-history",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/growth-history",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json",
+            },
+            {
+              rel: "interest-categories",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/interest-categories",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json",
+            },
+            {
+              rel: "members",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/members",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json",
+            },
+            {
+              rel: "merge-fields",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "segments",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/segments",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json",
+            },
+            {
+              rel: "webhooks",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/webhooks",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json",
+            },
+            {
+              rel: "signup-forms",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/signup-forms",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json",
+            },
+            {
+              rel: "locations",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/locations",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json",
+            },
+          ],
+        },
+        {
+          id: "6f890f62ee",
+          web_id: 365697,
+          name: "Demo (Andy)",
+          contact: {
+            company: "Grouparoo",
+            address1: "1001 University Dr",
+            address2: "",
+            city: "Menlo Park",
+            state: "CA",
+            zip: "94025-4614",
+            country: "US",
+            phone: "",
+          },
+          permission_reminder: "DEMO",
+          use_archive_bar: true,
+          campaign_defaults: {
+            from_name: "Grouparoo Demo",
+            from_email: "hello@grouparoo.com",
+            subject: "",
+            language: "en",
+          },
+          notify_on_subscribe: "",
+          notify_on_unsubscribe: "",
+          date_created: "2020-02-11T17:12:54+00:00",
+          list_rating: 0,
+          email_type_option: false,
+          subscribe_url_short: "http://eepurl.com/gSKdJ1",
+          subscribe_url_long:
+            "https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=6f890f62ee",
+          beamer_address: "us4-0c2a01eabd-80bbdfd596@inbound.mailchimp.com",
+          visibility: "pub",
+          double_optin: false,
+          has_welcome: false,
+          marketing_permissions: false,
+          modules: [],
+          stats: {
+            member_count: 0,
+            unsubscribe_count: 0,
+            cleaned_count: 0,
+            member_count_since_send: 5186,
+            unsubscribe_count_since_send: 0,
+            cleaned_count_since_send: 0,
+            campaign_count: 0,
+            campaign_last_sent: "",
+            merge_field_count: 7,
+            avg_sub_rate: 9517,
+            avg_unsub_rate: 0,
+            target_sub_rate: 0,
+            open_rate: 0,
+            click_rate: 0,
+            last_sub_date: "",
+            last_unsub_date: "",
+          },
+          _links: [
+            {
+              rel: "self",
+              href: "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+            },
+            {
+              rel: "parent",
+              href: "https://us4.api.mailchimp.com/3.0/lists",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json",
+            },
+            {
+              rel: "update",
+              href: "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json",
+            },
+            {
+              rel: "batch-sub-unsub-members",
+              href: "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee",
+              method: "POST",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json",
+            },
+            {
+              rel: "delete",
+              href: "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee",
+              method: "DELETE",
+            },
+            {
+              rel: "abuse-reports",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/abuse-reports",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json",
+            },
+            {
+              rel: "activity",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/activity",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json",
+            },
+            {
+              rel: "clients",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/clients",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json",
+            },
+            {
+              rel: "growth-history",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/growth-history",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json",
+            },
+            {
+              rel: "interest-categories",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/interest-categories",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json",
+            },
+            {
+              rel: "members",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/members",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json",
+            },
+            {
+              rel: "merge-fields",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "segments",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/segments",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json",
+            },
+            {
+              rel: "webhooks",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/webhooks",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json",
+            },
+            {
+              rel: "signup-forms",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/signup-forms",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json",
+            },
+            {
+              rel: "locations",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/locations",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json",
+            },
+          ],
+        },
+        {
+          id: "a42c031026",
+          web_id: 363225,
+          name: "Demo (Brian)",
+          contact: {
+            company: "Grouparoo",
+            address1: "1001 University Dr",
+            address2: "",
+            city: "Menlo Park",
+            state: "CA",
+            zip: "94025-4614",
+            country: "US",
+            phone: "",
+          },
+          permission_reminder: "STAGING",
+          use_archive_bar: true,
+          campaign_defaults: {
+            from_name: "Grouparoo Staging",
+            from_email: "hello@grouparoo.com",
+            subject: "",
+            language: "en",
+          },
+          notify_on_subscribe: "",
+          notify_on_unsubscribe: "",
+          date_created: "2020-02-06T21:50:53+00:00",
+          list_rating: 0,
+          email_type_option: false,
+          subscribe_url_short: "http://eepurl.com/gShnRT",
+          subscribe_url_long:
+            "https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=a42c031026",
+          beamer_address: "us4-0c2a01eabd-6eb9fef1e1@inbound.mailchimp.com",
+          visibility: "pub",
+          double_optin: false,
+          has_welcome: false,
+          marketing_permissions: false,
+          modules: [],
+          stats: {
+            member_count: 1,
+            unsubscribe_count: 0,
+            cleaned_count: 0,
+            member_count_since_send: 355,
+            unsubscribe_count_since_send: 0,
+            cleaned_count_since_send: 0,
+            campaign_count: 0,
+            campaign_last_sent: "",
+            merge_field_count: 7,
+            avg_sub_rate: 1373,
+            avg_unsub_rate: 0,
+            target_sub_rate: 0,
+            open_rate: 0,
+            click_rate: 0,
+            last_sub_date: "2020-03-31T16:51:30+00:00",
+            last_unsub_date: "",
+          },
+          _links: [
+            {
+              rel: "self",
+              href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+            },
+            {
+              rel: "parent",
+              href: "https://us4.api.mailchimp.com/3.0/lists",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json",
+            },
+            {
+              rel: "update",
+              href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json",
+            },
+            {
+              rel: "batch-sub-unsub-members",
+              href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026",
+              method: "POST",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json",
+            },
+            {
+              rel: "delete",
+              href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026",
+              method: "DELETE",
+            },
+            {
+              rel: "abuse-reports",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/abuse-reports",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json",
+            },
+            {
+              rel: "activity",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/activity",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json",
+            },
+            {
+              rel: "clients",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/clients",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json",
+            },
+            {
+              rel: "growth-history",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/growth-history",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json",
+            },
+            {
+              rel: "interest-categories",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/interest-categories",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json",
+            },
+            {
+              rel: "members",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json",
+            },
+            {
+              rel: "merge-fields",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "segments",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/segments",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json",
+            },
+            {
+              rel: "webhooks",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/webhooks",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json",
+            },
+            {
+              rel: "signup-forms",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/signup-forms",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json",
+            },
+            {
+              rel: "locations",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/locations",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json",
+            },
+          ],
+        },
+      ],
+      total_items: 4,
+      constraints: {
+        may_create: true,
+        max_instances: 5,
+        current_total_instances: 4,
+      },
+      _links: [
+        {
+          rel: "self",
+          href: "https://us4.api.mailchimp.com/3.0/lists",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json",
+        },
+        {
+          rel: "parent",
+          href: "https://us4.api.mailchimp.com/3.0/",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Root/Response.json",
+        },
+        {
+          rel: "create",
+          href: "https://us4.api.mailchimp.com/3.0/lists",
+          method: "POST",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/POST.json",
+        },
+      ],
+    },
+    [
+      "Server",
+      "openresty",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Vary",
+      "Accept-Encoding",
+      "X-Request-Id",
+      "3bb69483-e7da-4eae-9244-db453bd84649",
+      "Link",
+      '<https://us4.api.mailchimp.com/schema/3.0/Lists/Collection.json>; rel="describedBy"',
+      "Date",
+      "Wed, 19 Aug 2020 21:27:59 GMT",
+      "Content-Length",
+      "22915",
+      "Connection",
+      "close",
+    ]
+  );
 
-nock('https://us4.api.mailchimp.com:443', {"encodedQueryParams":true})
-  .get('/3.0/lists/a42c031026/merge-fields', {})
-  .reply(200, {"merge_fields":[{"merge_id":3,"tag":"ADDRESS","name":"Address","type":"address","required":false,"default_value":"","public":false,"display_order":4,"options":{"default_country":164},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/3","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/3","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/3","method":"DELETE"}]},{"merge_id":7,"tag":"COOL","name":"Cool","type":"text","required":false,"default_value":"","public":true,"display_order":8,"options":{"size":25},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/7","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/7","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/7","method":"DELETE"}]},{"merge_id":1,"tag":"FNAME","name":"First Name","type":"text","required":false,"default_value":"","public":true,"display_order":2,"options":{"size":25},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/1","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/1","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/1","method":"DELETE"}]},{"merge_id":2,"tag":"LNAME","name":"Last Name","type":"text","required":false,"default_value":"","public":true,"display_order":3,"options":{"size":25},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/2","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/2","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/2","method":"DELETE"}]},{"merge_id":6,"tag":"LTV","name":"LTV","type":"number","required":false,"default_value":"","public":true,"display_order":7,"options":{},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/6","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/6","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/6","method":"DELETE"}]},{"merge_id":4,"tag":"PHONE","name":"Phone Number","type":"phone","required":false,"default_value":"","public":false,"display_order":5,"options":{"phone_format":"none"},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/4","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/4","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/4","method":"DELETE"}]},{"merge_id":5,"tag":"USERID","name":"UserID","type":"number","required":false,"default_value":"","public":true,"display_order":6,"options":{},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/5","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/5","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/5","method":"DELETE"}]}],"list_id":"a42c031026","total_items":7,"_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"create","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/POST.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json"}]}, [
-  'Server',
-  'openresty',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Vary',
-  'Accept-Encoding',
-  'X-Request-Id',
-  '362442e6-376d-46ce-9049-ecdecce3f8e1',
-  'Link',
-  '<https://us4.api.mailchimp.com/schema/3.0/Lists/MergeFields/Collection.json>; rel="describedBy"',
-  'Date',
-  'Thu, 23 Apr 2020 18:33:59 GMT',
-  'Content-Length',
-  '8770',
-  'Connection',
-  'close',
-  'Set-Cookie',
-  '_AVESTA_ENVIRONMENT=prod; path=/',
-  'Set-Cookie',
-  '_mcid=1.2641a6b0d6148496171d6fbc38a9caef.9ce24b0be65708cd77276fb255ec8398d0d228dccd4d9f2eae601ad831624b21; expires=Fri, 23-Apr-2021 18:33:59 GMT; Max-Age=31536000; path=/; domain=.mailchimp.com'
-]);
+nock("https://us4.api.mailchimp.com:443", { encodedQueryParams: true })
+  .get("/3.0/lists", {})
+  .reply(
+    200,
+    {
+      lists: [
+        {
+          id: "1b724bb934",
+          web_id: 382062,
+          name: "Demo (Evan)",
+          contact: {
+            company: "Grouparoo",
+            address1: "1001 University Dr",
+            address2: "",
+            city: "Menlo Park",
+            state: "CA",
+            zip: "94025-4614",
+            country: "US",
+            phone: "8602639544",
+          },
+          permission_reminder: "You aren't a real person - this is a demo.",
+          use_archive_bar: true,
+          campaign_defaults: {
+            from_name: "Grouparoo",
+            from_email: "fake-evan@grouparoo.com",
+            subject: "",
+            language: "en",
+          },
+          notify_on_subscribe: "",
+          notify_on_unsubscribe: "",
+          date_created: "2020-08-12T16:21:04+00:00",
+          list_rating: 0,
+          email_type_option: false,
+          subscribe_url_short: "http://eepurl.com/haJ6YH",
+          subscribe_url_long:
+            "https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=1b724bb934",
+          beamer_address: "us4-0c2a01eabd-992b9e38fb@inbound.mailchimp.com",
+          visibility: "prv",
+          double_optin: false,
+          has_welcome: false,
+          marketing_permissions: false,
+          modules: [],
+          stats: {
+            member_count: 0,
+            unsubscribe_count: 0,
+            cleaned_count: 0,
+            member_count_since_send: 70,
+            unsubscribe_count_since_send: 0,
+            cleaned_count_since_send: 0,
+            campaign_count: 0,
+            campaign_last_sent: "",
+            merge_field_count: 6,
+            avg_sub_rate: 262,
+            avg_unsub_rate: 0,
+            target_sub_rate: 0,
+            open_rate: 0,
+            click_rate: 0,
+            last_sub_date: "",
+            last_unsub_date: "",
+          },
+          _links: [
+            {
+              rel: "self",
+              href: "https://us4.api.mailchimp.com/3.0/lists/1b724bb934",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+            },
+            {
+              rel: "parent",
+              href: "https://us4.api.mailchimp.com/3.0/lists",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json",
+            },
+            {
+              rel: "update",
+              href: "https://us4.api.mailchimp.com/3.0/lists/1b724bb934",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json",
+            },
+            {
+              rel: "batch-sub-unsub-members",
+              href: "https://us4.api.mailchimp.com/3.0/lists/1b724bb934",
+              method: "POST",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json",
+            },
+            {
+              rel: "delete",
+              href: "https://us4.api.mailchimp.com/3.0/lists/1b724bb934",
+              method: "DELETE",
+            },
+            {
+              rel: "abuse-reports",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/abuse-reports",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json",
+            },
+            {
+              rel: "activity",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/activity",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json",
+            },
+            {
+              rel: "clients",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/clients",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json",
+            },
+            {
+              rel: "growth-history",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/growth-history",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json",
+            },
+            {
+              rel: "interest-categories",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/interest-categories",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json",
+            },
+            {
+              rel: "members",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/members",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json",
+            },
+            {
+              rel: "merge-fields",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "segments",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/segments",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json",
+            },
+            {
+              rel: "webhooks",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/webhooks",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json",
+            },
+            {
+              rel: "signup-forms",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/signup-forms",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json",
+            },
+            {
+              rel: "locations",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/1b724bb934/locations",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json",
+            },
+          ],
+        },
+        {
+          id: "23d8e9cb6e",
+          web_id: 363213,
+          name: "Grouparoo",
+          contact: {
+            company: "Grouparoo",
+            address1: "1001 University Dr",
+            address2: "",
+            city: "Menlo Park",
+            state: "CA",
+            zip: "94025-4614",
+            country: "US",
+            phone: "",
+          },
+          permission_reminder:
+            "You are receiving this email because you opted in via our website.",
+          use_archive_bar: true,
+          campaign_defaults: {
+            from_name: "Evan",
+            from_email: "evan.tahler@grouparoo.com",
+            subject: "",
+            language: "en",
+          },
+          notify_on_subscribe: "",
+          notify_on_unsubscribe: "",
+          date_created: "2020-02-06T21:02:33+00:00",
+          list_rating: 0,
+          email_type_option: false,
+          subscribe_url_short: "http://eepurl.com/gShnbH",
+          subscribe_url_long:
+            "https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=23d8e9cb6e",
+          beamer_address: "us4-0c2a01eabd-840733a81d@inbound.mailchimp.com",
+          visibility: "pub",
+          double_optin: false,
+          has_welcome: false,
+          marketing_permissions: false,
+          modules: [],
+          stats: {
+            member_count: 1,
+            unsubscribe_count: 0,
+            cleaned_count: 0,
+            member_count_since_send: 1,
+            unsubscribe_count_since_send: 0,
+            cleaned_count_since_send: 0,
+            campaign_count: 0,
+            campaign_last_sent: "",
+            merge_field_count: 5,
+            avg_sub_rate: 0,
+            avg_unsub_rate: 0,
+            target_sub_rate: 0,
+            open_rate: 0,
+            click_rate: 0,
+            last_sub_date: "2020-02-06T21:02:34+00:00",
+            last_unsub_date: "",
+          },
+          _links: [
+            {
+              rel: "self",
+              href: "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+            },
+            {
+              rel: "parent",
+              href: "https://us4.api.mailchimp.com/3.0/lists",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json",
+            },
+            {
+              rel: "update",
+              href: "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json",
+            },
+            {
+              rel: "batch-sub-unsub-members",
+              href: "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e",
+              method: "POST",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json",
+            },
+            {
+              rel: "delete",
+              href: "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e",
+              method: "DELETE",
+            },
+            {
+              rel: "abuse-reports",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/abuse-reports",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json",
+            },
+            {
+              rel: "activity",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/activity",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json",
+            },
+            {
+              rel: "clients",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/clients",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json",
+            },
+            {
+              rel: "growth-history",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/growth-history",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json",
+            },
+            {
+              rel: "interest-categories",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/interest-categories",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json",
+            },
+            {
+              rel: "members",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/members",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json",
+            },
+            {
+              rel: "merge-fields",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "segments",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/segments",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json",
+            },
+            {
+              rel: "webhooks",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/webhooks",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json",
+            },
+            {
+              rel: "signup-forms",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/signup-forms",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json",
+            },
+            {
+              rel: "locations",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/locations",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json",
+            },
+          ],
+        },
+        {
+          id: "6f890f62ee",
+          web_id: 365697,
+          name: "Demo (Andy)",
+          contact: {
+            company: "Grouparoo",
+            address1: "1001 University Dr",
+            address2: "",
+            city: "Menlo Park",
+            state: "CA",
+            zip: "94025-4614",
+            country: "US",
+            phone: "",
+          },
+          permission_reminder: "DEMO",
+          use_archive_bar: true,
+          campaign_defaults: {
+            from_name: "Grouparoo Demo",
+            from_email: "hello@grouparoo.com",
+            subject: "",
+            language: "en",
+          },
+          notify_on_subscribe: "",
+          notify_on_unsubscribe: "",
+          date_created: "2020-02-11T17:12:54+00:00",
+          list_rating: 0,
+          email_type_option: false,
+          subscribe_url_short: "http://eepurl.com/gSKdJ1",
+          subscribe_url_long:
+            "https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=6f890f62ee",
+          beamer_address: "us4-0c2a01eabd-80bbdfd596@inbound.mailchimp.com",
+          visibility: "pub",
+          double_optin: false,
+          has_welcome: false,
+          marketing_permissions: false,
+          modules: [],
+          stats: {
+            member_count: 0,
+            unsubscribe_count: 0,
+            cleaned_count: 0,
+            member_count_since_send: 5186,
+            unsubscribe_count_since_send: 0,
+            cleaned_count_since_send: 0,
+            campaign_count: 0,
+            campaign_last_sent: "",
+            merge_field_count: 7,
+            avg_sub_rate: 9517,
+            avg_unsub_rate: 0,
+            target_sub_rate: 0,
+            open_rate: 0,
+            click_rate: 0,
+            last_sub_date: "",
+            last_unsub_date: "",
+          },
+          _links: [
+            {
+              rel: "self",
+              href: "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+            },
+            {
+              rel: "parent",
+              href: "https://us4.api.mailchimp.com/3.0/lists",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json",
+            },
+            {
+              rel: "update",
+              href: "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json",
+            },
+            {
+              rel: "batch-sub-unsub-members",
+              href: "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee",
+              method: "POST",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json",
+            },
+            {
+              rel: "delete",
+              href: "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee",
+              method: "DELETE",
+            },
+            {
+              rel: "abuse-reports",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/abuse-reports",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json",
+            },
+            {
+              rel: "activity",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/activity",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json",
+            },
+            {
+              rel: "clients",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/clients",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json",
+            },
+            {
+              rel: "growth-history",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/growth-history",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json",
+            },
+            {
+              rel: "interest-categories",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/interest-categories",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json",
+            },
+            {
+              rel: "members",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/members",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json",
+            },
+            {
+              rel: "merge-fields",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "segments",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/segments",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json",
+            },
+            {
+              rel: "webhooks",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/webhooks",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json",
+            },
+            {
+              rel: "signup-forms",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/signup-forms",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json",
+            },
+            {
+              rel: "locations",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/locations",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json",
+            },
+          ],
+        },
+        {
+          id: "a42c031026",
+          web_id: 363225,
+          name: "Demo (Brian)",
+          contact: {
+            company: "Grouparoo",
+            address1: "1001 University Dr",
+            address2: "",
+            city: "Menlo Park",
+            state: "CA",
+            zip: "94025-4614",
+            country: "US",
+            phone: "",
+          },
+          permission_reminder: "STAGING",
+          use_archive_bar: true,
+          campaign_defaults: {
+            from_name: "Grouparoo Staging",
+            from_email: "hello@grouparoo.com",
+            subject: "",
+            language: "en",
+          },
+          notify_on_subscribe: "",
+          notify_on_unsubscribe: "",
+          date_created: "2020-02-06T21:50:53+00:00",
+          list_rating: 0,
+          email_type_option: false,
+          subscribe_url_short: "http://eepurl.com/gShnRT",
+          subscribe_url_long:
+            "https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=a42c031026",
+          beamer_address: "us4-0c2a01eabd-6eb9fef1e1@inbound.mailchimp.com",
+          visibility: "pub",
+          double_optin: false,
+          has_welcome: false,
+          marketing_permissions: false,
+          modules: [],
+          stats: {
+            member_count: 1,
+            unsubscribe_count: 0,
+            cleaned_count: 0,
+            member_count_since_send: 355,
+            unsubscribe_count_since_send: 0,
+            cleaned_count_since_send: 0,
+            campaign_count: 0,
+            campaign_last_sent: "",
+            merge_field_count: 7,
+            avg_sub_rate: 1373,
+            avg_unsub_rate: 0,
+            target_sub_rate: 0,
+            open_rate: 0,
+            click_rate: 0,
+            last_sub_date: "2020-03-31T16:51:30+00:00",
+            last_unsub_date: "",
+          },
+          _links: [
+            {
+              rel: "self",
+              href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+            },
+            {
+              rel: "parent",
+              href: "https://us4.api.mailchimp.com/3.0/lists",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json",
+            },
+            {
+              rel: "update",
+              href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json",
+            },
+            {
+              rel: "batch-sub-unsub-members",
+              href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026",
+              method: "POST",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json",
+            },
+            {
+              rel: "delete",
+              href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026",
+              method: "DELETE",
+            },
+            {
+              rel: "abuse-reports",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/abuse-reports",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json",
+            },
+            {
+              rel: "activity",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/activity",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json",
+            },
+            {
+              rel: "clients",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/clients",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json",
+            },
+            {
+              rel: "growth-history",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/growth-history",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json",
+            },
+            {
+              rel: "interest-categories",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/interest-categories",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json",
+            },
+            {
+              rel: "members",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json",
+            },
+            {
+              rel: "merge-fields",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "segments",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/segments",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json",
+            },
+            {
+              rel: "webhooks",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/webhooks",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json",
+            },
+            {
+              rel: "signup-forms",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/signup-forms",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json",
+            },
+            {
+              rel: "locations",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/locations",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json",
+            },
+          ],
+        },
+      ],
+      total_items: 4,
+      constraints: {
+        may_create: true,
+        max_instances: 5,
+        current_total_instances: 4,
+      },
+      _links: [
+        {
+          rel: "self",
+          href: "https://us4.api.mailchimp.com/3.0/lists",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json",
+        },
+        {
+          rel: "parent",
+          href: "https://us4.api.mailchimp.com/3.0/",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Root/Response.json",
+        },
+        {
+          rel: "create",
+          href: "https://us4.api.mailchimp.com/3.0/lists",
+          method: "POST",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/POST.json",
+        },
+      ],
+    },
+    [
+      "Server",
+      "openresty",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Vary",
+      "Accept-Encoding",
+      "X-Request-Id",
+      "9b00a096-71a0-4e6e-bbd4-4e06c4d967b1",
+      "Link",
+      '<https://us4.api.mailchimp.com/schema/3.0/Lists/Collection.json>; rel="describedBy"',
+      "Date",
+      "Wed, 19 Aug 2020 21:27:59 GMT",
+      "Content-Length",
+      "22915",
+      "Connection",
+      "close",
+    ]
+  );
 
-// prettier-ignore
+nock("https://us4.api.mailchimp.com:443", { encodedQueryParams: true })
+  .get("/3.0/lists/a42c031026/merge-fields", {})
+  .reply(
+    200,
+    {
+      merge_fields: [
+        {
+          merge_id: 3,
+          tag: "ADDRESS",
+          name: "Address",
+          type: "address",
+          required: false,
+          default_value: "",
+          public: false,
+          display_order: 4,
+          options: { default_country: 164 },
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/3",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/3",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/3",
+              method: "DELETE",
+            },
+          ],
+        },
+        {
+          merge_id: 1,
+          tag: "FNAME",
+          name: "First Name",
+          type: "text",
+          required: false,
+          default_value: "",
+          public: true,
+          display_order: 2,
+          options: { size: 25 },
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/1",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/1",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/1",
+              method: "DELETE",
+            },
+          ],
+        },
+        {
+          merge_id: 7,
+          tag: "LANGUAGE",
+          name: "Language",
+          type: "text",
+          required: false,
+          default_value: "",
+          public: true,
+          display_order: 8,
+          options: { size: 25 },
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/7",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/7",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/7",
+              method: "DELETE",
+            },
+          ],
+        },
+        {
+          merge_id: 2,
+          tag: "LNAME",
+          name: "Last Name",
+          type: "text",
+          required: false,
+          default_value: "",
+          public: true,
+          display_order: 3,
+          options: { size: 25 },
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/2",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/2",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/2",
+              method: "DELETE",
+            },
+          ],
+        },
+        {
+          merge_id: 6,
+          tag: "LTV",
+          name: "LTV",
+          type: "number",
+          required: false,
+          default_value: "",
+          public: true,
+          display_order: 7,
+          options: {},
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/6",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/6",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/6",
+              method: "DELETE",
+            },
+          ],
+        },
+        {
+          merge_id: 4,
+          tag: "PHONE",
+          name: "Phone Number",
+          type: "phone",
+          required: false,
+          default_value: "",
+          public: false,
+          display_order: 5,
+          options: { phone_format: "none" },
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/4",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/4",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/4",
+              method: "DELETE",
+            },
+          ],
+        },
+        {
+          merge_id: 5,
+          tag: "USERID",
+          name: "UserID",
+          type: "number",
+          required: false,
+          default_value: "",
+          public: true,
+          display_order: 6,
+          options: {},
+          help_text: "",
+          list_id: "a42c031026",
+          _links: [
+            {
+              rel: "self",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/5",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+            },
+            {
+              rel: "parent",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+              method: "GET",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+            },
+            {
+              rel: "update",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/5",
+              method: "PATCH",
+              targetSchema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+              schema:
+                "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json",
+            },
+            {
+              rel: "delete",
+              href:
+                "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/5",
+              method: "DELETE",
+            },
+          ],
+        },
+      ],
+      list_id: "a42c031026",
+      total_items: 7,
+      _links: [
+        {
+          rel: "self",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json",
+        },
+        {
+          rel: "create",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields",
+          method: "POST",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/POST.json",
+        },
+        {
+          rel: "parent",
+          href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json",
+        },
+      ],
+    },
+    [
+      "Server",
+      "openresty",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Vary",
+      "Accept-Encoding",
+      "X-Request-Id",
+      "7354b309-85b7-4d96-bc96-cab289bb3cc9",
+      "Link",
+      '<https://us4.api.mailchimp.com/schema/3.0/Lists/MergeFields/Collection.json>; rel="describedBy"',
+      "Date",
+      "Wed, 19 Aug 2020 21:28:00 GMT",
+      "Content-Length",
+      "8778",
+      "Connection",
+      "close",
+    ]
+  );
 
-nock('https://us4.api.mailchimp.com:443', {"encodedQueryParams":true})
-  .get('/3.0/lists', {})
-  .reply(200, {"lists":[{"id":"23d8e9cb6e","web_id":363213,"name":"Grouparoo","contact":{"company":"Grouparoo","address1":"1001 University Dr","address2":"","city":"Menlo Park","state":"CA","zip":"94025-4614","country":"US","phone":""},"permission_reminder":"You are receiving this email because you opted in via our website.","use_archive_bar":true,"campaign_defaults":{"from_name":"Evan","from_email":"evan.tahler@grouparoo.com","subject":"","language":"en"},"notify_on_subscribe":"","notify_on_unsubscribe":"","date_created":"2020-02-06T21:02:33+00:00","list_rating":0,"email_type_option":false,"subscribe_url_short":"http://eepurl.com/gShnbH","subscribe_url_long":"https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=23d8e9cb6e","beamer_address":"us4-0c2a01eabd-840733a81d@inbound.mailchimp.com","visibility":"pub","double_optin":false,"has_welcome":false,"marketing_permissions":false,"modules":[],"stats":{"member_count":1,"unsubscribe_count":0,"cleaned_count":0,"member_count_since_send":1,"unsubscribe_count_since_send":0,"cleaned_count_since_send":0,"campaign_count":0,"campaign_last_sent":"","merge_field_count":5,"avg_sub_rate":0,"avg_unsub_rate":0,"target_sub_rate":0,"open_rate":0,"click_rate":0,"last_sub_date":"2020-02-06T21:02:34+00:00","last_unsub_date":""},"_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json"},{"rel":"batch-sub-unsub-members","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e","method":"DELETE"},{"rel":"abuse-reports","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/abuse-reports","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json"},{"rel":"activity","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/activity","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json"},{"rel":"clients","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/clients","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json"},{"rel":"growth-history","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/growth-history","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json"},{"rel":"interest-categories","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/interest-categories","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json"},{"rel":"members","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/members","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"merge-fields","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"segments","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/segments","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json"},{"rel":"webhooks","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/webhooks","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json"},{"rel":"signup-forms","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/signup-forms","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json"},{"rel":"locations","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/locations","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json"}]},{"id":"6f890f62ee","web_id":365697,"name":"Demo","contact":{"company":"Grouparoo","address1":"1001 University Dr","address2":"","city":"Menlo Park","state":"CA","zip":"94025-4614","country":"US","phone":""},"permission_reminder":"DEMO","use_archive_bar":true,"campaign_defaults":{"from_name":"Grouparoo Demo","from_email":"hello@grouparoo.com","subject":"","language":"en"},"notify_on_subscribe":"","notify_on_unsubscribe":"","date_created":"2020-02-11T17:12:54+00:00","list_rating":3,"email_type_option":false,"subscribe_url_short":"http://eepurl.com/gSKdJ1","subscribe_url_long":"https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=6f890f62ee","beamer_address":"us4-0c2a01eabd-80bbdfd596@inbound.mailchimp.com","visibility":"pub","double_optin":false,"has_welcome":false,"marketing_permissions":false,"modules":[],"stats":{"member_count":315,"unsubscribe_count":0,"cleaned_count":0,"member_count_since_send":1599,"unsubscribe_count_since_send":0,"cleaned_count_since_send":0,"campaign_count":0,"campaign_last_sent":"","merge_field_count":7,"avg_sub_rate":14338,"avg_unsub_rate":0,"target_sub_rate":0,"open_rate":0,"click_rate":0,"last_sub_date":"2020-04-22T19:22:42+00:00","last_unsub_date":""},"_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json"},{"rel":"batch-sub-unsub-members","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee","method":"DELETE"},{"rel":"abuse-reports","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/abuse-reports","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json"},{"rel":"activity","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/activity","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json"},{"rel":"clients","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/clients","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json"},{"rel":"growth-history","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/growth-history","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json"},{"rel":"interest-categories","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/interest-categories","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json"},{"rel":"members","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/members","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"merge-fields","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"segments","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/segments","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json"},{"rel":"webhooks","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/webhooks","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json"},{"rel":"signup-forms","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/signup-forms","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json"},{"rel":"locations","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/locations","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json"}]},{"id":"a42c031026","web_id":363225,"name":"Staging","contact":{"company":"Grouparoo","address1":"1001 University Dr","address2":"","city":"Menlo Park","state":"CA","zip":"94025-4614","country":"US","phone":""},"permission_reminder":"STAGING","use_archive_bar":true,"campaign_defaults":{"from_name":"Grouparoo Staging","from_email":"hello@grouparoo.com","subject":"","language":"en"},"notify_on_subscribe":"","notify_on_unsubscribe":"","date_created":"2020-02-06T21:50:53+00:00","list_rating":0,"email_type_option":false,"subscribe_url_short":"http://eepurl.com/gShnRT","subscribe_url_long":"https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=a42c031026","beamer_address":"us4-0c2a01eabd-6eb9fef1e1@inbound.mailchimp.com","visibility":"pub","double_optin":false,"has_welcome":false,"marketing_permissions":false,"modules":[],"stats":{"member_count":1,"unsubscribe_count":0,"cleaned_count":0,"member_count_since_send":6423,"unsubscribe_count_since_send":0,"cleaned_count_since_send":0,"campaign_count":0,"campaign_last_sent":"","merge_field_count":7,"avg_sub_rate":2744,"avg_unsub_rate":0,"target_sub_rate":0,"open_rate":0,"click_rate":0,"last_sub_date":"2020-03-31T16:51:30+00:00","last_unsub_date":""},"_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json"},{"rel":"batch-sub-unsub-members","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026","method":"DELETE"},{"rel":"abuse-reports","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/abuse-reports","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json"},{"rel":"activity","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/activity","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json"},{"rel":"clients","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/clients","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json"},{"rel":"growth-history","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/growth-history","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json"},{"rel":"interest-categories","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/interest-categories","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json"},{"rel":"members","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"merge-fields","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"segments","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/segments","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json"},{"rel":"webhooks","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/webhooks","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json"},{"rel":"signup-forms","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/signup-forms","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json"},{"rel":"locations","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/locations","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json"}]}],"total_items":3,"constraints":{"may_create":false,"max_instances":3,"current_total_instances":3},"_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Root/Response.json"},{"rel":"create","href":"https://us4.api.mailchimp.com/3.0/lists","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/POST.json"}]}, [
-  'Server',
-  'openresty',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Vary',
-  'Accept-Encoding',
-  'X-Request-Id',
-  '2dae7812-6d25-4099-82e2-7e8195a46a97',
-  'Link',
-  '<https://us4.api.mailchimp.com/schema/3.0/Lists/Collection.json>; rel="describedBy"',
-  'Date',
-  'Thu, 23 Apr 2020 18:33:59 GMT',
-  'Content-Length',
-  '17396',
-  'Connection',
-  'close',
-  'Set-Cookie',
-  '_AVESTA_ENVIRONMENT=prod; path=/',
-  'Set-Cookie',
-  '_mcid=1.6b1e3d7d3ce4f59f04abe0b4e7ccc899.dd7b201e48845f59a2dded255edb4967393e308c7eaf057501afc08947787902; expires=Fri, 23-Apr-2021 18:33:59 GMT; Max-Age=31536000; path=/; domain=.mailchimp.com'
-]);
+nock("https://us4.api.mailchimp.com:443", { encodedQueryParams: true })
+  .get("/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2", {})
+  .reply(
+    200,
+    {
+      id: "c0d3f5ab2377be2c897398242b9703e2",
+      email_address: "luigi@grouparoo.com",
+      unique_email_id: "f621d67732",
+      web_id: 349069938,
+      email_type: "html",
+      status: "subscribed",
+      merge_fields: {
+        FNAME: "Luigi",
+        LNAME: "Mario",
+        ADDRESS: "",
+        PHONE: "",
+        USERID: 100,
+        LTV: "",
+        LANGUAGE: "",
+      },
+      stats: { avg_open_rate: 0, avg_click_rate: 0 },
+      ip_signup: "",
+      timestamp_signup: "",
+      ip_opt: "71.231.106.197",
+      timestamp_opt: "2020-03-31T16:51:30+00:00",
+      member_rating: 2,
+      last_changed: "2020-08-19T21:25:35+00:00",
+      language: "",
+      vip: false,
+      email_client: "",
+      location: {
+        latitude: 0,
+        longitude: 0,
+        gmtoff: 0,
+        dstoff: 0,
+        country_code: "",
+        timezone: "",
+      },
+      source: "API - Generic",
+      tags_count: 1,
+      tags: [{ id: 1701334, name: "mailchimp people" }],
+      list_id: "a42c031026",
+      _links: [
+        {
+          rel: "self",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json",
+        },
+        {
+          rel: "parent",
+          href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json",
+        },
+        {
+          rel: "update",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2",
+          method: "PATCH",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json",
+        },
+        {
+          rel: "upsert",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2",
+          method: "PUT",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json",
+        },
+        {
+          rel: "delete",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2",
+          method: "DELETE",
+        },
+        {
+          rel: "activity",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/activity",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json",
+        },
+        {
+          rel: "goals",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/goals",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json",
+        },
+        {
+          rel: "notes",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/notes",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json",
+        },
+        {
+          rel: "events",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/events",
+          method: "POST",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Events/POST.json",
+        },
+        {
+          rel: "delete_permanent",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/actions/delete-permanent",
+          method: "POST",
+        },
+      ],
+    },
+    [
+      "Server",
+      "openresty",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Content-Length",
+      "3213",
+      "Vary",
+      "Accept-Encoding",
+      "X-Request-Id",
+      "b69e31f2-06da-4234-9251-8222c74f7590",
+      "Link",
+      '<https://us4.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy", <https://us4.admin.mailchimp.com/lists/members/view?id=349069938>; rel="dashboard"',
+      "Date",
+      "Wed, 19 Aug 2020 21:28:00 GMT",
+      "Connection",
+      "close",
+    ]
+  );
 
-// prettier-ignore
+nock("https://us4.api.mailchimp.com:443", { encodedQueryParams: true })
+  .put("/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2", {
+    email_address: "luigi@grouparoo.com",
+    status: "subscribed",
+    merge_fields: {
+      email_address: "luigi@grouparoo.com",
+      USERID: 100,
+      FNAME: "Luigi",
+      LNAME: "Mario",
+    },
+  })
+  .reply(
+    200,
+    {
+      id: "c0d3f5ab2377be2c897398242b9703e2",
+      email_address: "luigi@grouparoo.com",
+      unique_email_id: "f621d67732",
+      web_id: 349069938,
+      email_type: "html",
+      status: "subscribed",
+      merge_fields: {
+        FNAME: "Luigi",
+        LNAME: "Mario",
+        ADDRESS: "",
+        PHONE: "",
+        USERID: 100,
+        LTV: "",
+        LANGUAGE: "",
+      },
+      stats: { avg_open_rate: 0, avg_click_rate: 0 },
+      ip_signup: "",
+      timestamp_signup: "",
+      ip_opt: "71.231.106.197",
+      timestamp_opt: "2020-03-31T16:51:30+00:00",
+      member_rating: 2,
+      last_changed: "2020-08-19T21:25:35+00:00",
+      language: "",
+      vip: false,
+      email_client: "",
+      location: {
+        latitude: 0,
+        longitude: 0,
+        gmtoff: 0,
+        dstoff: 0,
+        country_code: "",
+        timezone: "",
+      },
+      source: "API - Generic",
+      tags_count: 1,
+      tags: [{ id: 1701334, name: "mailchimp people" }],
+      list_id: "a42c031026",
+      _links: [
+        {
+          rel: "self",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json",
+        },
+        {
+          rel: "parent",
+          href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json",
+        },
+        {
+          rel: "update",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2",
+          method: "PATCH",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json",
+        },
+        {
+          rel: "upsert",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2",
+          method: "PUT",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json",
+        },
+        {
+          rel: "delete",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2",
+          method: "DELETE",
+        },
+        {
+          rel: "activity",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/activity",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json",
+        },
+        {
+          rel: "goals",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/goals",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json",
+        },
+        {
+          rel: "notes",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/notes",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json",
+        },
+        {
+          rel: "events",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/events",
+          method: "POST",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Events/POST.json",
+        },
+        {
+          rel: "delete_permanent",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/actions/delete-permanent",
+          method: "POST",
+        },
+      ],
+    },
+    [
+      "Server",
+      "openresty",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Content-Length",
+      "3213",
+      "Vary",
+      "Accept-Encoding",
+      "X-Request-Id",
+      "1a9383b6-2373-489c-ac25-0ecb6e6477c1",
+      "Link",
+      '<https://us4.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy", <https://us4.admin.mailchimp.com/lists/members/view?id=349069938>; rel="dashboard"',
+      "Date",
+      "Wed, 19 Aug 2020 21:28:00 GMT",
+      "Connection",
+      "close",
+    ]
+  );
 
-nock('https://us4.api.mailchimp.com:443', {"encodedQueryParams":true})
-  .get('/3.0/lists', {})
-  .reply(200, {"lists":[{"id":"23d8e9cb6e","web_id":363213,"name":"Grouparoo","contact":{"company":"Grouparoo","address1":"1001 University Dr","address2":"","city":"Menlo Park","state":"CA","zip":"94025-4614","country":"US","phone":""},"permission_reminder":"You are receiving this email because you opted in via our website.","use_archive_bar":true,"campaign_defaults":{"from_name":"Evan","from_email":"evan.tahler@grouparoo.com","subject":"","language":"en"},"notify_on_subscribe":"","notify_on_unsubscribe":"","date_created":"2020-02-06T21:02:33+00:00","list_rating":0,"email_type_option":false,"subscribe_url_short":"http://eepurl.com/gShnbH","subscribe_url_long":"https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=23d8e9cb6e","beamer_address":"us4-0c2a01eabd-840733a81d@inbound.mailchimp.com","visibility":"pub","double_optin":false,"has_welcome":false,"marketing_permissions":false,"modules":[],"stats":{"member_count":1,"unsubscribe_count":0,"cleaned_count":0,"member_count_since_send":1,"unsubscribe_count_since_send":0,"cleaned_count_since_send":0,"campaign_count":0,"campaign_last_sent":"","merge_field_count":5,"avg_sub_rate":0,"avg_unsub_rate":0,"target_sub_rate":0,"open_rate":0,"click_rate":0,"last_sub_date":"2020-02-06T21:02:34+00:00","last_unsub_date":""},"_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json"},{"rel":"batch-sub-unsub-members","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e","method":"DELETE"},{"rel":"abuse-reports","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/abuse-reports","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json"},{"rel":"activity","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/activity","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json"},{"rel":"clients","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/clients","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json"},{"rel":"growth-history","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/growth-history","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json"},{"rel":"interest-categories","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/interest-categories","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json"},{"rel":"members","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/members","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"merge-fields","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"segments","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/segments","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json"},{"rel":"webhooks","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/webhooks","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json"},{"rel":"signup-forms","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/signup-forms","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json"},{"rel":"locations","href":"https://us4.api.mailchimp.com/3.0/lists/23d8e9cb6e/locations","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json"}]},{"id":"6f890f62ee","web_id":365697,"name":"Demo","contact":{"company":"Grouparoo","address1":"1001 University Dr","address2":"","city":"Menlo Park","state":"CA","zip":"94025-4614","country":"US","phone":""},"permission_reminder":"DEMO","use_archive_bar":true,"campaign_defaults":{"from_name":"Grouparoo Demo","from_email":"hello@grouparoo.com","subject":"","language":"en"},"notify_on_subscribe":"","notify_on_unsubscribe":"","date_created":"2020-02-11T17:12:54+00:00","list_rating":3,"email_type_option":false,"subscribe_url_short":"http://eepurl.com/gSKdJ1","subscribe_url_long":"https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=6f890f62ee","beamer_address":"us4-0c2a01eabd-80bbdfd596@inbound.mailchimp.com","visibility":"pub","double_optin":false,"has_welcome":false,"marketing_permissions":false,"modules":[],"stats":{"member_count":315,"unsubscribe_count":0,"cleaned_count":0,"member_count_since_send":1599,"unsubscribe_count_since_send":0,"cleaned_count_since_send":0,"campaign_count":0,"campaign_last_sent":"","merge_field_count":7,"avg_sub_rate":14338,"avg_unsub_rate":0,"target_sub_rate":0,"open_rate":0,"click_rate":0,"last_sub_date":"2020-04-22T19:22:42+00:00","last_unsub_date":""},"_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json"},{"rel":"batch-sub-unsub-members","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee","method":"DELETE"},{"rel":"abuse-reports","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/abuse-reports","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json"},{"rel":"activity","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/activity","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json"},{"rel":"clients","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/clients","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json"},{"rel":"growth-history","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/growth-history","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json"},{"rel":"interest-categories","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/interest-categories","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json"},{"rel":"members","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/members","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"merge-fields","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"segments","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/segments","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json"},{"rel":"webhooks","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/webhooks","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json"},{"rel":"signup-forms","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/signup-forms","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json"},{"rel":"locations","href":"https://us4.api.mailchimp.com/3.0/lists/6f890f62ee/locations","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json"}]},{"id":"a42c031026","web_id":363225,"name":"Staging","contact":{"company":"Grouparoo","address1":"1001 University Dr","address2":"","city":"Menlo Park","state":"CA","zip":"94025-4614","country":"US","phone":""},"permission_reminder":"STAGING","use_archive_bar":true,"campaign_defaults":{"from_name":"Grouparoo Staging","from_email":"hello@grouparoo.com","subject":"","language":"en"},"notify_on_subscribe":"","notify_on_unsubscribe":"","date_created":"2020-02-06T21:50:53+00:00","list_rating":0,"email_type_option":false,"subscribe_url_short":"http://eepurl.com/gShnRT","subscribe_url_long":"https://grouparoo.us4.list-manage.com/subscribe?u=5f6e3ecf127508cdb5e31e90b&id=a42c031026","beamer_address":"us4-0c2a01eabd-6eb9fef1e1@inbound.mailchimp.com","visibility":"pub","double_optin":false,"has_welcome":false,"marketing_permissions":false,"modules":[],"stats":{"member_count":1,"unsubscribe_count":0,"cleaned_count":0,"member_count_since_send":6423,"unsubscribe_count_since_send":0,"cleaned_count_since_send":0,"campaign_count":0,"campaign_last_sent":"","merge_field_count":7,"avg_sub_rate":2744,"avg_unsub_rate":0,"target_sub_rate":0,"open_rate":0,"click_rate":0,"last_sub_date":"2020-03-31T16:51:30+00:00","last_unsub_date":""},"_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/PATCH.json"},{"rel":"batch-sub-unsub-members","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST-Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/BatchPOST.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026","method":"DELETE"},{"rel":"abuse-reports","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/abuse-reports","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Abuse/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json"},{"rel":"activity","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/activity","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Activity/Response.json"},{"rel":"clients","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/clients","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Clients/Response.json"},{"rel":"growth-history","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/growth-history","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Growth/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json"},{"rel":"interest-categories","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/interest-categories","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json"},{"rel":"members","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"merge-fields","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"segments","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/segments","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json"},{"rel":"webhooks","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/webhooks","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Webhooks/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Webhooks.json"},{"rel":"signup-forms","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/signup-forms","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/SignupForms/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/SignupForms.json"},{"rel":"locations","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/locations","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Locations/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Locations.json"}]}],"total_items":3,"constraints":{"may_create":false,"max_instances":3,"current_total_instances":3},"_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Root/Response.json"},{"rel":"create","href":"https://us4.api.mailchimp.com/3.0/lists","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/POST.json"}]}, [
-  'Server',
-  'openresty',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Vary',
-  'Accept-Encoding',
-  'X-Request-Id',
-  '82d42a28-a3df-478a-a8f6-31f6a3d6db22',
-  'Link',
-  '<https://us4.api.mailchimp.com/schema/3.0/Lists/Collection.json>; rel="describedBy"',
-  'Date',
-  'Thu, 23 Apr 2020 18:33:59 GMT',
-  'Content-Length',
-  '17396',
-  'Connection',
-  'close',
-  'Set-Cookie',
-  '_AVESTA_ENVIRONMENT=prod; path=/',
-  'Set-Cookie',
-  '_mcid=1.6d6085a5dc653210ae24ccfbf374bfd2.a64813301219af607b652ca5c2f25d006b9526d1a6bfc913b47fafc4ae6ef518; expires=Fri, 23-Apr-2021 18:33:59 GMT; Max-Age=31536000; path=/; domain=.mailchimp.com'
-]);
-
-// prettier-ignore
-
-nock('https://us4.api.mailchimp.com:443', {"encodedQueryParams":true})
-  .get('/3.0/lists/a42c031026/merge-fields', {})
-  .reply(200, {"merge_fields":[{"merge_id":3,"tag":"ADDRESS","name":"Address","type":"address","required":false,"default_value":"","public":false,"display_order":4,"options":{"default_country":164},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/3","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/3","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/3","method":"DELETE"}]},{"merge_id":7,"tag":"COOL","name":"Cool","type":"text","required":false,"default_value":"","public":true,"display_order":8,"options":{"size":25},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/7","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/7","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/7","method":"DELETE"}]},{"merge_id":1,"tag":"FNAME","name":"First Name","type":"text","required":false,"default_value":"","public":true,"display_order":2,"options":{"size":25},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/1","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/1","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/1","method":"DELETE"}]},{"merge_id":2,"tag":"LNAME","name":"Last Name","type":"text","required":false,"default_value":"","public":true,"display_order":3,"options":{"size":25},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/2","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/2","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/2","method":"DELETE"}]},{"merge_id":6,"tag":"LTV","name":"LTV","type":"number","required":false,"default_value":"","public":true,"display_order":7,"options":{},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/6","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/6","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/6","method":"DELETE"}]},{"merge_id":4,"tag":"PHONE","name":"Phone Number","type":"phone","required":false,"default_value":"","public":false,"display_order":5,"options":{"phone_format":"none"},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/4","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/4","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/4","method":"DELETE"}]},{"merge_id":5,"tag":"USERID","name":"UserID","type":"number","required":false,"default_value":"","public":true,"display_order":6,"options":{},"help_text":"","list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/5","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/5","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/PATCH.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields/5","method":"DELETE"}]}],"list_id":"a42c031026","total_items":7,"_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"},{"rel":"create","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/merge-fields","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/MergeFields/POST.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json"}]}, [
-  'Server',
-  'openresty',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Vary',
-  'Accept-Encoding',
-  'X-Request-Id',
-  'f281575f-09fd-453c-be20-7fced4d1ee23',
-  'Link',
-  '<https://us4.api.mailchimp.com/schema/3.0/Lists/MergeFields/Collection.json>; rel="describedBy"',
-  'Date',
-  'Thu, 23 Apr 2020 18:34:00 GMT',
-  'Content-Length',
-  '8770',
-  'Connection',
-  'close',
-  'Set-Cookie',
-  '_AVESTA_ENVIRONMENT=prod; path=/',
-  'Set-Cookie',
-  '_mcid=1.15ba2607e68ff6a5e1dbf82024f58987.c1b6d6fbe1efa5b0825a4d21b15430bfc3b95d8dc551ba791e38afd82bd4a9d9; expires=Fri, 23-Apr-2021 18:34:00 GMT; Max-Age=31536000; path=/; domain=.mailchimp.com'
-]);
-
-// prettier-ignore
-
-nock('https://us4.api.mailchimp.com:443', {"encodedQueryParams":true})
-  .get('/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2', {})
-  .reply(200, {"id":"c0d3f5ab2377be2c897398242b9703e2","email_address":"luigi@grouparoo.com","unique_email_id":"f621d67732","web_id":349069938,"email_type":"html","status":"subscribed","merge_fields":{"FNAME":"","LNAME":"","ADDRESS":"","PHONE":"","USERID":"","LTV":"","COOL":""},"stats":{"avg_open_rate":0,"avg_click_rate":0},"ip_signup":"","timestamp_signup":"","ip_opt":"71.231.106.197","timestamp_opt":"2020-03-31T16:51:30+00:00","member_rating":2,"last_changed":"2020-04-23T18:32:01+00:00","language":"","vip":false,"email_client":"","location":{"latitude":0,"longitude":0,"gmtoff":0,"dstoff":0,"country_code":"","timezone":""},"source":"API - Generic","tags_count":0,"tags":[],"list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json"},{"rel":"upsert","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2","method":"PUT","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2","method":"DELETE"},{"rel":"activity","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/activity","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json"},{"rel":"goals","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/goals","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json"},{"rel":"notes","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/notes","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json"},{"rel":"events","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/events","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Events/POST.json"},{"rel":"delete_permanent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/actions/delete-permanent","method":"POST"}]}, [
-  'Server',
-  'openresty',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Content-Length',
-  '3158',
-  'Vary',
-  'Accept-Encoding',
-  'X-Request-Id',
-  'e70e2144-14ed-43c6-a397-9ab0072697ba',
-  'Link',
-  '<https://us4.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy", <https://us4.admin.mailchimp.com/lists/members/view?id=349069938>; rel="dashboard"',
-  'Date',
-  'Thu, 23 Apr 2020 18:34:00 GMT',
-  'Connection',
-  'close',
-  'Set-Cookie',
-  '_AVESTA_ENVIRONMENT=prod; path=/',
-  'Set-Cookie',
-  '_mcid=1.ea06822d1e3b8e8127713089c0871dac.7ed45180700a1a994629d129b0930b9a4c6d37410d2ca7e22052cc0e0a6fae1b; expires=Fri, 23-Apr-2021 18:34:00 GMT; Max-Age=31536000; path=/; domain=.mailchimp.com'
-]);
-
-// prettier-ignore
-
-nock('https://us4.api.mailchimp.com:443', {"encodedQueryParams":true})
-  .put('/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2', {"email_address":"luigi@grouparoo.com","status":"subscribed","merge_fields":{"email_address":"luigi@grouparoo.com","USERID":100,"FNAME":"Luigi","LNAME":"Mario","ADDRESS":"","PHONE":"","LTV":"","COOL":""}})
-  .reply(200, {"id":"c0d3f5ab2377be2c897398242b9703e2","email_address":"luigi@grouparoo.com","unique_email_id":"f621d67732","web_id":349069938,"email_type":"html","status":"subscribed","merge_fields":{"FNAME":"Luigi","LNAME":"Mario","ADDRESS":"","PHONE":"","USERID":100,"LTV":"","COOL":""},"stats":{"avg_open_rate":0,"avg_click_rate":0},"ip_signup":"","timestamp_signup":"","ip_opt":"71.231.106.197","timestamp_opt":"2020-03-31T16:51:30+00:00","member_rating":2,"last_changed":"2020-04-23T18:34:00+00:00","language":"","vip":false,"email_client":"","location":{"latitude":0,"longitude":0,"gmtoff":0,"dstoff":0,"country_code":"","timezone":""},"source":"API - Generic","tags_count":0,"tags":[],"list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json"},{"rel":"upsert","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2","method":"PUT","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2","method":"DELETE"},{"rel":"activity","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/activity","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json"},{"rel":"goals","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/goals","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json"},{"rel":"notes","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/notes","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json"},{"rel":"events","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/events","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Events/POST.json"},{"rel":"delete_permanent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/actions/delete-permanent","method":"POST"}]}, [
-  'Server',
-  'openresty',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Content-Length',
-  '3169',
-  'Vary',
-  'Accept-Encoding',
-  'X-Request-Id',
-  '5e816e1e-b206-4d1b-af0a-27a29abd72eb',
-  'Link',
-  '<https://us4.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy", <https://us4.admin.mailchimp.com/lists/members/view?id=349069938>; rel="dashboard"',
-  'Date',
-  'Thu, 23 Apr 2020 18:34:00 GMT',
-  'Connection',
-  'close',
-  'Set-Cookie',
-  '_AVESTA_ENVIRONMENT=prod; path=/',
-  'Set-Cookie',
-  '_mcid=1.7783339a0946fe40317af13af7b9f214.9d09ee9b947ab91816721d87b22c06c04837c66d8ca0bb4a0f42755d89cd89e9; expires=Fri, 23-Apr-2021 18:34:00 GMT; Max-Age=31536000; path=/; domain=.mailchimp.com'
-]);
-
-// prettier-ignore
-
-nock('https://us4.api.mailchimp.com:443', {"encodedQueryParams":true})
-  .post('/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/tags', {"tags":[{"name":"mailchimp people","status":"active"}]})
+nock("https://us4.api.mailchimp.com:443", { encodedQueryParams: true })
+  .post("/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/tags", {
+    tags: [],
+  })
   .reply(204, "", [
-  'Server',
-  'openresty',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'X-Request-Id',
-  'cfe8f56c-5cbe-42e4-8c64-ccc1c64a16fd',
-  'Date',
-  'Thu, 23 Apr 2020 18:34:00 GMT',
-  'Connection',
-  'close',
-  'Set-Cookie',
-  '_AVESTA_ENVIRONMENT=prod; path=/',
-  'Set-Cookie',
-  '_mcid=1.47a2ce37c299d9227097f654c3a82665.67fc0485a503749e9ea9936d530ef74fc43616f79c83f78e02315108b21efb17; expires=Fri, 23-Apr-2021 18:34:00 GMT; Max-Age=31536000; path=/; domain=.mailchimp.com'
-]);
+    "Server",
+    "openresty",
+    "Content-Type",
+    "application/json; charset=utf-8",
+    "X-Request-Id",
+    "f9af77d4-1731-49d3-99dd-aeddf167741b",
+    "Date",
+    "Wed, 19 Aug 2020 21:28:01 GMT",
+    "Connection",
+    "close",
+  ]);
 
-// prettier-ignore
-
-nock('https://us4.api.mailchimp.com:443', {"encodedQueryParams":true})
-  .get('/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2', {})
-  .reply(200, {"id":"c0d3f5ab2377be2c897398242b9703e2","email_address":"luigi@grouparoo.com","unique_email_id":"f621d67732","web_id":349069938,"email_type":"html","status":"subscribed","merge_fields":{"FNAME":"Luigi","LNAME":"Mario","ADDRESS":"","PHONE":"","USERID":100,"LTV":"","COOL":""},"stats":{"avg_open_rate":0,"avg_click_rate":0},"ip_signup":"","timestamp_signup":"","ip_opt":"71.231.106.197","timestamp_opt":"2020-03-31T16:51:30+00:00","member_rating":2,"last_changed":"2020-04-23T18:34:00+00:00","language":"","vip":false,"email_client":"","location":{"latitude":0,"longitude":0,"gmtoff":0,"dstoff":0,"country_code":"","timezone":""},"source":"API - Generic","tags_count":1,"tags":[{"id":1701334,"name":"mailchimp people"}],"list_id":"a42c031026","_links":[{"rel":"self","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json"},{"rel":"parent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"update","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2","method":"PATCH","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json"},{"rel":"upsert","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2","method":"PUT","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json"},{"rel":"delete","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2","method":"DELETE"},{"rel":"activity","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/activity","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json"},{"rel":"goals","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/goals","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json"},{"rel":"notes","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/notes","method":"GET","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json"},{"rel":"events","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/events","method":"POST","targetSchema":"https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Events/POST.json"},{"rel":"delete_permanent","href":"https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/actions/delete-permanent","method":"POST"}]}, [
-  'Server',
-  'openresty',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Content-Length',
-  '3209',
-  'Vary',
-  'Accept-Encoding',
-  'X-Request-Id',
-  '94fe5d1e-2bc5-4488-8901-c08914df19d3',
-  'Link',
-  '<https://us4.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy", <https://us4.admin.mailchimp.com/lists/members/view?id=349069938>; rel="dashboard"',
-  'Date',
-  'Thu, 23 Apr 2020 18:34:01 GMT',
-  'Connection',
-  'close',
-  'Set-Cookie',
-  '_AVESTA_ENVIRONMENT=prod; path=/',
-  'Set-Cookie',
-  '_mcid=1.59776f5e20c223236110f87c86c0728c.e5c09c161e7885cc3d7da8319b8f157263bfa0cd4ecbfdbd30de286be8a2ce68; expires=Fri, 23-Apr-2021 18:34:00 GMT; Max-Age=31536000; path=/; domain=.mailchimp.com'
-]);
+nock("https://us4.api.mailchimp.com:443", { encodedQueryParams: true })
+  .get("/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2", {})
+  .reply(
+    200,
+    {
+      id: "c0d3f5ab2377be2c897398242b9703e2",
+      email_address: "luigi@grouparoo.com",
+      unique_email_id: "f621d67732",
+      web_id: 349069938,
+      email_type: "html",
+      status: "subscribed",
+      merge_fields: {
+        FNAME: "Luigi",
+        LNAME: "Mario",
+        ADDRESS: "",
+        PHONE: "",
+        USERID: 100,
+        LTV: "",
+        LANGUAGE: "",
+      },
+      stats: { avg_open_rate: 0, avg_click_rate: 0 },
+      ip_signup: "",
+      timestamp_signup: "",
+      ip_opt: "71.231.106.197",
+      timestamp_opt: "2020-03-31T16:51:30+00:00",
+      member_rating: 2,
+      last_changed: "2020-08-19T21:25:35+00:00",
+      language: "",
+      vip: false,
+      email_client: "",
+      location: {
+        latitude: 0,
+        longitude: 0,
+        gmtoff: 0,
+        dstoff: 0,
+        country_code: "",
+        timezone: "",
+      },
+      source: "API - Generic",
+      tags_count: 1,
+      tags: [{ id: 1701334, name: "mailchimp people" }],
+      list_id: "a42c031026",
+      _links: [
+        {
+          rel: "self",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json",
+        },
+        {
+          rel: "parent",
+          href: "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json",
+        },
+        {
+          rel: "update",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2",
+          method: "PATCH",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json",
+        },
+        {
+          rel: "upsert",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2",
+          method: "PUT",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json",
+          schema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json",
+        },
+        {
+          rel: "delete",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2",
+          method: "DELETE",
+        },
+        {
+          rel: "activity",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/activity",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json",
+        },
+        {
+          rel: "goals",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/goals",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json",
+        },
+        {
+          rel: "notes",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/notes",
+          method: "GET",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json",
+        },
+        {
+          rel: "events",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/events",
+          method: "POST",
+          targetSchema:
+            "https://us4.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Events/POST.json",
+        },
+        {
+          rel: "delete_permanent",
+          href:
+            "https://us4.api.mailchimp.com/3.0/lists/a42c031026/members/c0d3f5ab2377be2c897398242b9703e2/actions/delete-permanent",
+          method: "POST",
+        },
+      ],
+    },
+    [
+      "Server",
+      "openresty",
+      "Content-Type",
+      "application/json; charset=utf-8",
+      "Content-Length",
+      "3213",
+      "Vary",
+      "Accept-Encoding",
+      "X-Request-Id",
+      "cf1c4e34-207b-41ec-ac78-b246f5389419",
+      "Link",
+      '<https://us4.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy", <https://us4.admin.mailchimp.com/lists/members/view?id=349069938>; rel="dashboard"',
+      "Date",
+      "Wed, 19 Aug 2020 21:28:01 GMT",
+      "Connection",
+      "close",
+    ]
+  );

--- a/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-export.ts
+++ b/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-export.ts
@@ -152,8 +152,13 @@ describe("integration/runs/mailchimp", () => {
     expect(error).toBeUndefined();
     expect(options).toEqual({
       listId: {
-        descriptions: ["Grouparoo", "Demo", "Staging"],
-        options: ["23d8e9cb6e", "6f890f62ee", "a42c031026"],
+        descriptions: [
+          "Demo (Evan)",
+          "Grouparoo",
+          "Demo (Andy)",
+          "Demo (Brian)",
+        ],
+        options: ["1b724bb934", "23d8e9cb6e", "6f890f62ee", "a42c031026"],
         type: "list",
       },
     });
@@ -181,8 +186,8 @@ describe("integration/runs/mailchimp", () => {
         required: [{ key: "email_address", type: "email" }],
         known: [
           { key: "ADDRESS", type: "any", important: true },
-          { key: "COOL", type: "any", important: true },
           { key: "FNAME", type: "any", important: true },
+          { key: "LANGUAGE", type: "any", important: true },
           { key: "LNAME", type: "any", important: true },
           { key: "LTV", type: "any", important: true },
           { key: "PHONE", type: "any", important: true },
@@ -249,7 +254,7 @@ describe("integration/runs/mailchimp", () => {
       PHONE: "",
       USERID: 100,
       LTV: "",
-      COOL: "",
+      LANGUAGE: "",
     });
     expect(response.tags.map((t) => t.name)).toEqual(["mailchimp people"]);
   });


### PR DESCRIPTION
This PR updates the Mailchimp plugin to match the behavior of Hubspot and Sailthru - we cannot assume that all the remote tags & properties on the Mailchimp user were set by Grouparoo.  We now only delete properties and tags if they come from the export in `oldProfileProperties` or `oldGroups`, and are not in the respective `new` collections.

This PR also ensures that all boolean Grouparoo properties are sent to Mailchimp as strings (as they require). 

Closes T-345