### PR TITLE
Export serialization

### DIFF
--- a/core/api/__tests__/models/export.ts
+++ b/core/api/__tests__/models/export.ts
@@ -27,9 +27,26 @@ describe("models/export", () => {
     profile = await helper.factories.profile();
   });
 
-  test("an export can be created", async () => {
-    const oldProfileProperties = { email: "oldEmail" };
-    const newProfileProperties = { email: "newEmail" };
+  test("an export can be created and saved with both single-value and array properties", async () => {
+    const oldProfileProperties = {
+      string: { type: "string", rawValue: "name" },
+      email: { type: "email", rawValue: "oldEmail" },
+      integer: { type: "integer", rawValue: "1" },
+      float: { type: "float", rawValue: "1.1" },
+      date: { type: "date", rawValue: "1" },
+      phoneNumber: { type: "phoneNumber", rawValue: "+1 412 897 0001" },
+    };
+    const newProfileProperties = {
+      string: { type: "string", rawValue: ["full", "name"] },
+      email: { type: "email", rawValue: ["oldEmail", "newEmail"] },
+      integer: { type: "integer", rawValue: ["1", "2"] },
+      float: { type: "float", rawValue: ["1.1", "2.2"] },
+      date: { type: "date", rawValue: ["1", "2"] },
+      phoneNumber: {
+        type: "phoneNumber",
+        rawValue: ["+1 412 897 0001", "+1 412 897 0002"],
+      },
+    };
     const oldGroups = [];
     const newGroups = ["cool-people"];
 
@@ -43,6 +60,28 @@ describe("models/export", () => {
       newGroups,
       mostRecent: true,
     });
+  });
+
+  test("an export can be deserialized returning Grouparoo types", async () => {
+    const _export = await Export.findOne();
+    expect(_export.oldProfileProperties).toEqual({
+      string: "name",
+      email: "oldEmail",
+      date: new Date(1),
+      float: 1.1,
+      integer: 1,
+      phoneNumber: "+1 412 897 0001",
+    });
+    expect(_export.newProfileProperties).toEqual({
+      string: ["full", "name"],
+      email: ["oldEmail", "newEmail"],
+      date: [new Date(1), new Date(2)],
+      float: [1.1, 2.2],
+      integer: [1, 2],
+      phoneNumber: ["+1 412 897 0001", "+1 412 897 0002"],
+    });
+    expect(_export.oldGroups).toEqual([]);
+    expect(_export.newGroups).toEqual(["cool-people"]);
   });
 
   test("imports can be associated to the export via ExportImports", async () => {

--- a/core/api/src/models/Export.ts
+++ b/core/api/src/models/Export.ts
@@ -23,9 +23,20 @@ import { Profile } from "./Profile";
 import { plugin } from "../modules/plugin";
 import Moment from "moment";
 import { Op } from "sequelize";
+import { ExportOps } from "../modules/ops/export";
 
-interface ExportProfileProperties {
-  [key: string]: any;
+/**
+ * The Profile Properties in their normal data types (string, boolean, date, etc)
+ */
+export interface ExportProfileProperties {
+  [key: string]: any | any[];
+}
+
+/**
+ * The Profile Properties as stringified rawValues + types
+ */
+export interface ExportProfilePropertiesWithType {
+  [key: string]: { type: string; rawValue: string | string[] };
 }
 
 @Table({ tableName: "exports", paranoid: false })
@@ -64,12 +75,10 @@ export class Export extends Model<Export> {
 
   @Column(DataType.TEXT)
   get oldProfileProperties(): ExportProfileProperties {
-    try {
+    return ExportOps.deserializeExportProfileProperties(
       //@ts-ignore
-      return JSON.parse(this.getDataValue("oldProfileProperties"));
-    } catch (e) {
-      return {};
-    }
+      this.getDataValue("oldProfileProperties")
+    );
   }
   set oldProfileProperties(value: ExportProfileProperties) {
     //@ts-ignore
@@ -78,12 +87,10 @@ export class Export extends Model<Export> {
 
   @Column(DataType.TEXT)
   get newProfileProperties(): ExportProfileProperties {
-    try {
+    return ExportOps.deserializeExportProfileProperties(
       //@ts-ignore
-      return JSON.parse(this.getDataValue("newProfileProperties"));
-    } catch (e) {
-      return {};
-    }
+      this.getDataValue("newProfileProperties")
+    );
   }
   set newProfileProperties(value: ExportProfileProperties) {
     //@ts-ignore

--- a/core/api/src/modules/ops/export.ts
+++ b/core/api/src/modules/ops/export.ts
@@ -1,0 +1,35 @@
+import {
+  ExportProfileProperties,
+  ExportProfilePropertiesWithType,
+} from "../../models/Export";
+import { ProfilePropertyRule } from "../../models/ProfilePropertyRule";
+import { ProfilePropertyOps } from "../../modules/ops/profileProperty";
+
+export namespace ExportOps {
+  /**
+   * Given an export with stringified old/new profile properties, this method will re-'inflate' them, ie turning date strings back to date objects.
+   * To be used in the getter, this method cannot be async.
+   */
+  export function deserializeExportProfileProperties(
+    serializedStringifiedProperties: string
+  ): ExportProfileProperties {
+    const response = {};
+    const serializedProperties: ExportProfilePropertiesWithType = serializedStringifiedProperties
+      ? JSON.parse(serializedStringifiedProperties)
+      : {};
+
+    for (const key in serializedProperties) {
+      const type = serializedProperties[key].type;
+      const rawValue = serializedProperties[key].rawValue;
+      if (Array.isArray(rawValue)) {
+        response[key] = rawValue.map((rv) =>
+          ProfilePropertyOps.getValue(rv, type)
+        );
+      } else {
+        response[key] = ProfilePropertyOps.getValue(rawValue, type);
+      }
+    }
+
+    return response;
+  }
+}

--- a/core/api/src/modules/ops/export.ts
+++ b/core/api/src/modules/ops/export.ts
@@ -21,12 +21,20 @@ export namespace ExportOps {
     for (const key in serializedProperties) {
       const type = serializedProperties[key].type;
       const rawValue = serializedProperties[key].rawValue;
-      if (Array.isArray(rawValue)) {
-        response[key] = rawValue.map((rv) =>
-          ProfilePropertyOps.getValue(rv, type)
-        );
+
+      if (!type || !rawValue) {
+        // legacy formatting
+        response[key] = serializedProperties[key];
       } else {
-        response[key] = ProfilePropertyOps.getValue(rawValue, type);
+        // current formatting
+        const rawValue = serializedProperties[key].rawValue;
+        if (Array.isArray(rawValue)) {
+          response[key] = rawValue.map((rv) =>
+            ProfilePropertyOps.getValue(rv, type)
+          );
+        } else {
+          response[key] = ProfilePropertyOps.getValue(rawValue, type);
+        }
       }
     }
 

--- a/core/api/src/modules/ops/profileProperty.ts
+++ b/core/api/src/modules/ops/profileProperty.ts
@@ -1,0 +1,108 @@
+import { parsePhoneNumberFromString, CountryCode } from "libphonenumber-js/max";
+import { plugin } from "../../modules/plugin";
+import isEmail from "validator/lib/isEmail";
+import isURL from "validator/lib/isURL";
+
+export namespace ProfilePropertyOps {
+  export async function buildRawValue(value: any, type: string) {
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+
+    switch (type) {
+      case "float":
+        return value.toString();
+      case "integer":
+        return value.toString();
+      case "date":
+        if (value instanceof Date) {
+          return value.getTime().toString();
+        } else {
+          return new Date(value).getTime().toString();
+        }
+      case "string":
+        return value.toString();
+      case "email":
+        return formatEmail(value.toString());
+      case "phoneNumber":
+        return formatPhoneNumber(value.toString());
+      case "url":
+        return formatURL(value.toString());
+      case "boolean":
+        if (![true, false, 0, 1, "true", "false"].includes(value)) {
+          throw new Error(`${value} is not a valid boolean value`);
+        }
+        if ([true, 1, "true"].includes(value)) {
+          return "true";
+        } else {
+          return "false";
+        }
+      default:
+        throw new Error(`cannot coerce profileProperty type ${type}`);
+    }
+  }
+
+  export function getValue(rawValue: string, type: string) {
+    if (rawValue === null || rawValue === undefined) return null;
+
+    switch (type) {
+      case "float":
+        return parseFloat(rawValue);
+      case "integer":
+        return parseInt(rawValue);
+      case "date":
+        return new Date(parseInt(rawValue));
+      case "string":
+        return rawValue;
+      case "email":
+        return rawValue;
+      case "phoneNumber":
+        return rawValue;
+      case "url":
+        return rawValue;
+      case "boolean":
+        if ([true, 1, "true"].includes(rawValue)) {
+          return true;
+        } else {
+          return false;
+        }
+      default:
+        throw new Error(`cannot coerce profileProperty type ${type}`);
+    }
+  }
+}
+
+// formatters and validators (private)
+
+function formatURL(url: string) {
+  if (!isURL(url)) {
+    throw new Error(`url "${url}" is not valid`);
+  }
+
+  return url.toLocaleLowerCase();
+}
+
+function formatEmail(email: string) {
+  if (!isEmail(email)) {
+    throw new Error(`email "${email}" is not valid`);
+  }
+
+  return email.toLocaleLowerCase();
+}
+
+async function formatPhoneNumber(number: string) {
+  const defaultCountryCode = (
+    await plugin.readSetting("core", "default-country-code")
+  ).value as CountryCode;
+
+  const formattedPhoneNumber = parsePhoneNumberFromString(
+    number,
+    defaultCountryCode
+  );
+
+  if (!formattedPhoneNumber || !formattedPhoneNumber.isValid()) {
+    throw new Error(`phone number "${number}" is not valid`);
+  }
+
+  return formattedPhoneNumber.formatInternational();
+}


### PR DESCRIPTION
Exports store the types of their profile properties, along with the mapped values.  In this way, we can ensure the proper object types (specifically `Date`s) are passed to the `exportProfile(s)` method of our plugins.



Closes T-366