### PR TITLE
Relax scopes in associated getters

### DIFF
--- a/core/api/src/classes/loggedModel.ts
+++ b/core/api/src/classes/loggedModel.ts
@@ -100,14 +100,10 @@ export abstract class LoggedModel<T> extends Model<T> {
     const apiData = await this.apiData();
 
     config.general.filteredParams.forEach((p) => {
-      if (apiData[p]) {
-        apiData[p] = "** filtered **";
-      }
+      if (apiData[p]) apiData[p] = "** filtered **";
     });
 
-    if (apiData.options) {
-      apiData.options = "** filtered **";
-    }
+    if (apiData.options) apiData.options = "** filtered **";
 
     return apiData;
   }

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -103,8 +103,8 @@ export class Destination extends LoggedModel<Destination> {
   async apiData(includeApp = true, includeGroup = true) {
     let app: App;
     let group: Group;
-    if (includeApp) app = await this.$get("app");
-    if (includeGroup) group = await this.$get("group");
+    if (includeApp) app = await this.$get("app", { scope: null });
+    if (includeGroup) group = await this.$get("group", { scope: null });
 
     const mapping = await this.getMapping();
     const options = await this.getOptions();

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -203,8 +203,8 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
     return options;
   }
 
-  async setOptions(options: SimpleProfilePropertyRuleOptions) {
-    await this.test(options);
+  async setOptions(options: SimpleProfilePropertyRuleOptions, test = true) {
+    if (test) await this.test(options);
 
     for (const i in options) {
       options[
@@ -335,7 +335,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
   async apiData() {
     const options = await this.getOptions();
     const filters = await this.getFilters();
-    const source = await this.$get("source");
+    const source = await this.$get("source", { scope: null });
 
     return {
       guid: this.guid,
@@ -413,7 +413,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
     }
   }
 
-  @BeforeCreate
+  @BeforeSave
   static async ensureSourceReady(instance: ProfilePropertyRule) {
     const source = await Source.findByGuid(instance.sourceGuid);
     if (source.state !== "ready") throw new Error("source is not ready");

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -166,12 +166,10 @@ export class Source extends LoggedModel<Source> {
     let profilePropertyRules: ProfilePropertyRule[];
 
     if (includeApp) {
-      app = await this.$get("app");
+      app = await this.$get("app", { scope: null });
     }
     if (includeSchedule) {
-      schedule = await this.$get("schedule", {
-        scope: null,
-      });
+      schedule = await this.$get("schedule", { scope: null });
     }
     if (includeProfilePropertyRules) {
       profilePropertyRules = await this.$get("profilePropertyRules", {

--- a/core/api/src/modules/mappingHelper.ts
+++ b/core/api/src/modules/mappingHelper.ts
@@ -17,7 +17,7 @@ export namespace MappingHelper {
 
     for (const i in mappings) {
       const mapping = mappings[i];
-      const rule = await mapping.$get("profilePropertyRule");
+      const rule = await mapping.$get("profilePropertyRule", { scope: null });
       if (!rule) {
         throw new Error(
           `cannot find profile property rule or this source/destination not ready (remoteKey: ${mapping.remoteKey})`

--- a/core/api/src/modules/ops/profilePropertyRule.ts
+++ b/core/api/src/modules/ops/profilePropertyRule.ts
@@ -34,7 +34,7 @@ export namespace ProfilePropertyRuleOps {
   export async function pluginOptions(
     profilePropertyRule: ProfilePropertyRule
   ) {
-    const source = await profilePropertyRule.$get("source");
+    const source = await profilePropertyRule.$get("source", { scope: null });
     const { pluginConnection } = await source.getPlugin();
 
     if (!pluginConnection) {
@@ -100,7 +100,7 @@ export namespace ProfilePropertyRuleOps {
     }
 
     const profilePropertyRuleOptions = await profilePropertyRule.getOptions();
-    const source = await profilePropertyRule.$get("source");
+    const source = await profilePropertyRule.$get("source", { scope: null });
     const sourceOptions = await source.getOptions();
     const sourceMapping = await source.getMapping();
     const app = await App.findByGuid(source.appGuid);

--- a/core/api/src/modules/ops/source.ts
+++ b/core/api/src/modules/ops/source.ts
@@ -259,7 +259,7 @@ export namespace SourceOps {
           }
         );
 
-        await rule.setOptions(ruleOptions);
+        await rule.setOptions(ruleOptions, false);
       }
 
       return rule;

--- a/core/api/src/modules/ops/source.ts
+++ b/core/api/src/modules/ops/source.ts
@@ -8,6 +8,7 @@ import { App } from "../../models/App";
 import { OptionHelper } from "../optionHelper";
 import { MappingHelper } from "../mappingHelper";
 import { log, utils } from "actionhero";
+import { LoggedModel } from "../../classes/loggedModel";
 
 export namespace SourceOps {
   /**
@@ -233,8 +234,9 @@ export namespace SourceOps {
       await ProfilePropertyRule.ensureNonArrayAndUnique(rule);
       await ProfilePropertyRule.ensureOneIdentifyingProperty(rule);
 
-      // @ts-ignore
       // danger zone!
+      await LoggedModel.logCreate(rule);
+      // @ts-ignore
       await rule.save({ hooks: false });
       await ProfilePropertyRule.clearCacheAfterSave();
 

--- a/core/api/src/modules/optionHelper.ts
+++ b/core/api/src/modules/optionHelper.ts
@@ -87,7 +87,8 @@ export namespace OptionHelper {
 
       // @ts-ignore
       instance.changed("updatedAt", true);
-      await instance.save({ transaction });
+      // @ts-ignore
+      await instance.save({ transaction, hooks: false });
 
       await transaction.commit();
 

--- a/core/api/src/modules/optionHelper.ts
+++ b/core/api/src/modules/optionHelper.ts
@@ -10,6 +10,7 @@ import { Destination } from "./../models/Destination";
 import { Schedule } from "./../models/Schedule";
 import { ProfilePropertyRule } from "./../models/ProfilePropertyRule";
 import { App } from "./../models/App";
+import { LoggedModel } from "../classes/loggedModel";
 
 function modelName(instance): string {
   let name = instance.constructor.name;
@@ -87,6 +88,7 @@ export namespace OptionHelper {
 
       // @ts-ignore
       instance.changed("updatedAt", true);
+      await LoggedModel.logUpdate(instance);
       // @ts-ignore
       await instance.save({ transaction, hooks: false });
 

--- a/core/web/pages/settings/[tab].tsx
+++ b/core/web/pages/settings/[tab].tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useApi } from "../../hooks/useApi";
 import { useForm } from "react-hook-form";
 import { Button, Form, Card, Tabs, Tab } from "react-bootstrap";
@@ -16,7 +16,11 @@ export default function Page(props) {
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);
   const [settings, setSettings] = useState(props.settings);
-  const [activeTab] = useState(tab || "core");
+  const [activeTab, setActiveTab] = useState(tab || "core");
+
+  useEffect(() => {
+    setActiveTab(tab);
+  }, [tab]);
 
   async function updateSetting(setting) {
     setLoading(true);


### PR DESCRIPTION
Generally relaxes the scopes of `$get()` methods on models to include draft objects.  This prevents bugs in which the UI wouldn't load as mappings or other related objects could not be found, but were expected.

Also fixes a bug when switching tabs on the `/settings` pages.

Closes T-465