### PR TITLE
Start command replaces bash parent process with node process

### DIFF
--- a/core/api/bin/dev
+++ b/core/api/bin/dev
@@ -22,5 +22,6 @@ for p in $GROUPAROO_PIDS; do
 done
 
 "$NODEMON" -e js,jsx,ts,tsx --signal SIGTERM --ignore dist --watch ./src --watch ../../plugins/**/*.js \
-"$TS_NODE" --transpile-only --log-error src/grouparoo.ts || exit 0
+"$TS_NODE" --transpile-only --log-error src/grouparoo.ts \
+|| exit 0
 

--- a/core/api/bin/start
+++ b/core/api/bin/start
@@ -5,4 +5,4 @@ cd ..
 
 export NEXT_DEVELOPMENT_MODE=false
 
-node dist/grouparoo.js
+exec node dist/grouparoo.js

--- a/core/api/src/grouparoo.ts
+++ b/core/api/src/grouparoo.ts
@@ -16,7 +16,11 @@ async function main() {
   const app = new Process();
 
   app.registerProcessSignals((exitCode) => {
-    process.exit(exitCode);
+    log(
+      `All Grouparoo tasks complete - exiting with code ${exitCode}`,
+      "notice"
+    );
+    process.nextTick(() => process.exit(exitCode));
   });
 
   await app.start();


### PR DESCRIPTION
When starting Grouparoo in production, we recommend the use of our our `bin/start` script.  This is what we use in our [Docker guide](https://www.grouparoo.com/docs/deployment/docker) and [app-example](https://github.com/grouparoo/app-example/blob/master/Dockerfile).

However, in environments like Docker, only exported `CMD[]` will be sent termination signals when the container is to be stopped.  Before this PR, the parent bash process would get the stop/int signal but not pass it to the child.  This means that the underlying node/Grouparoo process would still be running and eventually be hard-killed on shutdown.  This PR uses the `exec` directive for `bin/start` to replace the bash parent process with the Grouparoo node process so it will receive the int/kill/etc signals directly.

This PR also adds a final log message, `All Grouparoo tasks complete - exiting with code ${exitCode}` to confirm that the Grouparoo process did, indeed, shut down properly. 

```
2020-10-10T16:08:01.113Z - notice: [ SIGNAL ] - SIGTERM
2020-10-10T16:08:01.113Z - notice: stopping process...
2020-10-10T16:08:01.220Z - info: resque scheduler ended
2020-10-10T16:08:01.564Z - info: [ worker ] ended workerId=1
...
2020-10-10T16:08:01.565Z - info: [ worker ] ended workerId=10
2020-10-10T16:08:01.722Z - notice: Stopping server: web
2020-10-10T16:08:01.722Z - notice: Stopping server: websocket
2020-10-10T16:08:01.729Z - notice: *** Actionhero Stopped ***
2020-10-10T16:08:01.829Z - notice: All Grouparoo tasks complete - exiting with code 0
{exit 0}
```

In development mode, we do not replace the process with `exec` as we want to always return an exit code of "0" back up to NPM so the exit of the Grouparoo process (with any exit code) doesn't look like an error. 