### PR TITLE
Explicitly type Destination#getRuns

### DIFF
--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -325,7 +325,7 @@ export class Destination extends LoggedModel<Destination> {
     return DestinationOps.destinationMappingOptions(this);
   }
 
-  async getRuns(state?: string, limit = 100, offset = 0) {
+  async getRuns(state?: string, limit = 100, offset = 0): Promise<Run[]> {
     const exportRuns = await ExportRun.findAll({
       raw: true,
       attributes: [
@@ -536,13 +536,13 @@ export class Destination extends LoggedModel<Destination> {
   @BeforeDestroy
   static async waitUpdatingGroupsPreviouslySynced(instance: Destination) {
     const recentRuns = await instance.getRuns(undefined, 1, 0);
-    const recentGroupGuids = [
-      ...new Set(
+    const recentGroupGuids = Array.from(
+      new Set(
         recentRuns
           .filter((run) => run.creatorGuid.match(/^grp_/))
           .map((run) => run.creatorGuid)
-      ),
-    ];
+      )
+    );
     const updatingGroups = await Group.findAll({
       where: { guid: { [Op.in]: recentGroupGuids }, state: "updating" },
     });


### PR DESCRIPTION
Sequelize does a strict type check for `Op.in`, to ensure that it's being compared to an array of strings or numbers. 

When Grouparoo is getting compiled by a client install, `seqeulize-typescript` sometimes looses the type responses of `Model.findAll()` and changes it to `any`, even though when used directly, it's OK:

Monorepo: 
<img width="359" alt="Screen Shot 2020-08-25 at 1 12 58 PM" src="https://user-images.githubusercontent.com/303226/91222909-b3aaec80-e6d4-11ea-81f9-a73aa9883227.png">

Client Install:
<img width="379" alt="Screen Shot 2020-08-25 at 1 13 17 PM" src="https://user-images.githubusercontent.com/303226/91222948-befe1800-e6d4-11ea-9120-ddec9a1ddbe2.png">

There's later code that loops through the response types which expect a model, but looping though `any.property` can lead to the type `unknown`, which sequelize will reject. 

<img width="836" alt="Screen Shot 2020-08-25 at 1 15 16 PM" src="https://user-images.githubusercontent.com/303226/91223123-05ec0d80-e6d5-11ea-88a4-99d336d7b627.png">
