### PR TITLE
Include .circleci files in docs build

### DIFF
--- a/core/api/bin/publish-docs
+++ b/core/api/bin/publish-docs
@@ -28,6 +28,7 @@ rm -rf docs
 mkdir docs
 npm run docs
 cp -a docs/. gh-pages/
+cp -a ../../.circleci gh-pages
 touch gh-pages/.nojekyll
 echo 'docs.grouparoo.com' >> gh-pages/CNAME
 


### PR DESCRIPTION
When building docs.grouparoo.com, this PR now includes the `.circle` folder.  This prevents errors like:

<img width="1395" alt="Screen Shot 2020-09-28 at 12 11 20 PM" src="https://user-images.githubusercontent.com/303226/94475306-b9886780-0183-11eb-9395-628e640e453d.png">
