### PR TITLE
Update Router and Link paths

### DIFF
--- a/core/api/src/actions/navigation.ts
+++ b/core/api/src/actions/navigation.ts
@@ -115,7 +115,7 @@ export class NavigationList extends OptionallyAuthenticatedAction {
         platformItems.push({
           type: "link",
           title: "Settings",
-          href: "/settings/core",
+          href: "/settings",
         });
 
         platformItems.push({

--- a/core/web/components/runs/list.tsx
+++ b/core/web/components/runs/list.tsx
@@ -222,10 +222,7 @@ export default function RunsList(props) {
                     ) : null}
                   </td>
                   <td>
-                    <Link
-                      href="/imports/[creatorGuid]"
-                      as={`/imports/${run.guid}`}
-                    >
+                    <Link href="/imports/[guid]" as={`/imports/${run.guid}`}>
                       <a>Imports Created: {run.importsCreated}</a>
                     </Link>
                     <br />

--- a/core/web/next.config.js
+++ b/core/web/next.config.js
@@ -64,6 +64,12 @@ module.exports = withSourceMaps({
 
     return config;
   },
+
+  async redirects() {
+    return [
+      { source: "/settings", destination: "/settings/core", statusCode: 307 },
+    ];
+  },
 });
 
 /**

--- a/core/web/pages/settings/[tab].tsx
+++ b/core/web/pages/settings/[tab].tsx
@@ -58,7 +58,7 @@ export default function Page(props) {
 
       <Tabs
         activeKey={activeTab}
-        onSelect={(k) => router.push(`/settings/${k}`)}
+        onSelect={(k) => router.push("/settings/[tab]", `/settings/${k}`)}
       >
         <Tab eventKey="actions" title="Actions">
           <ActionsTab


### PR DESCRIPTION
Solves errors in the web UI like  `Unknown key passed via urlObject into url.format: searchParams`.

The error message isn't intuitive, but results when the next Router or Link component is passed a `href` or `as` that doesn't match an existing page.