### PR TITLE
Destination Export Fixes

### DIFF
--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -554,21 +554,13 @@ export class Destination extends LoggedModel<Destination> {
     oldGroups: Group[] = [],
     newGroups: Group[] = []
   ) {
-    const combinedGroups = oldGroups.concat(newGroups);
-    const combinedGroupGuids = combinedGroups.map((g) => g.guid);
-    const relevantDestinations: Array<Destination> = [];
-
-    const destinations = await Destination.findAll({
-      where: { state: "ready" },
+    const combinedGroupGuids = [...oldGroups, ...newGroups].map((g) => g.guid);
+    const relevantDestinations = await Destination.scope(null).findAll({
+      where: {
+        state: "ready",
+        groupGuid: { [Op.in]: combinedGroupGuids },
+      },
     });
-
-    for (const i in destinations) {
-      const destination = destinations[i];
-      if (combinedGroupGuids.includes(destination.groupGuid)) {
-        relevantDestinations.push(destination);
-        break;
-      }
-    }
 
     return relevantDestinations;
   }

--- a/core/api/src/modules/ops/export.ts
+++ b/core/api/src/modules/ops/export.ts
@@ -102,7 +102,7 @@ export namespace ExportOps {
     const { pluginConnection } = await destination.getPlugin();
 
     // We use Export#startedAt to denote that this export needs to be worked.  We can update and claim them in one go.
-    // This does require a custom query.
+    // This requires a custom query.
     const query = `
 UPDATE "exports"
 SET "startedAt" = NOW()

--- a/core/api/src/tasks/profile/export.ts
+++ b/core/api/src/tasks/profile/export.ts
@@ -85,9 +85,7 @@ export class ProfileExport extends RetryableTask {
           const destination = await Destination.findOne({
             where: { guid: _import.data._meta.destinationGuid },
           });
-          if (destination) {
-            destinations.push(destination);
-          }
+          if (destination) destinations.push(destination);
         }
       }
 

--- a/core/web/pages/destination/[guid]/data.tsx
+++ b/core/web/pages/destination/[guid]/data.tsx
@@ -63,12 +63,21 @@ export default function Page(props) {
     });
 
     // update group being tracked after the edit
-    if (trackedGroupGuid.match(/^grp_/)) {
+    if (
+      trackedGroupGuid !== props.trackedGroupGuid &&
+      trackedGroupGuid.match(/^grp_/)
+    ) {
       await execApi("post", `/destination/${guid}/track`, {
         groupGuid: trackedGroupGuid,
       });
-    } else if (trackedGroupGuid === "_none") {
+    } else if (
+      trackedGroupGuid !== props.trackedGroupGuid &&
+      trackedGroupGuid === "_none"
+    ) {
       await execApi("post", `/destination/${guid}/untrack`);
+    } else {
+      // trigger a full export
+      await execApi("post", `/destination/${guid}/export`);
     }
 
     successHandler.set({


### PR DESCRIPTION
* Start a Destination/Group Run if there are changes to the data being tracked by the Destination
* Ensure that Exports are created for every Destination tracking a Group when membership changes

Closes T-434
Closes T-435