### PR TITLE
Automatically retry tasks from stuck workers

### DIFF
--- a/core/api/src/config/tasks.ts
+++ b/core/api/src/config/tasks.ts
@@ -57,6 +57,8 @@ export const DEFAULT = {
       maxEventLoopDelay: 5,
       // how long before we mark a resque worker / task processor as stuck/dead?
       stuckWorkerTimeout: 1000 * 60 * 10,
+      // should the scheduler automatically try to retry failed tasks which were failed due to being 'stuck'?
+      retryStuckJobs: true,
       // Customize Resque primitives, replace null with required replacement.
       resque_overrides: {
         queue: null,

--- a/core/package.json
+++ b/core/package.json
@@ -46,7 +46,7 @@
     "@grouparoo/client-web": "^0.1.16",
     "@nivo/line": "0.62.0",
     "@zeit/next-source-maps": "0.0.3",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "ah-next-plugin": "0.3.0",
     "ah-sequelize-plugin": "2.2.3",
     "axios": "0.20.0",

--- a/core/package.json
+++ b/core/package.json
@@ -46,7 +46,7 @@
     "@grouparoo/client-web": "^0.1.16",
     "@nivo/line": "0.62.0",
     "@zeit/next-source-maps": "0.0.3",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "ah-next-plugin": "0.3.0",
     "ah-sequelize-plugin": "2.2.3",
     "axios": "0.20.0",

--- a/core/package.json
+++ b/core/package.json
@@ -99,7 +99,7 @@
     "@types/faker": "5.1.2",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "@types/react": "16.9.49",
+    "@types/react": "16.9.50",
     "@types/react-dom": "16.9.8",
     "@types/validator": "13.1.0",
     "csv-parse": "4.12.0",

--- a/core/web/next.config.js
+++ b/core/web/next.config.js
@@ -51,11 +51,10 @@ module.exports = withSourceMaps({
       use: [options.defaultLoaders.babel],
     });
 
-    config.resolve.alias["react"] = path.resolve(nodeModulesPath, "react");
-    config.resolve.alias["react-dom"] = path.resolve(
-      nodeModulesPath,
-      "react-dom"
-    );
+    // There may be different version of these core packages in our dependency tree.  We need to pick only one version (our version).
+    ["react", "react-dom"].forEach((package) => {
+      config.resolve.alias[package] = path.resolve(nodeModulesPath, package);
+    });
 
     config.module.rules.push({
       test: /\.md$/,

--- a/plugins/@grouparoo/bigquery/package.json
+++ b/plugins/@grouparoo/bigquery/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/bigquery/package.json
+++ b/plugins/@grouparoo/bigquery/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/csv/package.json
+++ b/plugins/@grouparoo/csv/package.json
@@ -32,14 +32,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/csv/package.json
+++ b/plugins/@grouparoo/csv/package.json
@@ -32,14 +32,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/demo/package.json
+++ b/plugins/@grouparoo/demo/package.json
@@ -35,14 +35,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/demo/package.json
+++ b/plugins/@grouparoo/demo/package.json
@@ -35,14 +35,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/email-authentication/package.json
+++ b/plugins/@grouparoo/email-authentication/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "react": "16.13.1",
     "react-dom": "16.13.1"
   },
@@ -41,7 +41,7 @@
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
     "@types/react": "16.9.49",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/email-authentication/package.json
+++ b/plugins/@grouparoo/email-authentication/package.json
@@ -40,7 +40,7 @@
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "@types/react": "16.9.49",
+    "@types/react": "16.9.50",
     "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",

--- a/plugins/@grouparoo/email-authentication/package.json
+++ b/plugins/@grouparoo/email-authentication/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "react": "16.13.1",
     "react-dom": "16.13.1"
   },
@@ -41,7 +41,7 @@
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
     "@types/react": "16.9.49",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/files-local/package.json
+++ b/plugins/@grouparoo/files-local/package.json
@@ -31,13 +31,13 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/files-local/package.json
+++ b/plugins/@grouparoo/files-local/package.json
@@ -31,13 +31,13 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/files-s3/package.json
+++ b/plugins/@grouparoo/files-s3/package.json
@@ -32,13 +32,13 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/files-s3/package.json
+++ b/plugins/@grouparoo/files-s3/package.json
@@ -32,13 +32,13 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/google-sheets/package.json
+++ b/plugins/@grouparoo/google-sheets/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/google-sheets/package.json
+++ b/plugins/@grouparoo/google-sheets/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/hubspot/package.json
+++ b/plugins/@grouparoo/hubspot/package.json
@@ -32,14 +32,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "jest": "26.4.2",
     "nock": "13.0.4",
     "prettier": "2.1.2",

--- a/plugins/@grouparoo/hubspot/package.json
+++ b/plugins/@grouparoo/hubspot/package.json
@@ -32,14 +32,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "nock": "13.0.4",
     "prettier": "2.1.2",

--- a/plugins/@grouparoo/logger/package.json
+++ b/plugins/@grouparoo/logger/package.json
@@ -28,13 +28,13 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/logger/package.json
+++ b/plugins/@grouparoo/logger/package.json
@@ -28,13 +28,13 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/mailchimp/package.json
+++ b/plugins/@grouparoo/mailchimp/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "jest": "26.4.2",
     "nock": "13.0.4",
     "prettier": "2.1.2",

--- a/plugins/@grouparoo/mailchimp/package.json
+++ b/plugins/@grouparoo/mailchimp/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "nock": "13.0.4",
     "prettier": "2.1.2",

--- a/plugins/@grouparoo/marketo/package.json
+++ b/plugins/@grouparoo/marketo/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/marketo/package.json
+++ b/plugins/@grouparoo/marketo/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/mysql/package.json
+++ b/plugins/@grouparoo/mysql/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
@@ -39,7 +39,7 @@
     "@types/jest": "26.0.14",
     "@types/mysql": "2.15.15",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "csv-parse": "4.12.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",

--- a/plugins/@grouparoo/mysql/package.json
+++ b/plugins/@grouparoo/mysql/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
@@ -39,7 +39,7 @@
     "@types/jest": "26.0.14",
     "@types/mysql": "2.15.15",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "csv-parse": "4.12.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",

--- a/plugins/@grouparoo/newrelic/package.json
+++ b/plugins/@grouparoo/newrelic/package.json
@@ -31,13 +31,13 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/newrelic/package.json
+++ b/plugins/@grouparoo/newrelic/package.json
@@ -31,13 +31,13 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/postgres/package.json
+++ b/plugins/@grouparoo/postgres/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
@@ -41,7 +41,7 @@
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
     "@types/pg": "^7.14.4",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "csv-parse": "4.12.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",

--- a/plugins/@grouparoo/postgres/package.json
+++ b/plugins/@grouparoo/postgres/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
@@ -41,7 +41,7 @@
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
     "@types/pg": "^7.14.4",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "csv-parse": "4.12.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",

--- a/plugins/@grouparoo/redshift/package.json
+++ b/plugins/@grouparoo/redshift/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
     "@types/pg": "^7.14.4",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "prettier": "2.1.2",
     "typescript": "4.0.3"
   }

--- a/plugins/@grouparoo/redshift/package.json
+++ b/plugins/@grouparoo/redshift/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
     "@types/pg": "^7.14.4",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "prettier": "2.1.2",
     "typescript": "4.0.3"
   }

