### PR TITLE
Grouparoo can update the descriptions and default values of Settings

### DIFF
--- a/core/api/__tests__/models/setting.ts
+++ b/core/api/__tests__/models/setting.ts
@@ -70,6 +70,24 @@ describe("models/setting", () => {
     expect(latestLog).toBeTruthy();
   });
 
+  test("settings can be updated via subsequent calls to registerSetting", async () => {
+    await plugin.registerSetting(
+      "testPlugin",
+      "key",
+      "value2",
+      "this is a better description of the setting",
+      "string"
+    );
+
+    const setting = await plugin.readSetting("testPlugin", "key");
+    expect(setting.key).toBe("key");
+    expect(setting.value).toBe("new value"); // no change
+    expect(setting.defaultValue).toBe("value2");
+    expect(setting.description).toBe(
+      "this is a better description of the setting"
+    );
+  });
+
   test("deleting a setting creates a log entry", async () => {
     const setting = await Setting.findOne({
       where: {

--- a/core/api/src/modules/plugin.ts
+++ b/core/api/src/modules/plugin.ts
@@ -91,7 +91,7 @@ export namespace plugin {
   ) {
     const setting = await Setting.findOne({ where: { pluginName, key } });
 
-    if (setting) return setting;
+    if (setting) return setting.update({ defaultValue, description, type });
 
     try {
       const setting = await Setting.create({


### PR DESCRIPTION
As Grouparoo evolves, we will want to update the default values and descriptions of Settings.  This PR does that!  

We will not update the current value of a Setting.

Closes T-499