### PR TITLE
Button, Form, and Table Loading states

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
       - image: circleci/node:12
     steps:
       - checkout
-      - run: sudo apt-get install -y rsync
       - run:
           name: npm-install
           command: npm install

--- a/core/web/components/events/list.tsx
+++ b/core/web/components/events/list.tsx
@@ -5,10 +5,11 @@ import { useHistoryPagination } from "../../hooks/useHistoryPagination";
 import { useRealtimeModelStream } from "../../hooks/useRealtimeModelStream";
 import Link from "next/link";
 import Router from "next/router";
-import { Form, Button, Alert } from "react-bootstrap";
+import { Form, Alert } from "react-bootstrap";
 import Moment from "react-moment";
 import Pagination from "../../components/pagination";
 import LoadingTable from "../../components/loadingTable";
+import LoadingButton from "../../components/loadingButton";
 import { AsyncTypeahead } from "react-bootstrap-typeahead";
 
 import { EventAPIData } from "../../utils/apiData";
@@ -110,6 +111,7 @@ export default function EventsList(props) {
             <AsyncTypeahead
               key={`typeahead-search-${type}`}
               id={`typeahead-search-${type}`}
+              disabled={loading}
               minLength={0}
               isLoading={searchLoading}
               allowNew={true}
@@ -133,9 +135,9 @@ export default function EventsList(props) {
             />
           </Form.Group>
 
-          <Button size="sm" type="submit">
+          <LoadingButton size="sm" type="submit" disabled={loading}>
             Search
-          </Button>
+          </LoadingButton>
         </Form>
       )}
 
