### PR TITLE
Reset Cluster Action

### DIFF
--- a/core/api/__tests__/actions/cluster.ts
+++ b/core/api/__tests__/actions/cluster.ts
@@ -1,0 +1,74 @@
+import { helper } from "./../utils/specHelper";
+import { specHelper } from "actionhero";
+import { Log } from "../../src/models/Log";
+let actionhero;
+
+describe("actions/cluster", () => {
+  beforeAll(async () => {
+    const env = await helper.prepareForAPITest();
+    actionhero = env.actionhero;
+  }, 1000 * 30);
+
+  afterAll(async () => {
+    await helper.shutdown(actionhero);
+  });
+
+  describe("cluster:destroy", () => {
+    beforeAll(async () => {
+      await helper.factories.profilePropertyRules();
+      await specHelper.runAction("team:initialize", {
+        firstName: "Mario",
+        lastName: "Mario",
+        password: "P@ssw0rd!",
+        email: "mario@example.com",
+      });
+    });
+
+    describe("administrator signed in", () => {
+      let connection;
+      let csrfToken;
+
+      beforeAll(async () => {
+        connection = await specHelper.buildConnection();
+        connection.params = {
+          email: "mario@example.com",
+          password: "P@ssw0rd!",
+        };
+        const sessionResponse = await specHelper.runAction(
+          "session:create",
+          connection
+        );
+        csrfToken = sessionResponse.csrfToken;
+      });
+
+      test("the action will delete the data from most models", async () => {
+        connection.params = { csrfToken };
+        const { error, success, counts } = await specHelper.runAction(
+          "cluster:destroy",
+          connection
+        );
+
+        expect(error).toBeFalsy();
+        expect(success).toBe(true);
+        expect(counts).toEqual(
+          expect.objectContaining({
+            App: 1,
+            Source: 1,
+          })
+        );
+      });
+
+      test("log messages were created", async () => {
+        const logs = await Log.findAll({
+          order: [["createdAt", "desc"]],
+          limit: 2,
+        });
+
+        expect(logs[0].message).toEqual("Grouparoo Cluster Reset");
+        expect(logs[0].topic).toEqual("cluster");
+        expect(logs[1].message).toMatch(/erased \d* instances/);
+        expect(logs[1].topic).toEqual("cluster");
+      });
+    });
+  });
+});

--- a/core/api/__tests__/actions/cluster.ts
+++ b/core/api/__tests__/actions/cluster.ts
@@ -1,6 +1,7 @@
 import { helper } from "./../utils/specHelper";
 import { specHelper } from "actionhero";
 import { Log } from "../../src/models/Log";
