### PR TITLE
Stop runs when deleting parent Model

### DIFF
--- a/core/api/__tests__/tasks/sweeper.ts
+++ b/core/api/__tests__/tasks/sweeper.ts
@@ -1,4 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
+import { Run } from "../../src/models/Run";
 import { Log } from "../../src/models/Log";
 import { Import } from "../../src/models/Import";
 import { Export } from "../../src/models/Export";
@@ -39,23 +40,24 @@ describe("tasks/sweeper", () => {
       expect(found[0].timestamp).toBeNull();
     });
 
-    test("it will delete old logs", async () => {
-      await helper.factories.log();
-      const oldLog = await helper.factories.log();
+    test("it will delete old runs", async () => {
+      await Run.truncate();
+      await helper.factories.run();
+      const oldRun = await helper.factories.run();
 
-      oldLog.set({ createdAt: new Date(0) }, { raw: true });
-      oldLog.changed("createdAt", true);
-      await oldLog.save({
+      oldRun.set({ createdAt: new Date(0) }, { raw: true });
+      oldRun.changed("createdAt", true);
+      await oldRun.save({
         silent: true,
         fields: ["createdAt"],
       });
 
-      let count = await Log.count();
+      let count = await Run.count();
       expect(count).toBe(2);
 
       await specHelper.runTask("sweeper", {});
 
-      count = await Log.count();
+      count = await Run.count();
       expect(count).toBe(1);
     });
 
@@ -96,6 +98,27 @@ describe("tasks/sweeper", () => {
 
       count = await Export.count();
       expect(count).toBe(0);
+    });
+
+    test("it will delete old logs", async () => {
+      await Log.truncate();
+      await helper.factories.log();
+      const oldLog = await helper.factories.log();
+
+      oldLog.set({ createdAt: new Date(0) }, { raw: true });
+      oldLog.changed("createdAt", true);
+      await oldLog.save({
+        silent: true,
+        fields: ["createdAt"],
+      });
+
+      let count = await Log.count();
+      expect(count).toBe(2);
+
+      await specHelper.runTask("sweeper", {});
+
+      count = await Log.count();
+      expect(count).toBe(1);
     });
   });
 });

--- a/core/api/src/initializers/settings.ts
+++ b/core/api/src/initializers/settings.ts
@@ -94,11 +94,11 @@ export class Plugins extends Initializer {
         type: "string",
       },
       {
-        key: "sweeper-delete-old-logs-days",
-        title: "Sweeper: Delete Old Logs Days",
+        key: "sweeper-delete-old-runs-days",
+        title: "Sweeper: Delete Old Runs Days",
         defaultValue: 31,
         description:
-          "How many days should we keep Log records for on the server?",
+          "How many days should we keep Run records for on the server once they are stopped or complete?",
         type: "number",
       },
       {
@@ -115,6 +115,14 @@ export class Plugins extends Initializer {
         defaultValue: 31,
         description:
           "How many days should we keep Export records for on the server?  We will keep the most recent export for each Profile & Destination.",
+        type: "number",
+      },
+      {
+        key: "sweeper-delete-old-logs-days",
+        title: "Sweeper: Delete Old Logs Days",
+        defaultValue: 31,
+        description:
+          "How many days should we keep Log records for on the server?",
         type: "number",
       },
     ];

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -706,9 +706,13 @@ export class Group extends LoggedModel<Group> {
   }
 
   @AfterDestroy
