### PR TITLE
Setup Updates

### DIFF
--- a/core/web/__tests__/components/setupSteps/setupStepCard.tsx
+++ b/core/web/__tests__/components/setupSteps/setupStepCard.tsx
@@ -15,31 +15,15 @@ describe("<setupStepCard />", () => {
     outcome: "You did the thing!",
   };
 
-  describe("active", () => {
-    beforeAll(() => {
-      component = mount(<SetStepCard active={true} setupStep={setupStep} />);
-    });
-
-    afterAll(() => {
-      component.unmount();
-    });
-
-    it("renders a call to action", () => {
-      expect(component.html()).toContain("you should do the thing");
-    });
+  beforeAll(() => {
+    component = mount(<SetStepCard setupStep={setupStep} />);
   });
 
-  describe("inactive", () => {
-    beforeAll(() => {
-      component = mount(<SetStepCard active={false} setupStep={setupStep} />);
-    });
+  afterAll(() => {
+    component.unmount();
+  });
 
-    afterAll(() => {
-      component.unmount();
-    });
-
-    it("does not renders a call to action", () => {
-      expect(component.html()).not.toContain("you should do the thing");
-    });
+  it("renders a call to action", () => {
+    expect(component.html()).toContain("you should do the thing");
   });
 });

--- a/core/web/components/navigation.tsx
+++ b/core/web/components/navigation.tsx
@@ -1,14 +1,16 @@
 import { Fragment, useState, useEffect } from "react";
-import { Image, Accordion, Button, Badge, ProgressBar } from "react-bootstrap";
+import { Image, Accordion, Button, Badge } from "react-bootstrap";
 import Link from "next/link";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useRealtimeModelStream } from "../hooks/useRealtimeModelStream";
-import { RunAPIData, SetupStepAPIData } from "../utils/apiData";
 import { useApi } from "../hooks/useApi";
+import SetupStepsNavProgressBar from "./navigation/setupStepsNavProgressBar";
+import RunningRunsBadge from "./navigation/runningRunsBadge";
+import ResqueFailedCountBadge from "./navigation/resqueFailedBadgeCount";
+import HighlightingNavLink from "./navigation/highlightingNavLink";
 
-const navLiStyle = { marginTop: 20, marginBottom: 20 };
+export const navLiStyle = { marginTop: 20, marginBottom: 20 };
 
-const navIconStyle = {
+export const navIconStyle = {
   fontSize: 18,
   fontWeight: 300,
   paddingLeft: 0,
@@ -18,7 +20,7 @@ const navIconStyle = {
   textDecoration: "none",
 };
 
-const iconConstrainedStyle = { width: 20 };
+export const iconConstrainedStyle = { width: 20 };
 
 export default function Navigation(props) {
   const {
@@ -333,159 +335,6 @@ export default function Navigation(props) {
           </Accordion.Collapse>
         </Accordion>
       </div>
-    </div>
-  );
-}
-
-function HighlightingNavLink({ href, text, icon, idx }) {
-  const [active, setActive] = useState(false);
-  useEffect(() => {
-    const active = globalThis?.location?.pathname === href;
-    setActive(active);
-  }, [globalThis?.location?.href]);
-
-  return (
-    <li style={navLiStyle} key={idx}>
-      <Link href={href}>
-        <a role="tab" aria-selected={active} style={navIconStyle}>
-          {icon ? (
-            <FontAwesomeIcon
-              style={iconConstrainedStyle}
-              icon={icon}
-              size="xs"
-            />
-          ) : null}{" "}
-        </a>
-      </Link>{" "}
-      <Link href={href}>
-        <a
-          role="tab"
-          aria-selected={active}
-          style={{
-            fontSize: 18,
-            paddingLeft: 0,
-            color: "white",
-          }}
-        >
-          {text}
-        </a>
-      </Link>
-    </li>
-  );
-}
-
-function RunningRunsBadge({ execApi }) {
-  useRealtimeModelStream("run", "navigation-runs-badge", load);
-  const [runs, setRuns] = useState<RunAPIData[]>([]);
-
-  useEffect(() => {
-    load();
-  }, []);
-
-  async function load() {
-    const { runs } = await execApi(
-      "get",
-      `/runs`,
-      { state: "running" },
-      null,
-      null,
-      false
-    );
-    setRuns(runs);
-  }
-
-  if (runs.length === 0) return null;
-
-  return (
-    <span style={{ paddingLeft: 5 }}>
-      <Badge pill variant="info">
-        {runs.length}
-      </Badge>
-    </span>
-  );
-}
-
-function ResqueFailedCountBadge({
-  resqueFailedCount,
-  navigationMode,
-}: {
-  resqueFailedCount: number;
-  navigationMode: string;
-}) {
-  if (navigationMode === "unauthenticated") return null;
-  if (resqueFailedCount === 0) return null;
-
-  return (
-    <span style={{ paddingLeft: 5 }}>
-      <Badge pill variant="warning">
-        {resqueFailedCount}
-      </Badge>
-    </span>
-  );
-}
-
-function SetupStepsNavProgressBar({ execApi }) {
-  const [steps, setSteps] = useState<SetupStepAPIData[]>([]);
-  const [shouldDisplay, setShouldDisplay] = useState(false);
-
-  let timer: NodeJS.Timeout;
-  const timeout = 1000 * 15;
-
-  async function getSetupSteps() {
-    clearTimeout(timer);
-    const { setupSteps, toDisplay } = await execApi("get", `/setupSteps`);
-    setShouldDisplay(toDisplay);
-    setSteps(setupSteps);
-    if (toDisplay) timer = setTimeout(getSetupSteps, timeout);
-  }
-
-  useEffect(() => {
-    getSetupSteps();
-    return () => {
-      clearTimeout(timer);
-    };
-  }, []);
-
-  const activeStep = steps.find((step) => !step.complete);
-  const isOnBoardingComplete = steps.every((step) => step.complete);
-  const totalStepsCount = steps.length;
-  const completeStepsCount = steps.filter((step) => step.complete).length;
-  const percentComplete = Math.round(
-    (100 * completeStepsCount) / totalStepsCount
-  );
-
-  if (!shouldDisplay) return null;
-
-  return (
-    <div
-      style={{
-        backgroundColor: "white",
-        width: "100%",
-        padding: 20,
-        marginTop: 10,
-      }}
-    >
-      <div
-        style={{
-          fontSize: 18,
-          paddingLeft: 0,
-          color: "var(--secondary)",
-        }}
-      >
-        <Link href="/setup">
-          <a>{isOnBoardingComplete ? "Setup Complete 🎉" : "Get Started:"}</a>
-        </Link>
-      </div>
-      <div
-        style={{
-          paddingLeft: 0,
-          paddingBottom: 10,
-          color: "var(--secondary)",
-        }}
-      >
-        {activeStep?.title}
-      </div>
-      <ProgressBar now={percentComplete} />
     </div>
   );
 }

--- a/core/web/components/navigation.tsx
+++ b/core/web/components/navigation.tsx
@@ -32,6 +32,7 @@ export default function Navigation(props) {
     navExpanded,
     toggleNavExpanded,
     errorHandler,
+    setupStepHandler,
   } = props;
   const { execApi } = useApi(props, errorHandler);
   const [teamMember, setTeamMember] = useState(props.currentTeamMember);
@@ -167,7 +168,10 @@ export default function Navigation(props) {
         </div>
 
         {navigationMode !== "unauthenticated" && (
-          <SetupStepsNavProgressBar execApi={execApi} />
+          <SetupStepsNavProgressBar
+            execApi={execApi}
+            setupStepHandler={setupStepHandler}
+          />
         )}
 
         <div

--- a/core/web/components/navigation/highlightingNavLink.tsx
+++ b/core/web/components/navigation/highlightingNavLink.tsx
@@ -1,0 +1,41 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { navIconStyle, navLiStyle, iconConstrainedStyle } from "../navigation";
+
+export default function HighlightingNavLink({ href, text, icon, idx }) {
+  const [active, setActive] = useState(false);
+  useEffect(() => {
+    const active = globalThis?.location?.pathname === href;
+    setActive(active);
+  }, [globalThis?.location?.href]);
+
+  return (
+    <li style={navLiStyle} key={idx}>
+      <Link href={href}>
+        <a role="tab" aria-selected={active} style={navIconStyle}>
+          {icon ? (
+            <FontAwesomeIcon
+              style={iconConstrainedStyle}
+              icon={icon}
+              size="xs"
+            />
+          ) : null}{" "}
+        </a>
+      </Link>{" "}
+      <Link href={href}>
+        <a
+          role="tab"
+          aria-selected={active}
+          style={{
+            fontSize: 18,
+            paddingLeft: 0,
+            color: "white",
+          }}
+        >
+          {text}
+        </a>
+      </Link>
+    </li>
+  );
+}

--- a/core/web/components/navigation/resqueFailedBadgeCount.tsx
+++ b/core/web/components/navigation/resqueFailedBadgeCount.tsx
@@ -1,0 +1,20 @@
+import { Badge } from "react-bootstrap";
+
+export default function ResqueFailedCountBadge({
+  resqueFailedCount,
+  navigationMode,
+}: {
+  resqueFailedCount: number;
+  navigationMode: string;
+}) {
+  if (navigationMode === "unauthenticated") return null;
+  if (resqueFailedCount === 0) return null;
+
+  return (
+    <span style={{ paddingLeft: 5 }}>
+      <Badge pill variant="warning">
+        {resqueFailedCount}
+      </Badge>
+    </span>
+  );
+}

--- a/core/web/components/navigation/runningRunsBadge.tsx
+++ b/core/web/components/navigation/runningRunsBadge.tsx
@@ -1,0 +1,35 @@
+import { Badge } from "react-bootstrap";
+import { useRealtimeModelStream } from "./../../hooks/useRealtimeModelStream";
+import { useState, useEffect } from "react";
+import { RunAPIData } from "../../utils/apiData";
+
+export default function RunningRunsBadge({ execApi }) {
+  useRealtimeModelStream("run", "navigation-runs-badge", load);
+  const [runs, setRuns] = useState<RunAPIData[]>([]);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    const { runs } = await execApi(
+      "get",
+      `/runs`,
+      { state: "running" },
+      null,
+      null,
+      false
+    );
+    setRuns(runs);
+  }
+
+  if (runs.length === 0) return null;
+
+  return (
+    <span style={{ paddingLeft: 5 }}>
+      <Badge pill variant="info">
+        {runs.length}
+      </Badge>
+    </span>
+  );
+}

--- a/core/web/components/navigation/setupStepsNavProgressBar.tsx
+++ b/core/web/components/navigation/setupStepsNavProgressBar.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { SetupStepAPIData } from "../../utils/apiData";
+import { ProgressBar } from "react-bootstrap";
+import Link from "next/link";
+
+export default function SetupStepsNavProgressBar({ execApi }) {
+  const [steps, setSteps] = useState<SetupStepAPIData[]>([]);
+  const [shouldDisplay, setShouldDisplay] = useState(false);
+
+  let timer: NodeJS.Timeout;
+  const timeout = 1000 * 15;
+
+  async function getSetupSteps() {
+    clearTimeout(timer);
+    const { setupSteps, toDisplay } = await execApi("get", `/setupSteps`);
+    setShouldDisplay(toDisplay);
+    setSteps(setupSteps);
+    if (toDisplay) timer = setTimeout(getSetupSteps, timeout);
+  }
+
+  useEffect(() => {
+    getSetupSteps();
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+
+  const activeStep = steps.find((step) => !step.complete);
+  const isOnBoardingComplete = steps.every((step) => step.complete);
+  const totalStepsCount = steps.length;
+  const completeStepsCount = steps.filter((step) => step.complete).length;
+  const percentComplete = Math.round(
+    (100 * completeStepsCount) / totalStepsCount
+  );
+
+  if (!shouldDisplay) return null;
+
+  return (
+    <div
+      style={{
+        backgroundColor: "white",
+        width: "100%",
+        padding: 20,
+        marginTop: 10,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 18,
+          paddingLeft: 0,
+          color: "var(--secondary)",
+        }}
+      >
+        <Link href="/setup">
+          <a>{isOnBoardingComplete ? "Setup Complete 🎉" : "Get Started:"}</a>
+        </Link>
+      </div>
+      <div
+        style={{
+          paddingLeft: 0,
+          paddingBottom: 10,
+          color: "var(--secondary)",
+        }}
+      >
+        {activeStep?.title}
+      </div>
+      <ProgressBar now={percentComplete} />
+    </div>
+  );
+}

--- a/core/web/components/navigation/setupStepsNavProgressBar.tsx
+++ b/core/web/components/navigation/setupStepsNavProgressBar.tsx
@@ -10,10 +10,10 @@ export default function SetupStepsNavProgressBar({ execApi }) {
   const router = useRouter();
 
   useEffect(() => {
-    router.events.on("routeChangeStart", getSetupSteps);
+    router?.events?.on("routeChangeStart", getSetupSteps);
     getSetupSteps();
     return () => {
-      router.events.off("routeChangeStart", getSetupSteps);
+      router?.events?.off("routeChangeStart", getSetupSteps);
     };
   }, []);
 

--- a/core/web/components/navigation/setupStepsNavProgressBar.tsx
+++ b/core/web/components/navigation/setupStepsNavProgressBar.tsx
@@ -4,15 +4,23 @@ import { ProgressBar } from "react-bootstrap";
 import Link from "next/link";
 import { useRouter } from "next/router";
 
-export default function SetupStepsNavProgressBar({ execApi }) {
+export default function SetupStepsNavProgressBar({
+  execApi,
+  setupStepHandler,
+}) {
   const [steps, setSteps] = useState<SetupStepAPIData[]>([]);
   const [shouldDisplay, setShouldDisplay] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
     router?.events?.on("routeChangeStart", getSetupSteps);
+    setupStepHandler.subscribe("setup-steps-nav-progress-bar", getSetupSteps);
     getSetupSteps();
     return () => {
+      setupStepHandler.unsubscribe(
+        "setup-steps-nav-progress-bar",
+        getSetupSteps
+      );
       router?.events?.off("routeChangeStart", getSetupSteps);
     };
   }, []);
@@ -23,10 +31,14 @@ export default function SetupStepsNavProgressBar({ execApi }) {
     setSteps(setupSteps);
   }
 
-  const activeStep = steps.find((step) => !step.complete);
-  const isOnBoardingComplete = steps.every((step) => step.complete);
+  const activeStep = steps.find((step) => !step.complete && !step.skipped);
+  const isOnBoardingComplete = steps.every(
+    (step) => step.complete || step.skipped
+  );
   const totalStepsCount = steps.length;
-  const completeStepsCount = steps.filter((step) => step.complete).length;
+  const completeStepsCount = steps.filter(
+    (step) => step.complete || step.skipped
+  ).length;
   const percentComplete = Math.round(
     (100 * completeStepsCount) / totalStepsCount
   );

--- a/core/web/components/navigation/setupStepsNavProgressBar.tsx
+++ b/core/web/components/navigation/setupStepsNavProgressBar.tsx
@@ -14,10 +14,10 @@ export default function SetupStepsNavProgressBar({
 
   useEffect(() => {
     router?.events?.on("routeChangeStart", getSetupSteps);
-    setupStepHandler.subscribe("setup-steps-nav-progress-bar", getSetupSteps);
+    setupStepHandler?.subscribe("setup-steps-nav-progress-bar", getSetupSteps);
     getSetupSteps();
     return () => {
-      setupStepHandler.unsubscribe(
+      setupStepHandler?.unsubscribe(
         "setup-steps-nav-progress-bar",
         getSetupSteps
       );

--- a/core/web/components/navigation/setupStepsNavProgressBar.tsx
+++ b/core/web/components/navigation/setupStepsNavProgressBar.tsx
@@ -13,9 +13,13 @@ export default function SetupStepsNavProgressBar({
   const router = useRouter();
 
   useEffect(() => {
-    router?.events?.on("routeChangeStart", getSetupSteps);
-    setupStepHandler?.subscribe("setup-steps-nav-progress-bar", getSetupSteps);
     getSetupSteps();
+    router?.events?.on("routeChangeStart", (url) => {
+      if (url !== "/" && url.match(/^\/session\//)) getSetupSteps();
+    });
+
+    setupStepHandler?.subscribe("setup-steps-nav-progress-bar", getSetupSteps);
+
     return () => {
       setupStepHandler?.unsubscribe(
         "setup-steps-nav-progress-bar",

--- a/core/web/components/navigation/setupStepsNavProgressBar.tsx
+++ b/core/web/components/navigation/setupStepsNavProgressBar.tsx
@@ -2,28 +2,26 @@ import { useEffect, useState } from "react";
 import { SetupStepAPIData } from "../../utils/apiData";
 import { ProgressBar } from "react-bootstrap";
 import Link from "next/link";
+import { useRouter } from "next/router";
 
 export default function SetupStepsNavProgressBar({ execApi }) {
   const [steps, setSteps] = useState<SetupStepAPIData[]>([]);
   const [shouldDisplay, setShouldDisplay] = useState(false);
+  const router = useRouter();
 
-  let timer: NodeJS.Timeout;
-  const timeout = 1000 * 15;
+  useEffect(() => {
+    router.events.on("routeChangeStart", getSetupSteps);
+    getSetupSteps();
+    return () => {
+      router.events.off("routeChangeStart", getSetupSteps);
+    };
+  }, []);
 
   async function getSetupSteps() {
-    clearTimeout(timer);
     const { setupSteps, toDisplay } = await execApi("get", `/setupSteps`);
     setShouldDisplay(toDisplay);
     setSteps(setupSteps);
-    if (toDisplay) timer = setTimeout(getSetupSteps, timeout);
   }
-
-  useEffect(() => {
-    getSetupSteps();
-    return () => {
-      clearTimeout(timer);
-    };
-  }, []);
 
   const activeStep = steps.find((step) => !step.complete);
   const isOnBoardingComplete = steps.every((step) => step.complete);

--- a/core/web/components/setupSteps/setupStepCard.tsx
+++ b/core/web/components/setupSteps/setupStepCard.tsx
@@ -3,10 +3,8 @@ import { Accordion, Card, Row, Col, Button, Badge } from "react-bootstrap";
 
 export default function SetupStepCard({
   setupStep: step,
-  active,
 }: {
   setupStep: SetupStepAPIData;
-  active: boolean;
 }) {
   return (
     <>
@@ -36,11 +34,11 @@ export default function SetupStepCard({
           <Accordion.Collapse eventKey="0">
             <Card.Body>
               <p>{step.description}</p>
-              {active ? (
-                <p>
-                  <Button href={step.href}>{step.cta}</Button>
-                </p>
-              ) : null}
+              <p>
+                <Button size="sm" href={step.href}>
+                  {step.cta}
+                </Button>
+              </p>
             </Card.Body>
           </Accordion.Collapse>
         </Card>

--- a/core/web/components/setupSteps/setupStepCard.tsx
+++ b/core/web/components/setupSteps/setupStepCard.tsx
@@ -1,20 +1,42 @@
+import { useState } from "react";
 import { SetupStepAPIData } from "../../utils/apiData";
 import { Accordion, Card, Row, Col, Button, Badge } from "react-bootstrap";
 
 export default function SetupStepCard({
   setupStep: step,
+  execApi,
+  reload,
 }: {
   setupStep: SetupStepAPIData;
+  execApi: Function;
+  reload: Function;
 }) {
+  const [activeKey, setActiveKey] = useState(
+    step.skipped || step.complete ? null : "0"
+  );
+
+  async function skip() {
+    await execApi("put", `/setupStep/${step.guid}`, {
+      skipped: !step.skipped,
+    });
+    reload();
+    setActiveKey(step.skipped ? "0" : null);
+  }
+
   return (
     <>
-      <Accordion defaultActiveKey={step.complete ? null : "0"}>
+      <Accordion activeKey={activeKey}>
         <Card border={step.complete ? "success" : null}>
           <Card.Header>
             <Row>
               <Col>
                 <strong>
-                  <Accordion.Toggle as={Button} variant="link" eventKey="0">
+                  <Accordion.Toggle
+                    as={Button}
+                    variant="link"
+                    eventKey="0"
+                    onClick={() => setActiveKey(activeKey ? null : "0")}
+                  >
                     {step.position}: {step.title}
                   </Accordion.Toggle>
                 </strong>
@@ -28,17 +50,43 @@ export default function SetupStepCard({
                 {step.complete ? (
                   <span style={{ fontSize: 18 }}>✅</span>
                 ) : null}
+                {step.skipped && !step.complete ? (
+                  <span style={{ fontSize: 18 }}>➖</span>
+                ) : null}
               </Col>
             </Row>
           </Card.Header>
           <Accordion.Collapse eventKey="0">
             <Card.Body>
               <p>{step.description}</p>
-              <p>
-                <Button size="sm" href={step.href}>
-                  {step.cta}
-                </Button>
-              </p>
+              {step.complete ? null : (
+                <Row>
+                  <Col md={6}>
+                    <Button size="sm" href={step.href}>
+                      {step.cta}
+                    </Button>
+                  </Col>
+                  <Col md={6} style={{ textAlign: "right" }}>
+                    {step.skipped ? (
+                      <Button
+                        size="sm"
+                        variant="outline-dark"
+                        onClick={() => skip()}
+                      >
+                        un-skip
+                      </Button>
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant="outline-dark"
+                        onClick={() => skip()}
+                      >
+                        skip
+                      </Button>
+                    )}
+                  </Col>
+                </Row>
+              )}
             </Card.Body>
           </Accordion.Collapse>
         </Card>

--- a/core/web/pages/_app.tsx
+++ b/core/web/pages/_app.tsx
@@ -9,35 +9,37 @@ import Layout from "../components/layouts/main";
 
 import { ErrorHandler } from "../utils/errorHandler";
 import { SuccessHandler } from "../utils/successHandler";
-import { UploadHandler } from "../utils/uploadHandler";
+import { AppHandler } from "../utils/appHandler";
+import { DestinationHandler } from "../utils/destinationHandler";
+import { FileHandler } from "../utils/fileHandler";
+import { GroupHandler } from "../utils/groupHandler";
+import { ProfileHandler } from "../utils/profileHandler";
+import { ProfilePropertyRulesHandler } from "../utils/profilePropertyRulesHandler";
+import { RunsHandler } from "../utils/runsHandler";
+import { ScheduleHandler } from "../utils/scheduleHandler";
 import { SessionHandler } from "../utils/sessionHandler";
+import { SetupStepHandler } from "../utils/setupStepsHandler";
+import { SourceHandler } from "../utils/sourceHandler";
 import { TeamHandler } from "../utils/teamHandler";
 import { TeamMemberHandler } from "../utils/teamMembersHandler";
-import { AppHandler } from "../utils/appHandler";
-import { GroupHandler } from "../utils/groupHandler";
-import { RunsHandler } from "../utils/runsHandler";
-import { SourceHandler } from "../utils/sourceHandler";
-import { DestinationHandler } from "../utils/destinationHandler";
-import { ProfileHandler } from "../utils/profileHandler";
-import { ScheduleHandler } from "../utils/scheduleHandler";
-import { FileHandler } from "../utils/fileHandler";
-import { ProfilePropertyRulesHandler } from "../utils/profilePropertyRulesHandler";
+import { UploadHandler } from "../utils/uploadHandler";
 
 const successHandler = new SuccessHandler();
 const errorHandler = new ErrorHandler();
-const uploadHandler = new UploadHandler();
+const appHandler = new AppHandler();
+const destinationHandler = new DestinationHandler();
+const fileHandler = new FileHandler();
+const groupHandler = new GroupHandler();
+const profileHandler = new ProfileHandler();
+const profilePropertyRulesHandler = new ProfilePropertyRulesHandler();
+const runsHandler = new RunsHandler();
+const scheduleHandler = new ScheduleHandler();
 const sessionHandler = new SessionHandler();
+const setupStepHandler = new SetupStepHandler();
+const sourceHandler = new SourceHandler();
 const teamHandler = new TeamHandler();
 const teamMemberHandler = new TeamMemberHandler();
-const appHandler = new AppHandler();
-const groupHandler = new GroupHandler();
-const runsHandler = new RunsHandler();
-const sourceHandler = new SourceHandler();
-const destinationHandler = new DestinationHandler();
-const profileHandler = new ProfileHandler();
-const scheduleHandler = new ScheduleHandler();
-const fileHandler = new FileHandler();
-const profilePropertyRulesHandler = new ProfilePropertyRulesHandler();
+const uploadHandler = new UploadHandler();
 
 // we use require here because this is just a contained setup file that doesn't need to return any components or UI elements
 require("../components/icons");
@@ -76,21 +78,22 @@ export default function GrouparooWebApp(props) {
     previousPath,
     successHandler,
     errorHandler,
-    uploadHandler,
-    sessionHandler,
-    teamHandler,
-    teamMemberHandler,
-    appHandler,
-    groupHandler,
-    runsHandler,
-    sourceHandler,
-    destinationHandler,
-    profileHandler,
-    scheduleHandler,
-    fileHandler,
-    profilePropertyRulesHandler,
     query,
     pathname,
+    appHandler,
+    destinationHandler,
+    fileHandler,
+    groupHandler,
+    profileHandler,
+    profilePropertyRulesHandler,
+    runsHandler,
+    scheduleHandler,
+    sessionHandler,
+    setupStepHandler,
+    sourceHandler,
+    teamHandler,
+    teamMemberHandler,
+    uploadHandler,
   });
 
   return (

--- a/core/web/pages/profilePropertyRules.tsx
+++ b/core/web/pages/profilePropertyRules.tsx
@@ -5,7 +5,7 @@ import { useSecondaryEffect } from "../hooks/useSecondaryEffect";
 import { useHistoryPagination } from "../hooks/useHistoryPagination";
 import Router from "next/router";
 import Link from "next/link";
-import { Button, Form } from "react-bootstrap";
+import { Button, Form, Alert } from "react-bootstrap";
 import Moment from "react-moment";
 import Pagination from "../components/pagination";
 import LoadingTable from "../components/loadingTable";
@@ -86,6 +86,21 @@ export default function Page(props) {
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";
     Router[routerMethod](Router.route, url, { shallow: true });
+  }
+
+  if (sources.length === 0) {
+    return (
+      <>
+        <Alert variant="primary">
+          There are no Sources yet.
+          <br />
+          <br />
+          <Button size="sm" href="/sources">
+            Add Source
+          </Button>
+        </Alert>
+      </>
+    );
   }
 
   return (

--- a/core/web/pages/setup.tsx
+++ b/core/web/pages/setup.tsx
@@ -60,7 +60,6 @@ export default function Page({
             <SetupStepCard
               key={`setupStep-${setupStep.key}`}
               setupStep={setupStep}
-              active={currentStep?.position === setupStep.position}
             />
           ))}
         </Col>

--- a/core/web/utils/setupStepsHandler.ts
+++ b/core/web/utils/setupStepsHandler.ts
@@ -1,0 +1,3 @@
+import { EventDispatcher } from "./eventDispatcher";
+
+export class SetupStepHandler extends EventDispatcher {}


### PR DESCRIPTION
Enhancements to the Setup Steps (enhancing https://github.com/grouparoo/grouparoo/pull/715):
* Setup Steps can be Skipped and Un-Skipped
* Pull the latest Setup Steps state on a new page change
* Show all CTAs for every incomplete step

<img width="1334" alt="Screen Shot 2020-09-11 at 3 59 58 PM" src="https://user-images.githubusercontent.com/303226/92979523-d87ac000-f447-11ea-9885-55516050168f.png">

Closes T-501
Closes T-503
Closes T-469
Closes T-506