### PR TITLE
Only re-calculate groups in the ready state

### DIFF
--- a/core/api/__tests__/tasks/group/updateCalculatedGroups.ts
+++ b/core/api/__tests__/tasks/group/updateCalculatedGroups.ts
@@ -63,5 +63,16 @@ describe("tasks/group:updateCalculatedGroups", () => {
 
       expect(enqueuedTasks.length).toBe(0);
     });
+
+    test("groups already calculating will not be calculated again", async () => {
+      group.calculatedAt = new Date(0); // ~1970 or so
+      group.state = "updating";
+      await group.save();
+
+      await specHelper.runTask("group:updateCalculatedGroups", {});
+      const enqueuedTasks = await specHelper.findEnqueuedTasks("group:run");
+
+      expect(enqueuedTasks.length).toBe(0);
+    });
   });
 });

--- a/core/api/src/tasks/group/updateCalculatedGroups.ts
+++ b/core/api/src/tasks/group/updateCalculatedGroups.ts
@@ -23,9 +23,10 @@ export class GroupsUpdateCalculatedGroups extends RetryableTask {
     const delayMinutes = parseInt(setting.value);
     const lastCheckTime = Moment().subtract(delayMinutes, "minutes");
 
-    const calculatedGroups = await Group.findAll({
+    const calculatedGroups = await Group.scope(null).findAll({
       where: {
         type: "calculated",
+        state: "ready",
         calculatedAt: {
           [Op.or]: {
             [Op.eq]: null,


### PR DESCRIPTION
Do not enqueue another task to re-calculate the members of a Group if it is not in the ready state.

Closes T-557