### PR TITLE
Exports compute old and new Properties only from current state of the Profile and the most recent sent Export

### DIFF
--- a/core/api/__tests__/models/destination/plugins/destinationMappingOptions.ts
+++ b/core/api/__tests__/models/destination/plugins/destinationMappingOptions.ts
@@ -493,6 +493,7 @@ describe("models/destination", () => {
         required = [{ key: "remote-id", type: "number" }];
         await destination.setMapping({ "remote-id": "userId", email: "email" });
         await mario.export();
+        expect(oldProfileProperties).toEqual({});
         expect(newProfileProperties).toEqual({
           "remote-id": 1,
           email: "mario@example.com",
@@ -502,6 +503,10 @@ describe("models/destination", () => {
         required = [{ key: "remote-id", type: "string" }];
         await destination.setMapping({ "remote-id": "userId", email: "email" });
         await mario.export();
+        expect(oldProfileProperties).toEqual({
+          "remote-id": "1",
+          email: "mario@example.com",
+        });
         expect(newProfileProperties).toEqual({
           "remote-id": "1",
           email: "mario@example.com",

--- a/core/api/__tests__/models/destination/plugins/exportProfile.ts
+++ b/core/api/__tests__/models/destination/plugins/exportProfile.ts
@@ -802,7 +802,9 @@ describe("models/destination", () => {
 
         await destination.exportProfile(profile, [], [_import]);
 
-        const _exports = await profile.$get("exports");
+        const _exports = await profile.$get("exports", {
+          order: [["createdAt", "asc"]],
+        });
         expect(_exports.length).toBe(2);
         expect(_exports[1].oldProfileProperties).toEqual({
           purchases: ["hat", "mushroom"],
@@ -846,7 +848,9 @@ describe("models/destination", () => {
 
         await destination.exportProfile(profile, [], [_import]);
 
-        const _exports = await profile.$get("exports");
+        const _exports = await profile.$get("exports", {
+          order: [["createdAt", "asc"]],
+        });
         expect(_exports.length).toBe(2);
         expect(_exports[1].oldProfileProperties).toEqual({
           purchases: ["hat", "mushroom"],

--- a/core/api/__tests__/models/destination/plugins/exportProfile.ts
+++ b/core/api/__tests__/models/destination/plugins/exportProfile.ts
@@ -181,22 +181,26 @@ describe("models/destination", () => {
       );
 
       const profile = await helper.factories.profile();
-      const oldProfileProperties = { email: ["oldmail@example.com"] };
-      const newProfileProperties = { email: ["newemail@example.com"] };
-      const oldGroups = [];
-      const newGroups = [groupA, groupB];
+      await profile.addOrUpdateProperties({ email: ["newemail@example.com"] });
+      await groupA.addProfile(profile);
+      await groupB.addProfile(profile);
+
+      const oldExport = await helper.factories.export(profile, destination, {
+        newProfileProperties: {
+          customer_email: { type: "email", rawValue: "oldmail@example.com" },
+        },
+        newGroups: [],
+        startedAt: new Date(),
+        completedAt: new Date(),
+        mostRecent: true,
+      });
+      await specHelper.deleteEnqueuedTasks("exports:send", {
+        guid: oldExport.guid,
+      });
 
       const _import = await helper.factories.import();
 
-      await destination.exportProfile(
-        profile,
-        [],
-        [_import],
-        oldProfileProperties,
-        newProfileProperties,
-        oldGroups,
-        newGroups
-      );
+      await destination.exportProfile(profile, [], [_import]);
 
       await specHelper.runTask("export:enqueue", {});
       const foundTasks = await specHelper.findEnqueuedTasks("export:send");
@@ -214,35 +218,38 @@ describe("models/destination", () => {
       });
       expect(exportArgs.oldGroups).toEqual([]);
       expect(exportArgs.newGroups).toEqual(
-        newGroups.map((g) => `${g.name}+`).sort()
+        [groupA, groupB].map((g) => `${g.name}+`).sort()
       );
       expect(exportArgs.toDelete).toEqual(false);
 
       const _exports = await Export.findAll({
         where: { destinationGuid: destination.guid },
+        order: [["createdAt", "asc"]],
       });
-      expect(_exports.length).toBe(1);
-      expect(_exports[0].destinationGuid).toBe(destination.guid);
-      expect(_exports[0].profileGuid).toBe(profile.guid);
+      expect(_exports.length).toBe(2);
+      expect(_exports[1].destinationGuid).toBe(destination.guid);
+      expect(_exports[1].profileGuid).toBe(profile.guid);
       expect(
         _exports[0].completedAt.getTime() - _exports[0].startedAt.getTime()
-      ).toBeGreaterThan(0);
-      expect(_exports[0].errorMessage).toBeFalsy();
-      expect(_exports[0].oldProfileProperties).toEqual({
+      ).toBeGreaterThanOrEqual(0);
+      expect(_exports[1].errorMessage).toBeFalsy();
+      expect(_exports[1].oldProfileProperties).toEqual({
         customer_email: "oldmail@example.com",
       });
-      expect(_exports[0].newProfileProperties).toEqual({
+      expect(_exports[1].newProfileProperties).toEqual({
         customer_email: "newemail@example.com",
       });
-      expect(_exports[0].oldGroups).toEqual([]);
-      expect(_exports[0].newGroups).toEqual(
-        newGroups.map((g) => `${g.name}+`).sort()
+      expect(_exports[1].oldGroups).toEqual([]);
+      expect(_exports[1].newGroups).toEqual(
+        [groupA, groupB].map((g) => `${g.name}+`).sort()
       );
-      expect(_exports[0].mostRecent).toBe(true);
+      expect(_exports[1].mostRecent).toBe(true);
 
-      const exportedImports = await _exports[0].$get("imports");
+      const exportedImports = await _exports[1].$get("imports");
       expect(exportedImports.length).toBe(1);
       expect(exportedImports[0].guid).toBe(_import.guid);
+
+      await profile.destroy();
     });
 
     test("profile properties previously mapped but now removed will be included as oldProfileProperties in the export", async () => {
@@ -256,16 +263,17 @@ describe("models/destination", () => {
       await destination.trackGroup(groupA);
 
       const profile = await helper.factories.profile();
-      const oldProfileProperties = { email: ["oldmail@example.com"] };
-      const newProfileProperties = { email: ["newemail@example.com"] };
-      const oldGroups = [];
-      const newGroups = [groupA];
+      await profile.addOrUpdateProperties({ email: ["newemail@example.com"] });
+      await groupA.addProfile(profile);
 
       // create a previous export
       const _export = await Export.create({
         profileGuid: profile.guid,
         destinationGuid: destination.guid,
-        newProfileProperties: { gender: "Male" },
+        newProfileProperties: {
+          gender: { type: "string", rawValue: "Male" },
+          customer_email: { type: "email", rawValue: "oldmail@example.com" },
+        },
         oldProfileProperties: {},
         oldGroups: [],
         newGroups: [],
@@ -274,15 +282,7 @@ describe("models/destination", () => {
 
       const _import = await helper.factories.import();
 
-      await destination.exportProfile(
-        profile,
-        [],
-        [_import],
-        oldProfileProperties,
-        newProfileProperties,
-        oldGroups,
-        newGroups
-      );
+      await destination.exportProfile(profile, [], [_import]);
 
       await specHelper.runTask("export:enqueue", {});
       const foundTasks = await specHelper.findEnqueuedTasks("export:send");
@@ -293,11 +293,13 @@ describe("models/destination", () => {
 
       expect(exportArgs.oldProfileProperties).toEqual({
         customer_email: "oldmail@example.com",
-        gender: "unknown",
+        gender: "Male",
       });
       expect(exportArgs.newProfileProperties).toEqual({
         customer_email: "newemail@example.com",
       });
+
+      await profile.destroy();
     });
 
     test("newly tagged groups will appear new in next export", async () => {
@@ -311,11 +313,6 @@ describe("models/destination", () => {
 
       const profile = await helper.factories.profile();
       group.addProfile(profile);
-
-      const oldProfileProperties = {};
-      const newProfileProperties = {};
-      const oldGroups = [];
-      const newGroups = [group];
 
       // create a previous export
       const _export = await Export.create({
@@ -336,15 +333,7 @@ describe("models/destination", () => {
 
       const _import = await helper.factories.import();
 
-      await destination.exportProfile(
-        profile,
-        [],
-        [_import],
-        oldProfileProperties,
-        newProfileProperties,
-        oldGroups,
-        newGroups
-      );
+      await destination.exportProfile(profile, [], [_import]);
 
       await specHelper.runTask("export:enqueue", {});
       const foundTasks = await specHelper.findEnqueuedTasks("export:send");
@@ -355,6 +344,8 @@ describe("models/destination", () => {
 
       expect(exportArgs.oldGroups).toEqual([]);
       expect(exportArgs.newGroups).toEqual([group.name]);
+
+      await profile.destroy();
     });
 
     test("newly un-tagged groups will be removed from the next export", async () => {
@@ -368,11 +359,6 @@ describe("models/destination", () => {
 
       const profile = await helper.factories.profile();
       group.addProfile(profile);
-
-      const oldProfileProperties = {};
-      const newProfileProperties = {};
-      const oldGroups = [];
-      const newGroups = [group];
 
       const destinationGroupMemberships = {};
       destinationGroupMemberships[group.guid] = group.name;
@@ -395,15 +381,7 @@ describe("models/destination", () => {
 
       await destination.setDestinationGroupMemberships({});
 
-      await destination.exportProfile(
-        profile,
-        [],
-        [_import],
-        oldProfileProperties,
-        newProfileProperties,
-        oldGroups,
-        newGroups
-      );
+      await destination.exportProfile(profile, [], [_import]);
 
       await specHelper.runTask("export:enqueue", {});
       const foundTasks = await specHelper.findEnqueuedTasks("export:send");
@@ -414,6 +392,8 @@ describe("models/destination", () => {
 
       expect(exportArgs.oldGroups).toEqual([group.name]);
       expect(exportArgs.newGroups).toEqual([]);
+
+      await profile.destroy();
     });
 
     test("if a profile is removed from all groups tracked by this destination, toDelete is true", async () => {
@@ -433,22 +413,21 @@ describe("models/destination", () => {
       );
 
       const profile = await helper.factories.profile();
-      const oldProfileProperties = { email: ["oldmail@example.com"] };
-      const newProfileProperties = { email: ["newemail@example.com"] };
-      const oldGroups = [groupA, groupB];
-      const newGroups = [];
+
+      const oldExport = await helper.factories.export(profile, destination, {
+        newProfileProperties: {},
+        newGroups: [groupA.name, groupB.name].sort(),
+        startedAt: new Date(),
+        completedAt: new Date(),
+        mostRecent: true,
+      });
+      await specHelper.deleteEnqueuedTasks("exports:send", {
+        guid: oldExport.guid,
+      });
 
       const _import = await helper.factories.import();
 
-      await destination.exportProfile(
-        profile,
-        [],
-        [_import],
-        oldProfileProperties,
-        newProfileProperties,
-        oldGroups,
-        newGroups
-      );
+      await destination.exportProfile(profile, [], [_import]);
 
       await specHelper.runTask("export:enqueue", {});
       const foundTasks = await specHelper.findEnqueuedTasks("export:send");
@@ -456,9 +435,13 @@ describe("models/destination", () => {
       await specHelper.runTask("export:send", foundTasks[0].args[0]);
 
       expect(exportArgs.profile.guid).toEqual(profile.guid);
-      expect(exportArgs.oldGroups).toEqual(oldGroups.map((g) => g.name).sort());
+      expect(exportArgs.oldGroups).toEqual(
+        [groupA, groupB].map((g) => g.name).sort()
+      );
       expect(exportArgs.newGroups).toEqual([]);
       expect(exportArgs.toDelete).toEqual(true);
+
+      await profile.destroy();
     });
 
     test("if an export has the same data as the previous export, and force=false, it will not be sent to the destination", async () => {
@@ -478,15 +461,7 @@ describe("models/destination", () => {
         mostRecent: true,
       });
 
-      await destination.exportProfile(
-        profile,
-        [],
-        [],
-        {},
-        {},
-        [group],
-        [group]
-      );
+      await destination.exportProfile(profile, [], []);
       const newExport = await Export.findOne({
         where: {
           destinationGuid: destination.guid,
@@ -502,6 +477,8 @@ describe("models/destination", () => {
 
       await newExport.reload();
       expect(newExport.completedAt).toBeTruthy();
+
+      await profile.destroy();
     });
 
     test("if an export has the same data as the previous export, and force=true, it will be sent to the destination", async () => {
@@ -521,17 +498,7 @@ describe("models/destination", () => {
         mostRecent: true,
       });
 
-      await destination.exportProfile(
-        profile,
-        [],
-        [],
-        {},
-        {},
-        [group],
-        [group],
-        false,
-        true
-      );
+      await destination.exportProfile(profile, [], [], false, true);
       const newExport = await Export.findOne({
         where: {
           destinationGuid: destination.guid,
@@ -547,32 +514,45 @@ describe("models/destination", () => {
 
       await newExport.reload();
       expect(newExport.completedAt).toBeTruthy();
+
+      await profile.destroy();
     });
 
-    test("if there is no previous export, it will be sent to the destination", async () => {
+    test("if there is no previous export, it will be sent to the destination and all data will be new", async () => {
       const profile = await helper.factories.profile();
+      await profile.addOrUpdateProperties({ email: ["newEmail@example.com"] });
       const group = await helper.factories.group();
       await group.addProfile(profile);
       await destination.trackGroup(group);
 
-      await destination.exportProfile(
-        profile,
-        [],
-        [],
-        {},
-        {},
-        [group],
-        [group]
+      await destination.setMapping({
+        customer_email: "email",
+      });
+
+      const destinationGroupMemberships = {};
+      destinationGroupMemberships[group.guid] = group.name;
+      await destination.setDestinationGroupMemberships(
+        destinationGroupMemberships
       );
+
+      await destination.exportProfile(profile, [], []);
       const newExport = await Export.findOne({
         where: { destinationGuid: destination.guid },
       });
 
+      expect(newExport.oldProfileProperties).toEqual({});
+      expect(newExport.newProfileProperties).toEqual({
+        customer_email: "newemail@example.com",
+      });
+      expect(newExport.oldGroups).toEqual([]);
+      expect(newExport.newGroups).toEqual([group.name]);
       expect(newExport.toDelete).toBe(false);
       expect(newExport.hasChanges).toBe(true);
 
       await destination.sendExport(newExport, true);
       expect(exportArgs.profile).not.toBeNull(); // plugin#exportProfile was called
+
+      await profile.destroy();
     });
 
     test("exportProfile can return that it is rate limited and the export:send task will be re-enqueued", async () => {
@@ -586,7 +566,7 @@ describe("models/destination", () => {
       );
 
       const profile = await helper.factories.profile();
-      await destination.exportProfile(profile, [], [], {}, {}, [], []);
+      await destination.exportProfile(profile, [], []);
       const _export = await Export.findOne({
         where: { destinationGuid: destination.guid },
       });
@@ -611,6 +591,8 @@ describe("models/destination", () => {
       expect(foundSendTasks.length).toBe(1 + 1);
       await _export.reload();
       expect(_export.completedAt).toBeTruthy();
+
+      await profile.destroy();
     });
 
     test("sending an export with sync and producing a parallelism error will throw", async () => {
@@ -625,7 +607,7 @@ describe("models/destination", () => {
 
       const profile = await helper.factories.profile();
       await expect(
-        destination.exportProfile(profile, [], [], {}, {}, [], [], true)
+        destination.exportProfile(profile, [], [], true)
       ).rejects.toThrow(/parallelism limit reached for test-template-app/);
 
       parallelismResponse = Infinity;
@@ -646,7 +628,7 @@ describe("models/destination", () => {
       );
 
       const profile = await helper.factories.profile();
-      await destination.exportProfile(profile, [], [], {}, {}, [], []);
+      await destination.exportProfile(profile, [], []);
       const _export = await Export.findOne({
         where: { destinationGuid: destination.guid },
       });
@@ -694,7 +676,7 @@ describe("models/destination", () => {
 
       const profile = await helper.factories.profile();
       await expect(
-        destination.exportProfile(profile, [], [], {}, {}, [], [], true)
+        destination.exportProfile(profile, [], [], true)
       ).rejects.toThrow(/Error: oh no!/);
 
       exportProfileResponse = {
@@ -733,7 +715,7 @@ describe("models/destination", () => {
           creatorGuid: group.guid,
           state: "running",
         });
-        await destination.exportProfile(profile, [run], [], {}, {}, [], []);
+        await destination.exportProfile(profile, [run], []);
 
         const foundRuns = await destination.getRuns();
         expect(foundRuns.length).toBe(1);
@@ -748,7 +730,7 @@ describe("models/destination", () => {
           creatorGuid: group.guid,
           state: "running", // this run is running
         });
-        await destination.exportProfile(profile, [run], [], {}, {}, [], []);
+        await destination.exportProfile(profile, [run], []);
 
         await expect(destination.destroy()).rejects.toThrow(
           /cannot delete destination until all runs are complete/
@@ -763,7 +745,7 @@ describe("models/destination", () => {
           creatorGuid: group.guid,
           state: "complete", // the run is complete, so we can reference it later
         });
-        await destination.exportProfile(profile, [run], [], {}, {}, [], []);
+        await destination.exportProfile(profile, [run], []);
         await group.update({ state: "updating" });
         await expect(destination.destroy()).rejects.toThrow(
           /cannot delete destination until previous exported groups are done updating/
@@ -799,29 +781,33 @@ describe("models/destination", () => {
         );
 
         const profile = await helper.factories.profile();
-        const oldProfileProperties = { purchases: ["hat", "mushroom"] };
-        const newProfileProperties = { purchases: ["hat", "mushroom", "star"] };
-        const oldGroups = [group];
-        const newGroups = [];
+        await profile.addOrUpdateProperties({
+          purchases: ["hat", "mushroom", "star"],
+        });
+
+        const oldExport = await helper.factories.export(profile, destination, {
+          newProfileProperties: {
+            purchases: { type: "string", rawValue: ["hat", "mushroom"] },
+          },
+          newGroups: [group.name],
+          startedAt: new Date(),
+          completedAt: new Date(),
+          mostRecent: true,
+        });
+        await specHelper.deleteEnqueuedTasks("exports:send", {
+          guid: oldExport.guid,
+        });
 
         const _import = await helper.factories.import();
 
-        await destination.exportProfile(
-          profile,
-          [],
-          [_import],
-          oldProfileProperties,
-          newProfileProperties,
-          oldGroups,
-          newGroups
-        );
+        await destination.exportProfile(profile, [], [_import]);
 
         const _exports = await profile.$get("exports");
-        expect(_exports.length).toBe(1);
-        expect(_exports[0].oldProfileProperties).toEqual({
+        expect(_exports.length).toBe(2);
+        expect(_exports[1].oldProfileProperties).toEqual({
           purchases: ["hat", "mushroom"],
         });
-        expect(_exports[0].newProfileProperties).toEqual({
+        expect(_exports[1].newProfileProperties).toEqual({
           purchases: ["hat", "mushroom", "star"],
         });
       });
@@ -839,29 +825,33 @@ describe("models/destination", () => {
         );
 
         const profile = await helper.factories.profile();
-        const oldProfileProperties = { purchases: ["hat", "mushroom"] };
-        const newProfileProperties = { purchases: ["hat", "mushroom", "star"] };
-        const oldGroups = [group];
-        const newGroups = [];
+        await profile.addOrUpdateProperties({
+          purchases: ["hat", "mushroom", "star"],
+        });
+
+        const oldExport = await helper.factories.export(profile, destination, {
+          newProfileProperties: {
+            purchases: { type: "string", rawValue: ["hat", "mushroom"] },
+          },
+          newGroups: [group.name],
+          startedAt: new Date(),
+          completedAt: new Date(),
+          mostRecent: true,
+        });
+        await specHelper.deleteEnqueuedTasks("exports:send", {
+          guid: oldExport.guid,
+        });
 
         const _import = await helper.factories.import();
 
-        await destination.exportProfile(
-          profile,
-          [],
-          [_import],
-          oldProfileProperties,
-          newProfileProperties,
-          oldGroups,
-          newGroups
-        );
+        await destination.exportProfile(profile, [], [_import]);
 
         const _exports = await profile.$get("exports");
-        expect(_exports.length).toBe(1);
-        expect(_exports[0].oldProfileProperties).toEqual({
+        expect(_exports.length).toBe(2);
+        expect(_exports[1].oldProfileProperties).toEqual({
           purchases: ["hat", "mushroom"],
         });
-        expect(_exports[0].newProfileProperties).toEqual({
+        expect(_exports[1].newProfileProperties).toEqual({
           purchases: ["hat", "mushroom", "star"],
         });
       });

--- a/core/api/__tests__/models/export.ts
+++ b/core/api/__tests__/models/export.ts
@@ -268,7 +268,7 @@ describe("models/export", () => {
     });
 
     const rawProperties = JSON.parse(
-      _export["dataValues"].oldProfileProperties
+      _export["dataValues"].newProfileProperties
     );
 
     expect(rawProperties["primary-id"]).toEqual({
@@ -365,7 +365,7 @@ describe("models/export", () => {
 
   test("runs can be associated by ExportRuns", async () => {
     const run = await helper.factories.run();
-    await destination.exportProfile(profile, [run], [], {}, {}, [], []);
+    await destination.exportProfile(profile, [run], []);
 
     const exportRuns = await ExportRun.findAll({
       where: { runGuid: run.guid },
@@ -397,15 +397,7 @@ describe("models/export", () => {
       mostRecent: true,
     });
 
-    await destination.exportProfile(
-      profile,
-      [run],
-      [],
-      {},
-      {},
-      [group],
-      [group]
-    );
+    await destination.exportProfile(profile, [run], []);
 
     const exportRuns = await ExportRun.findAll({
       where: { runGuid: run.guid },

--- a/core/api/__tests__/tasks/profile/export.ts
+++ b/core/api/__tests__/tasks/profile/export.ts
@@ -221,15 +221,13 @@ describe("tasks/profile:export", () => {
         expect(_export.destinationGuid).toBe(destination.guid);
         expect(_export.profileGuid).toBe(profile.guid);
         expect(_export.completedAt).toBeTruthy();
-        expect(_export.oldProfileProperties).toEqual({
-          email: "mario@example.com",
-        });
+        expect(_export.oldProfileProperties).toEqual({});
         expect(_export.newProfileProperties).toEqual({
           email: "mario@example.com",
           firstName: "Super",
           lastName: "Mario",
         });
-        expect(_export.oldGroups).toEqual(["test group"]);
+        expect(_export.oldGroups).toEqual([]);
         expect(_export.newGroups).toEqual(["test group"]);
 
         await importA.reload();
@@ -296,9 +294,7 @@ describe("tasks/profile:export", () => {
         expect(_export.destinationGuid).toBe(destination.guid);
         expect(_export.profileGuid).not.toBe(profile.guid);
         expect(_export.completedAt).toBeTruthy();
-        expect(_export.oldProfileProperties).toEqual({
-          email: "bowser@example.com",
-        });
+        expect(_export.oldProfileProperties).toEqual({});
         expect(_export.newProfileProperties).toEqual({
           email: "bowser@example.com",
           firstName: "Bowser",

--- a/core/api/bin/dev
+++ b/core/api/bin/dev
@@ -20,6 +20,6 @@ for p in $GROUPAROO_PIDS; do
   kill -9 $p
 done
 
-"$NODEMON" -e js,jsx,ts,tsx --delay 2 --signal SIGTERM --ignore dist --watch ./ --watch ../../plugins/**/*.js \
+"$NODEMON" -e js,jsx,ts,tsx --signal SIGTERM --ignore dist --watch ./ --watch ../../plugins/**/*.js \
 "$TS_NODE" --transpile-only --log-error src/server.ts || exit 0
 

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -384,10 +384,6 @@ export class Destination extends LoggedModel<Destination> {
     profile: Profile,
     runs: Run[],
     imports: Array<Import>,
-    oldProfileProperties: { [key: string]: any[] },
-    newProfileProperties: { [key: string]: any[] },
-    oldGroups: Array<Group>,
-    newGroups: Array<Group>,
     sync = false,
     force = false
   ) {
@@ -396,10 +392,6 @@ export class Destination extends LoggedModel<Destination> {
       profile,
       runs,
       imports,
-      oldProfileProperties,
-      newProfileProperties,
-      oldGroups,
-      newGroups,
       sync,
       force
     );

--- a/core/api/src/modules/ops/profile.ts
+++ b/core/api/src/modules/ops/profile.ts
@@ -298,10 +298,6 @@ export namespace ProfileOps {
           profile,
           null,
           [],
-          oldSimpleProperties,
-          simpleProperties,
-          oldGroups,
-          groups,
           true, // sync = true -> do the export in-line
           true // force = true -> do the export even if it looks like the data hasn't changed
         )

--- a/core/api/src/tasks/profile/export.ts
+++ b/core/api/src/tasks/profile/export.ts
@@ -22,10 +22,9 @@ export class ProfileExport extends RetryableTask {
 
   async run(params) {
     const profile = await Profile.findOne({ where: { guid: params.guid } });
+
     // the profile may have been deleted or merged by the time this task ran
-    if (!profile) {
-      return;
-    }
+    if (!profile) return;
 
     const imports = await Import.findAll({
       where: {
@@ -37,9 +36,7 @@ export class ProfileExport extends RetryableTask {
       order: [["createdAt", "asc"]],
     });
 
-    if (imports.length === 0) {
-      return;
-    }
+    if (imports.length === 0) return;
 
     const runs = await Run.findAll({
       where: {
@@ -52,15 +49,8 @@ export class ProfileExport extends RetryableTask {
     });
 
     try {
-      // take the old data from the oldest, un-exported import
-      const oldProfileProperties = imports[0].oldProfileProperties;
       const oldGroupGuids = imports[0].oldGroupGuids;
-
-      // take the new data from the newest import
-      const newProfileProperties =
-        imports[imports.length - 1].newProfileProperties;
       const newGroupGuids = imports[imports.length - 1].newGroupGuids;
-
       const oldGroups = await Group.findAll({
         where: { guid: { [Op.in]: oldGroupGuids } },
       });
@@ -94,10 +84,6 @@ export class ProfileExport extends RetryableTask {
           profile,
           runs,
           imports,
-          oldProfileProperties,
-          newProfileProperties,
-          oldGroups,
-          newGroups,
           false,
           params.force ? params.force : undefined
         );

--- a/core/web/components/export/list.tsx
+++ b/core/web/components/export/list.tsx
@@ -231,9 +231,16 @@ export default function ExportsList(props) {
                             JSON.stringify(_export.newProfileProperties[k]) ? (
                               <>
                                 <Badge variant="danger">-</Badge>&nbsp;
-                                {_export.oldProfileProperties[k]?.toString()}|
-                                <Badge variant="success">+</Badge>&nbsp;
-                                {_export.newProfileProperties[k]?.toString()}
+                                {_export.oldProfileProperties[k]?.toString()}
+                                {_export.newProfileProperties[k] !== null &&
+                                _export.newProfileProperties[k] !==
+                                  undefined ? (
+                                  <>
+                                    {" "}
+                                    | <Badge variant="success">+</Badge>&nbsp;
+                                    {_export.newProfileProperties[k].toString()}
+                                  </>
+                                ) : null}
                               </>
                             ) : (
                               <>{_export.oldProfileProperties[k]?.toString()}</>

--- a/core/web/pages/export/[guid]/edit.tsx
+++ b/core/web/pages/export/[guid]/edit.tsx
@@ -64,9 +64,15 @@ export default function Page({ _export, groups }) {
                       _export.newProfileProperties[k] ? (
                         <>
                           <Badge variant="danger">-</Badge>{" "}
-                          {_export.oldProfileProperties[k]?.toString()}|
-                          <Badge variant="success">+</Badge>{" "}
-                          {_export.newProfileProperties[k]?.toString()}
+                          {_export.oldProfileProperties[k]?.toString()}
+                          {_export.newProfileProperties[k] !== null &&
+                          _export.newProfileProperties[k] !== undefined ? (
+                            <>
+                              {" "}
+                              | <Badge variant="success">+</Badge>{" "}
+                              {_export.newProfileProperties[k]?.toString()}
+                            </>
+                          ) : null}
                         </>
                       ) : (
                         _export.oldProfileProperties[k]?.toString()


### PR DESCRIPTION
This PR changes the behavior of Exports to store `newProfileProperties` and `oldProfileProperties` from the point of view of the Destination.  We will continue to store the stringified `rawVale` mapped to the Destination's key, but now rather than storing Grouparoo's internal view of the profile's properties (AKA all Profile Properties, just mapped), we store what was sent to the Destinations.  This means that:

* The first time a Profile is sent to a Destination, all Profile Properties and Groups appear as new
* Subsequent times that a Profile is sent to the destination, we look up the current Properties and Groups from the Profile, and compare them to the most recent Export that was sent without error.

As Destinations choose to send and not sent various Properties, they will appear as added or lost from the Export, mirroring the data that is sent to the Destination.

<img width="1534" alt="Screen Shot 2020-09-03 at 3 57 17 PM" src="https://user-images.githubusercontent.com/303226/92181470-25ceb000-edfe-11ea-9c83-2ca80aac583f.png">

This has the side effect of simplifying the `destination.export()` method, as we no longer need the Profile Property and Group information from the Imports.  

Closes T-439
Closes T-436