### PR TITLE
App.connect() should be locked to ensure that only one worker builds the connection

### DIFF
--- a/core/api/src/modules/ops/app.ts
+++ b/core/api/src/modules/ops/app.ts
@@ -134,7 +134,6 @@ export namespace AppOps {
   }
 
   async function getConnectionLock(app: App) {
-    console.log("waiting...");
     const key = `app:${app.guid}:connection:${id}:`;
     return waitForLock(key);
   }

--- a/core/api/src/modules/ops/app.ts
+++ b/core/api/src/modules/ops/app.ts
@@ -139,7 +139,7 @@ export namespace AppOps {
   }
 
   async function getConnectionLock(app: App) {
-    const key = `app:${app.guid}:connection:${id}:`;
+    const key = `app:${app.guid}:connection:${id}`;
     return waitForLock(key);
   }
 }


### PR DESCRIPTION
Prevents errors like the following at startup (likely visible in Resque):

```
Error: Error with Postgres SQL Statement: Query - SELECT COALESCE(SUM("price"), 0) as __result FROM %I WHERE "user_id" = %L AND "state" = %L LIMIT 1, Error - Error: Client was closed and is not queryable
```

Closes T-625