### PR TITLE
Relax the validation requirements of email addresses

### DIFF
--- a/core/api/__tests__/models/profileProperty.ts
+++ b/core/api/__tests__/models/profileProperty.ts
@@ -227,9 +227,20 @@ describe("models/profileProperty", () => {
         profileGuid: profile.guid,
         profilePropertyRuleGuid: emailRule.guid,
       });
-      await expect(
-        profileProperty.setValue("someone.com")
-      ).rejects.toThrowError(/email .* is not valid/);
+
+      const badEmails = [
+        "someone",
+        "someone.com",
+        "someone.com@",
+        "someone@site",
+        "someone with spaces@site.com",
+      ];
+
+      for (const i in badEmails) {
+        await expect(
+          profileProperty.setValue(badEmails[i])
+        ).rejects.toThrowError(/email .* is not valid/);
+      }
     });
 
     test("very long emails are valid", async () => {
@@ -241,7 +252,7 @@ describe("models/profileProperty", () => {
         "Deleted-user-id-19430-Team-5051deleted-user-id-19430-team-5051XXXXXX@example.com";
       await profileProperty.setValue(value);
       const response = await profileProperty.getValue();
-      expect(response).toBe(value);
+      expect(response).toBe(value.toLowerCase());
     });
 
     test("urls", async () => {

--- a/core/api/__tests__/models/profileProperty.ts
+++ b/core/api/__tests__/models/profileProperty.ts
@@ -232,6 +232,18 @@ describe("models/profileProperty", () => {
       ).rejects.toThrowError(/email .* is not valid/);
     });
 
+    test("very long emails are valid", async () => {
+      const profileProperty = new ProfileProperty({
+        profileGuid: profile.guid,
+        profilePropertyRuleGuid: emailRule.guid,
+      });
+      const value =
+        "Deleted-user-id-19430-Team-5051deleted-user-id-19430-team-5051XXXXXX@example.com";
+      await profileProperty.setValue(value);
+      const response = await profileProperty.getValue();
+      expect(response).toBe(value);
+    });
+
     test("urls", async () => {
       const profileProperty = new ProfileProperty({
         profileGuid: profile.guid,

--- a/core/api/src/modules/ops/profileProperty.ts
+++ b/core/api/src/modules/ops/profileProperty.ts
@@ -1,6 +1,6 @@
 import { parsePhoneNumberFromString, CountryCode } from "libphonenumber-js/max";
 import { plugin } from "../../modules/plugin";
-import isEmail from "validator/lib/isEmail";
+import isEmail from "../validators/isEmail";
 import isURL from "validator/lib/isURL";
 
 export namespace ProfilePropertyOps {
@@ -83,15 +83,7 @@ function formatURL(url: string) {
 }
 
 function formatEmail(email: string) {
-  // The full set of validator options can be found at https://github.com/validatorjs/validator.js
-  const options = {
-    require_tld: false,
-    allow_display_name: true,
-    ignore_max_length: true,
-    allow_ip_domain: true,
-  };
-
-  if (!isEmail(email, options)) {
+  if (!isEmail(email)) {
     throw new Error(`email "${email}" is not valid`);
   }
 

--- a/core/api/src/modules/ops/profileProperty.ts
+++ b/core/api/src/modules/ops/profileProperty.ts
@@ -83,7 +83,15 @@ function formatURL(url: string) {
 }
 
 function formatEmail(email: string) {
-  if (!isEmail(email)) {
+  // The full set of validator options can be found at https://github.com/validatorjs/validator.js
+  const options = {
+    require_tld: false,
+    allow_display_name: true,
+    ignore_max_length: true,
+    allow_ip_domain: true,
+  };
+
+  if (!isEmail(email, options)) {
     throw new Error(`email "${email}" is not valid`);
   }
 

--- a/core/api/src/modules/validators/isEmail.ts
+++ b/core/api/src/modules/validators/isEmail.ts
@@ -1,0 +1,10 @@
+/**
+ * While there are many more robust ways to validate an email, we have seen our customers use long domains or suffixes to map to internal tools, deactivated users, etc.
+ * We will only be validating that 1) there is an @ and 2) there is a . after the @.
+ *
+ * We cannot use import isEmail from "validator/lib/isEmail" until https://github.com/validatorjs/validator.js/pull/1435 is merged in.
+ */
+export default function isEmail(string: string) {
+  if (string.match(/^\S+@\S+\.\S+$/)) return true;
+  return false;
+}


### PR DESCRIPTION
Relax the validation requirements of email addresses - Email addresses can now:
* Be longer than 254 chars
* The user (part of the email address before the `@`) and the domain can be longer than 64 and 254 bytes respectively
* Use an internal-looking domain (like `@company.internal`) 
* Include the display name (like `<evan>`) before the real email address
* Be against an IP address (like `person@1.2.3.4`)

Requires https://github.com/validatorjs/validator.js/pull/1435
Closes T-510