### PR TITLE
Do not update Group#calculatedAt within transaction (SequelizeConnectionAcquireTimeoutError)

### DIFF
--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -8,7 +8,6 @@ import {
   Default,
   BelongsToMany,
   BeforeSave,
-  AfterSave,
   BeforeDestroy,
   AfterDestroy,
   Is,

--- a/core/api/src/modules/ops/group.ts
+++ b/core/api/src/modules/ops/group.ts
@@ -277,11 +277,8 @@ export namespace GroupOps {
         groupMembersCount++;
       }
 
-      group.calculatedAt = new Date();
-      await group.save({ transaction });
-
       await transaction.commit();
-
+      await group.update({ calculatedAt: new Date() });
       return groupMembersCount;
     } catch (error) {
       await transaction.rollback();
@@ -334,11 +331,8 @@ export namespace GroupOps {
         groupMembersCount++;
       }
 
-      group.calculatedAt = new Date();
-      await group.save({ transaction });
-
       await transaction.commit();
-
+      await group.update({ calculatedAt: new Date() });
       return groupMembersCount;
     } catch (error) {
       await transaction.rollback();


### PR DESCRIPTION
If there were many Runs which were attempting to update a single Group, it was possible to end up with lock contention between the transactions to update `Group#calculatedAt`.   This leads to a class of error like `SequelizeConnectionAcquireTimeoutError `

The relevant transactions exist to ensure that the creation of Imports for the profiles in that Group all succeed or fail together, and as they are newly created, should not be victim to the same types of lock contention.    However, if there were 2 parallel transactions, both would attempt to get a lock on the Group to update `Group#calculatedAt`, and eventually timeout and fail.

This PR moves the update of `Group#calculatedAt` outside of the transaction.  It's OK if this is re-updated by the other run - the timestamp will be close enough. 

Closes T-484