### PR TITLE
Do not sort by Random()

### DIFF
--- a/core/api/src/actions/profilePropertyRules.ts
+++ b/core/api/src/actions/profilePropertyRules.ts
@@ -54,7 +54,7 @@ export class ProfilePropertyRulesList extends AuthenticatedAction {
           profilePropertyRuleGuid: rule.guid,
           rawValue: { [Op.not]: null },
         },
-        order: api.sequelize.random(),
+        order: [["guid", "asc"]],
         limit: 5,
       });
       const exampleValues = examples.map((e) => e.rawValue);
@@ -278,7 +278,7 @@ export class ProfilePropertyRuleProfilePreview extends AuthenticatedAction {
     if (params.profileGuid) {
       profile = await Profile.findByGuid(params.profileGuid);
     } else {
-      profile = await Profile.findOne({ order: api.sequelize.random() });
+      profile = await Profile.findOne({ logging: true });
       if (!profile) {
         response.errorMessage = "no profiles found";
         return;

--- a/core/api/src/actions/profilePropertyRules.ts
+++ b/core/api/src/actions/profilePropertyRules.ts
@@ -278,7 +278,7 @@ export class ProfilePropertyRuleProfilePreview extends AuthenticatedAction {
     if (params.profileGuid) {
       profile = await Profile.findByGuid(params.profileGuid);
     } else {
-      profile = await Profile.findOne({ logging: true });
+      profile = await Profile.findOne({ order: [["guid", "asc"]] });
       if (!profile) {
         response.errorMessage = "no profiles found";
         return;

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -184,7 +184,7 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
   }
 
   async test(options?: SimpleProfilePropertyRuleOptions) {
-    const profile = await Profile.findOne({ order: api.sequelize.random() });
+    const profile = await Profile.findOne({ order: [["guid", "asc"]] });
     if (profile) {
       const source = await Source.findByGuid(this.sourceGuid);
       return source.importProfileProperty(profile, this, options);

--- a/core/api/src/models/Run.ts
+++ b/core/api/src/models/Run.ts
@@ -268,7 +268,7 @@ export class Run extends Model<Run> {
    * This method tries to import a random profile to check if the ProfilePropertyRules are valid
    */
   async test() {
-    const profile = await Profile.findOne({ order: api.sequelize.random() });
+    const profile = await Profile.findOne({ order: [["guid", "asc"]] });
 
     if (profile) {
       try {

--- a/core/api/src/models/Schedule.ts
+++ b/core/api/src/models/Schedule.ts
@@ -159,7 +159,7 @@ export class Schedule extends LoggedModel<Schedule> {
     });
 
     log(
-      `[ run ] starting run ${run.guid} for schedule ${this.guid}, ${this.name}`,
+      `[ run ] starting run ${run.guid} for schedule ${this.name} (${this.guid})`,
       "notice"
     );
 

--- a/core/api/src/modules/internalRun.ts
+++ b/core/api/src/modules/internalRun.ts
@@ -27,7 +27,7 @@ export async function internalRun(creatorType: string, creatorGuid: string) {
   log(
     `[ run ] starting run ${
       run.guid
-    } for ${creatorType} ${creatorGuid}, ${await run.getCreatorName()}`,
+    } for ${creatorType} ${await run.getCreatorName()} (${creatorGuid})`,
     "notice"
   );
 

--- a/core/api/src/tasks/schedule/updateSchedules.ts
+++ b/core/api/src/tasks/schedule/updateSchedules.ts
@@ -62,7 +62,7 @@ export class UpdateSchedules extends Task {
         });
 
         log(
-          `[ run ] starting run ${run.guid} for schedule ${schedule.guid}, ${schedule.name}`,
+          `[ run ] starting run ${run.guid} for schedule ${schedule.name} (${schedule.guid})`,
           "notice"
         );
       }

--- a/plugins/@grouparoo/demo/src/bin/grouparoo/demo/eventStream.ts
+++ b/plugins/@grouparoo/demo/src/bin/grouparoo/demo/eventStream.ts
@@ -244,9 +244,11 @@ class MockSession {
       return;
     }
 
+    // normally, don't use random(), but this is not a runtime operation, so it should be OK
     this.currentUser = await Profile.findOne({
       order: api.sequelize.random(),
     });
+
     this.anonymousId = `?-${uuid.v4()}`;
     this.profileProperties = await this.currentUser.properties();
     if (!this.profileProperties[this.identifyingProfilePropertyRuleKey]) {

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -235,7 +235,7 @@ describe("integration/runs/mysql", () => {
       session
     );
     expect(error).toBeUndefined();
-    expect(preview.length).toBe(10);
+    expect(preview.length).toBeGreaterThan(1); // the number of rows is sort of random (per getRandomNumbersInRange)
     expect(Object.keys(preview[0]).sort()).toEqual([
       "android_app",
       "email",

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -235,7 +235,7 @@ describe("integration/runs/mysql", () => {
       session
     );
     expect(error).toBeUndefined();
-    expect(preview.length).toBeGreaterThan(1); // the number of rows is sort of random (per getRandomNumbersInRange)
+    expect(preview.length).toBe(10);
     expect(Object.keys(preview[0]).sort()).toEqual([
       "android_app",
       "email",

--- a/plugins/@grouparoo/mysql/src/lib/table-import/sourcePreview.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/sourcePreview.ts
@@ -15,7 +15,7 @@ export const sourcePreview: SourcePreviewMethod = async ({
     `SELECT COUNT(1) as __count FROM ??`,
     [sourceOptions.table]
   );
-  const count = parseInt(countResult[0]["__count"]) - 1;
+  const count = parseInt(countResult[0]["__count"]);
   const offsets = getRandomNumbersInRange(count, 10);
 
   for (const i in offsets) {
@@ -34,7 +34,7 @@ function getRandomNumbersInRange(max: number, size: number) {
   let attempts = 0;
 
   while (array.length < size && attempts < size * 2) {
-    var attempt = Math.floor(Math.random() * max) + 1;
+    var attempt = Math.floor(Math.random() * max - 1) + 1;
     if (!array.includes(attempt)) array.push(attempt);
     attempts++;
   }

--- a/plugins/@grouparoo/mysql/src/lib/table-import/sourcePreview.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/sourcePreview.ts
@@ -7,7 +7,7 @@ export const sourcePreview: SourcePreviewMethod = async ({
   const response = [];
 
   // For large datasets, `order by RAND()` is actually very slow in MySQL
-  // To that end, we are going to pick numbers at random in JS and select just the rows we want, one at a time.
+  // To that end, we are going to pick numbers at random in JS and select just the rows we want, one at a time, as we cannot use functions in the OFFSET in MySQL.
   // We also cannot assume that our source has an incremental & unique primary key.
   // https://stackoverflow.com/questions/1244555/how-can-i-optimize-mysqls-order-by-rand-function
 

--- a/plugins/@grouparoo/mysql/src/lib/table-import/sourcePreview.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/sourcePreview.ts
@@ -12,9 +12,10 @@ export const sourcePreview: SourcePreviewMethod = async ({
   // https://stackoverflow.com/questions/1244555/how-can-i-optimize-mysqls-order-by-rand-function
   // ... But for now we will just show the first 10 rows of the table
 
-  await connection
-    .asyncQuery(`SELECT * FROM ?? LIMIT 10`, [sourceOptions.table])
-    .map((row) => response.push(row));
+  const rows = await connection.asyncQuery(`SELECT * FROM ?? LIMIT 10`, [
+    sourceOptions.table,
+  ]);
+  rows.map((row) => response.push(row));
 
   return response;
 };

--- a/plugins/@grouparoo/mysql/src/lib/table-import/sourcePreview.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/sourcePreview.ts
@@ -7,37 +7,14 @@ export const sourcePreview: SourcePreviewMethod = async ({
   const response = [];
 
   // For large datasets, `order by RAND()` is actually very slow in MySQL
-  // To that end, we are going to pick numbers at random in JS and select just the rows we want, one at a time, as we cannot use functions in the OFFSET in MySQL.
+  // To that end, we would need to pick numbers at random in JS and select just the rows we want, one at a time, as we cannot use functions in the OFFSET in MySQL.
   // We also cannot assume that our source has an incremental & unique primary key.
   // https://stackoverflow.com/questions/1244555/how-can-i-optimize-mysqls-order-by-rand-function
+  // ... But for now we will just show the first 10 rows of the table
 
-  const countResult = await connection.asyncQuery(
-    `SELECT COUNT(1) as __count FROM ??`,
-    [sourceOptions.table]
-  );
-  const count = parseInt(countResult[0]["__count"]);
-  const offsets = getRandomNumbersInRange(count, 10);
-
-  for (const i in offsets) {
-    const rowResult = await connection.asyncQuery(
-      `SELECT * FROM ?? LIMIT 1 OFFSET ?`,
-      [sourceOptions.table, offsets[i]]
-    );
-    response.push(rowResult[0]);
-  }
+  await connection
+    .asyncQuery(`SELECT * FROM ?? LIMIT 10`, [sourceOptions.table])
+    .map((row) => response.push(row));
 
   return response;
 };
-
-function getRandomNumbersInRange(max: number, size: number) {
-  const array: number[] = [];
-  let attempts = 0;
-
-  while (array.length < size && attempts < size * 2) {
-    var attempt = Math.floor(Math.random() * max - 1) + 1;
-    if (!array.includes(attempt)) array.push(attempt);
-    attempts++;
-  }
-
-  return array;
-}

--- a/plugins/@grouparoo/mysql/src/lib/table-import/sourcePreview.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/sourcePreview.ts
@@ -6,11 +6,38 @@ export const sourcePreview: SourcePreviewMethod = async ({
 }) => {
   const response = [];
 
-  const preview = await connection.asyncQuery(
-    `SELECT * FROM ?? ORDER BY RAND() LIMIT 10 `,
+  // For large datasets, `order by RAND()` is actually very slow in MySQL
+  // To that end, we are going to pick numbers at random in JS and select just the rows we want, one at a time.
+  // We also cannot assume that our source has an incremental & unique primary key.
+  // https://stackoverflow.com/questions/1244555/how-can-i-optimize-mysqls-order-by-rand-function
+
+  const countResult = await connection.asyncQuery(
+    `SELECT COUNT(1) as __count FROM ??`,
     [sourceOptions.table]
   );
-  preview.map((row) => response.push(row));
+  const count = parseInt(countResult[0]["__count"]) - 1;
+  const offsets = getRandomNumbersInRange(count, 10);
+
+  for (const i in offsets) {
+    const rowResult = await connection.asyncQuery(
+      `SELECT * FROM ?? LIMIT 1 OFFSET ?`,
+      [sourceOptions.table, offsets[i]]
+    );
+    response.push(rowResult[0]);
+  }
 
   return response;
 };
+
+function getRandomNumbersInRange(max: number, size: number) {
+  const array: number[] = [];
+  let attempts = 0;
+
+  while (array.length < size && attempts < size * 2) {
+    var attempt = Math.floor(Math.random() * max) + 1;
+    if (!array.includes(attempt)) array.push(attempt);
+    attempts++;
+  }
+
+  return array;
+}

--- a/plugins/@grouparoo/postgres/src/lib/table-import/sourcePreview.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/sourcePreview.ts
@@ -8,7 +8,7 @@ export const sourcePreview: SourcePreviewMethod = async ({
   const response = [];
 
   // For large datasets, `order by RANDOM()` is actually very slow in Postgres
-  // To that end, we are going to pick numbers at random in JS and select just the rows we want, one at a time.
+  // To that end, we are going to pick numbers at random in the Offset as a multiple of the number of rows.
   // We also cannot assume that our source has an incremental & unique primary key.
   // We cannot use TABLESAMPLE as it was only introduced in Postgres 9.5 (redshift for example uses Postgres 8)
   // https://stackoverflow.com/questions/8674718/best-way-to-select-random-rows-postgresql
@@ -17,31 +17,21 @@ export const sourcePreview: SourcePreviewMethod = async ({
     format(`SELECT COUNT(1) as __count FROM %I`, sourceOptions.table)
   );
   const count = parseInt(countRows[0]["__count"]) - 1;
-  const offsets = getRandomNumbersInRange(count, 10);
+  const limit = 10;
+  let attempts = 0;
 
-  for (const i in offsets) {
+  while (attempts < limit) {
     const { rows: recordRows } = await connection.query(
       format(
-        `SELECT * FROM %I LIMIT 1 OFFSET ?`,
+        `SELECT * FROM %I LIMIT 1 OFFSET floor(random() * %L)`,
         sourceOptions.table,
-        offsets[i]
+        count
       )
     );
+
     response.push(recordRows[0]);
+    attempts++;
   }
 
   return response;
 };
-
-function getRandomNumbersInRange(max: number, size: number) {
-  const array: number[] = [];
-  let attempts = 0;
-
-  while (array.length < size && attempts < size * 2) {
-    var attempt = Math.floor(Math.random() * max) + 1;
-    if (!array.includes(attempt)) array.push(attempt);
-    attempts++;
-  }
-
-  return array;
-}

--- a/plugins/@grouparoo/postgres/src/lib/table-import/sourcePreview.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/sourcePreview.ts
@@ -16,7 +16,7 @@ export const sourcePreview: SourcePreviewMethod = async ({
   const { rows: countRows } = await connection.query(
     format(`SELECT COUNT(1) as __count FROM %I`, sourceOptions.table)
   );
-  const count = parseInt(countRows[0]["__count"]) - 1;
+  const count = parseInt(countRows[0]["__count"]);
   const limit = 10;
   let attempts = 0;
 

--- a/plugins/@grouparoo/postgres/src/lib/table-import/sourcePreview.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/sourcePreview.ts
@@ -7,10 +7,41 @@ export const sourcePreview: SourcePreviewMethod = async ({
 }) => {
   const response = [];
 
-  const { rows } = await connection.query(
-    format(`SELECT * FROM %I ORDER BY RANDOM() LIMIT 10`, sourceOptions.table)
+  // For large datasets, `order by RANDOM()` is actually very slow in Postgres
+  // To that end, we are going to pick numbers at random in JS and select just the rows we want, one at a time.
+  // We also cannot assume that our source has an incremental & unique primary key.
+  // We cannot use TABLESAMPLE as it was only introduced in Postgres 9.5 (redshift for example uses Postgres 8)
+  // https://stackoverflow.com/questions/8674718/best-way-to-select-random-rows-postgresql
+
+  const { rows: countRows } = await connection.query(
+    format(`SELECT COUNT(1) as __count FROM %I`, sourceOptions.table)
   );
-  rows.map((row) => response.push(row));
+  const count = parseInt(countRows[0]["__count"]) - 1;
+  const offsets = getRandomNumbersInRange(count, 10);
+
+  for (const i in offsets) {
+    const { rows: recordRows } = await connection.query(
+      format(
+        `SELECT * FROM %I LIMIT 1 OFFSET ?`,
+        sourceOptions.table,
+        offsets[i]
+      )
+    );
+    response.push(recordRows[0]);
+  }
 
   return response;
 };
+
+function getRandomNumbersInRange(max: number, size: number) {
+  const array: number[] = [];
+  let attempts = 0;
+
+  while (array.length < size && attempts < size * 2) {
+    var attempt = Math.floor(Math.random() * max) + 1;
+    if (!array.includes(attempt)) array.push(attempt);
+    attempts++;
+  }
+
+  return array;
+}

--- a/plugins/@grouparoo/postgres/src/lib/table-import/sourcePreview.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/sourcePreview.ts
@@ -8,30 +8,16 @@ export const sourcePreview: SourcePreviewMethod = async ({
   const response = [];
 
   // For large datasets, `order by RANDOM()` is actually very slow in Postgres
-  // To that end, we are going to pick numbers at random in the Offset as a multiple of the number of rows.
+  // To that end, we would need to pick numbers at random in the Offset as a multiple of the number of rows.
   // We also cannot assume that our source has an incremental & unique primary key.
   // We cannot use TABLESAMPLE as it was only introduced in Postgres 9.5 (redshift for example uses Postgres 8)
   // https://stackoverflow.com/questions/8674718/best-way-to-select-random-rows-postgresql
+  // ... But for now we will just show the first 10 rows of the table
 
-  const { rows: countRows } = await connection.query(
-    format(`SELECT COUNT(1) as __count FROM %I`, sourceOptions.table)
+  const { rows } = await connection.query(
+    format(`SELECT * FROM %I LIMIT 10`, sourceOptions.table)
   );
-  const count = parseInt(countRows[0]["__count"]);
-  const limit = 10;
-  let attempts = 0;
-
-  while (attempts < limit) {
-    const { rows: recordRows } = await connection.query(
-      format(
-        `SELECT * FROM %I LIMIT 1 OFFSET floor(random() * %L)`,
-        sourceOptions.table,
-        count
-      )
-    );
-
-    response.push(recordRows[0]);
-    attempts++;
-  }
+  rows.map((row) => response.push(row));
 
   return response;
 };


### PR DESCRIPTION
Sorting by `RAND()` or `RANDOM()` depending on your database, can be very slow with large datasets.  This is due to the need to first apply a random number to each row in memory before sorting.  
* https://stackoverflow.com/questions/8674718/best-way-to-select-random-rows-postgresql
* https://stackoverflow.com/questions/1244555/how-can-i-optimize-mysqls-order-by-rand-function

There are a few cases when a Random sort was being used:
* Internally (against the Grouparoo database) 
  1. To find a random Profile to either test an import against or display.  We now switch to sorting by `guid`, which is semi-random but deterministic.  For a static collection of Profiles, the same profile will now always be returned.  
  2. Collecting random Profile Properties to display as examples to what values exist (like a list of first names).  We now switch to sorting by `guid`, which is semi-random but deterministic.  This will generate the same list each time for a static collection of Profiles
* For Source Previews
  * We re-use the `sourcePreview()` method in a number of places (previewing a source's data, creating a source's mapping, building or editing a Profile Property) to show samples of the data in the Source.  In these cases, showing a random collection of data remains a good idea.  In these cases we now:
    1. Only show the first 10 records in the source table, ordered naturally
  ~1. `count()` how large the table is~
  ~2. Generate random numbers (in JS) between 0 the number of rows in the table~
  ~3. Select rows with an `offset` 1-by-1 (so 10 unique select statements) to use the natural sort of the table, avoiding a `sort by` call.~
  * This closes T-86 as a side effect.

Closes T-482