### PR TITLE
Do not import Profile Properties when the Source's mapping key is missing

### DIFF
--- a/core/api/src/modules/internalRun.ts
+++ b/core/api/src/modules/internalRun.ts
@@ -1,4 +1,4 @@
-import { task } from "actionhero";
+import { task, log } from "actionhero";
 import { Run } from "../models/Run";
 
 /**
@@ -23,6 +23,13 @@ export async function internalRun(creatorType: string, creatorGuid: string) {
     creatorGuid,
     state: "running",
   });
+
+  log(
+    `[ run ] starting run ${
+      run.guid
+    } for ${creatorType} ${creatorGuid}, ${await run.getCreatorName()}`,
+    "notice"
+  );
 
   await task.enqueue("run:internalRun", { runGuid: run.guid });
 

--- a/core/web/components/profile/getProfileDisplayName.ts
+++ b/core/web/components/profile/getProfileDisplayName.ts
@@ -1,14 +1,15 @@
 import { ProfileAPIData } from "../../utils/apiData";
 
 export default function getProfileDisplayName(profile: ProfileAPIData) {
-  const propertiesArray = [];
-  let displayName = profile.guid;
+  let displayName = "";
 
   for (const key in profile.properties) {
     if (profile.properties[key].identifying) {
       displayName = profile.properties[key].values.join(", ");
     }
   }
+
+  if (displayName === "") displayName = profile.guid;
 
   return displayName;
 }

--- a/core/web/components/profile/list.tsx
+++ b/core/web/components/profile/list.tsx
@@ -4,7 +4,7 @@ import { useHistoryPagination } from "../../hooks/useHistoryPagination";
 import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
 import Link from "next/link";
 import Router from "next/router";
-import { Form, Col, Button } from "react-bootstrap";
+import { Form, Col, Button, Badge } from "react-bootstrap";
 import Moment from "react-moment";
 import Pagination from "../pagination";
 import LoadingTable from "../loadingTable";
@@ -231,7 +231,8 @@ export default function ProfilesList(props) {
                   >
                     <a className="text-muted">
                       {identifyingProfileProperty?.key &&
-                      profile.properties[identifyingProfileProperty.key] ? (
+                      profile.properties[identifyingProfileProperty.key] &&
+                      searchKey !== identifyingProfileProperty.key ? (
                         <>
                           {identifyingProfileProperty.key}:{" "}
                           {profile.properties[
@@ -243,8 +244,26 @@ export default function ProfilesList(props) {
                       <span>Grouparoo Guid: {profile.guid}</span>
                     </a>
                   </Link>
+
+                  {searchKey === "" ? null : (
+                    <div key={`key-${profile.guid}-${searchKey}`}>
+                      <span className="text-muted">
+                        <strong>{searchKey}</strong>:{" "}
+                        {profile.properties[searchKey] ? (
+                          <Badge variant="info">
+                            <ArrayProfilePropertyList
+                              type={profile.properties[searchKey].type}
+                              values={profile.properties[searchKey].values}
+                            />
+                          </Badge>
+                        ) : null}
+                      </span>
+                      <br />
+                    </div>
+                  )}
+
                   {uniqueProfilePropertyKeys.map((key) => {
-                    if (!profile.properties[key]) {
+                    if (!profile.properties[key] || searchKey === key) {
                       return null;
                     }
 
@@ -261,20 +280,6 @@ export default function ProfilesList(props) {
                       </div>
                     );
                   })}
-                  {searchKey === "" ? null : (
-                    <div key={`key-${profile.guid}-${searchKey}`}>
-                      <span className="text-muted">
-                        {searchKey}:{" "}
-                        {profile.properties[searchKey] ? (
-                          <ArrayProfilePropertyList
-                            type={profile.properties[searchKey].type}
-                            values={profile.properties[searchKey].values}
-                          />
-                        ) : null}
-                      </span>
-                      <br />
-                    </div>
-                  )}
                 </td>
                 <td>
                   <Moment fromNow>{profile.createdAt}</Moment>

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/profileProperty.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/profileProperty.ts
@@ -24,10 +24,11 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
 
   if (!aggregationMethod || !column) return;
 
-  // don't `select userId where userId = userId` if we already know it
+  // don't `select userId where userId = {userId}` if we don't know {userId}
   if (tableCol === column && aggregationMethod === "exact") {
+    const tableMappingCol: string = Object.values(sourceMapping)[0];
     const properties = await profile.properties();
-    if (properties[profilePropertyRule.key]?.values.length > 0) return;
+    if (properties[tableMappingCol]?.values.length === 0) return;
   }
 
   const columns = await getColumns(connection, table);

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/profileProperty.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/profileProperty.ts
@@ -22,13 +22,12 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
   const aggregationMethod = profilePropertyRuleOptions["aggregation method"];
   const sortColumn = profilePropertyRuleOptions["sort column"];
 
-  if (!aggregationMethod || !column) {
-    return;
-  }
+  if (!aggregationMethod || !column) return;
 
+  // don't `select userId where userId = userId` if we already know it
   if (tableCol === column && aggregationMethod === "exact") {
-    // don't return userId where userId = userId
-    return;
+    const properties = await profile.properties();
+    if (properties[profilePropertyRule.key]?.values.length > 0) return;
   }
 
   const columns = await getColumns(connection, table);

--- a/plugins/@grouparoo/mysql/src/lib/query-import/profileProperty.ts
+++ b/plugins/@grouparoo/mysql/src/lib/query-import/profileProperty.ts
@@ -7,7 +7,6 @@ import {
 export const profileProperty: ProfilePropertyPluginMethod = async ({
   connection,
   profile,
-  appOptions,
   profilePropertyRule,
   profilePropertyRuleOptions,
 }) => {

--- a/plugins/@grouparoo/mysql/src/lib/table-import/profileProperty.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/profileProperty.ts
@@ -20,13 +20,12 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
   const aggregationMethod = profilePropertyRuleOptions["aggregation method"];
   const sortColumn = profilePropertyRuleOptions["sort column"];
 
-  if (!aggregationMethod || !column) {
-    return;
-  }
+  if (!aggregationMethod || !column) return;
 
+  // don't `select userId where userId = userId` if we already know it
   if (tableCol === column && aggregationMethod === "exact") {
-    // don't return userId where userId = userId
-    return;
+    const properties = await profile.properties();
+    if (properties[profilePropertyRule.key]?.values.length > 0) return;
   }
 
   let aggSelect = `\`${column}\``;

--- a/plugins/@grouparoo/mysql/src/lib/table-import/profileProperty.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/profileProperty.ts
@@ -22,10 +22,11 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
 
   if (!aggregationMethod || !column) return;
 
-  // don't `select userId where userId = userId` if we already know it
+  // don't `select userId where userId = {userId}` if we don't know {userId}
   if (tableCol === column && aggregationMethod === "exact") {
+    const tableMappingCol: string = Object.values(sourceMapping)[0];
     const properties = await profile.properties();
-    if (properties[profilePropertyRule.key]?.values.length > 0) return;
+    if (properties[tableMappingCol]?.values.length === 0) return;
   }
 
   let aggSelect = `\`${column}\``;

--- a/plugins/@grouparoo/postgres/src/lib/table-import/profileProperty.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/profileProperty.ts
@@ -22,10 +22,11 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
 
   if (!aggregationMethod || !column) return;
 
-  // don't `select userId where userId = userId` if we already know it
+  // don't `select userId where userId = {userId}` if we don't know {userId}
   if (tableCol === column && aggregationMethod === "exact") {
+    const tableMappingCol: string = Object.values(sourceMapping)[0];
     const properties = await profile.properties();
-    if (properties[profilePropertyRule.key]?.values.length > 0) return;
+    if (properties[tableMappingCol]?.values.length === 0) return;
   }
 
   let aggSelect = `"${column}"`;

--- a/plugins/@grouparoo/postgres/src/lib/table-import/profileProperty.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/profileProperty.ts
@@ -7,7 +7,6 @@ import {
 export const profileProperty: ProfilePropertyPluginMethod = async ({
   profile,
   connection,
-  appOptions,
   profilePropertyRule,
   sourceOptions,
   sourceMapping,
@@ -21,13 +20,12 @@ export const profileProperty: ProfilePropertyPluginMethod = async ({
   const aggregationMethod = profilePropertyRuleOptions["aggregation method"];
   const sortColumn = profilePropertyRuleOptions["sort column"];
 
-  if (!aggregationMethod || !column) {
-    return;
-  }
+  if (!aggregationMethod || !column) return;
 
+  // don't `select userId where userId = userId` if we already know it
   if (tableCol === column && aggregationMethod === "exact") {
-    // don't return userId where userId = userId
-    return;
+    const properties = await profile.properties();
+    if (properties[profilePropertyRule.key]?.values.length > 0) return;
   }
 
   let aggSelect = `"${column}"`;


### PR DESCRIPTION
When importing Profile Properties, we previously skipped those that shared the same column as the Source's mapping and using the `exact` aggregation.  This was to avoid queries like `select id from users where id = id`.  
* Either we already know `id`, and this is a redundant query
* Or we don't know id at all, and the query will fail (event/anonymous profiles)

This PR now checks that the profile property exists first (aka: we know userID).

This PR also fixes up some of the rendering of list results when searching profile properties, by highlighting the search term's value.

<img width="1580" alt="Screen Shot 2020-08-26 at 11 53 30 AM" src="https://user-images.githubusercontent.com/303226/91344407-c3890600-e792-11ea-8d38-8fdc8b7e03e9.png">

Closes T-403