### PR TITLE
Ensure that we do not touch updatedAt when incrementing a model and do not await SQL when a Transaction is in play

### DIFF
--- a/core/api/src/config/sequelize.ts
+++ b/core/api/src/config/sequelize.ts
@@ -62,6 +62,12 @@ export const DEFAULT = {
       password: password,
       models: [join(__dirname, "..", "models")],
       migrations: [join(__dirname, "..", "migrations")],
+      pool: {
+        max: process.env.WORKERS ? parseInt(process.env.WORKERS) + 1 : 5,
+        min: 0,
+        acquire: 30000,
+        idle: 10000,
+      },
     };
   },
 };

--- a/core/api/src/config/sequelize.ts
+++ b/core/api/src/config/sequelize.ts
@@ -63,7 +63,9 @@ export const DEFAULT = {
       models: [join(__dirname, "..", "models")],
       migrations: [join(__dirname, "..", "migrations")],
       pool: {
-        max: process.env.WORKERS ? parseInt(process.env.WORKERS) + 1 : 5,
+        max: process.env.SEQUELIZE_POOL_SIZE
+          ? parseInt(process.env.SEQUELIZE_POOL_SIZE)
+          : 5,
         min: 0,
         acquire: 30000,
         idle: 10000,

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -151,7 +151,7 @@ export class Group extends LoggedModel<Group> {
     return this.$count("groupMembers", search);
   }
 
-  async getRules() {
+  async getRules(transaction = undefined) {
     // We won't be deleting the model for GroupRule until the group is really deleted (to validate other models)
     // But we want to be sure that all membership matching will fail
     if (this.state === "deleted") return [];
@@ -159,11 +159,14 @@ export class Group extends LoggedModel<Group> {
     const rulesWithKey: GroupRuleWithKey[] = [];
     const rules = await this.$get("groupRules", {
       order: [["position", "asc"]],
+      transaction,
     });
 
     for (const i in rules) {
       const rule: GroupRule = rules[i];
-      const profilePropertyRule = await rule.$get("profilePropertyRule");
+      const profilePropertyRule = await rule.$get("profilePropertyRule", {
+        transaction,
+      });
       const type = profilePropertyRule
         ? profilePropertyRule.type
         : TopLevelGroupRules.filter(

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -151,7 +151,9 @@ export class Group extends LoggedModel<Group> {
     return this.$count("groupMembers", search);
   }
 
-  async getRules(transaction = undefined) {
+  async getRules() {
+    if (this.type === "manual") return [];
+
     // We won't be deleting the model for GroupRule until the group is really deleted (to validate other models)
     // But we want to be sure that all membership matching will fail
     if (this.state === "deleted") return [];
@@ -159,14 +161,11 @@ export class Group extends LoggedModel<Group> {
     const rulesWithKey: GroupRuleWithKey[] = [];
     const rules = await this.$get("groupRules", {
       order: [["position", "asc"]],
-      transaction,
     });
 
     for (const i in rules) {
       const rule: GroupRule = rules[i];
-      const profilePropertyRule = await rule.$get("profilePropertyRule", {
-        transaction,
-      });
+      const profilePropertyRule = await rule.$get("profilePropertyRule");
       const type = profilePropertyRule
         ? profilePropertyRule.type
         : TopLevelGroupRules.filter(

--- a/core/api/src/modules/groupExport.ts
+++ b/core/api/src/modules/groupExport.ts
@@ -97,8 +97,14 @@ export async function groupExportToCSV(group: Group, limit = 1000) {
       const profile = profiles[i];
       const row = await buildCsvRowFromProperty(profile);
       csvStream.write(row);
-      await run.increment(["profilesExported"]);
     }
+
+    await run.increment(["profilesExported"], {
+      by: profiles.length,
+      silent: true,
+    });
+    run.set("updatedAt", new Date());
+    await run.save();
 
     offset = limit + offset;
     profiles = await getProfiles();

--- a/core/api/src/modules/ops/destination.ts
+++ b/core/api/src/modules/ops/destination.ts
@@ -367,7 +367,7 @@ export namespace DestinationOps {
       force,
     });
 
-    if (runs) {
+    if (runs && runs.length > 0) {
       const transaction = await api.sequelize.transaction();
 
       try {

--- a/core/api/src/modules/ops/event.ts
+++ b/core/api/src/modules/ops/event.ts
@@ -4,6 +4,7 @@ import { ProfileProperty } from "../../models/ProfileProperty";
 import { ProfilePropertyRule } from "../../models/ProfilePropertyRule";
 import { ProfileOps } from "../ops/profile";
 import { Op } from "sequelize";
+import { utils } from "actionhero";
 
 export namespace EventOps {
   /**
@@ -11,7 +12,8 @@ export namespace EventOps {
    */
   export async function associate(
     event: Event,
-    identifyingProfilePropertyRuleGuid: string
+    identifyingProfilePropertyRuleGuid: string,
+    isRetry = false
   ) {
     // find the cached profile property rule
     const profilePropertyRules = await ProfilePropertyRule.cached();
@@ -24,103 +26,117 @@ export namespace EventOps {
     const profilePropertyRule =
       profilePropertyRules[profilePropertyRuleCacheKey];
 
-    if (event.profileGuid) {
-      // we are already identified
-      try {
-        const profile = await event.$get("profile");
-        await event.updateProfile(profile);
-        return profile;
-      } catch (error) {
-        // the event may have been moved to another profile
-        const updatedEvent = await event.reload();
-        if (updatedEvent.profileGuid !== event.profileGuid) {
-          return updatedEvent.associate(updatedEvent.profileGuid);
-        } else {
-          throw error;
+    try {
+      if (event.profileGuid) {
+        // we are already identified
+        try {
+          const profile = await event.$get("profile");
+          await event.updateProfile(profile);
+          return profile;
+        } catch (error) {
+          // the event may have been moved to another profile
+          const updatedEvent = await event.reload();
+          if (updatedEvent.profileGuid !== event.profileGuid) {
+            return updatedEvent.associate(updatedEvent.profileGuid);
+          } else {
+            throw error;
+          }
         }
-      }
-    } else if (event.userId) {
-      // we have a userId (primaryIdentifyingProfilePropertyRule)
-      let profile = await Profile.findOne({
-        include: [
-          {
-            model: ProfileProperty,
-            where: {
-              rawValue: event.userId,
-              profilePropertyRuleGuid: profilePropertyRule.guid,
+      } else if (event.userId) {
+        // we have a userId (primaryIdentifyingProfilePropertyRule)
+        let profile = await Profile.findOne({
+          include: [
+            {
+              model: ProfileProperty,
+              where: {
+                rawValue: event.userId,
+                profilePropertyRuleGuid: profilePropertyRule.guid,
+              },
             },
-          },
-        ],
-      });
-
-      if (!profile) {
-        [profile] = await Profile.findOrCreate({
-          where: { anonymousId: event.anonymousId },
+          ],
         });
-      }
 
-      const profileProperties = {};
-      profileProperties[profilePropertyRule.key] = event.userId;
-      await profile.addOrUpdateProperties(profileProperties);
-
-      event.profileGuid = profile.guid;
-      event.profileAssociatedAt = new Date();
-      await event.save();
-
-      const otherProfileWithAnonymousId = await Profile.findOne({
-        where: {
-          guid: { [Op.ne]: profile.guid },
-          anonymousId: event.anonymousId,
-        },
-      });
-      if (!otherProfileWithAnonymousId) {
-        await profile.update({ anonymousId: event.anonymousId });
-      } else {
-        await ProfileOps.merge(profile, otherProfileWithAnonymousId);
-      }
-
-      await event.updateProfile(profile);
-      return profile;
-    } else if (event.anonymousId) {
-      // we have an anonymousId
-
-      // can we find the profile by anonymousId?
-      let profile = await Profile.findOne({
-        where: { anonymousId: event.anonymousId },
-      });
-
-      // can we find the profile from other events with the same anonymousId?
-      if (!profile) {
-        const otherEvent = await Event.findOne({
-          where: {
-            anonymousId: event.anonymousId,
-            profileGuid: { [Op.ne]: null },
-          },
-        });
-        if (otherEvent) {
-          profile = await Profile.findOne({
-            where: { guid: otherEvent.profileGuid },
+        if (!profile) {
+          [profile] = await Profile.findOrCreate({
+            where: { anonymousId: event.anonymousId },
           });
         }
-      }
 
-      // if we still don't have a profile, make a new one
-      if (!profile) {
-        [profile] = await Profile.findOrCreate({
+        const profileProperties = {};
+        profileProperties[profilePropertyRule.key] = event.userId;
+        await profile.addOrUpdateProperties(profileProperties);
+
+        event.profileGuid = profile.guid;
+        event.profileAssociatedAt = new Date();
+        await event.save();
+
+        const otherProfileWithAnonymousId = await Profile.findOne({
+          where: {
+            guid: { [Op.ne]: profile.guid },
+            anonymousId: event.anonymousId,
+          },
+        });
+        if (!otherProfileWithAnonymousId) {
+          await profile.update({ anonymousId: event.anonymousId });
+        } else {
+          await ProfileOps.merge(profile, otherProfileWithAnonymousId);
+        }
+
+        await event.updateProfile(profile);
+        return profile;
+      } else if (event.anonymousId) {
+        // we have an anonymousId
+
+        // can we find the profile by anonymousId?
+        let profile = await Profile.findOne({
           where: { anonymousId: event.anonymousId },
         });
-      }
 
-      event.profileGuid = profile.guid;
-      event.profileAssociatedAt = new Date();
-      await event.save();
-      await event.updateProfile(profile);
-      return profile;
-    } else {
-      // we can't identify this event
-      throw new Error(
-        "cannot associate a profile without profileGuid, userId, or anonymousId"
-      );
+        // can we find the profile from other events with the same anonymousId?
+        if (!profile) {
+          const otherEvent = await Event.findOne({
+            where: {
+              anonymousId: event.anonymousId,
+              profileGuid: { [Op.ne]: null },
+            },
+          });
+          if (otherEvent) {
+            profile = await Profile.findOne({
+              where: { guid: otherEvent.profileGuid },
+            });
+          }
+        }
+
+        // if we still don't have a profile, make a new one
+        if (!profile) {
+          [profile] = await Profile.findOrCreate({
+            where: { anonymousId: event.anonymousId },
+          });
+        }
+
+        event.profileGuid = profile.guid;
+        event.profileAssociatedAt = new Date();
+        await event.save();
+        await event.updateProfile(profile);
+        return profile;
+      } else {
+        // we can't identify this event
+        throw new Error(
+          "cannot associate a profile without profileGuid, userId, or anonymousId"
+        );
+      }
+    } catch (error) {
+      // It's possible that 2 events for the same profile are getting processed at the same time, which would create a conflicting profile.
+      // In these cases, retry one more time
+      if (
+        isRetry === false &&
+        error.toString().match(/SequelizeUniqueConstraintError/)
+      ) {
+        await utils.sleep(100);
+        return associate(event, identifyingProfilePropertyRuleGuid, true);
+      } else {
+        throw error;
+      }
     }
   }
 }

--- a/core/api/src/modules/ops/group.ts
+++ b/core/api/src/modules/ops/group.ts
@@ -211,7 +211,6 @@ export namespace GroupOps {
     destinationGuid?: string
   ) {
     let groupMembersCount = 0;
-    // let runIncrementCount = 0;
     let profiles: ProfileMultipleAssociationShim[];
     const rules = await group.getRules();
 

--- a/core/api/src/modules/ops/group.ts
+++ b/core/api/src/modules/ops/group.ts
@@ -228,7 +228,7 @@ export namespace GroupOps {
           transaction,
         });
       } else {
-        const rules = await group.getRules();
+        const rules = await group.getRules(transaction);
         if (Object.keys(rules).length === 0) {
           await transaction.commit();
           return { groupMembersCount: 0, nextHighWaterMark: 0, nextOffset: 0 };

--- a/core/api/src/modules/ops/group.ts
+++ b/core/api/src/modules/ops/group.ts
@@ -213,6 +213,8 @@ export namespace GroupOps {
     let groupMembersCount = 0;
     let runIncrementCount = 0;
     let profiles: ProfileMultipleAssociationShim[];
+    const rules = await group.getRules();
+
     const transaction = await api.sequelize.transaction();
 
     try {
@@ -228,7 +230,6 @@ export namespace GroupOps {
           transaction,
         });
       } else {
-        const rules = await group.getRules(transaction);
         if (Object.keys(rules).length === 0) {
           await transaction.commit();
           return { groupMembersCount: 0, nextHighWaterMark: 0, nextOffset: 0 };

--- a/core/api/src/modules/ops/group.ts
+++ b/core/api/src/modules/ops/group.ts
@@ -210,7 +210,6 @@ export namespace GroupOps {
     force = false,
     destinationGuid?: string
   ) {
-    let groupMembersCount = 0;
     let profiles: ProfileMultipleAssociationShim[];
     const rules = await group.getRules();
 
@@ -314,13 +313,18 @@ export namespace GroupOps {
       await run.save({ transaction });
 
       await transaction.commit();
+
+      await group.update({ calculatedAt: new Date() });
+
+      return {
+        groupMembersCount: profiles.length,
+        nextHighWaterMark,
+        nextOffset,
+      };
     } catch (error) {
       await transaction.rollback();
       throw error;
     }
-
-    await group.update({ calculatedAt: new Date() });
-    return { groupMembersCount, nextHighWaterMark, nextOffset };
   }
 
   /**

--- a/core/api/src/modules/ops/group.ts
+++ b/core/api/src/modules/ops/group.ts
@@ -230,6 +230,7 @@ export namespace GroupOps {
           transaction,
         });
       } else {
+        // if there are no group rules, there's nothing to do
         if (Object.keys(rules).length === 0) {
           await transaction.commit();
           return { groupMembersCount: 0, nextHighWaterMark: 0, nextOffset: 0 };
@@ -276,6 +277,7 @@ export namespace GroupOps {
             profileGuid: profile.guid,
             groupGuid: group.guid,
           },
+          lock: true,
           transaction,
         });
 
@@ -293,7 +295,6 @@ export namespace GroupOps {
         if (groupMember) {
           groupMember.removedAt = null;
           groupMember.set("updatedAt", new Date());
-          groupMember.changed("updatedAt", true);
           await groupMember.save({ transaction });
         }
 

--- a/core/api/src/modules/ops/group.ts
+++ b/core/api/src/modules/ops/group.ts
@@ -408,6 +408,9 @@ export namespace GroupOps {
       groupMembersCount++;
     }
 
+    run.set("updatedAt", new Date());
+    await run.save();
+
     return groupMembersCount;
   }
 }

--- a/core/api/src/modules/plugin.ts
+++ b/core/api/src/modules/plugin.ts
@@ -184,7 +184,9 @@ export namespace plugin {
         },
         { transaction }
       );
-      await run.increment(["importsCreated"], { transaction });
+      await run.increment(["importsCreated"], { transaction, silent: true });
+      run.set("updatedAt", new Date());
+      await run.save({ transaction });
       await transaction.commit();
 
       return _import;

--- a/core/api/src/tasks/event/associateProfiles.ts
+++ b/core/api/src/tasks/event/associateProfiles.ts
@@ -6,22 +6,24 @@ export class EventsAssociateProfiles extends Task {
     super();
     this.name = "event:associateProfiles";
     this.description =
-      "ensure that events are associated to profiles, even if they were created outside of our API";
+      "ensure that events are associated to profiles, even if they were created outside of the Grouparoo API";
     this.frequency = 60 * 1000;
     this.queue = "events";
     this.inputs = {};
   }
 
-  async run(params) {
+  async run() {
     const limit = 1000;
     let offset = 0;
     let events: Event[] = [];
 
     while (events.length > 0 || offset === 0) {
       events = await Event.findAll({
+        attributes: ["guid"],
         where: { profileGuid: null },
         limit,
         offset,
+        order: [["createdAt", "asc"]],
       });
 
       for (const i in events) {

--- a/core/api/src/tasks/group/run.ts
+++ b/core/api/src/tasks/group/run.ts
@@ -48,7 +48,6 @@ export class RunGroup extends Task {
     let run: Run;
     if (params.runGuid) {
       run = await Run.findByGuid(params.runGuid);
-      if (run.state === "stopped") return;
     } else {
       run = await Run.create({
         creatorGuid: group.guid,
@@ -62,6 +61,8 @@ export class RunGroup extends Task {
         "notice"
       );
     }
+
+    if (run.state === "stopped") return;
 
     await run.update({
       groupMemberLimit: limit,

--- a/core/api/src/tasks/run/internalRun.ts
+++ b/core/api/src/tasks/run/internalRun.ts
@@ -63,9 +63,15 @@ export class RunInternalRun extends Task {
           },
           { transaction }
         );
-
-        await run.increment(["importsCreated"], { transaction });
       }
+
+      await run.increment(["importsCreated"], {
+        by: profiles.length,
+        transaction,
+        silent: true,
+      });
+      run.set("updatedAt", new Date());
+      await run.save({ transaction });
 
       await transaction.commit();
 

--- a/plugins/@grouparoo/demo/src/bin/grouparoo/demo/scale.ts
+++ b/plugins/@grouparoo/demo/src/bin/grouparoo/demo/scale.ts
@@ -1,4 +1,4 @@
-import { CLI } from "actionhero";
+import { CLI, log } from "actionhero";
 import { teams } from "../../../teams";
 import { users, purchases } from "../../../sample_data";
 import { groups } from "../../../groups";
@@ -11,10 +11,14 @@ export class Console extends CLI {
     this.name = "grouparoo demo eCommerce data";
     this.description =
       "Load eCommerce users and purchases into a source database.";
+    this.inputs = {
+      scale: { required: true, default: 2000 }, // 2M users and purchases
+    };
   }
 
-  async run() {
-    const scale = 2000; // 2M users and purchases
+  async run({ params }) {
+    log(`Using scale = ${params.scale}`);
+    const scale = params.scale;
     await init({ reset: true });
     await teams();
     await users({ scale });


### PR DESCRIPTION
This PR prevents a class of bugs that resulted in errors like `SequelizeConnectionAcquireTimeoutError` or `SequelizeTimeoutError`.

1. **Do not update `updatedAt` when using `increment()`** 

We now explicitly ask the `increment()` method not to bump the `updatedAt`, and then update `updatedAt` in a subsequent SQL statement.  By Default, Sequelize will try to update `updatedAt` every time a row is altered (which makes sense). 
 However, in the cases we think a row might be altered rapidly, we use the `model.increment()` method to avoid collisions...
but the increment command also tries to set `updatedAt` - which creates contention!

<img width="1611" alt="Screen Shot 2020-09-28 at 2 54 02 PM" src="https://user-images.githubusercontent.com/303226/94494565-5955ed80-01a4-11eb-8d15-bde36e32186d.png">

A negative side effect of this change: we may be a few seconds off for `run.updatedAt`... but that's OK.

2. **Ensure that no other SQL statements are await-ed when a transaction is in play**
`Group.getRules()` was potentially used within a transaction, but not included in the transaction.  This was bad.  Also, rather than making many references to single rows in a transaction which may be changing, it's better to make one big SQL statement to update the bulk of items at once.

3. **Provide an environment variable, `SEQUELIZE_POOL_SIZE` to up the Sequelize Connection Pool Size (default: 5)**
ie: `SEQUELIZE_POOL_SIZE=10`

4. **Allow the Event#associate method to be retried once**
With many workers all processing events from the same anonymous profile, multiple workers may attempt to create the same profile at once.  One will fail as there is a unique database constraint.  We now retry this specific type of failure so the newly created Profile can found and linked.  

--- 

Things to watch out for in the future:

* As indicated in https://github.com/sequelize/sequelize/issues/11024 and https://github.com/sequelize/sequelize/pull/11633 it appears that if you attempt to run more Sequelize transactions than there are available slots in the connection pool, you'll get a deadlock maybe?

Closes T-541
Closes T-553