### PR TITLE
Clearer upgrade path information on About page

### DIFF
--- a/core/api/__tests__/actions/plugins.ts
+++ b/core/api/__tests__/actions/plugins.ts
@@ -42,7 +42,7 @@ describe("actions/plugins", () => {
       version: coreVersion,
       latestVersion: "0.1.17", // from nock recording
       license: "MPL-2.0",
-      url: "https://www.grouparoo.com",
+      url: "https://github.com/grouparoo/grouparoo",
     });
   });
 });

--- a/core/api/src/actions/plugins.ts
+++ b/core/api/src/actions/plugins.ts
@@ -35,7 +35,7 @@ export class PluginsList extends Action {
         name: "@grouparoo/core",
         version: coreVersion,
         license: "MPL-2.0",
-        url: "https://www.grouparoo.com",
+        url: "https://github.com/grouparoo/grouparoo",
       },
     ].concat(pluginManifest.plugins);
 

--- a/core/web/__tests__/pages/about.tsx
+++ b/core/web/__tests__/pages/about.tsx
@@ -7,7 +7,7 @@ describe("pages/about", () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = mount(<Page {...commonProps} version="v1.2.3" plugins={[]} />);
+    wrapper = mount(<Page {...commonProps} plugins={[]} />);
   });
 
   afterEach(() => {
@@ -17,6 +17,6 @@ describe("pages/about", () => {
 
   test("should display the current api version", async () => {
     expect(wrapper.html()).not.toContain("...");
-    expect(wrapper.html()).toContain("v1.2.3");
+    expect(wrapper.html()).toContain("v1");
   });
 });

--- a/core/web/hooks/useApi.ts
+++ b/core/web/hooks/useApi.ts
@@ -2,7 +2,7 @@ import { Client } from "../client/client";
 import { ErrorHandler } from "../utils/errorHandler";
 import { UploadHandler } from "../utils/uploadHandler";
 
-const client = new Client();
+export const client = new Client();
 
 export function useApi(
   ctx: {

--- a/core/web/pages/about.tsx
+++ b/core/web/pages/about.tsx
@@ -1,25 +1,31 @@
 import Head from "next/head";
-import { Table, Badge } from "react-bootstrap";
+import { client } from "../hooks/useApi";
+import { Table, Badge, Alert, Button } from "react-bootstrap";
 import { useApi } from "../hooks/useApi";
 import { Actions } from "../utils/apiData";
 
-function formatUrl(s = "unknown") {
+const upgradeHelpPage =
+  "https://www.grouparoo.com/docs/deployment/upgrading-grouparoo";
+
+function formatUrl(s = "unknown", label: string) {
   const url = s.replace(/\.git$/, "");
 
   return (
     <a target="_blank" href={url === "unknown" ? "#" : url}>
-      {url}
+      {label}
     </a>
   );
 }
 
 export default function Page({
-  version,
   plugins,
 }: {
-  version: string;
   plugins: Actions.PluginsList["plugins"];
 }) {
+  const hasOutOfDatePlugin = plugins.find((p) => p.version !== p.latestVersion)
+    ? true
+    : false;
+
   return (
     <>
       <Head>
@@ -30,50 +36,67 @@ export default function Page({
       <p>Welcome to your Grouparoo instance!</p>
 
       <p>
-        You can learn more and get help by visiting our website,{" "}
+        You can learn more and get help by visiting{" "}
         <a target="_blank" href="https://www.grouparoo.com">
           www.grouparoo.com
         </a>
         .
       </p>
 
-      <h2>Version</h2>
+      <h2>API Version</h2>
       <p>
         <strong>
-          Connected to <Badge variant="info">{version}</Badge> of the Grouparoo
-          API.
+          Connected to <Badge variant="info">{client.apiVersion}</Badge> of the
+          Grouparoo API.
         </strong>
       </p>
 
       <h2>Plugins</h2>
+
+      {hasOutOfDatePlugin ? (
+        <Alert variant="warning">
+          Some of the plugins installed in this Grouparoo cluster are out of
+          date.
+          <br />
+          <br />
+          <Button
+            variant="warning"
+            size="sm"
+            href={upgradeHelpPage}
+            target="_new"
+          >
+            Learn about upgrading your Grouparoo cluster
+          </Button>
+        </Alert>
+      ) : null}
+
       <p>The following plugins are active:</p>
       <Table size="sm">
         <thead>
           <tr>
             <th>Name</th>
-            <th>Version</th>
+            <th>Installed Version</th>
+            <th>Latest Version</th>
+            <th>Links</th>
             <th>License</th>
-            <th>URL</th>
           </tr>
         </thead>
         <tbody>
-          {plugins.map((plugin) => (
+          {plugins.map((plugin, idx) => (
             <tr key={`plugin-${plugin.name}`}>
               <td>{plugin.name}</td>
               <td>
-                <Badge
-                  variant={
-                    plugin.version === plugin.latestVersion ||
-                    plugin.latestVersion === "unknown"
-                      ? "success"
-                      : "warning"
-                  }
-                >
-                  {plugin.version}
-                </Badge>
+                {plugin.version}{" "}
+                {plugin.version !== plugin.latestVersion ? (
+                  <Badge variant={"warning"}>Out of Date</Badge>
+                ) : null}
+              </td>
+              <td>{plugin.latestVersion}</td>
+              <td>
+                {formatUrl(plugin.url, "homepage")} |{" "}
+                {formatUrl(`https://www.npmjs.com/${plugin.name}`, "npm")}
               </td>
               <td>{plugin.license}</td>
-              <td>{formatUrl(plugin.url)}</td>
             </tr>
           ))}
         </tbody>

--- a/core/web/pages/about.tsx
+++ b/core/web/pages/about.tsx
@@ -107,7 +107,6 @@ export default function Page({
 
 Page.getInitialProps = async (ctx) => {
   const { execApi } = useApi(ctx);
-  const { version } = await execApi("get", `/status/private`);
   const { plugins } = await execApi("get", `/plugins`);
-  return { version, plugins };
+  return { plugins };
 };


### PR DESCRIPTION
* Show both current version and latest version of installed packages
* Only badge "out of date" warning
* Show both NPM and package-url/homepage links for each package
* Show button to learn more about upgrading when there is an out of date package
* Clarify that we are showing connected `apiVersion`

<img width="1499" alt="Screen Shot 2020-10-12 at 4 01 00 PM" src="https://user-images.githubusercontent.com/303226/95797467-76121b00-0ca4-11eb-94f8-a7298fae0a4f.png">
<img width="1499" alt="Screen Shot 2020-10-12 at 4 01 20 PM" src="https://user-images.githubusercontent.com/303226/95797498-8de99f00-0ca4-11eb-9762-20fa4e32fe0c.png">

Closes T-599
Closes T-600