### PR TITLE
Use fixed version numbers when generating a new Grouparoo project

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -2,7 +2,7 @@
 
 _The Grouparoo project generator_
 
-This package is released as `grouparoo` (no namespace) on NPM. It is used to generate new Grouparoo projects.
+This package is released as `grouparoo` on NPM. It is used to generate and update Grouparoo projects.
 
 ## Installation
 
@@ -27,10 +27,10 @@ Commands:
 
 - To generate a grouparoo project in the current directory (`process.cwd()`): `npx grouparoo generate`
 - To generate a grouparoo project in another directory: `npx grouparoo generate /path/to/project`
-- `npx grouparoo upgrade` assumes you are tracking the `latest` version of all the Grouparoo dependencies, and will simply run `npm update` under the hood.
+- `npx grouparoo upgrade` assumes you are tracking the `latest` version of all the Grouparoo dependencies, and will update your `package.json` to use the latest versions of your packages and then run `npm install` again to install new dependencies and build the project.
 
 ## Notes
 
 - We assume `node` and `npm` are installed and available within your `$PATH`
-- We will not override an existing `package.json` or `.env` file if they already exist in the directory
+- We will not override an existing `package.json` or `.env` file if they already exist in the directory (except in the `upgrade` case)
 - We will attempt to run `npm install` in the new directory

--- a/cli/package.json
+++ b/cli/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "chalk": "4.1.0",
     "commander": "6.1.0",
-    "fs-extra": "9.0.1"
+    "fs-extra": "9.0.1",
+    "npm-check-updates": "9.1.0"
   },
   "devDependencies": {
     "@types/fs-extra": "9.0.2",

--- a/cli/src/lib/generate.ts
+++ b/cli/src/lib/generate.ts
@@ -18,6 +18,7 @@ export default async function Generate(workDir: string = process.cwd()) {
   if (!fs.existsSync(packageJson)) {
     log.info("Creating package.json");
     fs.copyFileSync(getTemplatePath("package.json"), packageJson);
+    injectVersion(packageJson);
   } else {
     log.warn("package.json already exists, not modifying");
   }
@@ -49,4 +50,14 @@ export default async function Generate(workDir: string = process.cwd()) {
 
 function getTemplatePath(filename: string) {
   return path.join(__dirname, "..", "..", "templates", filename);
+}
+
+function injectVersion(filename: string) {
+  const localPackageJSONContents = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "..", "package.json")).toString()
+  );
+  const version = localPackageJSONContents.version;
+  const contents = fs.readFileSync(filename).toString();
+  const updatedContents = contents.replace(/~~VERSION~~/g, version);
+  fs.writeFileSync(filename, updatedContents);
 }

--- a/cli/templates/package.json
+++ b/cli/templates/package.json
@@ -9,17 +9,20 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@grouparoo/core": "latest",
-    "@grouparoo/csv": "latest",
-    "@grouparoo/email-authentication": "latest",
-    "@grouparoo/google-sheets": "latest",
-    "@grouparoo/logger": "latest",
-    "@grouparoo/mailchimp": "latest",
-    "@grouparoo/hubspot": "latest",
-    "@grouparoo/sailthru": "latest",
-    "@grouparoo/mysql": "latest",
-    "@grouparoo/bigquery": "latest",
-    "@grouparoo/postgres": "latest"
+    "@grouparoo/bigquery": "~~VERSION~~",
+    "@grouparoo/core": "~~VERSION~~",
+    "@grouparoo/csv": "~~VERSION~~",
+    "@grouparoo/email-authentication": "~~VERSION~~",
+    "@grouparoo/google-sheets": "~~VERSION~~",
+    "@grouparoo/hubspot": "~~VERSION~~",
+    "@grouparoo/logger": "~~VERSION~~",
+    "@grouparoo/mailchimp": "~~VERSION~~",
+    "@grouparoo/mysql": "~~VERSION~~",
+    "@grouparoo/postgres": "~~VERSION~~",
+    "@grouparoo/redshift": "~~VERSION~~",
+    "@grouparoo/salesforce": "~~VERSION~~",
+    "@grouparoo/snowflake": "~~VERSION~~",
+    "@grouparoo/zendesk": "~~VERSION~~"
   },
   "scripts": {
     "prepare": "cd node_modules/@grouparoo/core && npm run prepare",
@@ -29,16 +32,19 @@
   },
   "grouparoo": {
     "plugins": [
+      "@grouparoo/bigquery",
       "@grouparoo/csv",
       "@grouparoo/email-authentication",
       "@grouparoo/google-sheets",
+      "@grouparoo/hubspot",
       "@grouparoo/logger",
       "@grouparoo/mailchimp",
-      "@grouparoo/hubspot",
-      "@grouparoo/sailthru",
       "@grouparoo/mysql",
-      "@grouparoo/bigquery",
-      "@grouparoo/postgres"
+      "@grouparoo/postgres",
+      "@grouparoo/redshift",
+      "@grouparoo/salesforce",
+      "@grouparoo/snowflake",
+      "@grouparoo/zendesk"
     ],
     "includedFiles": [
       "assets"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1255,9 +1255,9 @@
       },
       "dependencies": {
         "hosted-git-info": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
-          "integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.6.tgz",
+          "integrity": "sha512-VRvqVD5T6t9HdmNDWTwbi8H/EC722MemAhOSP5QvYAXpDAY0Nhu2I/i+bXsktu4sU5LVHSh/wmXtVU8bDtjedQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -1279,12 +1279,12 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.0.1.tgz",
-          "integrity": "sha512-/h5Fm6a/exByzFSTm7jAyHbgOqErl9qSNJDQF32Si/ZzgwT2TERVxRxn3Jurw1wflgyVVAxnFR4fRHPM7y1ClQ==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.0.tgz",
+          "integrity": "sha512-/ep6QDxBkm9HvOhOg0heitSd7JHA1U7y1qhhlRlteYYAi9Pdb/ZV7FW5aHpkrpM8+P+4p/jjR8zCyKPBMBjSig==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^3.0.2",
+            "hosted-git-info": "^3.0.6",
             "semver": "^7.0.0",
             "validate-npm-package-name": "^3.0.0"
           }
@@ -7092,9 +7092,9 @@
       }
     },
     "npm-check-updates": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-9.0.4.tgz",
