### PR TITLE
Share and centralize `destinationTypeConversions`

### DIFF
--- a/core/api/__tests__/actions/destinations.ts
+++ b/core/api/__tests__/actions/destinations.ts
@@ -1,9 +1,6 @@
 import { helper } from "./../utils/specHelper";
 import { specHelper } from "actionhero";
-import {
-  Destination,
-  destinationTypeConversions,
-} from "./../../src/models/Destination";
+import { Destination } from "./../../src/models/Destination";
 import { Group } from "./../../src/models/Group";
 import { Profile } from "./../../src/models/Profile";
 
@@ -190,7 +187,16 @@ describe("actions/destinations", () => {
           allowOptionalFromProfilePropertyRules: true,
         },
       });
-      expect(_destinationTypeConversions).toEqual(destinationTypeConversions);
+      expect(_destinationTypeConversions).toEqual({
+        boolean: ["any", "string", "boolean", "number"],
+        date: ["any", "float", "integer", "string", "date", "number"],
+        email: ["any", "string", "email"],
+        float: ["any", "float", "string", "number"],
+        integer: ["any", "float", "integer", "string", "number"],
+        phoneNumber: ["any", "string", "phoneNumber"],
+        string: ["any", "string"],
+        url: ["any", "string", "url"],
+      });
     });
 
     test("an administrator can set the mapping with valid mappings", async () => {

--- a/core/api/src/actions/destinations.ts
+++ b/core/api/src/actions/destinations.ts
@@ -1,12 +1,13 @@
 import { api } from "actionhero";
 import { AuthenticatedAction } from "../classes/authenticatedAction";
-import { Destination, destinationTypeConversions } from "../models/Destination";
+import { Destination } from "../models/Destination";
 import { App } from "../models/App";
 import { Profile } from "../models/Profile";
 import { Group } from "../models/Group";
 import { GroupMember } from "../models/GroupMember";
 import { GrouparooPlugin } from "../classes/plugin";
 import { OptionHelper } from "../modules/optionHelper";
+import { destinationTypeConversions } from "../modules/destinationTypeConversions";
 
 export class DestinationsList extends AuthenticatedAction {
   constructor() {
@@ -203,7 +204,15 @@ export class DestinationMappingOptions extends AuthenticatedAction {
   async run({ params, response }) {
     const destination = await Destination.findByGuid(params.guid);
     response.options = await destination.destinationMappingOptions(false); // never use cache when displaying to the user
-    response.destinationTypeConversions = destinationTypeConversions;
+
+    const _destinationTypeConversions: { [key: string]: Array<string> } = {};
+    for (const k in destinationTypeConversions) {
+      _destinationTypeConversions[k] = Object.keys(
+        destinationTypeConversions[k]
+      );
+    }
+
+    response.destinationTypeConversions = _destinationTypeConversions;
   }
 }
 

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -34,6 +34,7 @@ import { StateMachine } from "./../modules/stateMachine";
 import { ProfilePropertyRule } from "./ProfilePropertyRule";
 import { DestinationOps } from "./../modules/ops/destination";
 import { ExportOps } from "../modules/ops/export";
+import { destinationTypeConversions } from "../modules/destinationTypeConversions";
 
 export interface DestinationMapping extends MappingHelper.Mappings {}
 export interface SimpleDestinationGroupMembership {
@@ -42,18 +43,6 @@ export interface SimpleDestinationGroupMembership {
   groupName: string;
 }
 export interface SimpleDestinationOptions extends OptionHelper.SimpleOptions {}
-
-// From Grouparoo Type to Destination Type
-export const destinationTypeConversions = {
-  float: ["any", "float", "integer", "string", "number"],
-  integer: ["any", "float", "integer", "string", "number"],
-  string: ["any", "string", "boolean"],
-  url: ["any", "string", "url"],
-  email: ["any", "string", "email"],
-  phoneNumber: ["any", "string", "phoneNumber"],
-  boolean: ["any", "string", "boolean", "number"],
-  date: ["any", "float", "integer", "string", "number", "date"],
-};
 
 const STATE_TRANSITIONS = [
   { from: "draft", to: "ready", checks: ["validateOptions"] },
@@ -277,12 +266,11 @@ export class Destination extends LoggedModel<Destination> {
       }
 
       const profilePropertyRule = cachedProfilePropertyRules[mappings[opt.key]];
-      if (
-        profilePropertyRule &&
-        !destinationTypeConversions[profilePropertyRule.type]?.includes(
-          opt.type
-        )
-      ) {
+      const validDestinationTypes = profilePropertyRule?.type
+        ? Object.keys(destinationTypeConversions[profilePropertyRule.type])
+        : [];
+
+      if (profilePropertyRule && !validDestinationTypes?.includes(opt.type)) {
         throw new Error(
           `${opt.key} requires a profile property rule of type ${opt.type}, but a ${profilePropertyRule.type} (${profilePropertyRule.key}) was mapped`
         );
@@ -293,12 +281,11 @@ export class Destination extends LoggedModel<Destination> {
     for (const i in destinationMappingOptions.profilePropertyRules.known) {
       const opt = destinationMappingOptions.profilePropertyRules.known[i];
       const profilePropertyRule = cachedProfilePropertyRules[mappings[opt.key]];
-      if (
-        profilePropertyRule &&
-        !destinationTypeConversions[profilePropertyRule.type]?.includes(
-          opt.type
-        )
-      ) {
+      const validDestinationTypes = profilePropertyRule?.type
+        ? Object.keys(destinationTypeConversions[profilePropertyRule.type])
+        : [];
+
+      if (profilePropertyRule && !validDestinationTypes?.includes(opt.type)) {
         throw new Error(
           `${opt.key} requires a profile property rule of type ${opt.type}, but a ${profilePropertyRule.type} (${profilePropertyRule.key}) was mapped`
         );

--- a/core/api/src/modules/destinationTypeConversions.ts
+++ b/core/api/src/modules/destinationTypeConversions.ts
@@ -1,0 +1,61 @@
+/**
+ * List of conversions from Grouparoo Types to Destination Types
+ * In many cases, we can do conversions, ie: 'integer' or 'float' to 'number' or there are cast-able representations in other types, like 'integer' to 'string'.
+ * Any conversion that's not listed here is not valid.
+ * Learn more at https://docs.google.com/spreadsheets/d/1Fbkdsq_IR8deOYF4QpVq_XIdqpvAah3tJbVP2K5nCdc
+ */
+export const destinationTypeConversions = {
+  float: {
+    any: (v: number) => v,
+    float: (v: number) => v,
+    string: (v: number) => v.toString(),
+    number: (v: number) => v,
+  },
+
+  integer: {
+    any: (v: number) => v,
+    float: (v: number) => v,
+    integer: (v: number) => v,
+    string: (v: number) => v.toString(),
+    number: (v: number) => v,
+  },
+
+  string: {
+    any: (v: string) => v,
+    string: (v: string) => v,
+  },
+
+  url: {
+    any: (v: string) => v,
+    string: (v: string) => v,
+    url: (v: string) => v,
+  },
+
+  email: {
+    any: (v: string) => v,
+    string: (v: string) => v,
+    email: (v: string) => v,
+  },
+
+  phoneNumber: {
+    any: (v: string) => v,
+    string: (v: string) => v,
+    phoneNumber: (v: string) => v,
+  },
+
+  boolean: {
+    any: (v: boolean) => v,
+    string: (v: boolean) => v.toString(),
+    boolean: (v: boolean) => v,
+    number: (v: boolean) => (v === true ? 1 : 0),
+  },
+
+  date: {
+    any: (v: Date) => v,
+    float: (v: Date) => v.getTime(),
+    integer: (v: Date) => v.getTime(),
+    string: (v: Date) => v.toISOString(),
+    date: (v: Date) => v,
+    number: (v: Date) => v.getTime(),
+  },
+};


### PR DESCRIPTION
Centralizes `destinationTypeConversions` - both the list of what's valid and conversion methods in one place.  Solves a bug where the old list of destination type conversions didn't match the old collection of conversion methods. 

Closes T-424