--- a/plugins/@grouparoo/sailthru/package.json
+++ b/plugins/@grouparoo/sailthru/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/sailthru/package.json
+++ b/plugins/@grouparoo/sailthru/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/salesforce/package.json
+++ b/plugins/@grouparoo/salesforce/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/salesforce/package.json
+++ b/plugins/@grouparoo/salesforce/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/sample-ui-plugin/package.json
+++ b/plugins/@grouparoo/sample-ui-plugin/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "react": "16.13.1",
     "react-dom": "16.13.1"
   },
@@ -34,7 +34,7 @@
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
     "@types/react": "16.9.49",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/sample-ui-plugin/package.json
+++ b/plugins/@grouparoo/sample-ui-plugin/package.json
@@ -33,7 +33,7 @@
     "@grouparoo/core": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "@types/react": "16.9.49",
+    "@types/react": "16.9.50",
     "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",

--- a/plugins/@grouparoo/sample-ui-plugin/package.json
+++ b/plugins/@grouparoo/sample-ui-plugin/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "react": "16.13.1",
     "react-dom": "16.13.1"
   },
@@ -34,7 +34,7 @@
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
     "@types/react": "16.9.49",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/snowflake/package.json
+++ b/plugins/@grouparoo/snowflake/package.json
@@ -32,14 +32,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/snowflake/package.json
+++ b/plugins/@grouparoo/snowflake/package.json
@@ -32,14 +32,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/spec-helper/package.json
+++ b/plugins/@grouparoo/spec-helper/package.json
@@ -35,14 +35,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@types/faker": "5.1.2",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/spec-helper/package.json
+++ b/plugins/@grouparoo/spec-helper/package.json
@@ -35,14 +35,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@types/faker": "5.1.2",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "jest": "26.4.2",
     "prettier": "2.1.2",
     "ts-jest": "26.4.0",

--- a/plugins/@grouparoo/zendesk/package.json
+++ b/plugins/@grouparoo/zendesk/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.0.11"
+    "actionhero": "23.1.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.0.11",
+    "actionhero": "23.1.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",

--- a/plugins/@grouparoo/zendesk/package.json
+++ b/plugins/@grouparoo/zendesk/package.json
@@ -31,14 +31,14 @@
   },
   "peerDependencies": {
     "@grouparoo/core": "^0.1.1",
-    "actionhero": "23.1.0"
+    "actionhero": "24.0.0-alpha.0"
   },
   "devDependencies": {
     "@grouparoo/core": "^0.1.16",
     "@grouparoo/spec-helper": "^0.1.16",
     "@types/jest": "26.0.14",
     "@types/node": "14.11.2",
-    "actionhero": "23.1.0",
+    "actionhero": "24.0.0-alpha.0",
     "dotenv": "8.2.0",
     "fs-extra": "9.0.1",
     "jest": "26.4.2",


### PR DESCRIPTION
Thanks to https://github.com/actionhero/actionhero/pull/1605 and https://github.com/actionhero/node-resque/pull/450 (released in [v23.1.0](https://github.com/actionhero/actionhero/releases/tag/v23.1.0) of Actionhero), we can now ask the Resque Scheduler to automatically retry jobs which have been placed in the failed queue because the worker had timed out (gotten 'stuck').

Closes T-560