-  static async destroyRuns(instance: Group) {
-    await Run.destroy({
-      where: { creatorGuid: instance.guid },
+  static async stopRuns(instance: Group) {
+    const runs = await Run.findAll({
+      where: { creatorGuid: instance.guid, state: "running" },
     });
+
+    for (const i in runs) {
+      await runs[i].update({ state: "stopped" });
+    }
   }
 }

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -476,10 +476,14 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
   }
 
   @AfterDestroy
-  static async destroyRuns(instance: ProfilePropertyRule) {
-    await Run.destroy({
-      where: { creatorGuid: instance.guid },
+  static async stopRuns(instance: ProfilePropertyRule) {
+    const runs = await Run.findAll({
+      where: { creatorGuid: instance.guid, state: "running" },
     });
+
+    for (const i in runs) {
+      await runs[i].update({ state: "stopped" });
+    }
   }
 
   @AfterDestroy

--- a/core/api/src/models/Schedule.ts
+++ b/core/api/src/models/Schedule.ts
@@ -274,9 +274,13 @@ export class Schedule extends LoggedModel<Schedule> {
   }
 
   @AfterDestroy
-  static async destroyRuns(instance: Schedule) {
-    await Run.destroy({
-      where: { creatorGuid: instance.guid },
+  static async stopRuns(instance: Schedule) {
+    const runs = await Run.findAll({
+      where: { creatorGuid: instance.guid, state: "running" },
     });
+
+    for (const i in runs) {
+      await runs[i].update({ state: "stopped" });
+    }
   }
 }

--- a/core/api/src/tasks/sweeper.ts
+++ b/core/api/src/tasks/sweeper.ts
@@ -1,7 +1,8 @@
 import { Task, log } from "actionhero";
-import { Log } from "../models/Log";
+import { Run } from "../models/Run";
 import { Import } from "../models/Import";
 import { Export } from "../models/Export";
+import { Log } from "../models/Log";
 
 export class Sweeper extends Task {
   constructor() {
@@ -27,9 +28,13 @@ export class Sweeper extends Task {
     let count = 0;
     let response: { count: number; days: number };
 
-    // --- LOGS ---
-    response = await Log.sweep();
-    this.log("log", response.count, response.days);
+    // --- RUNS ---
+    count = -1;
+    while (count !== 0) {
+      response = await Run.sweep(limit);
+      count = response.count;
+      this.log("run", response.count, response.days);
+    }
 
     // --- IMPORTS ---
     count = -1;
@@ -46,5 +51,9 @@ export class Sweeper extends Task {
       count = response.count;
       this.log("export", response.count, response.days);
     }
+
+    // --- LOGS ---
+    response = await Log.sweep();
+    this.log("log", response.count, response.days);
   }
 }

--- a/core/web/pages/object/[guid].tsx
+++ b/core/web/pages/object/[guid].tsx
@@ -1,4 +1,5 @@
 import Loader from "../../components/loader";
+import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { useApi } from "../../hooks/useApi";
 import { Actions } from "../../utils/apiData";
@@ -30,6 +31,21 @@ export default function FindObject(props) {
   const prefix = guid.split("_")[0];
   const route = guidPrefixes[prefix];
 
+  useEffect(() => {
+    determineRoute();
+  }, []);
+
+  async function determineRoute() {
+    if (!route) {
+      errorHandler.set({ error: `Sorry, I don't know what a "${guid}" is :(` });
+    } else if (prefix === "sch") {
+      routeScheduleToSource();
+    } else {
+      const as = route.replace("[guid]", guid);
+      router.push(route, as);
+    }
+  }
+
   async function load(model: string, guid: string) {
     return execApi("get", `/${model}/${guid}`);
   }
@@ -42,15 +58,6 @@ export default function FindObject(props) {
         `/source/${response.schedule.sourceGuid}/schedule`
       );
     }
-  }
-
-  if (!route) {
-    errorHandler.set({ error: `Sorry, I don't know what a "${guid}" is :(` });
-  } else if (prefix === "sch") {
-    routeScheduleToSource();
-  } else {
-    const as = route.replace("[guid]", guid);
-    router.push(route, as);
   }
 
   return (

--- a/core/web/pages/profilePropertyRule/[guid]/edit.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/edit.tsx
@@ -69,6 +69,7 @@ export default function Page(props) {
           response.profilePropertyRule.state === "ready" &&
           profilePropertyRule.state === "draft"
         ) {
+          successHandler.set({ message: "Profile Property Rule Created" });
           router.push(nextPage || "/profilePropertyRules");
         } else {
           setLoading(false);
@@ -93,6 +94,7 @@ export default function Page(props) {
       );
       setLoading(false);
       if (response) {
+        successHandler.set({ message: "Profile Property Rule Deleted" });
         router.push(nextPage || "/profilePropertyRules");
       }
     }


### PR DESCRIPTION
When deleting a Schedule, Group, or Profile Property Rule, we now stop the run rather than delete it.  This prevents a class of Resque error in which imports or exports for that run were running, and suddenly the run can't be found.  This is common when deleting a Profile Property Rule which is still importing.

When `NODE_ENV` is development or test, new types of errors may appear like `Error: cannot find a profile property rule for key *`.  However, this error class is automatically handled by the `RetryableTask` class, which will retry those tasks in Production mode with an updated collection of Profile Property Rules. 

This PR also adds a sweeper and new Setting for old Runs which are stopped/completed.  By default, we keep them for 31 days.

Closes T-611