@@ -161,9 +163,9 @@ export default function EventsList(props) {
           {newEvents > 0 ? (
             <Alert variant="secondary">
               {newEvents} new events.{" "}
-              <Button size="sm" onClick={load}>
+              <LoadingButton size="sm" onClick={load} disabled={loading}>
                 Load
-              </Button>
+              </LoadingButton>
             </Alert>
           ) : null}
         </>

--- a/core/web/components/loader.tsx
+++ b/core/web/components/loader.tsx
@@ -1,6 +1,6 @@
-import "react";
+import * as React from "react";
 import { Spinner } from "react-bootstrap";
 
-export default function Loader() {
-  return <Spinner animation="grow" role="status" />;
+export default function Loader({ size }: { size?: "sm" }) {
+  return <Spinner animation="grow" role="status" size={size} />;
 }

--- a/core/web/components/loader.tsx
+++ b/core/web/components/loader.tsx
@@ -1,3 +1,4 @@
+import "react";
 import { Spinner } from "react-bootstrap";
 
 export default function Loader() {

--- a/core/web/components/loadingButton.tsx
+++ b/core/web/components/loadingButton.tsx
@@ -1,8 +1,13 @@
-import "react";
+import * as React from "react";
 import { Button } from "react-bootstrap";
 import Loader from "./loader";
 
 export default function LoadingButton(props) {
-  const message = props.disabled ? <Loader /> : props.children || "Submit";
+  const message = props.disabled ? (
+    <Loader size="sm" />
+  ) : (
+    props.children || "Submit"
+  );
+
   return <Button {...props}>{message}</Button>;
 }

--- a/core/web/components/loadingButton.tsx
+++ b/core/web/components/loadingButton.tsx
@@ -1,0 +1,7 @@
+import { Button } from "react-bootstrap";
+import Loader from "./loader";
+
+export default function LoadingButton(props) {
+  const message = props.disabled ? <Loader /> : props.children || "Submit";
+  return <Button {...props}>{message}</Button>;
+}

--- a/core/web/components/loadingButton.tsx
+++ b/core/web/components/loadingButton.tsx
@@ -1,3 +1,4 @@
+import "react";
 import { Button } from "react-bootstrap";
 import Loader from "./loader";
 

--- a/core/web/components/loadingTable.tsx
+++ b/core/web/components/loadingTable.tsx
@@ -7,26 +7,35 @@ interface Props {
   size?: string;
 }
 
-class LoadingTable extends Component<Props> {
+export default class LoadingTable extends Component<Props> {
   render() {
+    const { loading, ...propsExceptLoading } = this.props;
+
     if (this.props.loading) {
+      // @ts-ignore this.props.children is an array, it's OK
+      const head = this.props.children.find((c) => c.type === "thead");
+
+      return (
+        <Table {...propsExceptLoading}>
+          {head ? head : null}
+          <tbody>
+            <tr>
+              <td
+                colSpan={999} // arbitrarily large number to span all columns
+                style={{ textAlign: "center", verticalAlign: "middle" }}
+              >
+                <Loader />
+              </td>
+            </tr>
+          </tbody>
+        </Table>
+      );
+    } else {
       return (
         <>
-          <Loader />
-          <br />
-          <br />
+          <Table {...propsExceptLoading}>{this.props.children}</Table>
         </>
       );
     }
-
-    const { loading, ...propsExceptLoading } = this.props;
-
-    return (
-      <>
-        <Table {...propsExceptLoading}>{this.props.children}</Table>
-      </>
-    );
   }
 }
-
-export default LoadingTable;

--- a/core/web/components/profile/add.tsx
+++ b/core/web/components/profile/add.tsx
@@ -1,11 +1,14 @@
+import { useState } from "react";
 import { useApi } from "../../hooks/useApi";
 import Router from "next/router";
-import { Button } from "react-bootstrap";
+import LoadingButton from "../loadingButton";
 
 export default function (props) {
   const { execApi } = useApi(props);
+  const [loading, setLoading] = useState(false);
 
   async function create() {
+    setLoading(true);
     const response = await execApi("post", `/profile`);
     Router.push(
       "/profile/[guid]/edit",
@@ -15,9 +18,9 @@ export default function (props) {
 
   return (
     <>
-      <Button variant="warning" onClick={create}>
+      <LoadingButton variant="warning" disabled={loading} onClick={create}>
         Add new Profile
-      </Button>
+      </LoadingButton>
     </>
   );
 }

--- a/core/web/components/profile/list.tsx
+++ b/core/web/components/profile/list.tsx
@@ -4,10 +4,11 @@ import { useHistoryPagination } from "../../hooks/useHistoryPagination";
 import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
 import Link from "next/link";
 import Router from "next/router";
-import { Form, Col, Button, Badge } from "react-bootstrap";
+import { Form, Col, Badge } from "react-bootstrap";
 import Moment from "react-moment";
 import Pagination from "../pagination";
 import LoadingTable from "../loadingTable";
+import LoadingButton from "../loadingButton";
 import { AsyncTypeahead } from "react-bootstrap-typeahead";
 import { ProfileAPIData } from "../../utils/apiData";
 import ArrayProfilePropertyList from "../../components/profile/arrayProfilePropertyList";
@@ -132,7 +133,7 @@ export default function ProfilesList(props) {
                 name="searchKey"
                 as="select"
                 value={searchKey}
-                disabled={props.searchKey ? true : false}
+                disabled={props.searchKey || loading ? true : false}
                 onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                   setSearchKey(event.target.value);
                   setSearchValue("");
@@ -157,7 +158,7 @@ export default function ProfilesList(props) {
                   key={`typeahead-search-${searchKey}`}
                   id={`typeahead-search-${searchKey}`}
                   minLength={0}
-                  disabled={props.searchKey ? true : false}
+                  disabled={props.searchKey || loading ? true : false}
                   isLoading={searchLoading}
                   allowNew={true}
                   onChange={(selected) => {
@@ -187,9 +188,9 @@ export default function ProfilesList(props) {
           ) : null}
 
           <Col md={2} style={{ marginTop: 33 }}>
-            <Button size="sm" type="submit">
+            <LoadingButton size="sm" type="submit" disabled={loading}>
               Search
-            </Button>
+            </LoadingButton>
           </Col>
         </Form.Row>
       </Form>

--- a/core/web/components/profile/list.tsx
+++ b/core/web/components/profile/list.tsx
@@ -48,7 +48,6 @@ export default function ProfilesList(props) {
       event.preventDefault();
     }
 
-    setTotal(0);
     setLoading(true);
     const response = await execApi("get", `/profiles`, {
       searchKey,

--- a/core/web/components/profilePropertyRule/add.tsx
+++ b/core/web/components/profilePropertyRule/add.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useApi } from "../../hooks/useApi";
-import { Button } from "react-bootstrap";
+import LoadingButton from "../loadingButton";
 import Router from "next/router";
 
 export default function AddProfilePropertyRuleForm(props) {
@@ -9,31 +9,41 @@ export default function AddProfilePropertyRuleForm(props) {
   const [loading, setLoading] = useState(false);
 
   async function create() {
+    setLoading(true);
+
     const data = {
       sourceGuid: source.guid,
       unique: false,
       type: "string",
     };
 
-    setLoading(true);
     const response = await execApi("post", `/profilePropertyRule`, data);
-    setLoading(false);
 
     if (response?.profilePropertyRule) {
       Router.push(
         `/profilePropertyRule/${response.profilePropertyRule.guid}/edit`
       );
+    } else {
+      setLoading(false);
     }
   }
 
+  if (source.state === "draft") {
+    return (
+      <p>
+        <small>Source is not ready, cannot add Profile Property Rule</small>
+      </p>
+    );
+  }
+
   return (
-    <Button
+    <LoadingButton
       size="sm"
       variant="outline-primary"
-      disabled={loading || source.state === "draft"}
+      disabled={loading}
       onClick={create}
     >
       Add Profile Property Rule
-    </Button>
+    </LoadingButton>
   );
 }

--- a/core/web/components/schedule/add.tsx
+++ b/core/web/components/schedule/add.tsx
@@ -1,40 +1,38 @@
 import { useApi } from "../../hooks/useApi";
 import { useState } from "react";
 import Router from "next/router";
-import { Button } from "react-bootstrap";
+import LoadingButton from "../loadingButton";
 
 export default function AddScheduleForm(props) {
-  const { errorHandler, successHandler, source } = props;
+  const { errorHandler, source } = props;
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);
 
   async function create() {
-    createSchedule({
-      sourceGuid: source.guid,
-      setLoading,
-      successHandler,
-      execApi,
-    });
+    createSchedule({ execApi, sourceGuid: source.guid, setLoading });
+  }
+
+  if (source.state === "draft") {
+    return (
+      <p>
+        <small>Source is not ready, cannot add Schedule</small>
+      </p>
+    );
   }
 
   return (
-    <Button
+    <LoadingButton
       size="sm"
       variant="outline-primary"
-      disabled={loading || source.state === "draft"}
+      disabled={loading}
       onClick={create}
     >
       Add Schedule
-    </Button>
+    </LoadingButton>
   );
 }
 
-export async function createSchedule({
-  sourceGuid,
-  setLoading,
-  successHandler,
-  execApi,
-}) {
+export async function createSchedule({ execApi, sourceGuid, setLoading }) {
   const data = {
     sourceGuid,
     recurring: false,

--- a/core/web/components/session/signIn.tsx
+++ b/core/web/components/session/signIn.tsx
@@ -1,7 +1,8 @@
 import React from "react"; // needed because this is also used by a plugin
 import { useState } from "react";
 import Router from "next/router";
-import { Form, Button } from "react-bootstrap";
+import { Form } from "react-bootstrap";
+import LoadingButton from "../loadingButton";
 import { useForm } from "react-hook-form";
 import { SetupStepAPIData } from "../../utils/apiData";
 
@@ -15,7 +16,6 @@ export default function SignInForm(props) {
   const onSubmit = async (data) => {
     setLoading(true);
     const response = await execApi("post", `/session`, data);
-    setLoading(false);
     if (response?.teamMember) {
       window.localStorage.setItem("session:csrfToken", response.csrfToken);
       sessionHandler.set(response.teamMember);
@@ -31,6 +31,8 @@ export default function SignInForm(props) {
           Router.push("/setup");
         }
       }
+    } else {
+      setLoading(false);
     }
   };
 
@@ -78,9 +80,9 @@ export default function SignInForm(props) {
         </Form.Control.Feedback>
       </Form.Group>
 
-      <Button active={!loading} variant="primary" type="submit">
-        Submit
-      </Button>
+      <LoadingButton disabled={loading} variant="primary" type="submit">
+        Sign In
+      </LoadingButton>
     </Form>
   );
 }

--- a/core/web/components/session/signIn.tsx
+++ b/core/web/components/session/signIn.tsx
@@ -54,6 +54,7 @@ export default function SignInForm(props) {
       <Form.Group>
         <Form.Label>Email Address</Form.Label>
         <Form.Control
+          disabled={loading}
           autoFocus
           required
           name="email"
@@ -70,6 +71,7 @@ export default function SignInForm(props) {
         <Form.Label>Password</Form.Label>
         <Form.Control
           required
+          disabled={loading}
           name="password"
           type="password"
           placeholder="Password"

--- a/core/web/components/settings/clearCache.tsx
+++ b/core/web/components/settings/clearCache.tsx
@@ -1,17 +1,22 @@
+import { useState } from "react";
 import { useApi } from "../../hooks/useApi";
-import { Button, Card } from "react-bootstrap";
+import { Card } from "react-bootstrap";
+import LoadingButton from "../loadingButton";
 
 export default function ClearCache(props) {
   const { errorHandler, successHandler } = props;
   const { execApi } = useApi(props, errorHandler);
+  const [loading, setLoading] = useState(false);
 
   async function resetCluster() {
     if (!window.confirm("Are you sure?")) return;
 
+    setLoading(true);
     const response = await execApi("delete", `/cluster/cache`);
     if (response?.success) {
       successHandler.set({ message: `Cache Cleared!` });
     }
+    setLoading(false);
   }
 
   return (
@@ -31,9 +36,14 @@ export default function ClearCache(props) {
         <br />
 
         <Card.Text>
-          <Button onClick={resetCluster} size="sm" variant="outline-warning">
+          <LoadingButton
+            onClick={resetCluster}
+            size="sm"
+            variant="outline-warning"
+            disabled={loading}
+          >
             Clear Cache
-          </Button>
+          </LoadingButton>
         </Card.Text>
       </Card.Body>
     </Card>

--- a/core/web/components/settings/identifyingProfilePropertyRule.tsx
+++ b/core/web/components/settings/identifyingProfilePropertyRule.tsx
@@ -80,6 +80,7 @@ export default function IdentifyingProfilePropertyRule(props) {
             <Form.Label>Profile Property</Form.Label>
             <Form.Control
               as="select"
+              disabled={loading}
               value={identifyingProfilePropertyGuid}
               onChange={(e) =>
                 setIdentifyingProfilePropertyGuid(e.target.value)

--- a/core/web/components/settings/identifyingProfilePropertyRule.tsx
+++ b/core/web/components/settings/identifyingProfilePropertyRule.tsx
@@ -1,7 +1,8 @@
 import { useApi } from "../../hooks/useApi";
-import { Button, Card, Form } from "react-bootstrap";
+import { Card, Form } from "react-bootstrap";
 import { useState, useEffect } from "react";
 import { ProfilePropertyRuleAPIData } from "../../utils/apiData";
+import LoadingButton from "../loadingButton";
 
 export default function IdentifyingProfilePropertyRule(props) {
   const { errorHandler, successHandler } = props;
@@ -100,7 +101,7 @@ export default function IdentifyingProfilePropertyRule(props) {
             </Form.Control>
           </Form.Group>
 
-          <Button
+          <LoadingButton
             style={{ marginTop: 5 }}
             disabled={loading}
             size="sm"
@@ -108,7 +109,7 @@ export default function IdentifyingProfilePropertyRule(props) {
             variant="outline-secondary"
           >
             Update
-          </Button>
+          </LoadingButton>
         </Form>
       </Card.Body>
     </Card>

--- a/core/web/components/settings/importAndUpdate.tsx
+++ b/core/web/components/settings/importAndUpdate.tsx
@@ -10,10 +10,12 @@ export default function ImportAndUpdateProfile(props) {
 
   async function importAndUpdate() {
     if (window.confirm("Are you sure?")) {
+      setLoading(true);
       const response = await execApi("put", `/profiles/importAndUpdate`);
       if (response?.run) {
         successHandler.set({ message: `Run ${response.run.guid} enqueued` });
       }
+      setLoading(false);
     }
   }
 

--- a/core/web/components/settings/importAndUpdate.tsx
+++ b/core/web/components/settings/importAndUpdate.tsx
@@ -1,8 +1,11 @@
 import { useApi } from "../../hooks/useApi";
-import { Button, Card } from "react-bootstrap";
+import { useState } from "react";
+import { Card } from "react-bootstrap";
+import LoadingButton from "../loadingButton";
 
 export default function ImportAndUpdateProfile(props) {
   const { errorHandler, successHandler } = props;
+  const [loading, setLoading] = useState(false);
   const { execApi } = useApi(props, errorHandler);
 
   async function importAndUpdate() {
@@ -26,9 +29,14 @@ export default function ImportAndUpdateProfile(props) {
         <br />
 
         <Card.Text>
-          <Button onClick={importAndUpdate} size="sm" variant="outline-warning">
+          <LoadingButton
+            onClick={importAndUpdate}
+            disabled={loading}
+            size="sm"
+            variant="outline-warning"
+          >
             Import and Update all Profiles
-          </Button>
+          </LoadingButton>
         </Card.Text>
       </Card.Body>
     </Card>

--- a/core/web/components/settings/resetCluster.tsx
+++ b/core/web/components/settings/resetCluster.tsx
@@ -14,10 +14,12 @@ export default function ResetCluster(props) {
       return errorHandler.set({ error: "not proceeding" });
     }
 
+    setLoading(true);
     const response = await execApi("delete", `/cluster`);
     if (response?.success) {
       successHandler.set({ message: `Cluster Reset!` });
     }
+    setLoading(false);
   }
 
   return (

--- a/core/web/components/settings/resetCluster.tsx
+++ b/core/web/components/settings/resetCluster.tsx
@@ -1,8 +1,11 @@
 import { useApi } from "../../hooks/useApi";
-import { Button, Card } from "react-bootstrap";
+import { useState } from "react";
+import { Card } from "react-bootstrap";
+import LoadingButton from "../loadingButton";
 
 export default function ResetCluster(props) {
   const { errorHandler, successHandler } = props;
+  const [loading, setLoading] = useState(false);
   const { execApi } = useApi(props, errorHandler);
 
   async function resetCluster() {
@@ -37,9 +40,14 @@ export default function ResetCluster(props) {
         <br />
 
         <Card.Text>
-          <Button onClick={resetCluster} size="sm" variant="outline-danger">
+          <LoadingButton
+            onClick={resetCluster}
+            disabled={loading}
+            size="sm"
+            variant="outline-danger"
+          >
             Reset Cluster
-          </Button>
+          </LoadingButton>
         </Card.Text>
       </Card.Body>
     </Card>

--- a/core/web/pages/account.tsx
+++ b/core/web/pages/account.tsx
@@ -1,8 +1,9 @@
 import Head from "next/head";
 import { useState } from "react";
 import { useApi } from "../hooks/useApi";
-import { Form, Button, Row, Col } from "react-bootstrap";
+import { Form, Row, Col } from "react-bootstrap";
 import ProfileImageFromEmail from "../components/visualizations/profileImageFromEmail";
+import LoadingButton from "../components/loadingButton";
 
 export default function Page(props) {
   const { errorHandler, successHandler, sessionHandler } = props;
@@ -14,12 +15,12 @@ export default function Page(props) {
     event.preventDefault();
     setLoading(true);
     const response = await execApi("put", `/account`, teamMember);
-    setLoading(false);
     if (response?.teamMember) {
       successHandler.set({ message: "Account updated" });
       sessionHandler.set(teamMember);
       setTeamMember(response.teamMember);
     }
+    setLoading(false);
   }
 
   function update(event) {
@@ -83,9 +84,9 @@ export default function Page(props) {
               <Form.Control type="password" placeholder="*" onChange={update} />
             </Form.Group>
 
-            <Button variant="primary" type="submit" active={!loading}>
+            <LoadingButton variant="primary" type="submit" disabled={loading}>
               Update
-            </Button>
+            </LoadingButton>
           </Form>
         </Col>
       </Row>

--- a/core/web/pages/account.tsx
+++ b/core/web/pages/account.tsx
@@ -56,6 +56,7 @@ export default function Page(props) {
                 type="text"
                 defaultValue={teamMember.firstName}
                 onChange={update}
+                disabled={loading}
               />
             </Form.Group>
 
@@ -66,6 +67,7 @@ export default function Page(props) {
                 type="text"
                 defaultValue={teamMember.lastName}
                 onChange={update}
+                disabled={loading}
               />
             </Form.Group>
 
@@ -76,12 +78,18 @@ export default function Page(props) {
                 type="email"
                 defaultValue={teamMember.email}
                 onChange={update}
+                disabled={loading}
               />
             </Form.Group>
 
             <Form.Group controlId="password">
               <Form.Label>Password</Form.Label>
-              <Form.Control type="password" placeholder="*" onChange={update} />
+              <Form.Control
+                type="password"
+                placeholder="*"
+                onChange={update}
+                disabled={loading}
+              />
             </Form.Group>
 
             <LoadingButton variant="primary" type="submit" disabled={loading}>

--- a/core/web/pages/apiKey/[guid]/edit.tsx
+++ b/core/web/pages/apiKey/[guid]/edit.tsx
@@ -1,10 +1,11 @@
 import { useApi } from "../../../hooks/useApi";
 import { useState } from "react";
-import { Form, Button } from "react-bootstrap";
+import { Form } from "react-bootstrap";
 import Head from "next/head";
 import PermissionsList from "../../../components/permissions";
 import Router from "next/router";
 import ApiKeyTabs from "../../../components/tabs/apiKey";
+import LoadingButton from "../../../components/loadingButton";
 
 import { ApiKeyAPIData } from "../../../utils/apiData";
 
@@ -29,11 +30,11 @@ export default function Page(props) {
 
     setLoading(true);
     const response = await execApi("put", `/apiKey/${guid}`, _apiKey);
-    setLoading(false);
     if (response?.apiKey) {
       successHandler.set({ message: "API Key updated" });
       setApiKey(response.apiKey);
     }
+    setLoading(false);
   };
 
   async function handleDelete() {
@@ -42,6 +43,8 @@ export default function Page(props) {
       if (response) {
         successHandler.set({ message: "API Key deleted" });
         Router.push("/apiKeys");
+      } else {
+        setLoading(false);
       }
     }
   }
@@ -128,14 +131,14 @@ export default function Page(props) {
 
         <hr />
 
-        <Button variant="primary" type="submit">
+        <LoadingButton variant="primary" type="submit" disabled={loading}>
           Update
-        </Button>
+        </LoadingButton>
 
         <br />
         <br />
 
-        <Button
+        <LoadingButton
           disabled={loading}
           variant="danger"
           size="sm"
@@ -144,7 +147,7 @@ export default function Page(props) {
           }}
         >
           Delete
-        </Button>
+        </LoadingButton>
       </Form>
     </>
   );

--- a/core/web/pages/apiKey/[guid]/edit.tsx
+++ b/core/web/pages/apiKey/[guid]/edit.tsx
@@ -88,6 +88,7 @@ export default function Page(props) {
             required
             type="text"
             placeholder="API Key Name"
+            disabled={loading}
             value={apiKey.name}
             onChange={(event) => {
               const _apiKey = Object.assign({}, apiKey);

--- a/core/web/pages/apiKey/new.tsx
+++ b/core/web/pages/apiKey/new.tsx
@@ -40,6 +40,7 @@ export default function Page(props) {
           <Form.Control
             autoFocus
             required
+            disabled={loading}
             type="text"
             name="name"
             ref={register}

--- a/core/web/pages/apiKey/new.tsx
+++ b/core/web/pages/apiKey/new.tsx
@@ -3,10 +3,11 @@ import { useState } from "react";
 import { useApi } from "../../hooks/useApi";
 import { useForm } from "react-hook-form";
 import Router from "next/router";
-import { Form, Button } from "react-bootstrap";
+import { Form } from "react-bootstrap";
+import LoadingButton from "../../components/loadingButton";
 
 export default function Page(props) {
-  const { errorHandler, successHandler } = props;
+  const { errorHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const { handleSubmit, register } = useForm();
   const [loading, setLoading] = useState(false);
@@ -14,12 +15,14 @@ export default function Page(props) {
   async function onSubmit(data) {
     setLoading(true);
     const response = await execApi("post", `/apiKey`, data);
-    setLoading(false);
+
     if (response?.apiKey) {
       Router.push(
         "/apiKey/[guid]/edit",
         `/apiKey/${response.apiKey.guid}/edit`
       );
+    } else {
+      setLoading(false);
     }
   }
 
@@ -47,9 +50,9 @@ export default function Page(props) {
           </Form.Control.Feedback>
         </Form.Group>
 
-        <Button variant="primary" type="submit" disabled={loading}>
+        <LoadingButton variant="primary" type="submit" disabled={loading}>
           Submit
-        </Button>
+        </LoadingButton>
       </Form>
     </>
   );

--- a/core/web/pages/app/[guid]/edit.tsx
+++ b/core/web/pages/app/[guid]/edit.tsx
@@ -137,6 +137,7 @@ export default function Page(props) {
                 type="text"
                 placeholder="Name"
                 value={app.name}
+                disabled={loading}
                 onChange={(e) => update(e)}
               />
               <Form.Control.Feedback type="invalid">
@@ -187,6 +188,7 @@ export default function Page(props) {
                               <Typeahead
                                 id="typeahead"
                                 labelKey="key"
+                                disabled={loading}
                                 onChange={(selected) => {
                                   updateOption(opt.key, selected[0]?.key);
                                 }}
@@ -239,6 +241,7 @@ export default function Page(props) {
                                 as="select"
                                 required={opt.required}
                                 defaultValue={app.options[opt.key] || ""}
+                                disabled={loading}
                                 onChange={(e) => {
                                   updateOption(e.target.id, e.target.value);
                                 }}
@@ -275,6 +278,7 @@ export default function Page(props) {
                               <Form.Control
                                 required={opt.required}
                                 type="text"
+                                disabled={loading}
                                 defaultValue={app.options[opt.key]}
                                 placeholder={opt.placeholder}
                                 onChange={(e) => {

--- a/core/web/pages/app/new.tsx
+++ b/core/web/pages/app/new.tsx
@@ -1,9 +1,10 @@
 import Head from "next/head";
 import { useApi } from "../../hooks/useApi";
 import { useState } from "react";
-import { Form, Button } from "react-bootstrap";
+import { Form } from "react-bootstrap";
 import Router from "next/router";
 import SelectorList from "../../components/selectorList";
+import LoadingButton from "../../components/loadingButton";
 
 import { AppAPIData } from "../../utils/apiData";
 
@@ -17,9 +18,10 @@ export default function Page(props) {
     event.preventDefault();
     setLoading(true);
     const response = await execApi("post", `/app`, app);
-    setLoading(false);
     if (response?.app) {
       return Router.push("/app/[guid]/edit", `/app/${response.app.guid}/edit`);
+    } else {
+      setLoading(false);
     }
   }
 
@@ -38,9 +40,9 @@ export default function Page(props) {
       <Form id="form" onSubmit={submit}>
         <SelectorList onClick={updateApp} selectedItem={app} items={types} />
         <br />
-        <Button variant="primary" type="submit" active={!loading}>
+        <LoadingButton variant="primary" type="submit" disabled={loading}>
           Continue
-        </Button>
+        </LoadingButton>
       </Form>
     </>
   );

--- a/core/web/pages/destination/[guid]/data.tsx
+++ b/core/web/pages/destination/[guid]/data.tsx
@@ -292,6 +292,7 @@ export default function Page(props) {
                   as="select"
                   required={true}
                   value={trackedGroupGuid}
+                  disabled={loading}
                   onChange={(e) => setTrackedGroupGuid(e.target["value"])}
                 >
                   <option value={"_none"}>No Group</option>
@@ -350,6 +351,7 @@ export default function Page(props) {
                                 <Form.Control
                                   as="select"
                                   required={true}
+                                  disabled={loading}
                                   value={destination.mapping[key] || ""}
                                   onChange={(e) =>
                                     updateMapping(key, e.target["value"])
@@ -414,6 +416,7 @@ export default function Page(props) {
                                 <td>
                                   <Form.Control
                                     as="select"
+                                    disabled={loading}
                                     required={false}
                                     value={destination.mapping[key] || ""}
                                     onChange={(e) =>
@@ -479,6 +482,7 @@ export default function Page(props) {
                             id="displayedDestinationProperties"
                             ref={displayedDestinationPropertiesAutocomleteRef}
                             placeholder={`Choose a ${mappingOptions.labels.profilePropertyRule.singular}...`}
+                            disabled={loading}
                             onChange={(selected) => {
                               displayedDestinationPropertiesAutocomleteRef.current.clear();
 
@@ -535,6 +539,7 @@ export default function Page(props) {
                                 as="select"
                                 required={false}
                                 value={destination.mapping[key] || ""}
+                                disabled={loading}
                                 onChange={(e) =>
                                   updateMapping(
                                     e.target["value"],
@@ -648,6 +653,7 @@ export default function Page(props) {
                               as="select"
                               required={false}
                               value={groupGuid}
+                              disabled={loading}
                               onChange={(e) =>
                                 updateDestinationGroupMembership(
                                   e.target["value"],

--- a/core/web/pages/destination/[guid]/data.tsx
+++ b/core/web/pages/destination/[guid]/data.tsx
@@ -5,6 +5,7 @@ import ProfilePreview from "./../../../components/destination/profilePreview";
 import Head from "next/head";
 import { Typeahead } from "react-bootstrap-typeahead";
 import DestinationTabs from "../../../components/tabs/destination";
+import LoadingButton from "../../../components/loadingButton";
 
 import { DestinationAPIData } from "../../../utils/apiData";
 
@@ -756,9 +757,13 @@ export default function Page(props) {
               <Col>
                 <br />
                 <hr />
-                <Button type="submit" variant="primary" disabled={loading}>
+                <LoadingButton
+                  type="submit"
+                  variant="primary"
+                  disabled={loading}
+                >
                   Save Destination Data
-                </Button>
+                </LoadingButton>
               </Col>
             </Row>
           </Form>

--- a/core/web/pages/destination/[guid]/edit.tsx
+++ b/core/web/pages/destination/[guid]/edit.tsx
@@ -141,6 +141,7 @@ export default function Page(props) {
                 required
                 type="text"
                 placeholder="Destination Name"
+                disabled={loading}
                 defaultValue={destination.name}
                 onChange={(e) => update(e)}
               />
@@ -189,6 +190,7 @@ export default function Page(props) {
                           <Typeahead
                             id="typeahead"
                             labelKey="key"
+                            disabled={loading}
                             onChange={(selected) => {
                               updateOption(opt.key, selected[0]?.key);
                             }}
@@ -238,6 +240,7 @@ export default function Page(props) {
                           <Form.Control
                             as="select"
                             required={opt.required}
+                            disabled={loading}
                             defaultValue={destination.options[opt.key] || ""}
                             onChange={(e) =>
                               updateOption(
@@ -286,6 +289,7 @@ export default function Page(props) {
                           <Form.Control
                             required={opt.required}
                             type="text"
+                            disabled={loading}
                             defaultValue={destination.options[opt.key]}
                             placeholder={opt.placeholder}
                             onChange={(e) =>

--- a/core/web/pages/destination/[guid]/edit.tsx
+++ b/core/web/pages/destination/[guid]/edit.tsx
@@ -185,11 +185,6 @@ export default function Page(props) {
                         <Badge variant="info">required</Badge>&nbsp;
                       </>
                     ) : null}
-                    {/* {loadingOptions ? (
-                      <>
-                        <Badge variant="warning">loading</Badge>&nbsp;
-                      </>
-                    ) : null} */}
                     <code>{opt.key}</code>
                   </Form.Label>
                   {(() => {
@@ -199,7 +194,7 @@ export default function Page(props) {
                           <Typeahead
                             id="typeahead"
                             labelKey="key"
-                            disabled={loading || loadOptions}
+                            disabled={loading || loadingOptions}
                             onChange={(selected) => {
                               updateOption(opt.key, selected[0]?.key);
                             }}

--- a/core/web/pages/destination/[guid]/edit.tsx
+++ b/core/web/pages/destination/[guid]/edit.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useApi } from "../../../hooks/useApi";
-import { Row, Col, Form, Button, Badge } from "react-bootstrap";
+import { Row, Col, Form, Badge } from "react-bootstrap";
 import Router from "next/router";
 import Link from "next/link";
 import Head from "next/head";
@@ -8,6 +8,7 @@ import AppIcon from "./../../../components/appIcon";
 import StateBadge from "./../../../components/stateBadge";
 import { Typeahead } from "react-bootstrap-typeahead";
 import DestinationTabs from "./../../../components/tabs/destination";
+import LoadingButton from "../../../components/loadingButton";
 
 import { DestinationAPIData } from "../../../utils/apiData";
 
@@ -24,6 +25,7 @@ export default function Page(props) {
   const [destination, setDestination] = useState<DestinationAPIData>(
     props.destination
   );
+  const [loading, setLoading] = useState(false);
   const [connectionOptions, setConnectionOptions] = useState(
     props.connectionOptions
   );
@@ -37,6 +39,7 @@ export default function Page(props) {
     delete destination["destinationGroupMemberships"];
     delete destination["groups"];
 
+    setLoading(true);
     const response = await execApi(
       "put",
       `/destination/${guid}`,
@@ -57,9 +60,11 @@ export default function Page(props) {
         successHandler.set({ message: "Destination updated" });
       }
     }
+    setLoading(false);
   };
 
   async function refreshOptions() {
+    setLoading(true);
     const response = await execApi(
       "get",
       `/destination/${guid}/connectionOptions`,
@@ -69,13 +74,17 @@ export default function Page(props) {
       false
     );
     if (response?.options) setConnectionOptions(response.options);
+    setLoading(false);
   }
 
   async function handleDelete() {
     if (window.confirm("are you sure?")) {
+      setLoading(true);
       const response = await execApi("delete", `/destination/${guid}`);
       if (response) {
         Router.push("/destinations");
+      } else {
+        setLoading(false);
       }
     }
   }
@@ -87,7 +96,7 @@ export default function Page(props) {
         ? event.target.checked
         : event.target.value;
     setDestination(_destination);
-    setTimeout(refreshOptions, 100);
+    if (event.target.id !== "name") setTimeout(refreshOptions, 100);
   };
 
   const updateOption = async (optKey, optValue) => {
@@ -315,20 +324,23 @@ export default function Page(props) {
 
             <br />
 
-            <Button variant="primary" type="submit">
+            <LoadingButton variant="primary" type="submit" disabled={loading}>
               Update
-            </Button>
+            </LoadingButton>
+
             <br />
             <br />
-            <Button
+
+            <LoadingButton
               variant="danger"
               size="sm"
+              disabled={loading}
               onClick={() => {
                 handleDelete();
               }}
             >
               Delete
-            </Button>
+            </LoadingButton>
           </Form>
         </Col>
       </Row>

--- a/core/web/pages/destination/new.tsx
+++ b/core/web/pages/destination/new.tsx
@@ -1,14 +1,16 @@
 import Head from "next/head";
 import { useApi } from "../../hooks/useApi";
 import { useState } from "react";
-import { Form, Button } from "react-bootstrap";
+import { Form } from "react-bootstrap";
 import SelectorList from "../../components/selectorList";
+import LoadingButton from "../../components/loadingButton";
 import Link from "next/link";
 import Router from "next/router";
 
 export default function Page(props) {
   const { errorHandler, successHandler, connectionApps } = props;
   const { execApi } = useApi(props, errorHandler);
+  const [loading, setLoading] = useState(false);
   const [destination, setDestination] = useState({
     appGuid: "",
     type: "",
@@ -16,12 +18,15 @@ export default function Page(props) {
 
   const create = async (event) => {
     event.preventDefault();
+    setLoading(true);
     const response = await execApi("post", `/destination`, destination);
     if (response?.destination) {
       Router.push(
         "/destination/[guid]/edit",
         `/destination/${response.destination.guid}/edit`
       );
+    } else {
+      setLoading(false);
     }
   };
 
@@ -61,7 +66,9 @@ export default function Page(props) {
           displayAddAppButton={true}
         />
         <br />
-        <Button type="submit">Create Destination</Button>
+        <LoadingButton disabled={loading} type="submit">
+          Create Destination
+        </LoadingButton>
       </Form>
     </>
   );

--- a/core/web/pages/file/[guid]/edit.tsx
+++ b/core/web/pages/file/[guid]/edit.tsx
@@ -1,12 +1,15 @@
 import FileTabs from "../../../components/tabs/file";
 import Head from "next/head";
 import Router from "next/router";
+import { useState } from "react";
 import { useApi } from "../../../hooks/useApi";
 import { Row, Col, Button, Image } from "react-bootstrap";
+import LoadingButton from "../../../components/loadingButton";
 
 export default function Page(props) {
   const { errorhandler, successHandler, file } = props;
   const { execApi } = useApi(props, errorhandler);
+  const [loading, setLoading] = useState(false);
 
   const apiVersion = process.env.API_VERSION || "v1";
   const csrfToken = globalThis?.localStorage?.getItem("session:csrfToken");
@@ -21,10 +24,13 @@ export default function Page(props) {
 
   async function destroy(file) {
     if (confirm("are you sure?")) {
+      setLoading(true);
       const response = await execApi("delete", `/file/${file.guid}`);
       if (response?.success) {
         successHandler.set({ message: "File Deleted" });
         Router.push("/files");
+      } else {
+        setLoading(false);
       }
     }
   }
@@ -81,15 +87,16 @@ export default function Page(props) {
 
       <hr />
 
-      <Button
+      <LoadingButton
         size="sm"
         variant="danger"
+        disabled={loading}
         onClick={() => {
           destroy(file);
         }}
       >
         Delete
-      </Button>
+      </LoadingButton>
     </>
   );
 }

--- a/core/web/pages/file/new.tsx
+++ b/core/web/pages/file/new.tsx
@@ -54,6 +54,7 @@ export default function Page(props) {
             as="select"
             name="type"
             defaultValue=""
+            disabled={loading}
             ref={register}
           >
             <option disabled value="">
@@ -67,7 +68,13 @@ export default function Page(props) {
 
         <Form.Group>
           <Form.Label>File</Form.Label>
-          <Form.Control required type="file" name="file" ref={register} />
+          <Form.Control
+            required
+            type="file"
+            name="file"
+            ref={register}
+            disabled={loading}
+          />
           <Form.Control.Feedback type="invalid">
             Type is required
           </Form.Control.Feedback>

--- a/core/web/pages/file/new.tsx
+++ b/core/web/pages/file/new.tsx
@@ -2,8 +2,9 @@ import Head from "next/head";
 import { useState, useEffect } from "react";
 import { useApi } from "../../hooks/useApi";
 import { useForm } from "react-hook-form";
-import { Form, Button, ProgressBar } from "react-bootstrap";
+import { Form, ProgressBar } from "react-bootstrap";
 import Router from "next/router";
+import LoadingButton from "../../components/loadingButton";
 
 export default function Page(props) {
   const { errorHandler, uploadHandler, types } = props;
@@ -87,9 +88,9 @@ export default function Page(props) {
           </>
         ) : null}
 
-        <Button variant="primary" type="submit" disabled={loading}>
+        <LoadingButton variant="primary" type="submit" disabled={loading}>
           Submit
-        </Button>
+        </LoadingButton>
       </Form>
     </>
   );

--- a/core/web/pages/files.tsx
+++ b/core/web/pages/files.tsx
@@ -9,6 +9,7 @@ import { useHistoryPagination } from "../hooks/useHistoryPagination";
 import Moment from "react-moment";
 import Pagination from "../components/pagination";
 import LoadingTable from "../components/loadingTable";
+import LoadingButton from "../components/loadingButton";
 
 import { FileAPIData } from "../utils/apiData";
 
@@ -38,11 +39,11 @@ export default function Page(props) {
       limit,
       offset,
     });
-    setLoading(false);
     if (response?.files) {
       setFiles(response.files);
       setTotal(response.total);
     }
+    setLoading(false);
   }
 
   async function download(file) {
@@ -55,11 +56,11 @@ export default function Page(props) {
     if (confirm("are you sure?")) {
       setLoading(true);
       const response = await execApi("delete", `/file/${file.guid}`);
-      setLoading(false);
       if (response?.success) {
         successHandler.set({ message: "File Deleted" });
         await load();
       }
+      setLoading(false);
     }
   }
 
@@ -156,15 +157,16 @@ export default function Page(props) {
                   </Button>
                 </td>
                 <td>
-                  <Button
+                  <LoadingButton
                     size="sm"
+                    disabled={loading}
                     variant="outline-danger"
                     onClick={() => {
                       destroy(file);
                     }}
                   >
                     X
-                  </Button>
+                  </LoadingButton>
                 </td>
               </tr>
             );

--- a/core/web/pages/group/[guid]/edit.tsx
+++ b/core/web/pages/group/[guid]/edit.tsx
@@ -83,6 +83,7 @@ export default function Page(props) {
                 type="text"
                 placeholder="Group Name"
                 value={group.name}
+                disabled={loading}
                 onChange={update}
               />
               <Form.Control.Feedback type="invalid">
@@ -110,6 +111,7 @@ export default function Page(props) {
                 as="select"
                 value={group.matchType}
                 onChange={update}
+                disabled={loading}
               >
                 <option>any</option>
                 <option>all</option>

--- a/core/web/pages/group/[guid]/edit.tsx
+++ b/core/web/pages/group/[guid]/edit.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import { useApi } from "../../../hooks/useApi";
-import { Row, Col, Form, Button } from "react-bootstrap";
+import { Row, Col, Form } from "react-bootstrap";
 import StateBadge from "../../../components/stateBadge";
 import Moment from "react-moment";
 import Router from "next/router";
 import Head from "next/head";
 import GroupTabs from "../../../components/tabs/group";
+import LoadingButton from "../../../components/loadingButton";
 
 import { GroupAPIData } from "../../../utils/apiData";
 
@@ -29,12 +30,13 @@ export default function Page(props) {
     event.preventDefault();
     setLoading(true);
     const response = await execApi("put", `/group/${group.guid}`, group);
-    setLoading(false);
+
     if (response?.group) {
       successHandler.set({ message: "Group Updated" });
       setGroup(response.group);
       groupHandler.set(response.group);
     }
+    setLoading(false);
   }
 
   async function handleDelete(force = false) {
@@ -43,12 +45,13 @@ export default function Page(props) {
       const response = await execApi("delete", `/group/${group.guid}`, {
         force,
       });
-      setLoading(false);
       if (response?.success) {
         successHandler.set({
           message: force ? "Group Deleted" : "Group scheduled to be deleted",
         });
         Router.push("/groups");
+      } else {
+        setLoading(false);
       }
     }
   }
@@ -113,24 +116,25 @@ export default function Page(props) {
               </Form.Control>
             </Form.Group>
 
-            <Button variant="primary" type="submit" active={!loading}>
+            <LoadingButton variant="primary" type="submit" disabled={loading}>
               Update
-            </Button>
+            </LoadingButton>
 
             <br />
             <br />
 
             {group.state === "deleted" ? (
               <>
-                <Button
+                <LoadingButton
                   variant="danger"
+                  disabled={loading}
                   size="sm"
                   onClick={() => {
                     handleDelete(true);
                   }}
                 >
                   Force Delete
-                </Button>
+                </LoadingButton>
                 <p>
                   <br />
                   <em>
@@ -141,15 +145,16 @@ export default function Page(props) {
                 </p>
               </>
             ) : (
-              <Button
+              <LoadingButton
                 variant="danger"
+                disabled={loading}
                 size="sm"
                 onClick={() => {
                   handleDelete();
                 }}
               >
                 Delete
-              </Button>
+              </LoadingButton>
             )}
           </Form>
         </Col>

--- a/core/web/pages/group/[guid]/rules.tsx
+++ b/core/web/pages/group/[guid]/rules.tsx
@@ -215,6 +215,7 @@ export default function Page(props) {
                       <Form.Control
                         as="select"
                         value={rule.key}
+                        disabled={loading}
                         onChange={(e: any) => {
                           const _rules = [...localRules];
                           rule.key = e.target.value;
@@ -260,6 +261,7 @@ export default function Page(props) {
                       <Form.Control
                         as="select"
                         value={rule.operation.op}
+                        disabled={loading}
                         onChange={(e: any) => {
                           const _rules = [...localRules];
                           rule.operation.op = e.target.value;
@@ -314,6 +316,7 @@ export default function Page(props) {
                         <>
                           <Form.Control
                             type="number"
+                            disabled={loading}
                             placeholder="(number)"
                             value={rule.relativeMatchNumber?.toString() || ""}
                             onChange={(e: any) => {
@@ -329,6 +332,7 @@ export default function Page(props) {
 
                           <Form.Control
                             as="select"
+                            disabled={loading}
                             value={rule.relativeMatchUnit || ""}
                             onChange={(e: any) => {
                               const _rules = [...localRules];
@@ -358,6 +362,7 @@ export default function Page(props) {
                       ["integer", "float"].includes(type) ? (
                         <div className="form-inline" style={{ minWidth: 250 }}>
                           <Form.Control
+                            disabled={loading}
                             placeholder="(number)"
                             value={rule.match?.toString() || ""}
                             onChange={(e: any) => {

--- a/core/web/pages/group/[guid]/rules.tsx
+++ b/core/web/pages/group/[guid]/rules.tsx
@@ -4,8 +4,9 @@ import StateBadge from "../../../components/stateBadge";
 import Head from "next/head";
 import GroupTabs from "../../../components/tabs/group";
 import DatePicker from "../../../components/datePicker";
-import { Form, Button, Table, Badge } from "react-bootstrap";
+import { Form, Table, Badge, Button } from "react-bootstrap";
 import { AsyncTypeahead } from "react-bootstrap-typeahead";
+import LoadingButton from "../../../components/loadingButton";
 
 import { GroupAPIData } from "../../../utils/apiData";
 
@@ -53,7 +54,7 @@ export default function Page(props) {
       null,
       useCache
     );
-    setLoading(false);
+
     if (response?.componentCounts) {
       setComponentCounts(response.componentCounts);
       // setFunnelCounts(response.funnelCounts);
@@ -70,6 +71,8 @@ export default function Page(props) {
     if (response) {
       setCountPotentialMembers(response.count);
     }
+
+    setLoading(false);
   }
 
   function addRule() {
@@ -100,12 +103,12 @@ export default function Page(props) {
       guid: group.guid,
       rules: localRules,
     });
-    setLoading(false);
     if (response?.group) {
       successHandler.set({ message: "Group Updated" });
       setGroup(response.group);
       setLocalRules(response.group.rules);
     }
+    setLoading(false);
   }
 
   async function autocompleteProfilePropertySearch(localRule, match) {
@@ -448,7 +451,7 @@ export default function Page(props) {
         Add Rule
       </Button>
       &nbsp;
-      <Button
+      <LoadingButton
         disabled={loading}
         variant="outline-dark"
         size="sm"
@@ -457,11 +460,11 @@ export default function Page(props) {
         }}
       >
         Count Potential Group Members
-      </Button>
+      </LoadingButton>
       <br />
       <br />
-      <Button
-        active={!loading}
+      <LoadingButton
+        disabled={loading}
         variant="primary"
         onClick={async () => {
           await updateRules();
@@ -469,7 +472,7 @@ export default function Page(props) {
         }}
       >
         Save Rules
-      </Button>
+      </LoadingButton>
     </>
   );
 }

--- a/core/web/pages/group/new.tsx
+++ b/core/web/pages/group/new.tsx
@@ -48,6 +48,7 @@ export default function (props) {
             type="text"
             name="name"
             ref={register}
+            disabled={loading}
             placeholder="Group Name"
           />
           <Form.Control.Feedback type="invalid">
@@ -57,7 +58,12 @@ export default function (props) {
 
         <Form.Group>
           <Form.Label>Group Type</Form.Label>
-          <Form.Control as="select" name="type" ref={register}>
+          <Form.Control
+            as="select"
+            name="type"
+            ref={register}
+            disabled={loading}
+          >
             <option>calculated</option>
             <option>manual</option>
           </Form.Control>

--- a/core/web/pages/group/new.tsx
+++ b/core/web/pages/group/new.tsx
@@ -3,7 +3,8 @@ import { useState } from "react";
 import { useApi } from "../../hooks/useApi";
 import { useForm } from "react-hook-form";
 import Router from "next/router";
-import { Form, Button } from "react-bootstrap";
+import { Form } from "react-bootstrap";
+import LoadingButton from "../../components/loadingButton";
 
 export default function (props) {
   const { errorHandler, successHandler } = props;
@@ -19,13 +20,14 @@ export default function (props) {
       `/group`,
       Object.assign({}, data, { state })
     );
-    setLoading(false);
     if (response?.group) {
       const path = response.group.type === "calculated" ? "rules" : "edit";
       Router.push(
         `/group/[guid]/${path}`,
         `/group/${response.group.guid}/${path}`
       );
+    } else {
+      setLoading(false);
     }
   }
 
@@ -61,9 +63,9 @@ export default function (props) {
           </Form.Control>
         </Form.Group>
 
-        <Button variant="primary" type="submit" active={!loading}>
+        <LoadingButton variant="primary" type="submit" disabled={loading}>
           Submit
-        </Button>
+        </LoadingButton>
       </Form>
     </>
   );

--- a/core/web/pages/profile/[guid]/edit.tsx
+++ b/core/web/pages/profile/[guid]/edit.tsx
@@ -257,7 +257,7 @@ export default function Page(props) {
               <Col md={9}>
                 <Form.Group controlId="groupGuid">
                   <Form.Label>Add Group</Form.Label>
-                  <Form.Control as="select">
+                  <Form.Control as="select" disabled={loading}>
                     {allGroups.map((group) => {
                       const disabled =
                         group.type !== "manual" ||
@@ -321,6 +321,7 @@ export default function Page(props) {
                             <Form.Control
                               required
                               type="text"
+                              disabled={loading}
                               value={
                                 properties[key].values.length === 0
                                   ? ""

--- a/core/web/pages/profile/[guid]/edit.tsx
+++ b/core/web/pages/profile/[guid]/edit.tsx
@@ -3,7 +3,8 @@ import Link from "next/link";
 import ProfileTabs from "../../../components/tabs/profile";
 import { useState, useEffect } from "react";
 import { useApi } from "../../../hooks/useApi";
-import { Row, Col, Button, Form, ListGroup } from "react-bootstrap";
+import { Row, Col, Form, ListGroup } from "react-bootstrap";
+import LoadingButton from "../../../components/loadingButton";
 import Router from "next/router";
 import ProfileImageFromEmail from "../../../components/visualizations/profileImageFromEmail";
 import Moment from "react-moment";
@@ -43,13 +44,13 @@ export default function Page(props) {
   async function load() {
     setLoading(true);
     const response = await execApi("get", `/profile/${profile.guid}`);
-    setLoading(false);
     if (response?.profile) {
       profileHandler.set(response.profile);
       setProfile(response.profile);
       setProperties(response.profile.properties);
       setGroups(response.groups);
     }
+    setLoading(false);
   }
 
   async function importAndUpdate() {
@@ -59,25 +60,27 @@ export default function Page(props) {
       "post",
       `/profile/${profile.guid}/importAndUpdate`
     );
-    setLoading(false);
     if (response?.profile) {
       successHandler.set({ message: "Import and Export Complete!" });
       load();
     }
+    setLoading(false);
   }
 
   async function handleDelete() {
     if (window.confirm("are you sure?")) {
       setLoading(true);
       const response = await execApi("delete", `/profile/${profile.guid}`);
-      setLoading(false);
       if (response) {
         Router.push("/profiles");
+      } else {
+        setLoading(false);
       }
     }
   }
 
   async function handleRemove(group) {
+    setLoading(true);
     const response = await execApi("put", `/group/${group.guid}/remove`, {
       profileGuid: profile.guid,
     });
@@ -87,6 +90,7 @@ export default function Page(props) {
       });
       load();
     }
+    setLoading(false);
   }
 
   async function handleAdd(event) {
@@ -94,6 +98,7 @@ export default function Page(props) {
     event.preventDefault();
     const groupGuid = form.elements[0].value;
 
+    setLoading(true);
     const response = await execApi("put", `/group/${groupGuid}/add`, {
       profileGuid: profile.guid,
     });
@@ -103,6 +108,7 @@ export default function Page(props) {
       });
       load();
     }
+    setLoading(false);
   }
 
   async function handleUpdate(key) {
@@ -112,11 +118,11 @@ export default function Page(props) {
     const response = await execApi("put", `/profile/${profile.guid}`, {
       properties: hash,
     });
-    setLoading(false);
     if (response?.profile?.properties) {
       successHandler.set({ message: `property ${key} updated` });
       load();
     }
+    setLoading(false);
   }
 
   const keys = Object.keys(properties);
@@ -186,18 +192,20 @@ export default function Page(props) {
                 );
               })}
               <br />
-              <Button
+              <LoadingButton
+                disabled={loading}
                 onClick={() => {
                   importAndUpdate();
                 }}
               >
                 Import and Export
-              </Button>
+              </LoadingButton>
 
               <br />
               <br />
 
-              <Button
+              <LoadingButton
+                disabled={loading}
                 variant="danger"
                 size="sm"
                 onClick={() => {
@@ -205,7 +213,7 @@ export default function Page(props) {
                 }}
               >
                 Delete
-              </Button>
+              </LoadingButton>
             </Col>
           </Row>
         </Col>
@@ -219,7 +227,8 @@ export default function Page(props) {
               <ListGroup.Item key={`groupMember-${group.guid}`} variant="info">
                 {group.type === "manual" ? (
                   <>
-                    <Button
+                    <LoadingButton
+                      disabled={loading}
                       size="sm"
                       variant="danger"
                       onClick={() => {
@@ -227,7 +236,7 @@ export default function Page(props) {
                       }}
                     >
                       X
-                    </Button>
+                    </LoadingButton>
                     &nbsp; &nbsp;
                   </>
                 ) : null}
@@ -268,9 +277,14 @@ export default function Page(props) {
               </Col>
               <Col md={3}>
                 <div style={{ paddingTop: 34 }} />
-                <Button variant="outline-primary" size="sm" type="submit">
+                <LoadingButton
+                  variant="outline-primary"
+                  size="sm"
+                  type="submit"
+                  disabled={loading}
+                >
                   Add
-                </Button>
+                </LoadingButton>
               </Col>
             </Row>
           </Form>
@@ -316,16 +330,17 @@ export default function Page(props) {
                             />
                           </Form.Group>
 
-                          <Button
+                          <LoadingButton
                             size="sm"
                             type="submit"
                             variant="info"
+                            disabled={loading}
                             onClick={() => {
                               handleUpdate(key);
                             }}
                           >
                             Update
-                          </Button>
+                          </LoadingButton>
                         </Form>
                       ) : (
                         <span>

--- a/core/web/pages/profilePropertyRule/[guid]/edit.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/edit.tsx
@@ -191,6 +191,7 @@ export default function Page(props) {
               <Form.Control
                 required
                 type="text"
+                disabled={loading}
                 value={profilePropertyRule.key}
                 onChange={(e) => update(e)}
               />
@@ -204,6 +205,7 @@ export default function Page(props) {
                 as="select"
                 value={profilePropertyRule.type}
                 onChange={(e) => update(e)}
+                disabled={loading}
               >
                 <option value="" disabled>
                   Choose a Type
@@ -219,6 +221,7 @@ export default function Page(props) {
                 label="Unique"
                 checked={profilePropertyRule.unique}
                 onChange={(e) => update(e)}
+                disabled={loading}
               />
             </Form.Group>
             <Form.Group controlId="isArray">
@@ -227,6 +230,7 @@ export default function Page(props) {
                 label="Is Array?"
                 checked={profilePropertyRule.isArray}
                 onChange={(e) => update(e)}
+                disabled={loading}
               />
             </Form.Group>
             <Form.Group controlId="sourceGuid">
@@ -265,6 +269,7 @@ export default function Page(props) {
                     <Typeahead
                       id="typeahead"
                       labelKey="key"
+                      disabled={loading}
                       onChange={(selected) => {
                         if (selected.length === 1 && selected[0].key) {
                           updateOption(opt.key, selected[0].key);
@@ -332,6 +337,7 @@ export default function Page(props) {
                                 inline
                                 type="radio"
                                 name={opt.key}
+                                disabled={loading}
                                 defaultChecked={
                                   profilePropertyRule.options[opt.key] ===
                                   col.key
@@ -362,6 +368,7 @@ export default function Page(props) {
                     <Form.Group controlId="key">
                       <Form.Control
                         required
+                        disabled={loading}
                         type="text"
                         value={profilePropertyRule.options[opt.key]}
                         onChange={(e) => updateOption(opt.key, e.target.value)}
@@ -383,6 +390,7 @@ export default function Page(props) {
                       <Form.Control
                         required
                         as="textarea"
+                        disabled={loading}
                         rows={5}
                         value={profilePropertyRule.options[opt.key]}
                         onChange={(e) =>
@@ -490,6 +498,7 @@ export default function Page(props) {
                               <Form.Control
                                 as="select"
                                 value={localFilter.key}
+                                disabled={loading}
                                 onChange={(e: any) => {
                                   const _localFilters = [...localFilters];
                                   localFilter.key = e.target.value;
@@ -514,6 +523,7 @@ export default function Page(props) {
                             >
                               <Form.Control
                                 as="select"
+                                disabled={loading}
                                 value={localFilter.op}
                                 onChange={(e: any) => {
                                   const _localFilters = [...localFilters];
@@ -564,6 +574,7 @@ export default function Page(props) {
                                 <Form.Control
                                   required
                                   type="text"
+                                  disabled={loading}
                                   value={localFilter.match.toString()}
                                   onChange={(e: any) => {
                                     const _localFilter = [...localFilters];

--- a/core/web/pages/profilePropertyRule/[guid]/edit.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/edit.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, Fragment } from "react";
 import { useApi } from "../../../hooks/useApi";
-import { Row, Col, Button, Form, Table, Badge } from "react-bootstrap";
+import { Row, Col, Form, Table, Badge, Button } from "react-bootstrap";
 import Router from "next/router";
 import Link from "next/link";
 import Loader from "../../../components/loader";
@@ -9,6 +9,7 @@ import StateBadge from "../../../components/stateBadge";
 import ProfilePreview from "../../../components/profilePropertyRule/profilePreview";
 import { Typeahead } from "react-bootstrap-typeahead";
 import DatePicker from "../../../components/datePicker";
+import LoadingButton from "../../../components/loadingButton";
 
 import Head from "next/head";
 import ProfilePropertyRuleTabs from "../../../components/tabs/profilePropertyRule";
@@ -603,14 +604,19 @@ export default function Page(props) {
               </>
             ) : null}
             <hr />
-            <Button variant="primary" type="submit" active={!loading}>
+            <LoadingButton variant="primary" type="submit" disabled={loading}>
               Update
-            </Button>
+            </LoadingButton>
             <br />
             <br />
-            <Button variant="danger" size="sm" onClick={() => handleDelete()}>
+            <LoadingButton
+              variant="danger"
+              size="sm"
+              disabled={loading}
+              onClick={() => handleDelete()}
+            >
               Delete
-            </Button>
+            </LoadingButton>
           </Col>
           <Col md={3}>
             <ProfilePreview

--- a/core/web/pages/profilePropertyRules.tsx
+++ b/core/web/pages/profilePropertyRules.tsx
@@ -210,6 +210,7 @@ export default function Page(props) {
               as="select"
               size="sm"
               value={newRuleSourceGuid}
+              disabled={loading}
               onChange={(e) => {
                 setNewRuleSourceGuid(e.target.value);
               }}

--- a/core/web/pages/profilePropertyRules.tsx
+++ b/core/web/pages/profilePropertyRules.tsx
@@ -6,6 +6,7 @@ import { useHistoryPagination } from "../hooks/useHistoryPagination";
 import Router from "next/router";
 import Link from "next/link";
 import { Button, Form, Alert } from "react-bootstrap";
+import LoadingButton from "../components/loadingButton";
 import Moment from "react-moment";
 import Pagination from "../components/pagination";
 import LoadingTable from "../components/loadingTable";
@@ -219,14 +220,14 @@ export default function Page(props) {
                 </option>
               ))}
             </Form.Control>{" "}
-            <Button
+            <LoadingButton
               type="submit"
               size="sm"
               disabled={newRuleLoading}
               variant="primary"
             >
               Create
-            </Button>
+            </LoadingButton>
           </p>
         </Form>
       ) : null}

--- a/core/web/pages/resque/delayed.tsx
+++ b/core/web/pages/resque/delayed.tsx
@@ -1,16 +1,18 @@
 import { useState, useEffect } from "react";
 import { useApi } from "../../hooks/useApi";
-import { Button, Table, Row, Col } from "react-bootstrap";
+import { Table, Row, Col } from "react-bootstrap";
 import Pagination from "../../components/pagination";
 import Router from "next/router";
 import Head from "next/head";
 import ResqueTabs from "../../components/tabs/resque";
+import LoadingButton from "../../components/loadingButton";
 
 export default function ResqueDelayedList(props) {
   const { errorHandler, query, successHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const [timestamps, setTimestamps] = useState([]);
   const [delayedJobs, setDelayedJobs] = useState({});
+  const [loading, setLoading] = useState(false);
 
   // pagination
   const limit = 100;
@@ -23,6 +25,7 @@ export default function ResqueDelayedList(props) {
 
   async function load() {
     updateURLParams();
+    setLoading(true);
     const response = await execApi(
       "get",
       "/resque/delayedjobs",
@@ -49,26 +52,31 @@ export default function ResqueDelayedList(props) {
 
     setDelayedJobs(response.delayedjobs);
     setTimestamps(_timestamps);
+    setLoading(false);
   }
 
   async function delDelayed(timestamp, count) {
     if (window.confirm("Are you sure?")) {
+      setLoading(true);
       await execApi("post", "/resque/delDelayed", {
         timestamp: timestamp,
         count: count,
       });
       successHandler.set({ message: "deleted" });
       await load();
+      setLoading(false);
     }
   }
 
   async function runDelayed(timestamp, count) {
+    setLoading(true);
     await execApi("post", "/resque/runDelayed", {
       timestamp: timestamp,
       count: count,
     });
     successHandler.set({ message: "run" });
     await load();
+    setLoading(false);
   }
 
   function updateURLParams() {
@@ -143,22 +151,24 @@ export default function ResqueDelayedList(props) {
                                   </ul>
                                 </td>
                                 <td>
-                                  <Button
+                                  <LoadingButton
+                                    disabled={loading}
                                     onClick={() => runDelayed(t.key, jidx)}
                                     variant="warning"
                                     size="sm"
                                   >
                                     Run Now
-                                  </Button>
+                                  </LoadingButton>
                                 </td>
                                 <td>
-                                  <Button
+                                  <LoadingButton
+                                    disabled={loading}
                                     onClick={() => delDelayed(t.key, jidx)}
                                     variant="danger"
                                     size="sm"
                                   >
                                     Remove
-                                  </Button>
+                                  </LoadingButton>
                                 </td>
                               </tr>
                             );

--- a/core/web/pages/resque/failed.tsx
+++ b/core/web/pages/resque/failed.tsx
@@ -5,10 +5,12 @@ import Pagination from "../../components/pagination";
 import Router from "next/router";
 import Head from "next/head";
 import ResqueTabs from "../../components/tabs/resque";
+import LoadingButton from "../../components/loadingButton";
 
 export default function ResqueFailedList(props) {
   const { errorHandler, query, successHandler } = props;
   const { execApi } = useApi(props, errorHandler);
+  const [loading, setLoading] = useState(false);
   const [failed, setFailed] = useState([]);
   const [focusedException, setFocusedException] = useState({
     exception: "",
@@ -31,6 +33,7 @@ export default function ResqueFailedList(props) {
 
   async function load() {
     updateURLParams();
+    setLoading(true);
     const response = await execApi("get", "/resque/resqueFailed", {
       offset,
       limit,
@@ -38,35 +41,44 @@ export default function ResqueFailedList(props) {
 
     setFailed(response.failed);
     setTotal(response.total);
+    setLoading(false);
   }
 
   async function removeFailedJob(index) {
+    setLoading(true);
     await execApi("post", "/resque/removeFailed", { id: index });
     successHandler.set({ message: "removed" });
     await load();
+    setLoading(false);
   }
 
   async function retryFailedJob(index) {
+    setLoading(true);
     await execApi("post", "/resque/retryAndRemoveFailed", {
       id: index,
     });
     successHandler.set({ message: "retried" });
     await load();
+    setLoading(false);
   }
 
   async function removeAllFailedJobs() {
     if (window.confirm("Are you sure?")) {
+      setLoading(true);
       await execApi("post", "/resque/removeAllFailed");
       successHandler.set({ message: "removed all" });
       await load();
+      setLoading(false);
     }
   }
 
   async function retryAllFailedJobs() {
     if (window.confirm("Are you sure?")) {
+      setLoading(true);
       await execApi("post", "/resque/retryAndRemoveAllFailed");
       successHandler.set({ message: "retried all" });
       await load();
+      setLoading(false);
     }
   }
 
@@ -104,7 +116,8 @@ export default function ResqueFailedList(props) {
       <Row>
         <Col md={12}>
           <ButtonToolbar>
-            <Button
+            <LoadingButton
+              disabled={loading}
               onClick={() => {
                 retryAllFailedJobs();
               }}
@@ -112,9 +125,10 @@ export default function ResqueFailedList(props) {
               variant="warning"
             >
               Retry All
-            </Button>
+            </LoadingButton>
             &nbsp;
-            <Button
+            <LoadingButton
+              disabled={loading}
               onClick={() => {
                 removeAllFailedJobs();
               }}
@@ -122,7 +136,7 @@ export default function ResqueFailedList(props) {
               variant="danger"
             >
               Remove All
-            </Button>
+            </LoadingButton>
           </ButtonToolbar>
         </Col>
         <br />
@@ -182,22 +196,24 @@ export default function ResqueFailedList(props) {
                       </ul>
                     </td>
                     <td>
-                      <Button
+                      <LoadingButton
+                        disabled={loading}
                         onClick={() => retryFailedJob(offset + idx)}
                         variant="warning"
                         size="sm"
                       >
                         Retry
-                      </Button>
+                      </LoadingButton>
                     </td>
                     <td>
-                      <Button
+                      <LoadingButton
+                        disabled={loading}
                         onClick={() => removeFailedJob(offset + idx)}
                         variant="danger"
                         size="sm"
                       >
                         Remove
-                      </Button>
+                      </LoadingButton>
                     </td>
                   </tr>
                 );

--- a/core/web/pages/resque/locks.tsx
+++ b/core/web/pages/resque/locks.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react";
 import { useApi } from "../../hooks/useApi";
-import { Table, Row, Col, Button } from "react-bootstrap";
+import { Table, Row, Col } from "react-bootstrap";
 import Pagination from "../../components/pagination";
 import Router from "next/router";
 import Head from "next/head";
 import ResqueTabs from "../../components/tabs/resque";
+import LoadingButton from "../../components/loadingButton";
 
 export default function ResqueLocksList(props) {
   const { errorHandler, successHandler, query } = props;
@@ -89,7 +90,8 @@ export default function ResqueLocksList(props) {
                     <td>{l.lock}</td>
                     <td>{l.at.toString()}</td>
                     <td>
-                      <Button
+                      <LoadingButton
+                        disabled={loading}
                         onClick={() => {
                           delLock(l.lock);
                         }}
@@ -97,7 +99,7 @@ export default function ResqueLocksList(props) {
                         variant="warning"
                       >
                         Delete
-                      </Button>
+                      </LoadingButton>
                     </td>
                   </tr>
                 );

--- a/core/web/pages/resque/queue/[queue].tsx
+++ b/core/web/pages/resque/queue/[queue].tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react";
 import { useApi } from "../../../hooks/useApi";
-import { Button, Table, Row, Col } from "react-bootstrap";
+import { Table, Row, Col } from "react-bootstrap";
 import Pagination from "../../../components/pagination";
 import Router from "next/router";
 import Head from "next/head";
 import ResqueTabs from "../../../components/tabs/resque";
+import LoadingButton from "../../../components/loadingButton";
 
 export default function ResqueQueue(props) {
   const { errorHandler, query } = props;
@@ -63,7 +64,8 @@ export default function ResqueQueue(props) {
       </h1>
 
       <p>
-        <Button
+        <LoadingButton
+          disabled={loading}
           onClick={() => {
             delQueue();
           }}
@@ -71,7 +73,7 @@ export default function ResqueQueue(props) {
           size="sm"
         >
           Delete Queue
-        </Button>
+        </LoadingButton>
       </p>
 
       <Row>

--- a/core/web/pages/resque/workers.tsx
+++ b/core/web/pages/resque/workers.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
 import { useApi } from "../../hooks/useApi";
-import { Table, Button, Row, Col } from "react-bootstrap";
+import { Table, Row, Col } from "react-bootstrap";
 import Head from "next/head";
 import ResqueTabs from "../../components/tabs/resque";
+import LoadingButton from "../../components/loadingButton";
 
 export default function ResqueWorkersList(props) {
   const { errorHandler, successHandler } = props;
@@ -149,7 +150,8 @@ export default function ResqueWorkersList(props) {
                       </span>
                     </td>
                     <td>
-                      <Button
+                      <LoadingButton
+                        disabled={loading}
                         onClick={() => {
                           forceCleanWorker(w.workerName);
                         }}
@@ -157,7 +159,7 @@ export default function ResqueWorkersList(props) {
                         size="sm"
                       >
                         Remove Worker
-                      </Button>
+                      </LoadingButton>
                     </td>
                   </tr>
                 );

--- a/core/web/pages/run/[guid]/edit.tsx
+++ b/core/web/pages/run/[guid]/edit.tsx
@@ -1,11 +1,13 @@
 import { useApi } from "../../../hooks/useApi";
 import { useState } from "react";
-import { Row, Col, Badge, Alert, Button } from "react-bootstrap";
+import { Row, Col, Badge, Alert } from "react-bootstrap";
 import Moment from "react-moment";
 import Link from "next/link";
 import { ResponsiveLine } from "@nivo/line";
 import RunTabs from "../../../components/tabs/run";
 import Head from "next/head";
+import LoadingButton from "../../../components/loadingButton";
+
 import { RunAPIData } from "../../../utils/apiData";
 
 export default function Page(props) {
@@ -55,14 +57,14 @@ export default function Page(props) {
               <>
                 <br />
                 <br />
-                <Button
+                <LoadingButton
                   variant="warning"
                   size="sm"
                   disabled={loading}
                   onClick={stopRun}
                 >
                   Stop run
-                </Button>
+                </LoadingButton>
               </>
             ) : null}
           </p>

--- a/core/web/pages/settings/[tab].tsx
+++ b/core/web/pages/settings/[tab].tsx
@@ -2,11 +2,12 @@ import Head from "next/head";
 import { useState, useEffect } from "react";
 import { useApi } from "../../hooks/useApi";
 import { useForm } from "react-hook-form";
-import { Button, Form, Card, Tabs, Tab } from "react-bootstrap";
+import { Form, Card, Tabs, Tab } from "react-bootstrap";
 import Moment from "react-moment";
 import { capitalize } from "../../components/tabs";
 import { useRouter } from "next/router";
 import { SettingAPIData } from "../../utils/apiData";
+import LoadingButton from "../../components/loadingButton";
 
 import ImportAndUpdateAllProfiles from "../../components/settings/importAndUpdate";
 import IdentifyingProfilePropertyRule from "../../components/settings/identifyingProfilePropertyRule";
@@ -176,7 +177,7 @@ function SettingCard({
               ) : null}
             </Form.Group>
 
-            <Button
+            <LoadingButton
               style={{ marginTop: 5 }}
               disabled={loading}
               size="sm"
@@ -184,7 +185,7 @@ function SettingCard({
               variant="outline-secondary"
             >
               Update
-            </Button>
+            </LoadingButton>
           </Form>
 
           <br />

--- a/core/web/pages/settings/[tab].tsx
+++ b/core/web/pages/settings/[tab].tsx
@@ -152,6 +152,7 @@ function SettingCard({
                   required
                   type="text"
                   name="value"
+                  disabled={loading}
                   ref={register}
                   defaultValue={setting.value}
                 />
@@ -162,6 +163,7 @@ function SettingCard({
                   required
                   type="number"
                   name="value"
+                  disabled={loading}
                   ref={register}
                   defaultValue={setting.value}
                 />
@@ -170,6 +172,7 @@ function SettingCard({
                 <Form.Check
                   type="checkbox"
                   name="value"
+                  disabled={loading}
                   label={setting.description}
                   ref={register}
                   defaultChecked={setting.value === "true"}

--- a/core/web/pages/source/[guid]/edit.tsx
+++ b/core/web/pages/source/[guid]/edit.tsx
@@ -2,12 +2,13 @@ import { useApi } from "../../../hooks/useApi";
 import SourceTabs from "../../../components/tabs/source";
 import Head from "next/head";
 import { useState, useEffect } from "react";
-import { Row, Col, Form, Button, Badge, Table } from "react-bootstrap";
+import { Row, Col, Form, Badge, Table } from "react-bootstrap";
 import Router from "next/router";
 import AppIcon from "./../../../components/appIcon";
 import StateBadge from "./../../../components/stateBadge";
 import { Typeahead } from "react-bootstrap-typeahead";
 import { SourceAPIData } from "../../../utils/apiData";
+import LoadingButton from "../../../components/loadingButton";
 import Loader from "../../../components/loader";
 
 export default function Page(props) {
@@ -60,6 +61,7 @@ export default function Page(props) {
 
   const onSubmit = async (event) => {
     event.preventDefault();
+    setLoading(true);
     const state = source.connection.skipSourceMapping
       ? "ready"
       : source.previewAvailable
@@ -82,6 +84,7 @@ export default function Page(props) {
       ) {
         Router.push(`/source/${guid}/overview`);
       } else {
+        setLoading(false);
         successHandler.set({ message: "Source updated" });
       }
     }
@@ -101,10 +104,13 @@ export default function Page(props) {
 
   async function handleDelete() {
     if (window.confirm("are you sure?")) {
+      setLoading(true);
       const response = await execApi("delete", `/source/${guid}`);
       if (response) {
         successHandler.set({ message: "source deleted" });
         Router.push("/sources");
+      } else {
+        setLoading(false);
       }
     }
   }
@@ -369,12 +375,13 @@ export default function Page(props) {
 
             <br />
 
-            <Button variant="primary" type="submit">
+            <LoadingButton variant="primary" type="submit" disabled={loading}>
               Update
-            </Button>
+            </LoadingButton>
             <br />
             <br />
-            <Button
+            <LoadingButton
+              disabled={loading}
               variant="danger"
               size="sm"
               onClick={() => {
@@ -382,7 +389,7 @@ export default function Page(props) {
               }}
             >
               Delete
-            </Button>
+            </LoadingButton>
           </Form>
         </Col>
       </Row>

--- a/core/web/pages/source/[guid]/edit.tsx
+++ b/core/web/pages/source/[guid]/edit.tsx
@@ -163,6 +163,7 @@ export default function Page(props) {
               <Form.Label>Name</Form.Label>
               <Form.Control
                 required
+                disabled={loading}
                 type="text"
                 placeholder="Source Name"
                 defaultValue={source.name}
@@ -202,6 +203,7 @@ export default function Page(props) {
                           <Typeahead
                             id="typeahead"
                             labelKey="key"
+                            disabled={loading}
                             onChange={(selected) => {
                               updateOption(opt.key, selected[0]?.key);
                             }}
@@ -251,6 +253,7 @@ export default function Page(props) {
                           <Form.Control
                             as="select"
                             required={opt.required}
+                            disabled={loading}
                             defaultValue={source.options[opt.key] || ""}
                             onChange={(e) =>
                               updateOption(
@@ -299,6 +302,7 @@ export default function Page(props) {
                           <Form.Control
                             required={opt.required}
                             type="text"
+                            disabled={loading}
                             defaultValue={source.options[opt.key]}
                             placeholder={opt.placeholder}
                             onChange={(e) =>

--- a/core/web/pages/source/[guid]/mapping.tsx
+++ b/core/web/pages/source/[guid]/mapping.tsx
@@ -18,7 +18,11 @@ export default function Page(props) {
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);
   const [newMappingKey, setNewMappingKey] = useState("");
-  const [newMappingValue, setNewMappingValue] = useState("");
+  const [newMappingValue, setNewMappingValue] = useState(
+    Object.keys(props.source.mapping)[0]
+      ? Object.keys(props.source.mapping)[0]
+      : ""
+  );
   const [profilePropertyRules, setProfilePropertyRules] = useState(
     props.profilePropertyRules
   );
@@ -168,6 +172,7 @@ export default function Page(props) {
                           type="radio"
                           id={col}
                           name="remoteProfileIdColumn"
+                          disabled={loading}
                           defaultChecked={
                             Object.keys(source.mapping)[0] === col
                           }
@@ -227,6 +232,7 @@ export default function Page(props) {
                               type="radio"
                               id={rule.guid}
                               name="remoteProfileRuleGuid"
+                              disabled={loading}
                               defaultChecked={
                                 Object.values(source.mapping)[0] === rule.key
                               }
@@ -269,6 +275,7 @@ export default function Page(props) {
                     type="text"
                     placeholder="Profile Property Rule Key"
                     defaultValue={newProfilePropertyRule.key}
+                    disabled={loading}
                     onChange={(e) => {
                       setNewProfilePropertyRule(
                         Object.assign({}, newProfilePropertyRule, {
@@ -288,6 +295,7 @@ export default function Page(props) {
                     as="select"
                     required
                     defaultValue={newProfilePropertyRule.type}
+                    disabled={loading}
                     onChange={(e) => {
                       setNewProfilePropertyRule(
                         Object.assign({}, newProfilePropertyRule, {

--- a/core/web/pages/source/[guid]/overview.tsx
+++ b/core/web/pages/source/[guid]/overview.tsx
@@ -1,5 +1,5 @@
 import { useApi } from "../../../hooks/useApi";
-import { Row, Col, Table, Card, Badge, Alert } from "react-bootstrap";
+import { Row, Col, Table, Badge, Alert } from "react-bootstrap";
 import AppIcon from "./../../../components/appIcon";
 import StateBadge from "./../../../components/stateBadge";
 import Link from "next/link";

--- a/core/web/pages/source/[guid]/schedule.tsx
+++ b/core/web/pages/source/[guid]/schedule.tsx
@@ -3,7 +3,8 @@ import SourceTabs from "../../../components/tabs/source";
 import Head from "next/head";
 import { useState } from "react";
 import Moment from "react-moment";
-import { Alert, Row, Col, Form, Button, Badge, Table } from "react-bootstrap";
+import { Alert, Row, Col, Form, Badge, Table } from "react-bootstrap";
+import LoadingButton from "../../../components/loadingButton";
 import Router from "next/router";
 import Link from "next/link";
 import AppIcon from "../../../components/appIcon";
@@ -312,16 +313,21 @@ export default function Page(props) {
 
             <hr />
 
-            <Button variant="primary" type="submit" disabled={loading}>
+            <LoadingButton variant="primary" type="submit" disabled={loading}>
               Update
-            </Button>
+            </LoadingButton>
 
             <br />
             <br />
 
-            <Button variant="danger" size="sm" onClick={handleDelete}>
+            <LoadingButton
+              variant="danger"
+              disabled={loading}
+              size="sm"
+              onClick={handleDelete}
+            >
               Delete
-            </Button>
+            </LoadingButton>
           </Col>
         </Row>
       </Form>

--- a/core/web/pages/source/[guid]/schedule.tsx
+++ b/core/web/pages/source/[guid]/schedule.tsx
@@ -105,6 +105,7 @@ export default function Page(props) {
               <Form.Check
                 type="checkbox"
                 label="Recurring"
+                disabled={loading}
                 checked={schedule.recurring}
                 onChange={(e) => update(e)}
               />
@@ -119,6 +120,7 @@ export default function Page(props) {
                       type="number"
                       min={1}
                       placeholder="Recurring Frequency"
+                      disabled={loading}
                       value={recurringFrequencyMinutes.toString()}
                       onChange={(e) =>
                         setRecurringFrequencyMinutes(parseInt(e.target.value))
@@ -290,8 +292,8 @@ export default function Page(props) {
                         required
                         as="textarea"
                         rows={5}
+                        disabled={loading}
                         value={schedule.options[opt.key]}
-                        disabled={schedule.state !== "draft"}
                         onChange={(e) =>
                           updateOption(opt.key, e.target["value"])
                         }

--- a/core/web/pages/source/new.tsx
+++ b/core/web/pages/source/new.tsx
@@ -1,14 +1,16 @@
 import Head from "next/head";
 import { useState } from "react";
 import { useApi } from "../../hooks/useApi";
-import { Form, Button } from "react-bootstrap";
+import { Form } from "react-bootstrap";
 import SelectorList from "../../components/selectorList";
+import LoadingButton from "../../components/loadingButton";
 import Link from "next/link";
 import Router from "next/router";
 
 export default function Page(props) {
-  const { errorHandler, successHandler, connectionApps } = props;
+  const { errorHandler, connectionApps } = props;
   const { execApi } = useApi(props, errorHandler);
+  const [loading, setLoading] = useState(false);
   const [source, setSource] = useState({
     appGuid: "",
     type: "",
@@ -16,12 +18,15 @@ export default function Page(props) {
 
   const create = async (event) => {
     event.preventDefault();
+    setLoading(true);
     const response = await execApi("post", `/source`, source);
     if (response?.source) {
       Router.push(
         "/source/[guid]/edit",
         `/source/${response.source.guid}/edit`
       );
+    } else {
+      setLoading(false);
     }
   };
 
@@ -62,7 +67,9 @@ export default function Page(props) {
         />
 
         <br />
-        <Button type="submit">Create Source</Button>
+        <LoadingButton type="submit" disabled={loading}>
+          Create Source
+        </LoadingButton>
       </Form>
     </>
   );

--- a/core/web/pages/team/[guid]/edit.tsx
+++ b/core/web/pages/team/[guid]/edit.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useApi } from "../../../hooks/useApi";
-import { Form, Button } from "react-bootstrap";
+import { Form } from "react-bootstrap";
+import LoadingButton from "../../../components/loadingButton";
 import PermissionsList from "../../../components/permissions";
 import Router from "next/router";
 import { TeamAPIData } from "../../../utils/apiData";
@@ -24,20 +25,24 @@ export default function Page(props) {
 
     setLoading(true);
     const response = await execApi("put", `/team/${team.guid}`, _team);
-    setLoading(false);
+
     if (response?.team) {
       successHandler.set({ message: "Team updated" });
       setTeam(response.team);
       teamHandler.set(response.team);
     }
+    setLoading(false);
   };
 
   async function handleDelete() {
     if (window.confirm("are you sure?")) {
+      setLoading(true);
       const response = await execApi("delete", `/team/${team.guid}`);
       if (response) {
         successHandler.set({ message: "Team deleted" });
         Router.push("/teams");
+      } else {
+        setLoading(false);
       }
     }
   }
@@ -100,21 +105,27 @@ export default function Page(props) {
 
         <hr />
 
-        <Button variant="primary" type="submit">
-          Update
-        </Button>
-        <br />
-        <br />
-        <Button
-          disabled={loading || team.locked}
-          variant="danger"
-          size="sm"
-          onClick={() => {
-            handleDelete();
-          }}
-        >
-          Delete
-        </Button>
+        {team.locked ? null : (
+          <>
+            <LoadingButton disabled={loading} variant="primary" type="submit">
+              Update
+            </LoadingButton>
+
+            <br />
+            <br />
+
+            <LoadingButton
+              disabled={loading}
+              variant="danger"
+              size="sm"
+              onClick={() => {
+                handleDelete();
+              }}
+            >
+              Delete
+            </LoadingButton>
+          </>
+        )}
       </Form>
     </>
   );

--- a/core/web/pages/team/[guid]/edit.tsx
+++ b/core/web/pages/team/[guid]/edit.tsx
@@ -83,6 +83,7 @@ export default function Page(props) {
             type="text"
             placeholder="Team Name"
             value={team.name}
+            disabled={loading}
             onChange={(event) => {
               const _team = Object.assign({}, team);
               _team.name = event.target.value;

--- a/core/web/pages/team/[guid]/members.tsx
+++ b/core/web/pages/team/[guid]/members.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useApi } from "../../../hooks/useApi";
-import { Button } from "react-bootstrap";
+import LoadingButton from "../../../components/loadingButton";
 import Link from "next/link";
 import Router from "next/router";
 import Moment from "react-moment";
@@ -19,6 +19,7 @@ export default function Page(props) {
 
   async function handleDelete(teamMember) {
     if (window.confirm("are you sure?")) {
+      setLoading(true);
       const response = await execApi(
         "delete",
         `/team/member/${teamMember.guid}`
@@ -31,6 +32,7 @@ export default function Page(props) {
         );
         setTeamMembers(_teamMembers);
       }
+      setLoading(false);
     }
   }
 
@@ -81,15 +83,16 @@ export default function Page(props) {
                   <Moment fromNow>{teamMember.createdAt}</Moment>
                 </td>
                 <td>
-                  <Button
+                  <LoadingButton
                     size="sm"
+                    disabled={loading}
                     variant="danger"
                     onClick={() => {
                       handleDelete(teamMember);
                     }}
                   >
                     X
-                  </Button>
+                  </LoadingButton>
                 </td>
               </tr>
             );
@@ -97,14 +100,15 @@ export default function Page(props) {
         </tbody>
       </LoadingTable>
 
-      <Button
+      <LoadingButton
         variant="primary"
+        disabled={loading}
         onClick={() => {
           Router.push(`/team/${team.guid}/teamMember/new`);
         }}
       >
         Add Team Member
-      </Button>
+      </LoadingButton>
     </>
   );
 }

--- a/core/web/pages/team/initialize.tsx
+++ b/core/web/pages/team/initialize.tsx
@@ -43,6 +43,7 @@ export default function TeamInitializePage(props) {
             name="firstName"
             ref={register}
             placeholder="First Name"
+            disabled={loading}
           />
           <Form.Control.Feedback type="invalid">
             First Name is required
@@ -56,6 +57,7 @@ export default function TeamInitializePage(props) {
             type="text"
             name="lastName"
             placeholder="Last Name"
+            disabled={loading}
             ref={register}
           />
           <Form.Control.Feedback type="invalid">
@@ -70,6 +72,7 @@ export default function TeamInitializePage(props) {
             type="email"
             name="email"
             placeholder="Email Address"
+            disabled={loading}
             ref={register}
           />
           <Form.Control.Feedback type="invalid">
@@ -84,6 +87,7 @@ export default function TeamInitializePage(props) {
             type="password"
             name="password"
             placeholder="Password"
+            disabled={loading}
             ref={register}
           />
           <Form.Control.Feedback type="invalid">
@@ -96,6 +100,7 @@ export default function TeamInitializePage(props) {
             type="checkbox"
             name="subscribe"
             label={`Subscribe to Grouparoo Newsletter`}
+            disabled={loading}
             defaultChecked
             ref={register}
           />

--- a/core/web/pages/team/initialize.tsx
+++ b/core/web/pages/team/initialize.tsx
@@ -3,7 +3,8 @@ import { useState } from "react";
 import { useApi } from "../../hooks/useApi";
 import { useForm } from "react-hook-form";
 import Router from "next/router";
-import { Form, Button } from "react-bootstrap";
+import { Form } from "react-bootstrap";
+import LoadingButton from "../../components/loadingButton";
 
 export default function TeamInitializePage(props) {
   const { errorHandler, successHandler } = props;
@@ -102,9 +103,9 @@ export default function TeamInitializePage(props) {
 
         <br />
 
-        <Button variant="primary" type="submit" active={!loading}>
+        <LoadingButton variant="primary" type="submit" disabled={loading}>
           Submit
-        </Button>
+        </LoadingButton>
       </Form>
     </>
   );

--- a/core/web/pages/team/new.tsx
+++ b/core/web/pages/team/new.tsx
@@ -3,10 +3,11 @@ import { useState } from "react";
 import { useApi } from "../../hooks/useApi";
 import { useForm } from "react-hook-form";
 import Router from "next/router";
-import { Form, Button } from "react-bootstrap";
+import { Form } from "react-bootstrap";
+import LoadingButton from "../../components/loadingButton";
 
 export default function NewTeamPage(props) {
-  const { errorHandler, successHandler } = props;
+  const { errorHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const { handleSubmit, register } = useForm();
   const [loading, setLoading] = useState(false);
@@ -44,9 +45,9 @@ export default function NewTeamPage(props) {
           </Form.Control.Feedback>
         </Form.Group>
 
-        <Button variant="primary" type="submit" disabled={loading}>
+        <LoadingButton variant="primary" type="submit" disabled={loading}>
           Submit
-        </Button>
+        </LoadingButton>
       </Form>
     </>
   );

--- a/core/web/pages/team/new.tsx
+++ b/core/web/pages/team/new.tsx
@@ -39,6 +39,7 @@ export default function NewTeamPage(props) {
             name="name"
             ref={register}
             placeholder="Team Name"
+            disabled={loading}
           />
           <Form.Control.Feedback type="invalid">
             Name is required

--- a/core/web/pages/teamMember/[guid]/edit.tsx
+++ b/core/web/pages/teamMember/[guid]/edit.tsx
@@ -1,7 +1,8 @@
 import Head from "next/head";
 import { useState } from "react";
 import { useApi } from "../../../hooks/useApi";
-import { Row, Col, Form, Button } from "react-bootstrap";
+import { Row, Col, Form } from "react-bootstrap";
+import LoadingButton from "../../../components/loadingButton";
 import Router from "next/router";
 import Moment from "react-moment";
 import ProfileImageFromEmail from "../../../components/visualizations/profileImageFromEmail";
@@ -33,6 +34,7 @@ export default function Page(props) {
 
   async function handleDelete() {
     if (window.confirm("are you sure?")) {
+      setLoading(true);
       const response = await execApi(
         "delete",
         `/team/member/${teamMember.guid}`
@@ -40,6 +42,8 @@ export default function Page(props) {
       if (response) {
         successHandler.set({ message: "team member deleted" });
         Router.push("/teams");
+      } else {
+        setLoading(false);
       }
     }
   }
@@ -137,12 +141,13 @@ export default function Page(props) {
               <Form.Control type="password" placeholder="*" onChange={update} />
             </Form.Group>
 
-            <Button variant="primary" type="submit">
+            <LoadingButton variant="primary" disabled={loading} type="submit">
               Update
-            </Button>
+            </LoadingButton>
             <br />
             <br />
-            <Button
+            <LoadingButton
+              disabled={loading}
               variant="danger"
               size="sm"
               onClick={() => {
@@ -150,7 +155,7 @@ export default function Page(props) {
               }}
             >
               Delete
-            </Button>
+            </LoadingButton>
           </Form>
         </Col>
       </Row>

--- a/core/web/pages/teamMember/[guid]/edit.tsx
+++ b/core/web/pages/teamMember/[guid]/edit.tsx
@@ -87,6 +87,7 @@ export default function Page(props) {
                 placeholder="Email"
                 value={teamMember.email}
                 onChange={update}
+                disabled={loading}
               />
               <Form.Control.Feedback type="invalid">
                 Email is required
@@ -101,6 +102,7 @@ export default function Page(props) {
                 placeholder="First Name"
                 value={teamMember.firstName}
                 onChange={update}
+                disabled={loading}
               />
               <Form.Control.Feedback type="invalid">
                 First Name is required
@@ -115,6 +117,7 @@ export default function Page(props) {
                 placeholder="Last Name"
                 value={teamMember.lastName}
                 onChange={update}
+                disabled={loading}
               />
               <Form.Control.Feedback type="invalid">
                 Last Name is required
@@ -127,6 +130,7 @@ export default function Page(props) {
                 as="select"
                 value={teamMember.teamGuid}
                 onChange={update}
+                disabled={loading}
               >
                 {teams.map((team) => (
                   <option key={`team-${team.guid}`} value={team.guid}>
@@ -138,7 +142,12 @@ export default function Page(props) {
 
             <Form.Group controlId="password">
               <Form.Label>Password</Form.Label>
-              <Form.Control type="password" placeholder="*" onChange={update} />
+              <Form.Control
+                type="password"
+                placeholder="*"
+                onChange={update}
+                disabled={loading}
+              />
             </Form.Group>
 
             <LoadingButton variant="primary" disabled={loading} type="submit">

--- a/core/web/pages/teamMember/new.tsx
+++ b/core/web/pages/teamMember/new.tsx
@@ -49,12 +49,11 @@ export default function Page(props) {
           <Form.Control
             as="select"
             name="teamGuid"
-            disabled={loading}
             ref={register}
             defaultValue={
               teamGuid ? teamGuid : teams.length > 0 ? teams[0].guid : null
             }
-            disabled={teamGuid ? true : false}
+            disabled={teamGuid || loading ? true : false}
           >
             {teams.map((team) => (
               <option key={`team-${team.guid}`} value={team.guid}>

--- a/core/web/pages/teamMember/new.tsx
+++ b/core/web/pages/teamMember/new.tsx
@@ -49,6 +49,7 @@ export default function Page(props) {
           <Form.Control
             as="select"
             name="teamGuid"
+            disabled={loading}
             ref={register}
             defaultValue={
               teamGuid ? teamGuid : teams.length > 0 ? teams[0].guid : null
@@ -72,6 +73,7 @@ export default function Page(props) {
             name="firstName"
             placeholder="First Name"
             ref={register}
+            disabled={loading}
           />
           <Form.Control.Feedback type="invalid">
             First Name is required
@@ -86,6 +88,7 @@ export default function Page(props) {
             name="lastName"
             placeholder="Last Name"
             ref={register}
+            disabled={loading}
           />
           <Form.Control.Feedback type="invalid">
             Last Name is required
@@ -100,6 +103,7 @@ export default function Page(props) {
             name="email"
             placeholder="email"
             ref={register}
+            disabled={loading}
           />
           <Form.Control.Feedback type="invalid">
             Email is required
@@ -114,6 +118,7 @@ export default function Page(props) {
             type="password"
             placeholder="password"
             ref={register}
+            disabled={loading}
           />
           <Form.Control.Feedback type="invalid">
             Password is required
@@ -127,6 +132,7 @@ export default function Page(props) {
             label={`Subscribe to Grouparoo Newsletter`}
             defaultChecked
             ref={register}
+            disabled={loading}
           />
         </Form.Group>
 

--- a/core/web/pages/teamMember/new.tsx
+++ b/core/web/pages/teamMember/new.tsx
@@ -2,7 +2,8 @@ import Head from "next/head";
 import { useState } from "react";
 import { useApi } from "../../hooks/useApi";
 import { useForm } from "react-hook-form";
-import { Form, Button } from "react-bootstrap";
+import { Form } from "react-bootstrap";
+import LoadingButton from "../../components/loadingButton";
 import Router from "next/router";
 
 export default function Page(props) {
@@ -22,12 +23,15 @@ export default function Page(props) {
     // if the option is disabled, the default value is not set
     if (!data.teamGuid && teamGuid) data.teamGuid = teamGuid;
 
+    setLoading(true);
     const response = await execApi("post", `/team/member`, data);
-    setLoading(false);
+
     if (response?.teamMember) {
       teamMemberHandler.set(response.teamMember);
       successHandler.set({ message: "Team Member Created" });
       Router.push(`/team/${response.teamMember.teamGuid}/members`);
+    } else {
+      setLoading(false);
     }
   }
 
@@ -128,9 +132,9 @@ export default function Page(props) {
 
         <br />
 
-        <Button variant="primary" type="submit" active={!loading}>
+        <LoadingButton variant="primary" type="submit" disabled={loading}>
           Submit
-        </Button>
+        </LoadingButton>
       </Form>
     </>
   );

--- a/tools/merger/data/ci/base.yml.template
+++ b/tools/merger/data/ci/base.yml.template
@@ -25,7 +25,6 @@ jobs:
       - image: circleci/node:12
     steps:
       - checkout
-      - run: sudo apt-get install -y rsync
       - run:
           name: npm-install
           command: npm install


### PR DESCRIPTION
* Revamp the `<LoadingTable/>` component to always show the headers of the table and denote that the `tbody` is loading
* Use new component `<LoadingButton />` any time the hitting a button hits the API.  The button now shows a loading state and is disabled.
  * Fixes bugs in which some buttons were using `active` to indicate that the button was disabled rather than `disabled`
* Form Fields become disabled when the form is submitting
* For Sources and Destinations, we no longer attempt to load the options as part of page hydration, as it may be slow
  * We now load the options after loading the page, and show a banner as the options are loading

|   |   |   | 
|---|---|---|
| ![table](https://user-images.githubusercontent.com/303226/95136369-d8a26e80-071a-11eb-85ca-d235ae0579c5.gif) | ![sign-in](https://user-images.githubusercontent.com/303226/95136378-dc35f580-071a-11eb-8758-9e0a738b56dc.gif)  | 
![loading](https://user-images.githubusercontent.com/303226/95141063-12787280-0725-11eb-8979-b889441d59a2.gif)


(network calls were slowed down artificially to make these videos)