### PR TITLE
MySQL and Postgres apps use connection pooling

### DIFF
--- a/plugins/@grouparoo/mysql/src/lib/connect.ts
+++ b/plugins/@grouparoo/mysql/src/lib/connect.ts
@@ -20,52 +20,48 @@ export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
     ],
   };
   // @ts-ignore datestrings supports array but it's not in the types
-  const client = mysql.createConnection(config);
+  const pool = mysql.createPool(config);
 
   const asyncQuery = function (
     query: string,
     replacementValues: { [key: string]: any } | Array<string | number> = []
   ): Promise<Array<QueryResultObject>> {
     return new Promise((resolve, reject) => {
-      const q = this.query(
-        query,
-        replacementValues,
-        (error: Error, rows: Array<QueryResultObject>) => {
-          if (error) {
-            return reject(
-              new Error(`error with mysql query: "${q.sql}" - ${error}`)
-            );
-          }
+      this.getConnection(function (acquireError, connection) {
+        if (acquireError) return reject(acquireError);
 
-          const cleanedRows = [];
-          for (const i in rows) {
-            cleanedRows.push(Object.assign({}, rows[i]));
-          }
+        const q = connection.query(
+          query,
+          replacementValues,
+          (error: Error, rows: Array<QueryResultObject>) => {
+            connection.release();
 
-          return resolve(cleanedRows);
-        }
-      );
+            if (error) {
+              return reject(
+                new Error(`error with mysql query: "${q.sql}" - ${error}`)
+              );
+            }
+
+            const cleanedRows = [];
+            for (const i in rows) {
+              cleanedRows.push(Object.assign({}, rows[i]));
+            }
+
+            return resolve(cleanedRows);
+          }
+        );
+      });
     });
   };
 
   const asyncEnd = async function () {
     return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        client.end((error) => {
-          if (error) return reject(error);
-          return resolve();
-        });
-      }, 1000);
+      pool.end((error) => {
+        if (error) return reject(error);
+        return resolve();
+      });
     });
   };
 
-  // connect
-  await new Promise((resolve, reject) => {
-    client.connect((error) => {
-      if (error) return reject(error);
-      return resolve();
-    });
-  });
-
-  return Object.assign(client, { asyncQuery, asyncEnd });
+  return Object.assign(pool, { asyncQuery, asyncEnd });
 };


### PR DESCRIPTION
When connecting to Postgres and MySQL Sources (and Destinations), we should use a connection pool.  This will create more connections between the node.js process and the database, which should speed up imports and exports.  

Using a connection pool in this way /may/ also help solve a class of bugs in which a connection is "polluted" by a previous request, like `Cannot enqueue Query after invoking quit` or `Cannot enqueue Query after fatal error` for MySQL connections.

---

From https://github.com/mysqljs/mysql
> With Pool, disconnected connections will be removed from the pool freeing up space for a new connection to be created on the next getConnection call.

and https://github.com/mysqljs/mysql/issues/1694 hits that if we aren't using the pool, we'll need to manually check if `error.fatal` and rebuild the connection ourselves
