### PR TITLE
Event source filters

### DIFF
--- a/core/api/src/initializers/events.ts
+++ b/core/api/src/initializers/events.ts
@@ -1,5 +1,5 @@
 import { api, Initializer, log } from "actionhero";
-import { ProfilePropertyRule } from "../index";
+import { ProfilePropertyRule } from "../models/ProfilePropertyRule";
 import { plugin } from "../modules/plugin";
 import { SourceOptionsMethodResponse } from "../classes/plugin";
 import { App } from "../models/App";
@@ -11,7 +11,7 @@ import {
   PluginConnectionProfilePropertyRuleOption,
   SourceFilterMethod,
   ProfilePropertyPluginMethod,
-} from "./../index";
+} from "../classes/plugin";
 
 export class Events extends Initializer {
   constructor() {
@@ -231,7 +231,6 @@ const eventProfileProperty: ProfilePropertyPluginMethod = async ({
   sourceOptions,
   profilePropertyRuleOptions,
   profilePropertyRuleFilters,
-  profilePropertyRule,
 }) => {
   let events: Event[];
   if (!profilePropertyRuleOptions["column"]) return;
@@ -253,6 +252,17 @@ const eventProfileProperty: ProfilePropertyPluginMethod = async ({
     );
     events = await Event.findAll({
       where,
+      include:
+        Object.keys(includeWhere).length > 0
+          ? [
+              {
+                model: EventData,
+                required: true,
+                where: includeWhere,
+                attributes: [],
+              },
+            ]
+          : undefined,
       order: [["occurredAt", "asc"]],
     });
   } else if (aggregationMethod === "most recent value") {
@@ -265,6 +275,17 @@ const eventProfileProperty: ProfilePropertyPluginMethod = async ({
     );
     events = await Event.findAll({
       where,
+      include:
+        Object.keys(includeWhere).length > 0
+          ? [
+              {
+                model: EventData,
+                required: true,
+                where: includeWhere,
+                attributes: [],
+              },
+            ]
+          : undefined,
       order: [["occurredAt", "desc"]],
       limit: 1,
     });
@@ -278,6 +299,17 @@ const eventProfileProperty: ProfilePropertyPluginMethod = async ({
     );
     events = await Event.findAll({
       where,
+      include:
+        Object.keys(includeWhere).length > 0
+          ? [
+              {
+                model: EventData,
+                required: true,
+                where: includeWhere,
+                attributes: [],
+              },
+            ]
+          : undefined,
       order: [["occurredAt", "asc"]],
       limit: 1,
     });
@@ -293,6 +325,7 @@ const eventProfileProperty: ProfilePropertyPluginMethod = async ({
       profileGuid: profile.guid,
       type: sourceOptions["type"],
     };
+
     Event.applyProfilePropertyRuleFilters(
       includeWhere,
       where,

--- a/core/api/src/models/Event.ts
+++ b/core/api/src/models/Event.ts
@@ -200,7 +200,7 @@ export class Event extends LoggedModel<Event> {
       }
 
       let match = filter.match;
-      let opSymbol: any; // symbol...
+      let opSymbol: symbol;
       switch (filter.op) {
         case "equals":
           opSymbol = Op["eq"];
@@ -210,13 +210,11 @@ export class Event extends LoggedModel<Event> {
           break;
         case "contains":
           opSymbol = Op["iLike"];
-          match = `%${match.toString().toLowerCase()}%`;
-          key = `LOWER("${key}")`;
+          match = `%${match.toString()}%`;
           break;
         case "does not contain":
           opSymbol = Op["notILike"];
-          match = `%${match.toString().toLowerCase()}%`;
-          key = `LOWER("${key}")`;
+          match = `%${match.toString()}%`;
           break;
         case "greater than":
           opSymbol = Op["gt"];
@@ -226,10 +224,12 @@ export class Event extends LoggedModel<Event> {
           break;
       }
 
-      const localWhere = {};
+      let localWhere = {};
       if (filter.key.match(/^\[data\]-/)) {
+        // we need to check both the value and key in the case of negation matches
         localWhere[opSymbol] = match;
         eventDataWhere["value"] = localWhere;
+        eventDataWhere["key"] = key;
       } else if (key === "occurredAt") {
         localWhere[opSymbol] = new Date(parseInt(match.toString()));
         eventWhere[key] = localWhere;

--- a/core/web/components/destination/profilePreview.tsx
+++ b/core/web/components/destination/profilePreview.tsx
@@ -2,16 +2,18 @@ import { useState, useEffect } from "react";
 import { useApi } from "../../hooks/useApi";
 import { Card, ListGroup } from "react-bootstrap";
 import Loader from "../loader";
+import Router from "next/router";
 
 export default function ProfilePreview(props) {
   const {
+    query,
     errorHandler,
     destination,
     groups,
     trackedGroupGuid,
     mappingOptions,
   } = props;
-  const [profileGuid, setProfileGuid] = useState("");
+  const [profileGuid, setProfileGuid] = useState(query.profileGuid);
   const [toHide, setToHide] = useState(true);
   const [profile, setProfile] = useState({
     guid: "",
@@ -39,6 +41,16 @@ export default function ProfilePreview(props) {
     JSON.stringify(destination.mapping),
     JSON.stringify(destination.destinationGroupMemberships),
   ]);
+
+  function storeProfilePropertyGuid(profileGuid: string) {
+    setProfileGuid(profileGuid);
+    let url = `${window.location.pathname}?`;
+    url += `profileGuid=${profileGuid}&`;
+
+    const routerMethod =
+      url === `${window.location.pathname}?` ? "replace" : "push";
+    Router[routerMethod](Router.route, url, { shallow: true });
+  }
 
   async function load(
     _profileGuid = profileGuid === "" ? undefined : profileGuid,
@@ -75,7 +87,7 @@ export default function ProfilePreview(props) {
       if (response?.profile) {
         setToHide(false);
         setProfile(response.profile);
-        setProfileGuid(response.profile.guid);
+        storeProfilePropertyGuid(response.profile.guid);
       }
 
       setSleeping(false);
@@ -85,7 +97,7 @@ export default function ProfilePreview(props) {
   function chooseProfileProperty() {
     const _profileGuid = prompt("Enter Profile Guid", profileGuid);
     if (_profileGuid) {
-      setProfileGuid(_profileGuid);
+      storeProfilePropertyGuid(_profileGuid);
       load(_profileGuid, 1);
     }
   }

--- a/core/web/components/profilePropertyRule/profilePreview.tsx
+++ b/core/web/components/profilePropertyRule/profilePreview.tsx
@@ -3,10 +3,11 @@ import { useApi } from "../../hooks/useApi";
 import { Card, ListGroup } from "react-bootstrap";
 import Loader from "../loader";
 import ProfileImageFromEmail from "../visualizations/profileImageFromEmail";
+import Router from "next/router";
 
 export default function ProfilePreview(props) {
-  const { errorHandler, profilePropertyRule } = props;
-  const [profileGuid, setProfileGuid] = useState("");
+  const { query, errorHandler, profilePropertyRule } = props;
+  const [profileGuid, setProfileGuid] = useState(query.profileGuid);
   const [toHide, setToHide] = useState(true);
   const [profile, setProfile] = useState({ guid: "", properties: {} });
   const [sleeping, setSleeping] = useState(false);
@@ -32,6 +33,16 @@ export default function ProfilePreview(props) {
     JSON.stringify(profilePropertyRule.options),
     JSON.stringify(profilePropertyRule.filters),
   ]);
+
+  function storeProfilePropertyGuid(profileGuid: string) {
+    setProfileGuid(profileGuid);
+    let url = `${window.location.pathname}?`;
+    url += `profileGuid=${profileGuid}&`;
+
+    const routerMethod =
+      url === `${window.location.pathname}?` ? "replace" : "push";
+    Router[routerMethod](Router.route, url, { shallow: true });
+  }
 
   async function load(
     _profileGuid = profileGuid === "" ? undefined : profileGuid,
@@ -64,7 +75,7 @@ export default function ProfilePreview(props) {
             : ""
         );
         setProfile(response.profile);
-        setProfileGuid(response.profile.guid);
+        storeProfilePropertyGuid(response.profile.guid);
       }
 
       setSleeping(false);
@@ -74,7 +85,7 @@ export default function ProfilePreview(props) {
   function chooseProfileProperty() {
     const _profileGuid = prompt("Enter Profile Guid", profileGuid);
     if (_profileGuid) {
-      setProfileGuid(_profileGuid);
+      storeProfilePropertyGuid(_profileGuid);
       load(_profileGuid, 1);
     }
   }

--- a/core/web/components/profilePropertyRule/profilePreview.tsx
+++ b/core/web/components/profilePropertyRule/profilePreview.tsx
@@ -6,7 +6,7 @@ import ProfileImageFromEmail from "../visualizations/profileImageFromEmail";
 import Router from "next/router";
 
 export default function ProfilePreview(props) {
-  const { query, errorHandler, profilePropertyRule } = props;
+  const { query, errorHandler, profilePropertyRule, localFilters } = props;
   const [profileGuid, setProfileGuid] = useState(query.profileGuid);
   const [toHide, setToHide] = useState(true);
   const [profile, setProfile] = useState({ guid: "", properties: {} });
@@ -32,6 +32,7 @@ export default function ProfilePreview(props) {
     profilePropertyRule.isArray,
     JSON.stringify(profilePropertyRule.options),
     JSON.stringify(profilePropertyRule.filters),
+    JSON.stringify(localFilters),
   ]);
 
   function storeProfilePropertyGuid(profileGuid: string) {
@@ -58,7 +59,7 @@ export default function ProfilePreview(props) {
         `/profilePropertyRule/${profilePropertyRule.guid}/profilePreview`,
         {
           options: profilePropertyRule.options,
-          filters: profilePropertyRule.filters,
+          filters: localFilters,
           profileGuid: _profileGuid,
         }
       );

--- a/core/web/pages/profile/[guid]/edit.tsx
+++ b/core/web/pages/profile/[guid]/edit.tsx
@@ -368,17 +368,3 @@ Page.getInitialProps = async (ctx) => {
   const { apps } = await execApi("get", `/apps`);
   return { profile, profilePropertyRules, groups, allGroups, apps };
 };
-
-function renderProperty(values: Array<any>, type: string) {
-  return values
-    .map((value) => {
-      if (value === true || value === false) {
-        return <input type="checkbox" value={value} checked={value} readOnly />;
-      } else if (type === "date") {
-        return value ? new Date(value).toLocaleString() : value;
-      } else {
-        return value;
-      }
-    })
-    .join(", ");
-}

--- a/core/web/pages/profilePropertyRule/[guid]/edit.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/edit.tsx
@@ -621,6 +621,7 @@ export default function Page(props) {
           <Col md={3}>
             <ProfilePreview
               {...props}
+              localFilters={localFilters}
               profilePropertyRule={profilePropertyRule}
             />
           </Col>


### PR DESCRIPTION
Fixes a Bug in which the filtering of Events being used for Profile Property Rules was not working.  

Also:
* The UI now remembers which Profile you are previewing by storing the ProfileGuid in the URL (allows for direct linking too).
* The Profile Preview now considers the local state of your Filters

<img width="1121" alt="Screen Shot 2020-09-17 at 2 56 39 PM" src="https://user-images.githubusercontent.com/303226/93532616-40bd1c00-f8f6-11ea-8a04-78aa3c2f3ee4.png">


Closes T-490
Closes T-125