### PR TITLE
Fix SetupStepsNavProgressBar reload check and Router warnings with dynamic pages

### DIFF
--- a/core/web/components/navigation.tsx
+++ b/core/web/components/navigation.tsx
@@ -163,7 +163,11 @@ export default function Navigation(props) {
               </a>
             </Link>
             <br />
-            <Badge variant="secondary">{clusterName}</Badge>
+            <Link href="/settings/[tab]" as="/settings/core">
+              <a>
+                <Badge variant="secondary">{clusterName}</Badge>
+              </a>
+            </Link>
           </div>
         </div>
 

--- a/core/web/components/navigation/setupStepsNavProgressBar.tsx
+++ b/core/web/components/navigation/setupStepsNavProgressBar.tsx
@@ -15,7 +15,7 @@ export default function SetupStepsNavProgressBar({
   useEffect(() => {
     getSetupSteps();
     router?.events?.on("routeChangeStart", (url) => {
-      if (url !== "/" && url.match(/^\/session\//)) getSetupSteps();
+      if (url !== "/" && !url.match(/^\/session\//)) getSetupSteps();
     });
 
     setupStepHandler?.subscribe("setup-steps-nav-progress-bar", getSetupSteps);

--- a/core/web/pages/destination/[guid]/edit.tsx
+++ b/core/web/pages/destination/[guid]/edit.tsx
@@ -49,7 +49,10 @@ export default function Page(props) {
         response.destination.state === "ready" &&
         destination.state === "draft"
       ) {
-        Router.push(`/destination/${destination.guid}/data`);
+        Router.push(
+          `/destination/[guid]/data`,
+          `/destination/${destination.guid}/data`
+        );
       } else {
         successHandler.set({ message: "Destination updated" });
       }

--- a/core/web/pages/destination/new.tsx
+++ b/core/web/pages/destination/new.tsx
@@ -18,9 +18,10 @@ export default function Page(props) {
     event.preventDefault();
     const response = await execApi("post", `/destination`, destination);
     if (response?.destination) {
-      Router.push({
-        pathname: `/destination/${response.destination.guid}/edit`,
-      });
+      Router.push(
+        "/destination/[guid]/edit",
+        `/destination/${response.destination.guid}/edit`
+      );
     }
   };
 

--- a/core/web/pages/setup.tsx
+++ b/core/web/pages/setup.tsx
@@ -54,6 +54,9 @@ export default function Page(props) {
           <a target="_blank" href="https://www.grouparoo.com/docs/community">
             Community
           </a>
+          <br />
+          <br />
+          <HideSetupButton />
         </Alert>
       )}
 
@@ -86,9 +89,7 @@ export default function Page(props) {
 
       <Row>
         <Col style={{ textAlign: "center" }}>
-          <Button href="/settings/interface" size="sm">
-            Hide this Setup Guide from everyone in your team
-          </Button>
+          <HideSetupButton />
         </Col>
       </Row>
     </>
@@ -100,3 +101,11 @@ Page.getInitialProps = async (ctx) => {
   const { setupSteps } = await execApi("get", `/setupSteps`);
   return { setupSteps };
 };
+
+function HideSetupButton() {
+  return (
+    <Button href="/settings/interface" size="sm">
+      Hide this Setup Guide from everyone in your team
+    </Button>
+  );
+}

--- a/core/web/pages/source/[guid]/edit.tsx
+++ b/core/web/pages/source/[guid]/edit.tsx
@@ -75,7 +75,7 @@ export default function Page(props) {
       setSource(response.source);
       sourceHandler.set(response.source);
       if (response.source.state !== "ready") {
-        Router.push(`/source/${guid}/mapping`);
+        Router.push(`/source/[guid]/mapping`, `/source/${guid}/mapping`);
       } else if (
         response.source.state === "ready" &&
         source.state === "draft"

--- a/core/web/pages/source/[guid]/mapping.tsx
+++ b/core/web/pages/source/[guid]/mapping.tsx
@@ -90,7 +90,10 @@ export default function Page(props) {
 
       // we just went 'ready'
       if (source.state !== response.source.state) {
-        Router.push(`/source/${source.guid}/overview`);
+        Router.push(
+          `/source/[guid]/overview`,
+          `/source/${source.guid}/overview`
+        );
       } else {
         successHandler.set({ message: "Source updated" });
       }

--- a/core/web/pages/source/new.tsx
+++ b/core/web/pages/source/new.tsx
@@ -18,7 +18,10 @@ export default function Page(props) {
     event.preventDefault();
     const response = await execApi("post", `/source`, source);
     if (response?.source) {
-      Router.push(`/source/${response.source.guid}/edit`);
+      Router.push(
+        "/source/[guid]/edit",
+        `/source/${response.source.guid}/edit`
+      );
     }
   };
 


### PR DESCRIPTION
Fix a few `next/router` errors and misc links.

Also closes T-448 making the name of the Cluster a link to `/settings/core`