### PR TITLE
When Destination Group Memberships are removed by deleting a Group, a run is started

### DIFF
--- a/core/api/__tests__/models/destination/plugins/destinationMappingOptions.ts
+++ b/core/api/__tests__/models/destination/plugins/destinationMappingOptions.ts
@@ -492,7 +492,7 @@ describe("models/destination", () => {
         // int -> number OK
         required = [{ key: "remote-id", type: "number" }];
         await destination.setMapping({ "remote-id": "userId", email: "email" });
-        await mario.export();
+        await mario.export(true);
         expect(oldProfileProperties).toEqual({});
         expect(newProfileProperties).toEqual({
           "remote-id": 1,
@@ -502,7 +502,7 @@ describe("models/destination", () => {
         // int -> string OK
         required = [{ key: "remote-id", type: "string" }];
         await destination.setMapping({ "remote-id": "userId", email: "email" });
-        await mario.export();
+        await mario.export(true);
         expect(oldProfileProperties).toEqual({
           "remote-id": "1",
           email: "mario@example.com",

--- a/core/api/__tests__/models/group/group.ts
+++ b/core/api/__tests__/models/group/group.ts
@@ -210,7 +210,7 @@ describe("models/group", () => {
         expect(foundTasks[0].args[0]).toEqual({
           destinationGuid: destination.guid,
           groupGuid: trackedGroup.guid,
-          force: true,
+          force: false,
         });
       });
     });

--- a/core/api/__tests__/models/group/group.ts
+++ b/core/api/__tests__/models/group/group.ts
@@ -7,7 +7,6 @@ import { Run } from "../../../src/models/Run";
 import { Import } from "../../../src/models/Import";
 import { GroupMember } from "../../../src/models/GroupMember";
 import { SharedGroupTests } from "../../utils/prepareSharedGroupTest";
-import { group } from "console";
 
 let actionhero;
 

--- a/core/api/bin/dev
+++ b/core/api/bin/dev
@@ -20,6 +20,6 @@ for p in $GROUPAROO_PIDS; do
   kill -9 $p
 done
 
-"$NODEMON" -e js,jsx,ts,tsx --signal SIGTERM --ignore dist --watch ./ --watch ../../plugins/**/*.js \
+"$NODEMON" -e js,jsx,ts,tsx --signal SIGTERM --ignore dist --watch ./src --watch ../../plugins/**/*.js \
 "$TS_NODE" --transpile-only --log-error src/server.ts || exit 0
 

--- a/core/api/src/actions/profiles.ts
+++ b/core/api/src/actions/profiles.ts
@@ -240,12 +240,13 @@ export class ProfileEdit extends AuthenticatedAction {
 
   async run({ params, response }) {
     const profile = await Profile.findByGuid(params.guid);
+    const oldGroups = await profile.$get("groups");
     await profile.update(params);
     await profile.addOrUpdateProperties(params.properties);
     await profile.removeProperties(params.removedProperties);
     await profile.import();
     await profile.updateGroupMembership();
-    await profile.export();
+    await profile.export(false, oldGroups);
     response.profile = await profile.apiData();
   }
 }

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -681,11 +681,17 @@ export class Group extends LoggedModel<Group> {
 
   @AfterDestroy
   static async destroyDestinationGroupMembership(instance: Group) {
-    return DestinationGroupMembership.destroy({
-      where: {
-        groupGuid: instance.guid,
-      },
-    });
+    const destinationGroupMemberships = await DestinationGroupMembership.findAll(
+      { where: { groupGuid: instance.guid } }
+    );
+
+    for (const i in destinationGroupMemberships) {
+      const destination = await destinationGroupMemberships[i].$get(
+        "destination"
+      );
+      await destinationGroupMemberships[i].destroy();
+      await destination.exportGroupMembers(true);
+    }
   }
 
   @AfterDestroy

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -690,7 +690,7 @@ export class Group extends LoggedModel<Group> {
         "destination"
       );
       await destinationGroupMemberships[i].destroy();
-      await destination.exportGroupMembers(true);
+      await destination.exportGroupMembers(false);
     }
   }
 

--- a/core/api/src/models/Profile.ts
+++ b/core/api/src/models/Profile.ts
@@ -117,8 +117,8 @@ export class Profile extends LoggedModel<Profile> {
     return ProfileOps._import(this, toSave, toLock);
   }
 
-  async export(force = false, groupsOverride?: Group[]) {
-    return ProfileOps._export(this, force, groupsOverride);
+  async export(force = false, oldGroupsOverride?: Group[]) {
+    return ProfileOps._export(this, force, oldGroupsOverride);
   }
 
   async logMessage(verb: "create" | "update" | "destroy") {

--- a/core/api/src/modules/ops/destination.ts
+++ b/core/api/src/modules/ops/destination.ts
@@ -257,7 +257,7 @@ export namespace DestinationOps {
       },
     });
 
-    if (mostRecentExport) {
+    if (mostRecentExport && mostRecentExport.toDelete !== true) {
       mappedOldProfileProperties = JSON.parse(
         // @ts-ignore
         mostRecentExport.getDataValue("newProfileProperties")

--- a/core/api/src/modules/ops/destination.ts
+++ b/core/api/src/modules/ops/destination.ts
@@ -43,7 +43,7 @@ export namespace DestinationOps {
     force = false
   ) {
     const group = await destination.$get("group");
-    await group.run(force, destination.guid);
+    if (group) await group.run(force, destination.guid);
   }
 
   /**

--- a/core/web/pages/destination/[guid]/data.tsx
+++ b/core/web/pages/destination/[guid]/data.tsx
@@ -77,7 +77,7 @@ export default function Page(props) {
       await execApi("post", `/destination/${guid}/untrack`);
     } else {
       // trigger a full export
-      await execApi("post", `/destination/${guid}/export`);
+      await execApi("post", `/destination/${guid}/export`, { force: false });
     }
 
     successHandler.set({

--- a/core/web/pages/destination/[guid]/data.tsx
+++ b/core/web/pages/destination/[guid]/data.tsx
@@ -77,7 +77,7 @@ export default function Page(props) {
       await execApi("post", `/destination/${guid}/untrack`);
     } else {
       // trigger a full export
-      await execApi("post", `/destination/${guid}/export`, { force: false });
+      await execApi("post", `/destination/${guid}/export`, { force: true });
     }
 
     successHandler.set({

--- a/core/web/pages/destination/[guid]/runs.tsx
+++ b/core/web/pages/destination/[guid]/runs.tsx
@@ -13,7 +13,9 @@ export default function Page(props) {
   const exportDestination = async () => {
     if (confirm("Are you sure?")) {
       try {
-        await execApi("post", `/destination/${destination.guid}/export`);
+        await execApi("post", `/destination/${destination.guid}/export`, {
+          force: true,
+        });
         successHandler.set({ message: "Profiles Exporting..." });
         runsHandler.set({});
       } finally {


### PR DESCRIPTION
When Destination Group Memberships are removed by deleting a group, a run should be started to re-export the profiles to that destination with the group tag removed.

Closes T-450