### PR TITLE
Sort team members in SQL to prevent Typescript bug

### DIFF
--- a/core/api/src/actions/teams.ts
+++ b/core/api/src/actions/teams.ts
@@ -152,7 +152,7 @@ export class TeamView extends AuthenticatedAction {
   async run({ params }) {
     const team = await Team.findOne({
       where: { guid: params.guid },
-      include: [{ model: TeamMember, order: [["email", "desc"]] }],
+      include: [{ model: TeamMember, order: [["email", "asc"]] }],
     });
 
     if (!team) throw new Error("team not found");

--- a/core/api/src/actions/teams.ts
+++ b/core/api/src/actions/teams.ts
@@ -1,4 +1,4 @@
-import { Action } from "actionhero";
+import { Action, api } from "actionhero";
 import { AuthenticatedAction } from "../classes/authenticatedAction";
 import { Team } from "../models/Team";
 import { TeamMember } from "../models/TeamMember";
@@ -152,7 +152,8 @@ export class TeamView extends AuthenticatedAction {
   async run({ params }) {
     const team = await Team.findOne({
       where: { guid: params.guid },
-      include: [{ model: TeamMember, order: [["email", "asc"]] }],
+      include: [{ model: TeamMember }],
+      order: [[api.sequelize.literal(`"teamMembers.email"`), "desc"]],
     });
 
     if (!team) throw new Error("team not found");

--- a/core/api/src/actions/teams.ts
+++ b/core/api/src/actions/teams.ts
@@ -152,26 +152,18 @@ export class TeamView extends AuthenticatedAction {
   async run({ params }) {
     const team = await Team.findOne({
       where: { guid: params.guid },
-      include: [{ model: TeamMember }],
+      include: [{ model: TeamMember, order: [["email", "desc"]] }],
     });
 
     if (!team) throw new Error("team not found");
 
     return {
       team: await team.apiData(),
-      teamMembers: (
-        await Promise.all(
-          team.teamMembers.map(async (mem) => {
-            return await mem.apiData();
-          })
-        )
-      ).sort((a, b) => {
-        if (a.email < b.email) {
-          return 1;
-        } else {
-          return -1;
-        }
-      }),
+      teamMembers: await Promise.all(
+        team.teamMembers.map(async (mem) => {
+          return await mem.apiData();
+        })
+      ),
     };
   }
 }


### PR DESCRIPTION
Building v0.1.18 has a compile error (outside the project) when sorting Team.TeamMembers in JS:

<img width="906" alt="Screen Shot 2020-10-12 at 12 52 31 PM" src="https://user-images.githubusercontent.com/303226/95785026-da73b100-0c89-11eb-9262-892e621dcaae.png">

This PR moves the sort into SQL