+import { App } from "../../src/models/App";
 let actionhero;
 
 describe("actions/cluster", () => {
@@ -56,6 +57,24 @@ describe("actions/cluster", () => {
             Source: 1,
           })
         );
+      });
+
+      test("only the event app remains, and it has been moved back to draft", async () => {
+        const apps = await App.scope(null).findAll();
+        expect(apps.length).toBe(1);
+        expect(apps[0].type).toBe("events");
+        expect(apps[0].state).toBe("draft");
+      });
+
+      test("teams still remain and the user is still logged in", async () => {
+        connection.params = { csrfToken };
+        const { teamMember, error } = await specHelper.runAction(
+          "session:view",
+          connection
+        );
+
+        expect(error).toBeUndefined();
+        expect(teamMember.guid).toBeTruthy();
       });
 
       test("log messages were created", async () => {

--- a/core/api/src/actions/cluster.ts
+++ b/core/api/src/actions/cluster.ts
@@ -1,0 +1,120 @@
+import { AuthenticatedAction } from "../classes/authenticatedAction";
+import { Op } from "sequelize";
+
+import { App } from "../models/App";
+// import { ApiKey } from "../models/ApiKey";
+import { Destination } from "../models/Destination";
+import { DestinationGroupMembership } from "../models/DestinationGroupMembership";
+// import { File } from "../models/File";
+import { Export } from "../models/Export";
+import { Event } from "../models/Event";
+import { EventData } from "../models/EventData";
+import { ExportImport } from "../models/ExportImport";
+import { ExportRun } from "../models/ExportRun";
+import { Group } from "../models/Group";
+import { GroupMember } from "../models/GroupMember";
+import { GroupRule } from "../models/GroupRule";
+import { Import } from "../models/Import";
+import { Log } from "../models/Log";
+import { Mapping } from "../models/Mapping";
+import { Option } from "../models/Option";
+// import { Permission } from "../models/Permission";
+import { Profile } from "../models/Profile";
+import { ProfileProperty } from "../models/ProfileProperty";
+import { ProfilePropertyRule } from "../models/ProfilePropertyRule";
+import { ProfilePropertyRuleFilter } from "../models/ProfilePropertyRuleFilter";
+import { Run } from "../models/Run";
+import { Schedule } from "../models/Schedule";
+// import { Setting } from "../models/Setting";
+import { Source } from "../models/Source";
+// import { Team } from "../models/Team";
+// import { TeamMember } from "../models/TeamMember";
+
+const models = [
+  // ApiKey,
+  App,
+  Destination,
+  DestinationGroupMembership,
+  Event,
+  EventData,
+  Export,
+  ExportImport,
+  ExportRun,
+  // File,
+  Group,
+  GroupMember,
+  GroupRule,
+  Import,
+  // Log,
+  Mapping,
+  Option,
+  // Permission,
+  Profile,
+  ProfileProperty,
+  ProfilePropertyRule,
+  ProfilePropertyRuleFilter,
+  Run,
+  Schedule,
+  // Setting,
+  Source,
+  // Team,
+  // TeamMember,
+];
+
+export class ClusterReset extends AuthenticatedAction {
+  constructor() {
+    super();
+    this.name = "cluster:destroy";
+    this.description = "erase most all of the data in this grouparoo cluster";
+    this.outputExample = {};
+    this.permission = { topic: "app", mode: "write" }; // TODO: do we need more elaborate checks?
+    this.inputs = {};
+  }
+
+  async run({ response, session: { teamMember } }) {
+    response.success = false;
+    const counts = {};
+
+    await Promise.all(
+      models.map(async (model) => {
+        const modelName = model.name;
+        const count = await model.count();
+
+        if (model === App) {
+          await model
+            .scope(null)
+            .destroy({ where: { type: { [Op.ne]: "events" } } });
+
+          const models = await model.findAll();
+          await Promise.all(
+            // @ts-ignore
+            models.map((m) => m.update({ state: "draft" }, { hooks: false }))
+          );
+        } else {
+          await model.destroy({ truncate: true, force: true });
+        }
+
+        counts[modelName] = count;
+
+        await Log.create({
+          topic: "cluster",
+          verb: "reset",
+          message: `erased ${count} instances of ${modelName}`,
+          ownerGuid: teamMember.guid,
+          data: { count },
+        });
+      })
+    );
+
+    await Log.create({
+      topic: "cluster",
+      verb: "reset",
+      message: "Grouparoo Cluster Reset",
+      ownerGuid: teamMember.guid,
+      data: { counts },
+    });
+
+    response.counts = counts;
+    response.success = true;
+  }
+}

--- a/core/api/src/config/routes.ts
+++ b/core/api/src/config/routes.ts
@@ -135,7 +135,8 @@ export const DEFAULT = {
         { path: "/v:apiVersion/source/:guid", action: "source:destroy" },
         { path: "/v:apiVersion/schedule/:guid", action: "schedule:destroy" },
         { path: "/v:apiVersion/destination/:guid", action: "destination:destroy" },
-        { path: "/v:apiVersion/file/:guid", action: "file:destroy" }
+        { path: "/v:apiVersion/file/:guid", action: "file:destroy" },
+        { path: "/v:apiVersion/cluster", action: "cluster:destroy" }
       ]
     };
   },

