### PR TITLE
Log config

### DIFF
--- a/apps/local-public/.env.example
+++ b/apps/local-public/.env.example
@@ -11,6 +11,14 @@ SCHEDULER=true
 WORKERS=1
 SERVER_TOKEN=change_me
 
+#############
+## LOGGING ##
+#############
+
+# GROUPAROO_LOGS_STDOUT_DISABLE_COLOR=true
+# GROUPAROO_LOGS_STDOUT_DISABLE_TIMESTAMP=true
+# GROUPAROO_LOGS_PATH="/path/to/logs"
+
 ###########
 ## REDIS ##
 ###########

--- a/apps/staging-public/.env.example
+++ b/apps/staging-public/.env.example
@@ -11,6 +11,14 @@ SCHEDULER=true
 WORKERS=1
 SERVER_TOKEN=change_me
 
+#############
+## LOGGING ##
+#############
+
+# GROUPAROO_LOGS_STDOUT_DISABLE_COLOR=true
+# GROUPAROO_LOGS_STDOUT_DISABLE_TIMESTAMP=true
+# GROUPAROO_LOGS_PATH="/path/to/logs"
+
 ###########
 ## REDIS ##
 ###########

--- a/cli/templates/.env
+++ b/cli/templates/.env
@@ -10,6 +10,14 @@ SCHEDULER=true
 WORKERS=1
 SERVER_TOKEN=my-serer-token
 
+#############
+## LOGGING ##
+#############
+
+# GROUPAROO_LOGS_STDOUT_DISABLE_COLOR=true
+# GROUPAROO_LOGS_STDOUT_DISABLE_TIMESTAMP=true
+# GROUPAROO_LOGS_PATH="/path/to/logs"
+
 ###########
 ## REDIS ##
 ###########

--- a/core/api/src/config/api.ts
+++ b/core/api/src/config/api.ts
@@ -49,7 +49,9 @@ export const DEFAULT = {
         next: [path.join(process.cwd(), "..", "web")],
         public: [path.join(process.cwd(), "..", "web", "public")],
         pid: [path.join(process.cwd(), "pids")],
-        log: [path.join(process.cwd(), "log")],
+        log: [
+          process.env.GROUPAROO_LOG_PATH || path.join(process.cwd(), "log"),
+        ],
         plugin: [path.join(process.cwd(), "..", "node_modules")],
         locale: [path.join(process.cwd(), "locales")],
         test: [path.join(process.cwd(), "__tests__")],

--- a/core/api/src/config/logger.ts
+++ b/core/api/src/config/logger.ts
@@ -39,17 +39,25 @@ export const test = {
 // helpers for building the winston loggers
 
 function buildConsoleLogger(level = "info") {
+  const formats = [];
+  if (!process.env.GROUPAROO_LOGS_STDOUT_DISABLE_COLOR) {
+    formats.push(winston.format.colorize());
+  }
+  if (!process.env.GROUPAROO_LOGS_STDOUT_DISABLE_TIMESTAMP) {
+    formats.push(winston.format.timestamp());
+  }
+
+  formats.push(
+    winston.format.printf((info) => {
+      return `${info.timestamp ? `${info.timestamp} - ` : ""}${info.level}: ${
+        info.message
+      } ${stringifyExtraMessagePropertiesForConsole(info)}`;
+    })
+  );
+
   return function (config) {
     return winston.createLogger({
-      format: winston.format.combine(
-        winston.format.timestamp(),
-        winston.format.colorize(),
-        winston.format.printf((info) => {
-          return `${info.timestamp} - ${info.level}: ${
-            info.message
-          } ${stringifyExtraMessagePropertiesForConsole(info)}`;
-        })
-      ),
+      format: winston.format.combine(...formats),
       level,
       levels: winston.config.syslog.levels,
       transports: [new winston.transports.Console()],


### PR DESCRIPTION
This PR adds 3 new environment variables to configure the Grouparoo logger(s):

* `GROUPAROO_LOGS_STDOUT_DISABLE_COLOR` - set to `"true"` to not use color in the `stdout` logs
* `GROUPAROO_LOGS_STDOUT_DISABLE_TIMESTAMP` - set to `"true"` to not append the current time to the start of each line
* `GROUPAROO_LOGS_PATH` - set to `"/path/to/logs"` to configure where you want the file logs from Grouparoo to be stored. 
 Grouparoo logs both to `stdout` and a file.  To disable the file logger, set the `GROUPAROO_LOGS_PATH` to `"/dev/null"`