### PR TITLE
Allow Postgres SSL Connections (w/ custom certs)

### DIFF
--- a/plugins/@grouparoo/postgres/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/postgres/src/initializers/plugin.ts
@@ -58,6 +58,27 @@ export class Plugins extends Initializer {
               required: false,
               description: "the postgres user's password",
             },
+            {
+              key: "ssl",
+              required: false,
+              description:
+                "require the use of a SSL connection (default: false).  If you need custom SSL certificates paste in their values below",
+            },
+            {
+              key: "ssl_cert",
+              required: false,
+              description: "the ssl certificate",
+            },
+            {
+              key: "ssl_key",
+              required: false,
+              description: "the ssl certificate's key",
+            },
+            {
+              key: "ssl_ca",
+              required: false,
+              description: "the ssl certificate authority",
+            },
           ],
           methods: { test, connect, disconnect },
         },

--- a/plugins/@grouparoo/postgres/src/lib/connect.ts
+++ b/plugins/@grouparoo/postgres/src/lib/connect.ts
@@ -3,7 +3,26 @@ import format from "pg-format";
 import { ConnectPluginAppMethod } from "@grouparoo/core";
 
 export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
-  const client = new Client(appOptions);
+  const formattedOptions = Object.assign({}, appOptions);
+
+  // handle SSL options
+  const sslOptions = ["ssl_cert", "ssl_key", "ssl_ca"];
+  sslOptions.forEach((opt) => {
+    if (formattedOptions[opt] !== null && formattedOptions[opt] !== undefined) {
+      if (
+        !formattedOptions["ssl"] ||
+        typeof formattedOptions["ssl"] === "boolean" ||
+        typeof formattedOptions["ssl"] === "string"
+      ) {
+        formattedOptions["ssl"] = { rejectUnauthorized: false };
+      }
+
+      formattedOptions["ssl"][opt.replace("ssl_", "")] = formattedOptions[opt];
+      delete formattedOptions[opt];
+    }
+  });
+
+  const client = new Client(formattedOptions);
   await client.connect();
 
   if (appOptions.schema) {


### PR DESCRIPTION
This PR adds additional options to `@grouparoo/postgres` and `@grouparoo/redshift` to connect to your databases over SSL.  

In the case that your database has either a publicly-trusted root certificate, or your application server has loaded the certificate into the operating system, you can just set `ssl=true`. 

However, if you are using a self-signed certificate, you'll need to load in (at least) the certificate authority PEM (`ssl_ca`). A bit of a debugging journey is described below:

---
Let's say you are creating a AWS RDS Postgres server that you want to enforce SSL connections on.  Following the docs here: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.SSL you will need to:
  1. Create the database
  2. Grant public access (in the DB settings)
  3. Grant public access (via a security group) and apply it
  4. Create a new RDS parameter group that has `rds.force_ssl=1`
  5. Reboot the database

You can now verify that your Postgres server requires SSL connections via:

```
# Doesn't work with sslmode=disable
PGPASSWORD="xxx" psql -h database-1.xxx.us-east-1.rds.amazonaws.com --user postgres sslmode=disable
psql: error: could not connect to server: FATAL:  no pg_hba.conf entry for host "71.231.106.197", user "postgres", database "postgres", SSL off

# Works with sslmode=require
PGPASSWORD="xxx" psql -h database-1.xxx.us-east-1.rds.amazonaws.com --user postgres sslmode=require
psql (12.3)
SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
Type "help" for help.
```

Confirming in Node / Grouparoo, you'll get a similar connection error with SSL disabled:

<img width="993" alt="Screen Shot 2020-09-14 at 3 05 39 PM" src="https://user-images.githubusercontent.com/303226/93145272-c3e53480-f6a0-11ea-86ea-1100d1c2bbc3.png">

Now, Node.JS has some pretty strict opinions about trusting new SSL certificates.  If you just try to connect with `ssl=true`, you'll get an error like:

<img width="1016" alt="Screen Shot 2020-09-14 at 3 33 42 PM" src="https://user-images.githubusercontent.com/303226/93145326-e414f380-f6a0-11ea-9d67-67d8f116670a.png">

So we need to include the /certificate authority/ CA from AWS.  You can get that here https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem and learn more about it @ https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html

Finally, with CA included in your Grouparoo App Options, you can connect!

<img width="1015" alt="Screen Shot 2020-09-14 at 3 33 53 PM" src="https://user-images.githubusercontent.com/303226/93145384-0870d000-f6a1-11ea-97c8-363a4de3f726.png">

--- 

Note: There's [another option](https://nodejs.org/api/cli.html#cli_node_tls_reject_unauthorized_value) you can use to tell Node.JS to just trust all new Certificate Authorities for SSL connections, but this is not recommended. 

---

Closes https://github.com/grouparoo/grouparoo/issues/734
Closes T-511