### PR TITLE
Settings have a Type

### DIFF
--- a/core/api/__tests__/actions/settings.ts
+++ b/core/api/__tests__/actions/settings.ts
@@ -35,19 +35,22 @@ describe("actions/settings", () => {
         "testPlugin",
         "enabled",
         false,
-        "Should we do that thing?"
+        "Should we do that thing?",
+        "string"
       );
       await plugin.registerSetting(
         "testPlugin",
         "number",
         10,
-        "How many of those things should we do?"
+        "How many of those things should we do?",
+        "number"
       );
       await plugin.registerSetting(
         "otherPlugin",
         "enabled",
         true,
-        "Should we do that thing?"
+        "Should we do that thing?",
+        "boolean"
       );
     });
 
@@ -71,15 +74,26 @@ describe("actions/settings", () => {
       );
       expect(error).toBeUndefined();
       expect(
-        settings.map((p) => {
-          return p.pluginName;
-        })
-      ).toEqual(["testPlugin", "testPlugin", "otherPlugin"]);
+        settings
+          .map((p) => {
+            return p.pluginName;
+          })
+          .sort()
+      ).toEqual(["otherPlugin", "testPlugin", "testPlugin"]);
       expect(
-        settings.map((p) => {
-          return p.key;
-        })
-      ).toEqual(["number", "enabled", "enabled"]);
+        settings
+          .map((p) => {
+            return p.type;
+          })
+          .sort()
+      ).toEqual(["boolean", "number", "string"]);
+      expect(
+        settings
+          .map((p) => {
+            return p.key;
+          })
+          .sort()
+      ).toEqual(["enabled", "enabled", "number"]);
       expect(
         settings.map((p) => {
           return p.value;

--- a/core/api/__tests__/models/setting.ts
+++ b/core/api/__tests__/models/setting.ts
@@ -20,7 +20,8 @@ describe("models/setting", () => {
       "testPlugin",
       "key",
       "value",
-      "this is a test setting"
+      "this is a test setting",
+      "string"
     );
 
     expect(setting.guid.length).toBe(40);

--- a/core/api/__tests__/modules/plugin.ts
+++ b/core/api/__tests__/modules/plugin.ts
@@ -5,6 +5,7 @@ import { Run } from "./../../src/models/Run";
 import { Import } from "./../../src/models/Import";
 import { specHelper } from "actionhero";
 import { ProfilePropertyRule } from "../../src/models/ProfilePropertyRule";
+import { SourceOptionsMethodResponse } from "../../src";
 let actionhero;
 
 describe("modules/plugin", () => {
@@ -51,7 +52,7 @@ describe("modules/plugin", () => {
             scheduleOptions: [],
             methods: {
               sourceOptions: async ({ sourceOptions }) => {
-                const response = {
+                const response: SourceOptionsMethodResponse = {
                   table: { type: "list", options: ["users"] },
                 };
                 return response;

--- a/core/api/__tests__/modules/plugin.ts
+++ b/core/api/__tests__/modules/plugin.ts
@@ -138,7 +138,8 @@ describe("modules/plugin", () => {
         "test-plugin",
         "sample-setting",
         "100",
-        "I am a test setting"
+        "I am a test setting",
+        "string"
       );
 
       let value = await plugin.readSetting("test-plugin", "sample-setting");

--- a/core/api/__tests__/utils/specHelper.ts
+++ b/core/api/__tests__/utils/specHelper.ts
@@ -43,7 +43,11 @@ import { Team } from "../../src/models/Team";
 import { TeamMember } from "../../src/models/TeamMember";
 
 import { Op } from "sequelize";
-import { plugin } from "../../src/index";
+import {
+  plugin,
+  SourceOptionsMethodResponse,
+  DestinationOptionsMethodResponse,
+} from "../../src/index";
 
 const { api, cache, Process } = require("actionhero");
 
@@ -223,7 +227,9 @@ export namespace helper {
           ],
           methods: {
             sourceOptions: async ({ sourceOptions }) => {
-              const response = { table: { type: "list", options: ["users"] } };
+              const response: SourceOptionsMethodResponse = {
+                table: { type: "list", options: ["users"] },
+              };
               if (sourceOptions.options)
                 response["receivedOptions"] = sourceOptions.options;
               return response;
@@ -283,7 +289,7 @@ export namespace helper {
               return { success: true };
             },
             destinationOptions: async ({ destinationOptions }) => {
-              const response = {
+              const response: DestinationOptionsMethodResponse = {
                 table: { type: "list", options: ["users_out"] },
               };
               if (destinationOptions.options)
@@ -326,7 +332,7 @@ export namespace helper {
               return { success: true };
             },
             destinationOptions: async ({ destinationOptions }) => {
-              const response = {
+              const response: DestinationOptionsMethodResponse = {
                 table: { type: "list", options: ["users_out"] },
               };
               if (destinationOptions.options)

--- a/core/api/src/classes/plugin.ts
+++ b/core/api/src/classes/plugin.ts
@@ -193,7 +193,7 @@ export interface ConnectionOption extends AppOption {}
 export interface AppOptionsMethod {
   (): Promise<{
     [optionName: string]: {
-      type: string;
+      type: PluginOptionTypes;
       options?: string[];
       descriptions?: string[];
     };
@@ -254,7 +254,7 @@ export interface SourceOptionsMethod {
 
 export interface SourceOptionsMethodResponse {
   [optionName: string]: {
-    type: string;
+    type: PluginOptionTypes;
     options?: string[];
     descriptions?: string[];
   };
@@ -349,7 +349,7 @@ export interface DestinationOptionsMethod {
 
 export interface DestinationOptionsMethodResponse {
   [optionName: string]: {
-    type: string;
+    type: PluginOptionTypes;
     options?: string[];
     descriptions?: string[];
   };
@@ -420,3 +420,5 @@ export interface ExportArrayPropertiesMethod {
 }
 
 export type ExportArrayPropertiesMethodResponse = Array<string>;
+
+export type PluginOptionTypes = "string" | "list" | "typeahead" | "pending";

--- a/core/api/src/initializers/events.ts
+++ b/core/api/src/initializers/events.ts
@@ -1,6 +1,7 @@
 import { api, Initializer, log } from "actionhero";
 import { ProfilePropertyRule } from "../index";
 import { plugin } from "../modules/plugin";
+import { SourceOptionsMethodResponse } from "../classes/plugin";
 import { App } from "../models/App";
 import { Event } from "../models/Event";
 import { EventData } from "../models/EventData";
@@ -88,7 +89,7 @@ export class Events extends Initializer {
 }
 
 const eventSourceOptions: SourceOptionsMethod = async () => {
-  const sourceOptions = {
+  const sourceOptions: SourceOptionsMethodResponse = {
     type: { type: "list", options: [] },
   };
   const types = await Event.getTypes();

--- a/core/api/src/initializers/settings.ts
+++ b/core/api/src/initializers/settings.ts
@@ -1,68 +1,123 @@
 import { Initializer } from "actionhero";
 import { plugin } from "../modules/plugin";
+import { settingTypes } from "../models/Setting";
+import * as UUID from "uuid";
 
+interface SettingsListItem {
+  key: string;
+  defaultValue: string | number;
+  description: string;
+  type: typeof settingTypes[number];
+}
 export class Plugins extends Initializer {
   constructor() {
     super();
     this.name = "settings";
   }
 
+  async registerSettingsArray(
+    settingsList: SettingsListItem[],
+    pluginName: string
+  ) {
+    for (const i in settingsList) {
+      const { key, defaultValue, description, type } = settingsList[i];
+      await plugin.registerSetting(
+        pluginName,
+        key,
+        defaultValue,
+        description,
+        type
+      );
+    }
+  }
+
   async start() {
-    // The core API configurable settings
-    const coreSettings = [
+    const coreSettings: SettingsListItem[] = [
       {
         key: "cluster-name",
         defaultValue: "My Grouparoo Cluster",
         description:
           "A way to identify this Grouparoo cluster.  Will be displayed in the web interface and sent with Telemetry.",
+        type: "string",
       },
       {
         key: "groups-calculation-delay-minutes",
         defaultValue: 60,
         description:
-          "How many minutes should wait before recalculating a calculated group's membership?",
+          "How many minutes should wait before recalculating a calculated Group's membership?",
+        type: "number",
       },
       {
         key: "runs-profile-batch-size",
         defaultValue: 100,
         description:
-          "How many profiles or imports should a run enqueue in each batch before deferring to process those imports already enqueued?",
+          "How many Profiles or Imports should a Run enqueue in each batch before deferring to process those Imports already enqueued?",
+        type: "number",
       },
       {
         key: "export-profile-batch-size",
         defaultValue: 100,
         description:
-          "How many profiles should a run try to send at once to destinations which support batch exporting?",
+          "How many Profiles should a Run try to send at once to Destinations which support batch exporting?",
+        type: "number",
       },
       {
         key: "default-country-code",
         defaultValue: "US",
         description:
           "The default country code Grouparoo will use to format phone numbers and display data",
+        type: "string",
       },
       {
         key: "sweeper-delete-old-logs-days",
         defaultValue: 31,
         description:
-          "How many days should we keep log records for on the server?",
+          "How many days should we keep Log records for on the server?",
+        type: "number",
       },
       {
         key: "sweeper-delete-old-imports-days",
         defaultValue: 31,
         description:
-          "How many days should we keep import records for on the server?",
+          "How many days should we keep Import records for on the server?",
+        type: "number",
       },
       {
         key: "sweeper-delete-old-exports-days",
         defaultValue: 31,
         description:
-          "How many days should we keep export records for on the server?  We will keep the most recent export for each profile & destination.",
+          "How many days should we keep Export records for on the server?  We will keep the most recent export for each Profile & Destination.",
+        type: "number",
       },
     ];
 
-    for (const i in coreSettings) {
-      const { key, defaultValue, description } = coreSettings[i];
-      await plugin.registerSetting("core", key, defaultValue, description);
-    }
+    const interfaceSettings: SettingsListItem[] = [
+      {
+        key: "display-startup-steps",
+        defaultValue: "true",
+        description:
+          "Should Grouparoo display the Setup Steps to all Team Members?",
+        type: "boolean",
+      },
+    ];
+
+    const telemetrySettings: SettingsListItem[] = [
+      {
+        key: "customer-guid",
+        defaultValue: `tcs_${UUID.v4()}`,
+        description: "A unique, anonymous ID for this Grouparoo cluster.",
+        type: "string",
+      },
+      {
+        key: "customer-license",
+        defaultValue: ``,
+        description: "Your Grouparoo License Key (for paid features).",
+        type: "string",
+      },
+    ];
+
+    await this.registerSettingsArray(coreSettings, "core");
+    await this.registerSettingsArray(interfaceSettings, "interface");
+    await this.registerSettingsArray(telemetrySettings, "telemetry");
   }
 }

--- a/core/api/src/initializers/telemetry.ts
+++ b/core/api/src/initializers/telemetry.ts
@@ -1,6 +1,6 @@
 import { Initializer, api } from "actionhero";
 import { plugin } from "../modules/plugin";
-import * as UUID from "uuid";
+
 import {
   TelemetryMetric,
   TelemetryReporters,
@@ -64,21 +64,5 @@ export class Plugins extends Initializer {
         };
       },
     };
-  }
-
-  async start() {
-    await plugin.registerSetting(
-      "telemetry",
-      "customer-guid",
-      `tcs_${UUID.v4()}`,
-      "A unique, anonymous ID for this Grouparoo cluster."
-    );
-
-    await plugin.registerSetting(
-      "telemetry",
-      "customer-license",
-      "",
-      "Your Grouparoo License Key (for paid features)."
-    );
   }
 }

--- a/core/api/src/migrations/000042-addSettingType.ts
+++ b/core/api/src/migrations/000042-addSettingType.ts
@@ -1,0 +1,33 @@
+module.exports = {
+  up: async function (migration, DataTypes) {
+    await migration.addColumn("settings", "type", {
+      type: DataTypes.STRING(191),
+      defaultValue: "string",
+      allowNull: true,
+    });
+
+    await migration.changeColumn("settings", "type", {
+      type: DataTypes.STRING(191),
+      allowNull: false,
+    });
+
+    // If the defaultValue is a regexp number, we can assume a numeric field
+    // There were no boolean type settings before this migration
+    // https://stackoverflow.com/questions/175739/built-in-way-in-javascript-to-check-if-a-string-is-a-valid-number
+    const [settings] = await migration.sequelize.query(
+      `select * from "settings"`
+    );
+    for (const i in settings) {
+      const setting = settings[i];
+      if (!isNaN(setting.defaultValue)) {
+        await migration.sequelize.query(
+          `update "settings" set type='number' where guid='${setting.guid}'`
+        );
+      }
+    }
+  },
+
+  down: async function (migration) {
+    await migration.removeColumn("settings", "type");
+  },
+};

--- a/core/api/src/models/App.ts
+++ b/core/api/src/models/App.ts
@@ -31,6 +31,7 @@ export interface AppOption {
 
 export interface SimpleAppOptions extends OptionHelper.SimpleOptions {}
 
+const STATES = ["draft", "ready"] as const;
 const STATE_TRANSITIONS = [
   { from: "draft", to: "ready", checks: ["validateOptions"] },
 ];
@@ -56,8 +57,8 @@ export class App extends LoggedModel<App> {
 
   @AllowNull(false)
   @Default("draft")
-  @Column(DataType.ENUM("draft", "ready"))
-  state: string;
+  @Column(DataType.ENUM(...STATES))
+  state: typeof STATES[number];
 
   @HasMany(() => Option, "ownerGuid")
   _options: Option[]; // the underscore is needed as "options" is an internal method on sequelize instances

--- a/core/api/src/models/Destination.ts
+++ b/core/api/src/models/Destination.ts
@@ -44,6 +44,7 @@ export interface SimpleDestinationGroupMembership {
 }
 export interface SimpleDestinationOptions extends OptionHelper.SimpleOptions {}
 
+const STATES = ["draft", "ready"] as const;
 const STATE_TRANSITIONS = [
   { from: "draft", to: "ready", checks: ["validateOptions"] },
 ];
@@ -74,8 +75,8 @@ export class Destination extends LoggedModel<Destination> {
 
   @AllowNull(false)
   @Default("draft")
-  @Column(DataType.ENUM("draft", "ready"))
-  state: string;
+  @Column(DataType.ENUM(...STATES))
+  state: typeof STATES[number];
 
   @AllowNull(true)
   @Column

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -80,6 +80,7 @@ interface ProfilePropertyRulesCache {
 export interface SimpleProfilePropertyRuleOptions
   extends OptionHelper.SimpleOptions {}
 
+const STATES = ["draft", "ready"] as const;
 const STATE_TRANSITIONS = [
   { from: "draft", to: "ready", checks: ["validateOptions"] },
 ];
@@ -156,8 +157,8 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
 
   @AllowNull(false)
   @Default("draft")
-  @Column(DataType.ENUM("draft", "ready"))
-  state: string;
+  @Column(DataType.ENUM(...STATES))
+  state: typeof STATES[number];
 
   @AllowNull(false)
   @Default(false)

--- a/core/api/src/models/Run.ts
+++ b/core/api/src/models/Run.ts
@@ -34,6 +34,7 @@ export interface HighWaterMark {
   [key: string]: string | number | Date;
 }
 
+const STATES = ["draft", "running", "complete", "stopped"] as const;
 // we have no checks, as those are managed by the lifecycle methods below (and tasks)
 const STATE_TRANSITIONS = [
   { from: "draft", to: "running", checks: [] },
@@ -67,8 +68,8 @@ export class Run extends Model<Run> {
   creatorType: string;
 
   @AllowNull(false)
-  @Column(DataType.ENUM("draft", "running", "complete", "stopped"))
-  state: string;
+  @Column(DataType.ENUM(...STATES))
+  state: typeof STATES[number];
 
   @Column
   completedAt: Date;

--- a/core/api/src/models/Schedule.ts
+++ b/core/api/src/models/Schedule.ts
@@ -53,6 +53,7 @@ export interface PluginConnectionScheduleOption {
 
 export interface SimpleScheduleOptions extends OptionHelper.SimpleOptions {}
 
+const STATES = ["draft", "ready"] as const;
 const STATE_TRANSITIONS = [
   { from: "draft", to: "ready", checks: ["validateOptions"] },
 ];
@@ -79,8 +80,8 @@ export class Schedule extends LoggedModel<Schedule> {
 
   @AllowNull(false)
   @Default("draft")
-  @Column(DataType.ENUM("draft", "ready"))
-  state: string;
+  @Column(DataType.ENUM(...STATES))
+  state: typeof STATES[number];
 
   @AllowNull(false)
   @Default(false)

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -34,6 +34,7 @@ import { SourceOps } from "../modules/ops/source";
 export interface SimpleSourceOptions extends OptionHelper.SimpleOptions {}
 export interface SourceMapping extends MappingHelper.Mappings {}
 
+const STATES = ["draft", "ready"] as const;
 const STATE_TRANSITIONS = [
   {
     from: "draft",
@@ -68,8 +69,8 @@ export class Source extends LoggedModel<Source> {
 
   @AllowNull(false)
   @Default("draft")
-  @Column(DataType.ENUM("draft", "ready"))
-  state: string;
+  @Column(DataType.ENUM(...STATES))
+  state: typeof STATES[number];
 
   @BelongsTo(() => App)
   app: App;

--- a/core/api/src/modules/plugin.ts
+++ b/core/api/src/modules/plugin.ts
@@ -24,7 +24,7 @@ import { ProfilePropertyRuleFilter } from "../models/ProfilePropertyRuleFilter";
 import { ProfileMultipleAssociationShim } from "../models/ProfileMultipleAssociationShim";
 import { Run } from "../models/Run";
 import { Schedule } from "../models/Schedule";
-import { Setting } from "../models/Setting";
+import { Setting, settingTypes } from "../models/Setting";
 import { Source } from "../models/Source";
 import { Team } from "../models/Team";
 import { TeamMember } from "../models/TeamMember";
@@ -86,7 +86,8 @@ export namespace plugin {
     pluginName: string,
     key: string,
     defaultValue: any,
-    description: string
+    description: string,
+    type: typeof settingTypes[number]
   ) {
     const setting = await Setting.findOne({ where: { pluginName, key } });
 
@@ -99,6 +100,7 @@ export namespace plugin {
         value: defaultValue,
         defaultValue,
         description,
+        type,
       });
 
       return setting;
@@ -109,6 +111,7 @@ export namespace plugin {
           key,
           defaultValue,
           description,
+          type,
         })}: ${error}`
       );
     }

--- a/core/web/utils/apiData.ts
+++ b/core/web/utils/apiData.ts
@@ -17,6 +17,7 @@ import {
   ProfileProperty,
   ProfilePropertyRule,
   Run,
+  Setting,
   Schedule,
   Source,
   Team,
@@ -50,6 +51,7 @@ export type ProfilePropertyAPIData = Partial<
 export type ProfilePropertyRuleAPIData = Partial<
   AsyncReturnType<ProfilePropertyRule["apiData"]>
 >;
+export type SettingAPIData = Partial<AsyncReturnType<Setting["apiData"]>>;
 export type RunAPIData = Partial<AsyncReturnType<Run["apiData"]>>;
 export type ScheduleAPIData = Partial<AsyncReturnType<Schedule["apiData"]>>;
 export type SourceAPIData = Partial<AsyncReturnType<Source["apiData"]>>;

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/sourceOptions.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/sourceOptions.ts
@@ -1,7 +1,10 @@
-import { SourceOptionsMethod } from "@grouparoo/core";
+import {
+  SourceOptionsMethod,
+  SourceOptionsMethodResponse,
+} from "@grouparoo/core";
 
 export const sourceOptions: SourceOptionsMethod = async ({ connection }) => {
-  const response = {
+  const response: SourceOptionsMethodResponse = {
     table: { type: "list", options: [] },
   };
 

--- a/plugins/@grouparoo/csv/src/lib/file-import/sourceOptions.ts
+++ b/plugins/@grouparoo/csv/src/lib/file-import/sourceOptions.ts
@@ -1,8 +1,12 @@
 import path from "path";
-import { File, SourceOptionsMethod } from "@grouparoo/core";
+import {
+  File,
+  SourceOptionsMethod,
+  SourceOptionsMethodResponse,
+} from "@grouparoo/core";
 
 export const sourceOptions: SourceOptionsMethod = async () => {
-  const response = {
+  const response: SourceOptionsMethodResponse = {
     fileGuid: { type: "list", options: [], descriptions: [] },
   };
   const csvFiles = await File.findAll({ where: { type: ["csv", "CSV"] } });

--- a/plugins/@grouparoo/mailchimp/src/lib/export/destinationOptions.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/export/destinationOptions.ts
@@ -1,10 +1,13 @@
-import { DestinationOptionsMethod } from "@grouparoo/core";
+import {
+  DestinationOptionsMethod,
+  DestinationOptionsMethodResponse,
+} from "@grouparoo/core";
 import { connect } from "./../connect";
 
 export const destinationOptions: DestinationOptionsMethod = async ({
   appOptions,
 }) => {
-  const response = {
+  const response: DestinationOptionsMethodResponse = {
     listId: { type: "list", options: [], descriptions: [] },
   };
 

--- a/plugins/@grouparoo/mysql/src/lib/export/destinationOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/destinationOptions.ts
@@ -1,4 +1,7 @@
-import { DestinationOptionsMethod } from "@grouparoo/core";
+import {
+  DestinationOptionsMethod,
+  DestinationOptionsMethodResponse,
+} from "@grouparoo/core";
 
 export const destinationOptions: DestinationOptionsMethod = async ({
   connection,
@@ -14,7 +17,7 @@ export const destinationOptions: DestinationOptionsMethod = async ({
     return colRows.map((row) => row.column_name).sort();
   }
 
-  const response = {
+  const response: DestinationOptionsMethodResponse = {
     table: { type: "typeahead", options: [] },
     groupsTable: { type: "typeahead", options: [] },
     primaryKey: { type: "pending", options: [] },

--- a/plugins/@grouparoo/mysql/src/lib/table-import/sourceOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/sourceOptions.ts
@@ -1,10 +1,15 @@
-import { SourceOptionsMethod } from "@grouparoo/core";
+import {
+  SourceOptionsMethod,
+  SourceOptionsMethodResponse,
+} from "@grouparoo/core";
 
 export const sourceOptions: SourceOptionsMethod = async ({
   connection,
   appOptions,
 }) => {
-  const response = { table: { type: "typeahead", options: [] } };
+  const response: SourceOptionsMethodResponse = {
+    table: { type: "typeahead", options: [] },
+  };
 
   const tables = await connection.asyncQuery(
     `SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = ?`,

--- a/plugins/@grouparoo/postgres/src/lib/export/destinationOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/export/destinationOptions.ts
@@ -1,5 +1,8 @@
 import format from "pg-format";
-import { DestinationOptionsMethod } from "@grouparoo/core";
+import {
+  DestinationOptionsMethod,
+  DestinationOptionsMethodResponse,
+} from "@grouparoo/core";
 
 export const destinationOptions: DestinationOptionsMethod = async ({
   connection,
@@ -19,7 +22,7 @@ export const destinationOptions: DestinationOptionsMethod = async ({
     return colRows.map((row) => row.column_name).sort();
   }
 
-  const response = {
+  const response: DestinationOptionsMethodResponse = {
     table: { type: "typeahead", options: [] },
     groupsTable: { type: "typeahead", options: [] },
     primaryKey: { type: "pending", options: [] },

--- a/plugins/@grouparoo/postgres/src/lib/table-import/sourceOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/sourceOptions.ts
@@ -1,11 +1,16 @@
 import format from "pg-format";
-import { SourceOptionsMethod } from "@grouparoo/core";
+import {
+  SourceOptionsMethod,
+  SourceOptionsMethodResponse,
+} from "@grouparoo/core";
 
 export const sourceOptions: SourceOptionsMethod = async ({
   appOptions,
   connection,
 }) => {
-  const response = { table: { type: "typeahead", options: [] } };
+  const response: SourceOptionsMethodResponse = {
+    table: { type: "typeahead", options: [] },
+  };
 
   const { rows } = await connection.query(
     format(


### PR DESCRIPTION
Settings gain a `type` (number, string, boolean) so we can display the right kind of interface in the UI.  This PR adds the first "boolean" type Setting, `display-startup-steps` for the `interface` plugin.

<img width="1065" alt="Screen Shot 2020-09-08 at 4 04 50 PM" src="https://user-images.githubusercontent.com/303226/92537368-cb17c880-f1f0-11ea-82f4-922d2a39f716.png">

<img width="1070" alt="Screen Shot 2020-09-08 at 4 04 41 PM" src="https://user-images.githubusercontent.com/303226/92537365-c9e69b80-f1f0-11ea-950a-ed675d382f62.png">

Also, this PR generally cleans up the initializers and creating Settings with their defaults.

Closes T-470