### PR TITLE
Groups can be force-deleted

### DIFF
--- a/core/api/__tests__/actions/groups.ts
+++ b/core/api/__tests__/actions/groups.ts
@@ -171,7 +171,7 @@ describe("actions/groups", () => {
       await destination.destroy();
     });
 
-    test("an administrator can destroy a group", async () => {
+    test("an administrator can enqueue a group to be destroyed", async () => {
       connection.params = {
         csrfToken,
         guid,
@@ -185,6 +185,24 @@ describe("actions/groups", () => {
 
       const foundTasks = await specHelper.findEnqueuedTasks("group:destroy");
       expect(foundTasks.length).toBe(1);
+    });
+
+    test("an administrator can force destroy a group", async () => {
+      const newGroup = await helper.factories.group();
+
+      connection.params = {
+        csrfToken,
+        guid: newGroup.guid,
+        force: true,
+      };
+      const destroyResponse = await specHelper.runAction(
+        "group:destroy",
+        connection
+      );
+      expect(destroyResponse.error).toBeUndefined();
+      expect(destroyResponse.success).toBe(true);
+
+      expect(await Group.count({ where: { guid: newGroup.guid } })).toBe(0);
     });
 
     describe("calculated group", () => {

--- a/core/api/src/tasks/group/destroy.ts
+++ b/core/api/src/tasks/group/destroy.ts
@@ -27,7 +27,8 @@ export class GroupDestroy extends Task {
         (await plugin.readSetting("core", "runs-profile-batch-size")).value
       );
 
-    const group = await Group.findByGuid(params.groupGuid);
+    const group = await Group.findOne({ where: { guid: params.groupGuid } });
+    if (!group) return; // the group may have been force-deleted
 
     let run: Run;
     if (params.runGuid) {

--- a/core/web/pages/group/[guid]/edit.tsx
+++ b/core/web/pages/group/[guid]/edit.tsx
@@ -37,13 +37,17 @@ export default function Page(props) {
     }
   }
 
-  async function handleDelete() {
+  async function handleDelete(force = false) {
     if (window.confirm("are you sure?")) {
       setLoading(true);
-      const response = await execApi("delete", `/group/${group.guid}`);
+      const response = await execApi("delete", `/group/${group.guid}`, {
+        force,
+      });
       setLoading(false);
       if (response?.success) {
-        successHandler.set({ message: "Group Deleted" });
+        successHandler.set({
+          message: force ? "Group Deleted" : "Group scheduled to be deleted",
+        });
         Router.push("/groups");
       }
     }
@@ -115,15 +119,38 @@ export default function Page(props) {
 
             <br />
             <br />
-            <Button
-              variant="danger"
-              size="sm"
-              onClick={() => {
-                handleDelete();
-              }}
-            >
-              Delete
-            </Button>
+
+            {group.state === "deleted" ? (
+              <>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  onClick={() => {
+                    handleDelete(true);
+                  }}
+                >
+                  Force Delete
+                </Button>
+                <p>
+                  <br />
+                  <em>
+                    Force-Deleting this Group will immediately remove all Group
+                    Members, but not export them to Destinations. Only use this
+                    if there is a problem with your Group.
+                  </em>
+                </p>
+              </>
+            ) : (
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => {
+                  handleDelete();
+                }}
+              >
+                Delete
+              </Button>
+            )}
           </Form>
         </Col>
         {group.type === "calculated" ? (


### PR DESCRIPTION
In the event that we are having trouble importing Profiles, we can choose to `force delete` a group.  This option will skip trying to import and export the profiles... and just delete the group.  This option only appears when the group is already in the "deleted" state.

<img width="1326" alt="Screen Shot 2020-09-16 at 5 50 49 PM" src="https://user-images.githubusercontent.com/303226/93407389-ee70f200-f846-11ea-9ce3-7dffbd96819b.png">


Closes T-362