-      "integrity": "sha512-kqevC9RXRsaosPZHg4Pm5CNwnOAG2ymvhU7Q3QIX01SDUID4fpoSAQIuXQH9V3Nnu96kSUz5bDPzQSku33Mz0A==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-9.1.0.tgz",
+      "integrity": "sha512-sx/hbKWAMPgflMffQLZXYt9uZeOK7Rnd6DLoL+8n2Sxe5yn5MMD4kXtkH5NXqJ3OxVA4JgnVbL7rvXhJKGMZrg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -7381,9 +7381,9 @@
           }
         },
         "hosted-git-info": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
-          "integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.6.tgz",
+          "integrity": "sha512-VRvqVD5T6t9HdmNDWTwbi8H/EC722MemAhOSP5QvYAXpDAY0Nhu2I/i+bXsktu4sU5LVHSh/wmXtVU8bDtjedQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -7474,12 +7474,12 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.0.1.tgz",
-          "integrity": "sha512-/h5Fm6a/exByzFSTm7jAyHbgOqErl9qSNJDQF32Si/ZzgwT2TERVxRxn3Jurw1wflgyVVAxnFR4fRHPM7y1ClQ==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.0.tgz",
+          "integrity": "sha512-/ep6QDxBkm9HvOhOg0heitSd7JHA1U7y1qhhlRlteYYAi9Pdb/ZV7FW5aHpkrpM8+P+4p/jjR8zCyKPBMBjSig==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^3.0.2",
+            "hosted-git-info": "^3.0.6",
             "semver": "^7.0.0",
             "validate-npm-package-name": "^3.0.0"
           }
@@ -7889,9 +7889,9 @@
           }
         },
         "hosted-git-info": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
-          "integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.6.tgz",
+          "integrity": "sha512-VRvqVD5T6t9HdmNDWTwbi8H/EC722MemAhOSP5QvYAXpDAY0Nhu2I/i+bXsktu4sU5LVHSh/wmXtVU8bDtjedQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -7932,12 +7932,12 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.0.1.tgz",
-          "integrity": "sha512-/h5Fm6a/exByzFSTm7jAyHbgOqErl9qSNJDQF32Si/ZzgwT2TERVxRxn3Jurw1wflgyVVAxnFR4fRHPM7y1ClQ==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.0.tgz",
+          "integrity": "sha512-/ep6QDxBkm9HvOhOg0heitSd7JHA1U7y1qhhlRlteYYAi9Pdb/ZV7FW5aHpkrpM8+P+4p/jjR8zCyKPBMBjSig==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^3.0.2",
+            "hosted-git-info": "^3.0.6",
             "semver": "^7.0.0",
             "validate-npm-package-name": "^3.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lerna-changelog": "1.0.1",
     "lerna-update-wizard": "0.17.8",
     "license-checker": "github:grouparoo/license-checker",
-    "npm-check-updates": "latest",
+    "npm-check-updates": "9.1.0",
     "prettier": "2.1.2"
   },
   "scripts": {


### PR DESCRIPTION
When new grouparoo projects are generated with `npx grouparoo generate`, the `package.json` generated should use the exact version numbers of the latest release.

When running `npx grouparoo upgrade`, we should check NPM for the latest version numbers of each package update to them.

<img width="557" alt="Screen Shot 2020-10-14 at 12 27 22 PM" src="https://user-images.githubusercontent.com/303226/96036222-04a7a900-0e19-11eb-9818-e0399b204a35.png">
