### PR TITLE
Display if Apps can create a Source or Destination

### DIFF
--- a/core/api/__tests__/actions/apps.ts
+++ b/core/api/__tests__/actions/apps.ts
@@ -55,7 +55,7 @@ describe("actions/apps", () => {
       guid = app.guid;
     });
 
-    test("an administrator can get the options for a new app", async () => {
+    test("an administrator can get the options for a new app and how they can be used", async () => {
       connection.params = {
         csrfToken,
       };
@@ -68,6 +68,31 @@ describe("actions/apps", () => {
       const names = types.map((t) => t.name);
       expect(names).toContain("manual");
       expect(names).toContain("test-plugin-app");
+
+      const pluginTestAppType = types.find((t) => t.name === "test-plugin-app");
+      expect(pluginTestAppType.options).toEqual([
+        { key: "fileGuid", required: true },
+      ]);
+      expect(pluginTestAppType.plugin).toEqual({
+        name: "@grouparoo/test-plugin",
+        icon: "/path/to/icon.png",
+      });
+      expect(pluginTestAppType.source).toBe(true);
+      expect(pluginTestAppType.destination).toBe(true);
+
+      const eventsAppType = types.find((t) => t.name === "events");
+      expect(eventsAppType.options).toEqual([
+        expect.objectContaining({
+          key: "identifyingProfilePropertyRuleGuid",
+          required: true,
+        }),
+      ]);
+      expect(eventsAppType.plugin).toEqual({
+        name: "@grouparoo/core/events",
+        icon: "/public/@grouparoo/events/events.png",
+      });
+      expect(eventsAppType.source).toBe(true);
+      expect(eventsAppType.destination).toBe(false);
     });
 
     describe("options from environment variables", () => {

--- a/core/api/__tests__/actions/apps.ts
+++ b/core/api/__tests__/actions/apps.ts
@@ -77,8 +77,8 @@ describe("actions/apps", () => {
         name: "@grouparoo/test-plugin",
         icon: "/path/to/icon.png",
       });
-      expect(pluginTestAppType.source).toBe(true);
-      expect(pluginTestAppType.destination).toBe(true);
+      expect(pluginTestAppType.provides.source).toBe(true);
+      expect(pluginTestAppType.provides.destination).toBe(true);
 
       const eventsAppType = types.find((t) => t.name === "events");
       expect(eventsAppType.options).toEqual([
@@ -91,8 +91,8 @@ describe("actions/apps", () => {
         name: "@grouparoo/core/events",
         icon: "/public/@grouparoo/events/events.png",
       });
-      expect(eventsAppType.source).toBe(true);
-      expect(eventsAppType.destination).toBe(false);
+      expect(eventsAppType.provides.source).toBe(true);
+      expect(eventsAppType.provides.destination).toBe(false);
     });
 
     describe("options from environment variables", () => {

--- a/core/api/__tests__/models/app.ts
+++ b/core/api/__tests__/models/app.ts
@@ -122,6 +122,17 @@ describe("models/app", () => {
     await app.destroy();
   });
 
+  test("apps can determine if they will provide a source or destination", async () => {
+    const app = await App.create({
+      name: "test log app",
+      type: "test-plugin-app",
+    });
+
+    const provides = app.provides();
+    expect(provides).toEqual({ source: true, destination: true });
+    await app.destroy();
+  });
+
   test("deleting a app creates a log entry", async () => {
     const app = await App.create({
       name: "bye app",

--- a/core/api/src/actions/apps.ts
+++ b/core/api/src/actions/apps.ts
@@ -78,8 +78,7 @@ export class AppOptions extends AuthenticatedAction {
             addible: app.addible,
             options: app.options,
             plugin: { name: plugin.name, icon: plugin.icon },
-            source,
-            destination,
+            provides: { source, destination },
           });
         });
       }

--- a/core/api/src/actions/apps.ts
+++ b/core/api/src/actions/apps.ts
@@ -57,11 +57,29 @@ export class AppOptions extends AuthenticatedAction {
     api.plugins.plugins.map((plugin: GrouparooPlugin) => {
       if (plugin.apps) {
         plugin.apps.map((app) => {
+          const source = api.plugins.plugins.find((p) =>
+            p?.connections?.find(
+              (c) => c.app === app.name && c.direction === "import"
+            )
+          )
+            ? true
+            : false;
+
+          const destination = api.plugins.plugins.find((p) =>
+            p?.connections?.find(
+              (c) => c.app === app.name && c.direction === "export"
+            )
+          )
+            ? true
+            : false;
+
           response.types.push({
             name: app.name,
             addible: app.addible,
             options: app.options,
             plugin: { name: plugin.name, icon: plugin.icon },
+            source,
+            destination,
           });
         });
       }

--- a/core/api/src/models/App.ts
+++ b/core/api/src/models/App.ts
@@ -153,6 +153,7 @@ export class App extends LoggedModel<App> {
   async apiData() {
     const options = await this.getOptions(false);
     const icon = await this._getIcon();
+    const provides = this.provides();
 
     return {
       guid: this.guid,
@@ -161,9 +162,33 @@ export class App extends LoggedModel<App> {
       type: this.type,
       state: this.state,
       options,
+      provides,
       createdAt: this.createdAt ? this.createdAt.getTime() : null,
       updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,
     };
+  }
+
+  /**
+   * Determine if this App can provide Source or Destination Connections
+   */
+  provides() {
+    const source = api.plugins.plugins.find((p) =>
+      p?.connections?.find(
+        (c) => c.app === this.type && c.direction === "import"
+      )
+    )
+      ? true
+      : false;
+
+    const destination = api.plugins.plugins.find((p) =>
+      p?.connections?.find(
+        (c) => c.app === this.type && c.direction === "export"
+      )
+    )
+      ? true
+      : false;
+
+    return { source, destination };
   }
 
   async _getIcon() {

--- a/core/web/components/selector.tsx
+++ b/core/web/components/selector.tsx
@@ -1,4 +1,5 @@
 import AppIcon from "../components/appIcon";
+import { Row, Col, Badge } from "react-bootstrap";
 
 export default function Selector({
   src = "",
@@ -7,6 +8,7 @@ export default function Selector({
   iconClassName = "",
   subheading = "",
   description = "",
+  badges = [],
   className = "",
   onClick = () => {},
 }: {
@@ -17,6 +19,7 @@ export default function Selector({
   iconClassName?: string;
   subheading?: string;
   description?: string;
+  badges: { message?: string; variant?: string }[];
   onClick?: any;
 }) {
   return (
@@ -63,6 +66,23 @@ export default function Selector({
             <br />
             {description}
           </p>
+        ) : null}
+        {badges ? (
+          <Row>
+            {badges.map(({ message, variant }, idx) => (
+              <Col
+                key={`badge-${title}-${idx}`}
+                md={6}
+                style={{ textAlign: "center" }}
+              >
+                {message ? (
+                  <Badge pill variant={variant}>
+                    {message}
+                  </Badge>
+                ) : null}
+              </Col>
+            ))}
+          </Row>
         ) : null}
       </div>
     </div>

--- a/core/web/components/selectorList.tsx
+++ b/core/web/components/selectorList.tsx
@@ -30,6 +30,7 @@ export default function SelectorList({
         let subheading: string;
         let description: string;
         let className: string;
+        let badges: { message?: string; variant?: string }[] = [];
 
         if (item?.app?.guid) {
           // these items are connectionApps, i.e.: ({connection: {}, app: {}})
@@ -50,6 +51,18 @@ export default function SelectorList({
             item.name === selectedItem.type
               ? "selector-list-selected"
               : "selector-list";
+
+          if (item.source) {
+            badges.push({ message: "source", variant: "primary" });
+          } else {
+            badges.push({});
+          }
+
+          if (item.destination) {
+            badges.push({ message: "destination", variant: "info" });
+          } else {
+            badges.push({});
+          }
         } else {
           throw new Error("I do not know what that is");
         }
@@ -63,6 +76,7 @@ export default function SelectorList({
             size={120}
             className={className}
             iconClassName="card-img"
+            badges={badges}
             onClick={() => onClick(item)}
             key={`card-${idx}`}
           />

--- a/core/web/components/selectorList.tsx
+++ b/core/web/components/selectorList.tsx
@@ -52,13 +52,13 @@ export default function SelectorList({
               ? "selector-list-selected"
               : "selector-list";
 
-          if (item.source) {
+          if (item.provides.source) {
             badges.push({ message: "source", variant: "primary" });
           } else {
             badges.push({});
           }
 
-          if (item.destination) {
+          if (item.provides.destination) {
             badges.push({ message: "destination", variant: "info" });
           } else {
             badges.push({});

--- a/core/web/pages/app/[guid]/edit.tsx
+++ b/core/web/pages/app/[guid]/edit.tsx
@@ -110,9 +110,18 @@ export default function Page(props) {
 
       <Form id="form" onSubmit={edit}>
         <Row>
-          <Col md={1}>
+          <Col md={1} style={{ textAlign: "center" }}>
             <br />
             <AppIcon src={app.icon} fluid size={100} />
+            <br />
+            <br />
+            {app.provides.source ? (
+              <Badge variant="primary">source</Badge>
+            ) : null}
+            <br />
+            {app.provides.destination ? (
+              <Badge variant="info">destination</Badge>
+            ) : null}
           </Col>
 
           <Col>

--- a/core/web/pages/destination/new.tsx
+++ b/core/web/pages/destination/new.tsx
@@ -35,7 +35,8 @@ export default function Page(props) {
   if (connectionApps.length === 0) {
     return (
       <p>
-        Please create an{" "}
+        There are no Apps in the <code>ready</code> state which can be used to
+        create a Destination. Please create an{" "}
         <Link href="/apps">
           <a>App</a>
         </Link>{" "}

--- a/core/web/pages/source/new.tsx
+++ b/core/web/pages/source/new.tsx
@@ -35,7 +35,8 @@ export default function Page(props) {
   if (connectionApps.length === 0) {
     return (
       <p>
-        Please create an{" "}
+        There are no Apps in the <code>ready</code> state which can be used to
+        create a Source. Please create an{" "}
         <Link href="/apps">
           <a>App</a>
         </Link>{" "}


### PR DESCRIPTION
This PR adds badges on the App Creation grid to display if the App can be used for a Destination, Source, or Both.  

<img width="1569" alt="Screen Shot 2020-09-15 at 9 08 01 AM" src="https://user-images.githubusercontent.com/303226/93237525-1a03b780-f735-11ea-9614-7ed6bb585532.png">

The badges also appear when editing an App

<img width="695" alt="Screen Shot 2020-09-15 at 9 35 14 AM" src="https://user-images.githubusercontent.com/303226/93239002-0ce7c800-f737-11ea-9f6d-afb5c0206eac.png">

This PR also clarifies the messaging for when you are attempting to create a new Source or Destination and you do not yet have an App that can provide the appropriate type:

<img width="1302" alt="Screen Shot 2020-09-15 at 9 20 00 AM" src="https://user-images.githubusercontent.com/303226/93237586-2f78e180-f735-11ea-9d5b-85921ce29d0b.png">

Closes https://github.com/grouparoo/grouparoo/issues/737
Closes T-513