### PR TITLE
Destinations can share the same App if they have different Options

### DIFF
--- a/core/api/__tests__/actions/destinations.ts
+++ b/core/api/__tests__/actions/destinations.ts
@@ -64,7 +64,7 @@ describe("actions/destinations", () => {
       guid = destination.guid;
     });
 
-    test("only one destination can be created for each app", async () => {
+    test("only one destination can be created for each app with the same options", async () => {
       connection.params = {
         csrfToken,
         name: "test destination again",
@@ -77,7 +77,7 @@ describe("actions/destinations", () => {
       );
 
       expect(error.message).toMatch(
-        'destination "test destination" is already using this app'
+        /destination "test destination" .* is already using this app with the same options/
       );
     });
 


### PR DESCRIPTION
This PR allows the same App to be used for multiple Destinations, provided that they have different Options. 

<img width="1484" alt="Screen Shot 2020-09-17 at 10 44 07 AM" src="https://user-images.githubusercontent.com/303226/93507741-faa29100-f8d2-11ea-9e9d-73d32f35704b.png">


Closes T-516