### PR TITLE
Handle about page errors

### DIFF
--- a/core/api/src/modules/pluginVersions.ts
+++ b/core/api/src/modules/pluginVersions.ts
@@ -35,7 +35,7 @@ export async function pluginVersions() {
         const manifest = await getLatestNPMVersion(plugin);
         latestVersion = manifest.version;
       } catch (error) {
-        log(error, "error");
+        log(error.toString(), "error");
       }
 
       return {

--- a/core/web/pages/about.tsx
+++ b/core/web/pages/about.tsx
@@ -87,7 +87,8 @@ export default function Page({
               <td>{plugin.name}</td>
               <td>
                 {plugin.version}{" "}
-                {plugin.version !== plugin.latestVersion ? (
+                {plugin.version !== plugin.latestVersion &&
+                plugin.latestVersion !== "unknown" ? (
                   <Badge variant={"warning"}>Out of Date</Badge>
                 ) : null}
               </td>


### PR DESCRIPTION
* Better error logging
* Do not show that the package is out of date if we can't find any information about it from NPM

Closes T-631