### PR TITLE
Do not block Group deletion if DestinationGroupMemberships exist

### DIFF
--- a/core/api/__tests__/models/group/group.ts
+++ b/core/api/__tests__/models/group/group.ts
@@ -145,7 +145,7 @@ describe("models/group", () => {
     });
 
     describe("with destinations", () => {
-      test("a group cannot be deleted if a destination is explicitly tracking it", async () => {
+      test("a group cannot be deleted if a destination is tracking it", async () => {
         const group = await Group.create({
           name: "tracked group",
           type: "manual",
@@ -162,7 +162,7 @@ describe("models/group", () => {
         await group.destroy(); // does not throw
       });
 
-      test("a group cannot be deleted if a destination membership is using it", async () => {
+      test("a group can be deleted even if a destination membership is using it", async () => {
         const group = await Group.create({
           name: "tracked group",
           type: "manual",
@@ -175,12 +175,6 @@ describe("models/group", () => {
         await destination.setDestinationGroupMemberships(
           destinationGroupMemberships
         );
-
-        await expect(group.destroy()).rejects.toThrow(
-          /this group still in use by 1 destinations, cannot delete/
-        );
-
-        await destination.setDestinationGroupMemberships({});
 
         await group.destroy(); // does not throw
       });

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -668,18 +668,6 @@ export class Group extends LoggedModel<Group> {
     }
   }
 
-  @BeforeDestroy
-  static async checkDestinationGroupMembership(instance: Group) {
-    const count = await DestinationGroupMembership.count({
-      where: { groupGuid: instance.guid },
-    });
-
-    if (count > 0)
-      throw new Error(
-        `this group still in use by ${count} destinations, cannot delete`
-      );
-  }
-
   @AfterDestroy
   static async destroyDestinationGroupTracking(instance: Group) {
     const destinations = await instance.$get("destinations", {


### PR DESCRIPTION
Allows Groups to be deleted when Destinations may be sending membership in this group to Destinations.  Groups remain unable to be deleted if a destination is Tracking it.

Closes T-408