### PR TITLE
When times are null Export for start and end don't show any timestamps

### DIFF
--- a/core/api/__tests__/actions/exports.ts
+++ b/core/api/__tests__/actions/exports.ts
@@ -106,6 +106,7 @@ describe("actions/exports", () => {
 
       expect(error).toBeUndefined();
       expect(_export.guid).toBe(guid);
+      expect(_export.createdAt).toBeGreaterThan(0);
       expect(_export.destination.guid).toBe(destination.guid);
     });
 

--- a/core/api/src/models/Export.ts
+++ b/core/api/src/models/Export.ts
@@ -190,6 +190,7 @@ export class Export extends Model<Export> {
       guid: this.guid,
       destination: destination ? await destination.apiData(false, false) : null,
       profileGuid: this.profileGuid,
+      createdAt: this.createdAt ? this.createdAt.getTime() : null,
       startedAt: this.startedAt ? this.startedAt.getTime() : null,
       completedAt: this.completedAt ? this.completedAt.getTime() : null,
       oldProfileProperties: this.oldProfileProperties,

--- a/core/web/components/export/list.tsx
+++ b/core/web/components/export/list.tsx
@@ -72,7 +72,7 @@ export default function ExportsList(props) {
     }
   }
 
-  function formatCreatedAt(timestamp) {
+  function formatTimestamp(timestamp) {
     const [date, time] = new Date(timestamp).toLocaleString().split(",");
     return `${date} ${time}`;
   }
@@ -198,18 +198,28 @@ export default function ExportsList(props) {
                     Has Changes? {_export.hasChanges.toString()}
                   </td>
                   <td>
-                    Start: {formatCreatedAt(_export.startedAt)}
+                    Created:{" "}
+                    {_export.createdAt
+                      ? formatTimestamp(_export.createdAt)
+                      : null}
+                    <br />
+                    Start:{" "}
+                    {_export.startedAt
+                      ? formatTimestamp(_export.startedAt)
+                      : null}
                     <br />
                     End:{" "}
                     {_export.completedAt
-                      ? formatCreatedAt(_export.completedAt)
+                      ? formatTimestamp(_export.completedAt)
                       : null}
                     <br />
                     Duration:{" "}
-                    <Moment
-                      duration={_export.startedAt}
-                      date={_export.completedAt}
-                    />
+                    {_export.completedAt ? (
+                      <Moment
+                        duration={_export.createdAt}
+                        date={_export.completedAt}
+                      />
+                    ) : null}
                   </td>
                   <td>
                     <ul>

--- a/core/web/pages/export/[guid]/edit.tsx
+++ b/core/web/pages/export/[guid]/edit.tsx
@@ -129,7 +129,7 @@ export default function Page({ _export, groups }) {
           <p>
             Total duration:{" "}
             <strong>
-              <Moment duration={_export.startedAt} date={_export.completedAt} />
+              <Moment duration={_export.createdAt} date={_export.completedAt} />
             </strong>
           </p>
           <Table size="sm">
@@ -142,19 +142,42 @@ export default function Page({ _export, groups }) {
             </thead>
             <tbody>
               <tr>
-                <td>Started</td>
-                <td>{new Date(_export.startedAt).toLocaleString()}</td>
+                <td>Created</td>
+                <td>{new Date(_export.createdAt).toLocaleString()}</td>
                 <td>⇣</td>
               </tr>
               <tr>
-                <td>Completed</td>
-                <td>{new Date(_export.completedAt).toLocaleString()}</td>
+                <td>Started</td>
+                <td>
+                  {_export.startedAt
+                    ? new Date(_export.startedAt).toLocaleString()
+                    : null}
+                </td>
                 <td>
                   ⇣
-                  <Moment
-                    duration={_export.startedAt}
-                    date={_export.completedAt}
-                  />
+                  {_export.startedAt ? (
+                    <Moment
+                      duration={_export.createdAt}
+                      date={_export.startedAt}
+                    />
+                  ) : null}
+                </td>
+              </tr>
+              <tr>
+                <td>Completed</td>
+                <td>
+                  {_export.completedAt
+                    ? new Date(_export.completedAt).toLocaleString()
+                    : null}
+                </td>
+                <td>
+                  ⇣
+                  {_export.completedAt ? (
+                    <Moment
+                      duration={_export.startedAt}
+                      date={_export.completedAt}
+                    />
+                  ) : null}
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
This PR also adds `export.createdAt`, so the whole timeline of the Export can be seen

<img width="1680" alt="Screen Shot 2020-08-26 at 9 46 25 AM" src="https://user-images.githubusercontent.com/303226/91332618-56b94000-e781-11ea-88a7-46f06f1a3d21.png">
<img width="1680" alt="Screen Shot 2020-08-26 at 9 47 46 AM" src="https://user-images.githubusercontent.com/303226/91332631-5b7df400-e781-11ea-9725-8a31e40d1e95.png">

Closes T-379