### PR TITLE
Display Hydration errors and do not 500

### DIFF
--- a/core/web/components/alerts/hydrationError.tsx
+++ b/core/web/components/alerts/hydrationError.tsx
@@ -1,0 +1,24 @@
+import { Card } from "react-bootstrap";
+
+export default function HydrationError({
+  hydrationError,
+}: {
+  hydrationError: string;
+}) {
+  const parsed = JSON.parse(hydrationError);
+  const error = new Error(parsed.message);
+  error.stack = parsed.stack;
+
+  return (
+    <>
+      <Card border={"warning"}>
+        <Card.Header>There was an Error loading this Page</Card.Header>
+        <Card.Body>
+          <blockquote className="blockquote mb-0">
+            <p>{error.message}</p>
+          </blockquote>
+        </Card.Body>
+      </Card>
+    </>
+  );
+}

--- a/core/web/components/layouts/main.tsx
+++ b/core/web/components/layouts/main.tsx
@@ -7,9 +7,16 @@ import SuccessAlert from "../alerts/success";
 import ErrorAlert from "../alerts/error";
 import Navigation from "../navigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import HydrationError from "../alerts/hydrationError";
 
 export default function Main(props) {
-  const { display, children, successHandler, errorHandler } = props;
+  const {
+    display,
+    children,
+    successHandler,
+    errorHandler,
+    hydrationError,
+  } = props;
   const [navExpanded, setNavExpanded] = useState(true);
   const [alertWidth, setAlertWidth] = useState(500);
   const contentAreaLeftPadding = 265;
@@ -140,6 +147,7 @@ export default function Main(props) {
           navExpanded={navExpanded}
           toggleNavExpanded={() => setNavExpanded(!navExpanded)}
         />
+
         <div
           id="navigation-toggle"
           style={{
@@ -183,7 +191,15 @@ export default function Main(props) {
               </div>
             </div>
           </div>
-          {display ? children : <Loader />}
+          {display ? (
+            hydrationError ? (
+              <HydrationError hydrationError={hydrationError} />
+            ) : (
+              children
+            )
+          ) : (
+            <Loader />
+          )}
         </div>
       </div>
     </>

--- a/core/web/pages/404.tsx
+++ b/core/web/pages/404.tsx
@@ -1,7 +1,15 @@
+import { Card } from "react-bootstrap";
+
 export default function FourOFourPage() {
   return (
-    <div>
-      <h1>Page not found :(</h1>
-    </div>
+    <>
+      <Card border={"warning"}>
+        <Card.Body>
+          <blockquote className="blockquote mb-0">
+            <p>This page cannot be found :(</p>
+          </blockquote>
+        </Card.Body>
+      </Card>
+    </>
   );
 }

--- a/core/web/pages/_app.tsx
+++ b/core/web/pages/_app.tsx
@@ -45,7 +45,7 @@ const uploadHandler = new UploadHandler();
 require("../components/icons");
 
 export default function GrouparooWebApp(props) {
-  const { Component, pageProps, err } = props;
+  const { Component, pageProps, err, hydrationError } = props;
   const [routerReady, setRouterReady] = useState(false);
   const [previousPath, setPreviousPath] = useState("");
   const router = useRouter();
@@ -98,7 +98,11 @@ export default function GrouparooWebApp(props) {
 
   return (
     <Injection {...combinedProps}>
-      <Layout display={routerReady} {...combinedProps}>
+      <Layout
+        display={routerReady}
+        hydrationError={hydrationError}
+        {...combinedProps}
+      >
         <Component {...combinedProps} err={err} />
       </Layout>
     </Injection>
@@ -120,7 +124,13 @@ GrouparooWebApp.getInitialProps = async (appContext) => {
   }
 
   // render page-specific getInitialProps
-  const appProps = await App.getInitialProps(appContext);
+  let appProps = {};
+  let hydrationError: string;
+  try {
+    appProps = await App.getInitialProps(appContext);
+  } catch (_error) {
+    hydrationError = JSON.stringify(_error, Object.getOwnPropertyNames(_error));
+  }
 
   return {
     ...appProps,
@@ -128,5 +138,6 @@ GrouparooWebApp.getInitialProps = async (appContext) => {
     navigationMode,
     navigation,
     clusterName,
+    hydrationError,
   };
 };


### PR DESCRIPTION
In the event that a page cannot be hydrated and gets an error from the API, we should not crash.  Now, we render the error and eject from the normal Component tree.  The exception to this is errors around loading the navigation and logged-in-user, which should continue to throw errors.

<img width="1241" alt="Screen Shot 2020-09-17 at 3 54 12 PM" src="https://user-images.githubusercontent.com/303226/93536617-4b7baf00-f8fe-11ea-9daa-2fbd5eb7c1b7.png">

Closes T-57