### PR TITLE
Group Rules can be built from Profile#guid or Profile#createdAt

### DIFF
--- a/core/api/__tests__/models/group/rules/topLevelGroupRules.ts
+++ b/core/api/__tests__/models/group/rules/topLevelGroupRules.ts
@@ -1,0 +1,250 @@
+import { Group } from "../../../../src/models/Group";
+import { GroupRule } from "../../../../src/models/GroupRule";
+import { Profile } from "../../../../src/models/Profile";
+import { SharedGroupTests } from "../../../utils/prepareSharedGroupTest";
+
+describe("model/group", () => {
+  let group: Group;
+  let mario: Profile;
+  let luigi: Profile;
+  let peach: Profile;
+  let toad: Profile;
+
+  beforeAll(async () => {
+    const response = await SharedGroupTests.beforeAll();
+    mario = response.mario;
+    luigi = response.luigi;
+    peach = response.peach;
+    toad = response.toad;
+  }, 1000 * 30);
+
+  afterAll(async () => {
+    await SharedGroupTests.afterAll();
+  });
+
+  beforeEach(async () => {
+    const response = await SharedGroupTests.beforeEach();
+    group = response.group;
+  });
+
+  afterEach(async () => {
+    await SharedGroupTests.afterEach();
+  });
+
+  describe("rules", () => {
+    describe("top level group rules", () => {
+      test("groupRule can be saved without topLevel indicating they have a profileColumn", async () => {
+        await group.setRules([
+          {
+            key: "guid",
+            operation: { op: "exists" },
+          },
+        ]);
+
+        const rules = await group.getRules();
+        expect(rules.length).toBe(1);
+        expect(rules[0]).toEqual({
+          key: "guid",
+          topLevel: true,
+          type: "string",
+          operation: { op: "ne", description: "exists with any value" },
+          match: "null",
+          relativeMatchNumber: null,
+          relativeMatchUnit: null,
+          relativeMatchDirection: null,
+        });
+
+        const groupRule = await GroupRule.findOne({
+          where: { groupGuid: group.guid },
+        });
+        expect(groupRule.profileColumn).toBe("guid");
+        expect(groupRule.profilePropertyRuleGuid).toBe(null);
+
+        expect(await group.countPotentialMembers()).toBe(4);
+      });
+
+      test("groupRule cannot be saved with topLevel with an invalid profileColumn", async () => {
+        await expect(
+          group.setRules([
+            {
+              key: "koopa",
+              operation: { op: "exists" },
+            },
+          ])
+        ).rejects.toThrow(/cannot find Profile Property Rule koopa/);
+      });
+
+      test("GroupRules must have either a profilePropertyGuid or a profileColumn", async () => {
+        await expect(
+          GroupRule.create({
+            position: 1,
+            op: "eq",
+            groupGuid: group.guid,
+          })
+        ).rejects.toThrow(
+          /either profilePropertyRuleGuid or profileColumn is required for a GroupRule/
+        );
+      });
+
+      test("testing group counts without saving woks when topLevel is provided", async () => {
+        await group.setRules([]);
+
+        // OK
+        const count = await group.countPotentialMembers([
+          {
+            key: "guid",
+            match: "pro%",
+            operation: { op: "like" },
+            topLevel: true,
+          },
+        ]);
+        expect(count).toBe(4);
+
+        // not OK
+        await expect(
+          group.countPotentialMembers([
+            {
+              key: "guid",
+              match: "pro%",
+              operation: { op: "exists" },
+            },
+          ])
+        ).rejects.toThrow(/cannot find type for ProfilePropertyRule gui/);
+      });
+
+      describe("guid", () => {
+        test("exact matches", async () => {
+          await group.setRules([
+            {
+              key: "guid",
+              match: mario.guid,
+              operation: { op: "eq" },
+            },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(1);
+        });
+
+        test("partial matches", async () => {
+          await group.setRules([
+            { key: "guid", match: "pro%", operation: { op: "like" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(4);
+        });
+
+        test("multiple rules with same key", async () => {
+          await group.setRules([
+            { key: "guid", match: "pro%", operation: { op: "iLike" } },
+            { key: "guid", match: "pro_%", operation: { op: "iLike" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(4);
+        });
+
+        test("null match", async () => {
+          await group.setRules([
+            { key: "guid", match: "null", operation: { op: "eq" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(0);
+        });
+
+        test("not null match", async () => {
+          await group.setRules([
+            { key: "guid", match: "null", operation: { op: "ne" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(4);
+        });
+
+        test("exists", async () => {
+          await group.setRules([{ key: "guid", operation: { op: "exists" } }]);
+          expect(await group.countPotentialMembers()).toBe(4);
+        });
+
+        test("notExists", async () => {
+          await group.setRules([
+            { key: "guid", operation: { op: "notExists" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(0);
+        });
+      });
+
+      describe("createdAt", () => {
+        test("exact matches", async () => {
+          await group.setRules([
+            {
+              key: "createdAt",
+              match: new Date(0).getTime(),
+              operation: { op: "eq" },
+            },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(0);
+        });
+
+        test("comparison matches", async () => {
+          await group.setRules([
+            {
+              key: "createdAt",
+              match: new Date(0).getTime(),
+              operation: { op: "gt" },
+            },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(4);
+        });
+
+        test("null match", async () => {
+          await group.setRules([
+            { key: "createdAt", match: "null", operation: { op: "eq" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(0);
+        });
+
+        test("not null match", async () => {
+          await group.setRules([
+            { key: "createdAt", match: "null", operation: { op: "ne" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(4);
+        });
+
+        test("exists", async () => {
+          await group.setRules([
+            { key: "createdAt", operation: { op: "exists" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(4);
+        });
+
+        test("notExists", async () => {
+          await group.setRules([
+            { key: "createdAt", operation: { op: "notExists" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(0);
+        });
+      });
+
+      describe("relative dates", () => {
+        test("comparison matches (with matches)", async () => {
+          await group.setRules([
+            {
+              key: "createdAt",
+              relativeMatchNumber: 2,
+              relativeMatchUnit: "days",
+              relativeMatchDirection: "subtract",
+              operation: { op: "gt" },
+            },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(4);
+        });
+
+        test("comparison matches (no matches)", async () => {
+          await group.setRules([
+            {
+              key: "createdAt",
+              relativeMatchNumber: 2,
+              relativeMatchUnit: "days",
+              relativeMatchDirection: "add",
+              operation: { op: "gt" },
+            },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(0);
+        });
+      });
+    });
+  });
+});

--- a/core/api/__tests__/models/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRule.ts
@@ -123,6 +123,19 @@ describe("models/profilePropertyRule", () => {
       await rule.destroy();
     });
 
+    test("keys cannot be from the reserved list of keys", async () => {
+      const reservedKeys = ["guid", "createdAt", "updatedAt"];
+      for (const i in reservedKeys) {
+        const key = reservedKeys[i];
+        await expect(
+          ProfilePropertyRule.create({
+            sourceGuid: source.guid,
+            key,
+          })
+        ).rejects.toThrow(/is a reserved key and cannot be used/);
+      }
+    });
+
     test("a profile property rule can be isArray", async () => {
       const rule = await ProfilePropertyRule.create({
         sourceGuid: source.guid,

--- a/core/api/src/actions/groups.ts
+++ b/core/api/src/actions/groups.ts
@@ -1,6 +1,6 @@
 import { task, api } from "actionhero";
 import { AuthenticatedAction } from "../classes/authenticatedAction";
-import { Group, GROUP_RULE_LIMIT } from "../models/Group";
+import { Group, GROUP_RULE_LIMIT, TopLevelGroupRules } from "../models/Group";
 import { ProfilePropertyRuleOpsDictionary } from "../modules/RuleOpsDictionary";
 import { Profile } from "../models/Profile";
 
@@ -55,6 +55,7 @@ export class GroupsRuleOptions extends AuthenticatedAction {
   async run({ response }) {
     response.ruleLimit = GROUP_RULE_LIMIT;
     response.ops = ProfilePropertyRuleOpsDictionary;
+    response.topLevelGroupRules = TopLevelGroupRules;
   }
 }
 

--- a/core/api/src/migrations/000038-groupRuleProfileColumn.ts
+++ b/core/api/src/migrations/000038-groupRuleProfileColumn.ts
@@ -1,0 +1,22 @@
+module.exports = {
+  up: async function (migration, DataTypes) {
+    await migration.changeColumn("groupRules", "profilePropertyRuleGuid", {
+      type: DataTypes.STRING(40),
+      allowNull: true,
+    });
+
+    await migration.addColumn("groupRules", "profileColumn", {
+      type: DataTypes.STRING(191),
+      allowNull: true,
+    });
+  },
+
+  down: async function (migration, DataTypes) {
+    await migration.changeColumn("groupRules", "profilePropertyRuleGuid", {
+      type: DataTypes.STRING(40),
+      allowNull: false,
+    });
+
+    await migration.removeColumn("groupRules", "profileColumn");
+  },
+};

--- a/core/api/src/models/GroupRule.ts
+++ b/core/api/src/models/GroupRule.ts
@@ -8,6 +8,7 @@ import {
   UpdatedAt,
   BeforeCreate,
   BelongsTo,
+  BeforeSave,
 } from "sequelize-typescript";
 import * as uuid from "uuid";
 import { Group } from "./Group";
@@ -33,10 +34,14 @@ export class GroupRule extends Model<GroupRule> {
   @Column
   groupGuid: string;
 
-  @AllowNull(false)
+  @AllowNull(true)
   @ForeignKey(() => ProfilePropertyRule)
   @Column
   profilePropertyRuleGuid: string;
+
+  @AllowNull(true)
+  @Column
+  profileColumn: string;
 
   @AllowNull(false)
   @Column
@@ -69,6 +74,7 @@ export class GroupRule extends Model<GroupRule> {
       guid: this.guid,
       groupGuid: this.groupGuid,
       profilePropertyRuleGuid: this.profilePropertyRuleGuid,
+      profileColumn: this.profileColumn,
       position: this.position,
       match: this.match,
       op: this.op,
@@ -92,6 +98,20 @@ export class GroupRule extends Model<GroupRule> {
   static generateGuid(instance) {
     if (!instance.guid) {
       instance.guid = `${instance.guidPrefix()}_${uuid.v4()}`;
+    }
+  }
+
+  @BeforeSave
+  static async ensureEitherProfilePropertyRuleOrProfileColumn(
+    instance: GroupRule
+  ) {
+    if (
+      (!instance.profilePropertyRuleGuid && !instance.profileColumn) ||
+      (instance.profilePropertyRuleGuid && instance.profileColumn)
+    ) {
+      throw new Error(
+        "either profilePropertyRuleGuid or profileColumn is required for a GroupRule"
+      );
     }
   }
 }

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -424,6 +424,16 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
     await instance.test();
   }
 
+  @BeforeSave
+  static async validateReservedKeys(instance: ProfilePropertyRule) {
+    const reservedKeys = ["guid", "createdAt", "updatedAt"];
+    if (reservedKeys.includes(instance.key)) {
+      throw new Error(
+        `${instance.key} is a reserved key and cannot be used as a profile property rule`
+      );
+    }
+  }
+
   @AfterSave
   static async clearCacheAfterSave() {
     return this.clearCache();

--- a/core/web/pages/group/[guid]/rules.tsx
+++ b/core/web/pages/group/[guid]/rules.tsx
@@ -152,8 +152,8 @@ export default function Page(props) {
   }
 
   let rowChanges = false;
-  const profilePropertyRulesAndTopLevelGroupRules = topLevelGroupRules.concat(
-    profilePropertyRules
+  const profilePropertyRulesAndTopLevelGroupRules = profilePropertyRules.concat(
+    topLevelGroupRules
   );
 
   return (
@@ -248,12 +248,12 @@ export default function Page(props) {
                             <Fragment key={`ruleKeyOpt-${rule.key}-${idx}`}>
                               {idx === 0 ? (
                                 <option disabled>
-                                  --- profile columns ---
+                                  --- profile properties ---
                                 </option>
                               ) : null}
-                              {idx === topLevelGroupRules.length ? (
+                              {idx === profilePropertyRules.length ? (
                                 <option disabled>
-                                  --- profile properties ---
+                                  --- profile columns ---
                                 </option>
                               ) : null}
                               <option>{rule.key}</option>


### PR DESCRIPTION
This PR allows Groups to be built from the columns on Profile (`guid` and `createdAt`), as well as Profile Property values.  In this way, you can:
1. create an 'everyone' group where `guid exists with any value`
2. create a 'new users' group where `createdAt is within the past 3 months`

<img width="1214" alt="Screen Shot 2020-08-28 at 4 22 59 PM" src="https://user-images.githubusercontent.com/303226/91622214-e78f4780-e94a-11ea-826c-1d33a85d2ba1.png">

We are still counting the list of Group members in a single query!

Closes T-416