### PR TITLE
Setup Steps Navigation Bar uses same color as background

### DIFF
--- a/core/web/components/navigation/setupStepsNavProgressBar.tsx
+++ b/core/web/components/navigation/setupStepsNavProgressBar.tsx
@@ -52,7 +52,7 @@ export default function SetupStepsNavProgressBar({
   return (
     <div
       style={{
-        backgroundColor: "white",
+        backgroundColor: "var(--grouparoo-background-blue)",
         width: "100%",
         padding: 20,
         marginTop: 10,

--- a/core/web/scss/grouparoo.scss
+++ b/core/web/scss/grouparoo.scss
@@ -15,6 +15,13 @@ $grouparoo-light-violet: #d3d3ff;
 $grouparoo-background-blue: #f6fafb;
 $grouparoo-green: #3fb618;
 
+// define colors we don't use elsewhere as bootstrap elements
+:root {
+  --grouparoo-background-blue: #{$grouparoo-background-blue};
+  --grouparoo-light-blue: #{$grouparoo-light-blue};
+  --grouparoo-violet: #{$grouparoo-violet};
+}
+
 // Bootstrap Colors
 
 $primary: $grouparoo-blue;


### PR DESCRIPTION

<img width="1196" alt="Screen Shot 2020-09-18 at 9 36 06 AM" src="https://user-images.githubusercontent.com/303226/93622676-63047780-f992-11ea-92ce-21230e02f412.png">


Closes T-522