--- a/core/web/components/settings/resetCluster.tsx
+++ b/core/web/components/settings/resetCluster.tsx
@@ -28,8 +28,9 @@ export default function ResetCluster(props) {
           <small>
             This will erase all of your Apps, Sources, Destinations, Profile
             Properties, Profile Property Rules, Groups and related data. The
-            only data that will be kept will be your Teams and Team Members.
-            This action will not remove data from your Destinations.
+            only data that will be kept will be your Settings, Teams, Team
+            Members, and ApiKeys. This action will not remove data from your
+            Destinations.
           </small>
         </Card.Subtitle>
 

--- a/core/web/components/settings/resetCluster.tsx
+++ b/core/web/components/settings/resetCluster.tsx
@@ -1,0 +1,46 @@
+import { useApi } from "../../hooks/useApi";
+import { Button, Card } from "react-bootstrap";
+
+export default function ResetCluster(props) {
+  const { errorHandler, successHandler } = props;
+  const { execApi } = useApi(props, errorHandler);
+
+  async function resetCluster() {
+    if (!window.confirm("Are you sure?")) return;
+    if (window.prompt("Type 'destroy' to proceed") !== "destroy") {
+      return errorHandler.set({ error: "not proceeding" });
+    }
+
+    const response = await execApi("delete", `/cluster`);
+    if (response?.success) {
+      successHandler.set({ message: `Cluster Reset!` });
+    }
+  }
+
+  return (
+    <Card border="danger">
+      <Card.Body>
+        <Card.Title>Reset Cluster</Card.Title>
+        <Card.Subtitle className="mb-2 text-muted">
+          Erase your Grouparoo Cluster.
+          <br />
+          <br />
+          <small>
+            This will erase all of your Apps, Sources, Destinations, Profile
+            Properties, Profile Property Rules, Groups and related data. The
+            only data that will be kept will be your Teams and Team Members.
+            This action will not remove data from your Destinations.
+          </small>
+        </Card.Subtitle>
+
+        <br />
+
+        <Card.Text>
+          <Button onClick={resetCluster} size="sm" variant="outline-danger">
+            Reset Cluster
+          </Button>
+        </Card.Text>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/core/web/pages/settings/[tab].tsx
+++ b/core/web/pages/settings/[tab].tsx
@@ -6,6 +6,7 @@ import { Button, Form, Card, Tabs, Tab } from "react-bootstrap";
 import Moment from "react-moment";
 import ImportAndUpdateAllProfiles from "../../components/settings/importAndUpdate";
 import IdentifyingProfilePropertyRule from "../../components/settings/identifyingProfilePropertyRule";
+import ResetCluster from "../../components/settings/resetCluster";
 import { capitalize } from "../../components/tabs";
 import { useRouter } from "next/router";
 
@@ -55,24 +56,14 @@ export default function Page(props) {
         onSelect={(k) => router.push(`/settings/${k}`)}
       >
         <Tab eventKey="actions" title="Actions">
-          <br />
-          <h2>Cluster Actions</h2>
-
-          <br />
-
-          <ImportAndUpdateAllProfiles
+          <ActionsTab
             errorHandler={errorHandler}
             successHandler={successHandler}
           />
         </Tab>
 
         <Tab eventKey="interface" title="Interface">
-          <br />
-          <h2>User Interface</h2>
-
-          <br />
-
-          <IdentifyingProfilePropertyRule
+          <InterfaceTab
             errorHandler={errorHandler}
             successHandler={successHandler}
           />
@@ -178,6 +169,46 @@ function SettingCard({ setting, updateSetting, loading }) {
         </Card.Body>
       </Card>
       <br />
+    </>
+  );
+}
+
+function ActionsTab({ errorHandler, successHandler }) {
+  return (
+    <>
+      <br />
+
+      <h2>Cluster Actions</h2>
+
+      <br />
+
+      <ImportAndUpdateAllProfiles
+        errorHandler={errorHandler}
+        successHandler={successHandler}
+      />
+
+      <br />
+
+      <ResetCluster
+        errorHandler={errorHandler}
+        successHandler={successHandler}
+      />
+    </>
+  );
+}
+
+function InterfaceTab({ errorHandler, successHandler }) {
+  return (
+    <>
+      <br />
+      <h2>User Interface</h2>
+
+      <br />
+
+      <IdentifyingProfilePropertyRule
+        errorHandler={errorHandler}
+        successHandler={successHandler}
+      />
     </>
   );
 }


### PR DESCRIPTION
This PR adds a new Action in `/settings/actions` to erase mostly all of the data in your Grouparoo cluster.   This is useful to solve hard problems. 

* Only teams with write access to `Apps` can use this action
* The UI confirms this action with typed prompt.

Models that are not destroyed by this action:
* ApiKey 
* File
* Permission
* Setting
* Team
* TeamMember

<img width="1330" alt="Screen Shot 2020-09-04 at 5 09 17 PM" src="https://user-images.githubusercontent.com/303226/92292361-a4e0e880-eed1-11ea-9600-bf7193dfaf80.png">

Closes T-453