### PR TITLE
GrouparooSubscription uses telemetry URL

### DIFF
--- a/core/api/src/modules/grouparooSubscription.ts
+++ b/core/api/src/modules/grouparooSubscription.ts
@@ -10,7 +10,7 @@ const packageJSON = require(path.join(
   "package.json"
 ));
 
-const host = "https://www.grouparoo.com";
+const host = "https://telemetry.grouparoo.com";
 const route = "/api/v1/subscribers";
 const method = "POST";
 const source = `${packageJSON.name}`;


### PR DESCRIPTION
... rather than www.grouparoo.com