### PR TITLE
Disconnect the App's connection after Options are set

### DIFF
--- a/core/api/__tests__/models/app.ts
+++ b/core/api/__tests__/models/app.ts
@@ -436,17 +436,8 @@ describe("models/app", () => {
   });
 
   describe("RPC methods", () => {
-    let mocks = [];
-
     beforeAll(() => {
-      // App.disconnect = jest.fn();
-      mocks.push(
-        jest.spyOn(App, "disconnect").mockImplementation(async () => {})
-      );
-    });
-
-    afterAll(() => {
-      mocks.forEach((mock) => mock.mockRestore());
+      jest.spyOn(App, "disconnect");
     });
 
     test("api.rpc.app.disconnect", async () => {

--- a/core/api/__tests__/models/app.ts
+++ b/core/api/__tests__/models/app.ts
@@ -3,7 +3,7 @@ import { App } from "./../../src/models/App";
 import { Option } from "./../../src/models/Option";
 import { Log } from "./../../src/models/Log";
 import { plugin } from "./../../src/modules/plugin";
-import { api } from "actionhero";
+import { api, redis, utils } from "actionhero";
 let actionhero;
 
 describe("models/app", () => {
@@ -432,6 +432,27 @@ describe("models/app", () => {
 
       await app.destroy();
       expect(await redis.exists(key)).toBe(0);
+    });
+  });
+
+  describe("RPC methods", () => {
+    let mocks = [];
+
+    beforeAll(() => {
+      // App.disconnect = jest.fn();
+      mocks.push(
+        jest.spyOn(App, "disconnect").mockImplementation(async () => {})
+      );
+    });
+
+    afterAll(() => {
+      mocks.forEach((mock) => mock.mockRestore());
+    });
+
+    test("api.rpc.app.disconnect", async () => {
+      await redis.doCluster("api.rpc.app.disconnect");
+      await utils.sleep(100);
+      expect(App.disconnect).toHaveBeenCalled();
     });
   });
 });

--- a/core/api/src/initializers/clients.ts
+++ b/core/api/src/initializers/clients.ts
@@ -2,7 +2,7 @@ import { Initializer } from "actionhero";
 import fs from "fs";
 import path from "path";
 
-export class Files extends Initializer {
+export class Clients extends Initializer {
   constructor() {
     super();
     this.name = "clients";

--- a/core/api/src/initializers/rpc.ts
+++ b/core/api/src/initializers/rpc.ts
@@ -1,0 +1,25 @@
+import { Initializer, api, log, redis } from "actionhero";
+import { App } from "../models/App";
+
+export class GrouparooRPC extends Initializer {
+  constructor() {
+    super();
+    this.name = "grouparooRPC";
+  }
+
+  async initialize() {
+    /**
+     * Here is where we list methods which will be invoked by `api.doCluster`
+     */
+    api.rpc = {
+      app: {},
+    };
+
+    /**
+     * Signal that all Apps in the cluster should disconnect form persistent connections.
+     */
+    api.rpc.app.disconnect = async () => {
+      await App.disconnect();
+    };
+  }
+}

--- a/core/api/src/modules/ops/app.ts
+++ b/core/api/src/modules/ops/app.ts
@@ -91,7 +91,7 @@ export namespace AppOps {
       error = err.message || err.toString();
       success = false;
       log(
-        `[ app ] testing app ${app.name || app.guid} threw error: ${error}`,
+        `[ app ] testing app ${app.name} (${app.guid}) threw error: ${error}`,
         "notice"
       );
     }


### PR DESCRIPTION
If An App's Options are changed, we should disconnect any persistent connections.  The App will be re-connected to the next time the connection is needed.  

We need to use Actionhero's RPC tooling to signal to all nodes in the cluster that they should disconnect, not just the node which got the API request to update the options.

Closes https://github.com/grouparoo/grouparoo/issues/767
Closes T-554