### PR TITLE
Grouparoo Users can choose whether or not to start the next Schedule Run against a Run with Errors

### DIFF
--- a/core/api/__tests__/actions/settings.ts
+++ b/core/api/__tests__/actions/settings.ts
@@ -34,6 +34,7 @@ describe("actions/settings", () => {
       await plugin.registerSetting(
         "testPlugin",
         "enabled",
+        "testPlugin:enabled",
         false,
         "Should we do that thing?",
         "string"
@@ -41,6 +42,7 @@ describe("actions/settings", () => {
       await plugin.registerSetting(
         "testPlugin",
         "number",
+        "testPlugin:number",
         10,
         "How many of those things should we do?",
         "number"
@@ -48,6 +50,7 @@ describe("actions/settings", () => {
       await plugin.registerSetting(
         "otherPlugin",
         "enabled",
+        "otherPlugin:enabled",
         true,
         "Should we do that thing?",
         "boolean"

--- a/core/api/__tests__/models/run.ts
+++ b/core/api/__tests__/models/run.ts
@@ -464,7 +464,7 @@ describe("models/run", () => {
       expect(foundPreviousRun).toBeNull();
     });
 
-    test("will can find a previous run with an error (setting=true)", async () => {
+    test("will find a previous run with an error (setting=true)", async () => {
       await plugin.updateSetting(
         "core",
         "runs-previous-can-include-errors",

--- a/core/api/__tests__/models/run.ts
+++ b/core/api/__tests__/models/run.ts
@@ -445,7 +445,13 @@ describe("models/run", () => {
       expect(foundPreviousRun).toBeNull();
     });
 
-    test("will not find a previous run with an error", async () => {
+    test("will not find a previous run with an error (setting=false)", async () => {
+      await plugin.updateSetting(
+        "core",
+        "runs-previous-can-include-errors",
+        "false"
+      );
+
       previousRun = await Run.create({
         creatorGuid: schedule.guid,
         creatorType: "schedule",
@@ -456,6 +462,25 @@ describe("models/run", () => {
 
       const foundPreviousRun = await nextRun.previousRun();
       expect(foundPreviousRun).toBeNull();
+    });
+
+    test("will can find a previous run with an error (setting=true)", async () => {
+      await plugin.updateSetting(
+        "core",
+        "runs-previous-can-include-errors",
+        "true"
+      );
+
+      previousRun = await Run.create({
+        creatorGuid: schedule.guid,
+        creatorType: "schedule",
+        state: "complete",
+        importsCreated: 1,
+        error: "OH NO!",
+      });
+
+      const foundPreviousRun = await nextRun.previousRun();
+      expect(foundPreviousRun.guid).toEqual(previousRun.guid);
     });
 
     test("will not find a previous run that is not complete", async () => {

--- a/core/api/__tests__/models/setting.ts
+++ b/core/api/__tests__/models/setting.ts
@@ -19,6 +19,7 @@ describe("models/setting", () => {
     const setting = await plugin.registerSetting(
       "testPlugin",
       "key",
+      "title",
       "value",
       "this is a test setting",
       "string"
@@ -26,6 +27,7 @@ describe("models/setting", () => {
 
     expect(setting.guid.length).toBe(40);
     expect(setting.key).toBe("key");
+    expect(setting.title).toBe("title");
     expect(setting.value).toBe("value");
     expect(setting.defaultValue).toBe("value");
     expect(setting.createdAt).toBeTruthy();
@@ -74,6 +76,7 @@ describe("models/setting", () => {
     await plugin.registerSetting(
       "testPlugin",
       "key",
+      "new title",
       "value2",
       "this is a better description of the setting",
       "string"
@@ -81,6 +84,7 @@ describe("models/setting", () => {
 
     const setting = await plugin.readSetting("testPlugin", "key");
     expect(setting.key).toBe("key");
+    expect(setting.title).toBe("new title");
     expect(setting.value).toBe("new value"); // no change
     expect(setting.defaultValue).toBe("value2");
     expect(setting.description).toBe(

--- a/core/api/__tests__/modules/plugin.ts
+++ b/core/api/__tests__/modules/plugin.ts
@@ -138,12 +138,14 @@ describe("modules/plugin", () => {
       await plugin.registerSetting(
         "test-plugin",
         "sample-setting",
+        "title",
         "100",
         "I am a test setting",
         "string"
       );
 
       let value = await plugin.readSetting("test-plugin", "sample-setting");
+      expect(value.title).toBe("title");
       expect(value.value).toBe("100");
       expect(value.description).toBe("I am a test setting");
       await plugin.updateSetting("test-plugin", "sample-setting", 200);

--- a/core/api/__tests__/tasks/export/enqueue.ts
+++ b/core/api/__tests__/tasks/export/enqueue.ts
@@ -108,7 +108,7 @@ describe("tasks/export:enqueue", () => {
     });
 
     afterEach(async () => {
-      await plugin.updateSetting("core", "export-profile-batch-size", 100);
+      await plugin.updateSetting("core", "exports-profile-batch-size", 100);
     });
 
     test("exports not yet exported or with an error will be enqueued", async () => {
@@ -126,7 +126,7 @@ describe("tasks/export:enqueue", () => {
     });
 
     test("batch size is variable", async () => {
-      await plugin.updateSetting("core", "export-profile-batch-size", 1);
+      await plugin.updateSetting("core", "exports-profile-batch-size", 1);
       await specHelper.runTask("export:enqueue", {});
 
       const foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");

--- a/core/api/src/actions/settings.ts
+++ b/core/api/src/actions/settings.ts
@@ -14,8 +14,8 @@ export class SettingsList extends AuthenticatedAction {
         required: false,
         default: [
           ["pluginName", "desc"],
+          ["title", "desc"],
           ["key", "desc"],
-          ["createdAt", "desc"],
         ],
       },
     };

--- a/core/api/src/initializers/settings.ts
+++ b/core/api/src/initializers/settings.ts
@@ -5,9 +5,11 @@ import * as UUID from "uuid";
 
 interface SettingsListItem {
   key: string;
+  title: string;
   defaultValue: string | number;
   description: string;
   type: typeof settingTypes[number];
+  variant?: string;
 }
 export class Plugins extends Initializer {
   constructor() {
@@ -20,13 +22,22 @@ export class Plugins extends Initializer {
     pluginName: string
   ) {
     for (const i in settingsList) {
-      const { key, defaultValue, description, type } = settingsList[i];
+      const {
+        key,
+        title,
+        defaultValue,
+        description,
+        type,
+        variant,
+      } = settingsList[i];
       await plugin.registerSetting(
         pluginName,
         key,
+        title,
         defaultValue,
         description,
-        type
+        type,
+        variant
       );
     }
   }
@@ -35,6 +46,7 @@ export class Plugins extends Initializer {
     const coreSettings: SettingsListItem[] = [
       {
         key: "cluster-name",
+        title: "Cluster: Name",
         defaultValue: "My Grouparoo Cluster",
         description:
           "A way to identify this Grouparoo cluster.  Will be displayed in the web interface and sent with Telemetry.",
@@ -42,6 +54,7 @@ export class Plugins extends Initializer {
       },
       {
         key: "groups-calculation-delay-minutes",
+        title: "Groups: Calculation Delay Minutes",
         defaultValue: 60,
         description:
           "How many minutes should wait before recalculating a calculated Group's membership?",
@@ -49,20 +62,32 @@ export class Plugins extends Initializer {
       },
       {
         key: "runs-profile-batch-size",
+        title: "Runs: Profile Batch Size",
         defaultValue: 100,
         description:
           "How many Profiles or Imports should a Run enqueue in each batch before deferring to process those Imports already enqueued?",
         type: "number",
       },
       {
-        key: "export-profile-batch-size",
+        key: "runs-previous-can-include-errors",
+        title: "Runs: Previous Runs with Errors Considered",
+        defaultValue: "false",
+        description:
+          "When creating a new Run for a Source/Schedule, we check the most recent complete run to configure it.  This includes setting the starting HighWaterMark for the Run.  Should we consider those Runs which have an error?",
+        type: "boolean",
+        variant: "warning",
+      },
+      {
+        key: "exports-profile-batch-size",
+        title: "Exports: Profile Batch Size",
         defaultValue: 100,
         description:
           "How many Profiles should a Run try to send at once to Destinations which support batch exporting?",
         type: "number",
       },
       {
-        key: "default-country-code",
+        key: "profiles-default-country-code",
+        title: "Profile: Default Country Code",
         defaultValue: "US",
         description:
           "The default country code Grouparoo will use to format phone numbers and display data",
@@ -70,6 +95,7 @@ export class Plugins extends Initializer {
       },
       {
         key: "sweeper-delete-old-logs-days",
+        title: "Sweeper: Delete Old Logs Days",
         defaultValue: 31,
         description:
           "How many days should we keep Log records for on the server?",
@@ -77,6 +103,7 @@ export class Plugins extends Initializer {
       },
       {
         key: "sweeper-delete-old-imports-days",
+        title: "Sweeper: Delete Old Imports Days",
         defaultValue: 31,
         description:
           "How many days should we keep Import records for on the server?",
@@ -84,6 +111,7 @@ export class Plugins extends Initializer {
       },
       {
         key: "sweeper-delete-old-exports-days",
+        title: "Sweeper: Delete Old Exports Days",
         defaultValue: 31,
         description:
           "How many days should we keep Export records for on the server?  We will keep the most recent export for each Profile & Destination.",
@@ -94,6 +122,7 @@ export class Plugins extends Initializer {
     const interfaceSettings: SettingsListItem[] = [
       {
         key: "display-startup-steps",
+        title: "Display Startup Steps",
         defaultValue: "true",
         description:
           "Should Grouparoo display the Setup Steps to all Team Members?  You can always visit /setup to see your setup steps.",
@@ -104,12 +133,14 @@ export class Plugins extends Initializer {
     const telemetrySettings: SettingsListItem[] = [
       {
         key: "customer-guid",
+        title: "Customer Guid",
         defaultValue: `tcs_${UUID.v4()}`,
         description: "A unique, anonymous ID for this Grouparoo cluster.",
         type: "string",
       },
       {
         key: "customer-license",
+        title: "Customer License",
         defaultValue: ``,
         description: "Your Grouparoo License Key (for paid features).",
         type: "string",

--- a/core/api/src/migrations/000044-settingTitleAndVariant.ts
+++ b/core/api/src/migrations/000044-settingTitleAndVariant.ts
@@ -1,0 +1,18 @@
+module.exports = {
+  up: async function (migration, DataTypes) {
+    await migration.addColumn("settings", "title", {
+      type: DataTypes.STRING(191),
+      allowNull: false,
+    });
+
+    await migration.addColumn("settings", "variant", {
+      type: DataTypes.STRING(191),
+      allowNull: false,
+    });
+  },
+
+  down: async function (migration) {
+    await migration.removeColumn("settings", "title");
+    await migration.removeColumn("settings", "variant");
+  },
+};

--- a/core/api/src/models/Setting.ts
+++ b/core/api/src/models/Setting.ts
@@ -35,15 +35,23 @@ export class Setting extends LoggedModel<Setting> {
   type: typeof settingTypes[number];
 
   @Column
+  title: string;
+
+  @Column
   description: string;
+
+  @Column
+  variant: string;
 
   async apiData() {
     return {
       guid: this.guid,
       pluginName: this.pluginName,
       key: this.key,
+      title: this.title,
       value: this.value,
       type: this.type,
+      variant: this.variant,
       defaultValue: this.defaultValue,
       description: this.description,
       createdAt: this.createdAt ? this.createdAt.getTime() : null,

--- a/core/api/src/modules/ops/export.ts
+++ b/core/api/src/modules/ops/export.ts
@@ -95,7 +95,7 @@ export namespace ExportOps {
   ) {
     if (!limit) {
       limit = parseInt(
-        (await plugin.readSetting("core", "export-profile-batch-size")).value
+        (await plugin.readSetting("core", "exports-profile-batch-size")).value
       );
     }
     const app = await destination.$get("app");

--- a/core/api/src/modules/ops/profileProperty.ts
+++ b/core/api/src/modules/ops/profileProperty.ts
@@ -92,7 +92,7 @@ function formatEmail(email: string) {
 
 async function formatPhoneNumber(number: string) {
   const defaultCountryCode = (
-    await plugin.readSetting("core", "default-country-code")
+    await plugin.readSetting("core", "profiles-default-country-code")
   ).value as CountryCode;
 
   const formattedPhoneNumber = parsePhoneNumberFromString(

--- a/core/api/src/modules/plugin.ts
+++ b/core/api/src/modules/plugin.ts
@@ -94,22 +94,34 @@ export namespace plugin {
   export async function registerSetting(
     pluginName: string,
     key: string,
+    title: string,
     defaultValue: any,
     description: string,
-    type: typeof settingTypes[number]
+    type: typeof settingTypes[number],
+    variant = "info"
   ) {
     const setting = await Setting.findOne({ where: { pluginName, key } });
 
-    if (setting) return setting.update({ defaultValue, description, type });
+    if (setting) {
+      return setting.update({
+        title,
+        defaultValue,
+        description,
+        type,
+        variant,
+      });
+    }
 
     try {
       const setting = await Setting.create({
         pluginName,
         key,
+        title,
         value: defaultValue,
         defaultValue,
         description,
         type,
+        variant,
       });
 
       return setting;

--- a/core/web/components/settings/identifyingProfilePropertyRule.tsx
+++ b/core/web/components/settings/identifyingProfilePropertyRule.tsx
@@ -66,7 +66,7 @@ export default function IdentifyingProfilePropertyRule(props) {
   }
 
   return (
-    <Card>
+    <Card border={"info"}>
       <Card.Body>
         <Card.Title>Identifying Profile Property</Card.Title>
         <Card.Subtitle className="mb-2 text-muted">

--- a/core/web/pages/settings/[tab].tsx
+++ b/core/web/pages/settings/[tab].tsx
@@ -132,20 +132,11 @@ function SettingCard({
     updateSetting(setting);
   }
 
-  function capitalize(key: string) {
-    return key
-      .split("-")
-      .map((word) => {
-        return word.charAt(0).toUpperCase() + word.slice(1);
-      })
-      .join(" ");
-  }
-
   return (
     <>
-      <Card>
+      <Card border={setting.variant}>
         <Card.Body>
-          <Card.Title>{capitalize(setting.key)}</Card.Title>
+          <Card.Title>{setting.title}</Card.Title>
           {setting.type !== "boolean" ? (
             <Card.Subtitle className="mb-2 text-muted">
               {setting.description}


### PR DESCRIPTION
By default, the `run.previousRun()` will find the previous run from this creator (source/schedule/etc) which:
* is complete
* has no errors
* has at least one import

This method is used to find the `highWaterMark` of the previous run.

However, there may be some customers who have data issues and cannot complete that first import of all of their customers without error.  In those cases, we want to allow the `run.previousRun()` method to skip the "Has no errors" constraint.  Otherwise, the'll be (re)-importing all their profiles every run.  A new Setting is added to toggle this option.

This PR also updates the setting system to include a `title` and `variant` which can be used to make the Setting UI page a little more pleasant. 

<img width="1397" alt="Screen Shot 2020-10-01 at 4 42 46 PM" src="https://user-images.githubusercontent.com/303226/94873930-6d4c5a00-0405-11eb-80d2-5ac3e3bdc414.png">

Closes T-565
Closes T-566