### PR TITLE
Use the URL Search Query or Environment Variable DATABASE_SSL to signal a SSL Postgres connection

### DIFF
--- a/apps/local-public/.env.example
+++ b/apps/local-public/.env.example
@@ -29,5 +29,5 @@ REDIS_URL="redis://localhost:6379/0"
 ##############
 
 DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
-# DATABASE_SSL="true"
+# DATABASE_SSL=true
 

--- a/apps/local-public/.env.example
+++ b/apps/local-public/.env.example
@@ -2,7 +2,6 @@
 ## GENERAL ##
 #############
 
-# For the API server; the web server runs on port 3000 locally
 PORT=3000
 WEB_URL=http://localhost:3000
 
@@ -30,4 +29,5 @@ REDIS_URL="redis://localhost:6379/0"
 ##############
 
 DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
+# DATABASE_SSL="true"
 

--- a/apps/staging-public/.env.example
+++ b/apps/staging-public/.env.example
@@ -29,7 +29,7 @@ REDIS_URL="redis://localhost:6379/0"
 ##############
 
 DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
-# DATABASE_SSL="true"
+# DATABASE_SSL=true
 
 ########
 ## S3 ##

--- a/apps/staging-public/.env.example
+++ b/apps/staging-public/.env.example
@@ -2,7 +2,6 @@
 ## GENERAL ##
 #############
 
-# For the API server; the web server runs on port 3000 locally
 PORT=3000
 WEB_URL=http://localhost:3000
 
@@ -30,6 +29,7 @@ REDIS_URL="redis://localhost:6379/0"
 ##############
 
 DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
+# DATABASE_SSL="true"
 
 ########
 ## S3 ##

--- a/cli/templates/.env
+++ b/cli/templates/.env
@@ -29,3 +29,4 @@ REDIS_URL="redis://localhost:6379/0"
 ##############
 
 DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
+# DATABASE_SSL=true

--- a/core/api/src/config/logger.ts
+++ b/core/api/src/config/logger.ts
@@ -40,10 +40,15 @@ export const test = {
 
 function buildConsoleLogger(level = "info") {
   const formats = [];
-  if (!process.env.GROUPAROO_LOGS_STDOUT_DISABLE_COLOR) {
+  if (
+    process.env.GROUPAROO_LOGS_STDOUT_DISABLE_COLOR?.toLowerCase() !== "true"
+  ) {
     formats.push(winston.format.colorize());
   }
-  if (!process.env.GROUPAROO_LOGS_STDOUT_DISABLE_TIMESTAMP) {
+  if (
+    process.env.GROUPAROO_LOGS_STDOUT_DISABLE_TIMESTAMP?.toLowerCase() !==
+    "true"
+  ) {
     formats.push(winston.format.timestamp());
   }
 

--- a/core/api/src/config/sequelize.ts
+++ b/core/api/src/config/sequelize.ts
@@ -27,29 +27,16 @@ export const DEFAULT = {
 
     if (connectionURL) {
       const parsed = new URL(connectionURL);
-      if (parsed.protocol) {
-        dialect = parsed.protocol.slice(0, -1);
-      }
-      if (parsed.username) {
-        username = parsed.username;
-      }
-      if (parsed.password) {
-        password = parsed.password;
-      }
-      if (parsed.hostname) {
-        host = parsed.hostname;
-      }
-      if (parsed.port) {
-        port = parsed.port;
-      }
-      if (parsed.pathname) {
-        database = parsed.pathname.substring(1);
-      }
+      if (parsed.protocol) dialect = parsed.protocol.slice(0, -1);
+      if (parsed.username) username = parsed.username;
+      if (parsed.password) password = parsed.password;
+      if (parsed.hostname) host = parsed.hostname;
+      if (parsed.port) port = parsed.port;
+      if (parsed.pathname) database = parsed.pathname.substring(1);
     }
 
-    if (dialect === "postgresql") {
-      dialect = "postgres";
-    }
+    if (dialect === "postgresql") dialect = "postgres";
+    if (dialect === "psql") dialect = "postgres";
 
     return {
       autoMigrate: true,
@@ -69,6 +56,9 @@ export const DEFAULT = {
         min: 0,
         acquire: 30000,
         idle: 10000,
+      },
+      dialectOptions: {
+        ssl: process.env.DATABASE_SSL?.toLowerCase() === "true",
       },
     };
   },

--- a/core/api/src/config/sequelize.ts
+++ b/core/api/src/config/sequelize.ts
@@ -19,6 +19,7 @@ export const DEFAULT = {
     let username =
       process.env.DB_USER || process.env.CI ? "postgres" : undefined;
     let password = process.env.DB_PASS || undefined;
+    let ssl = false;
 
     // if your environment provides database information via a single JDBC-style URL
     // like mysql://username:password@hostname:port/default_schema
@@ -33,10 +34,21 @@ export const DEFAULT = {
       if (parsed.hostname) host = parsed.hostname;
       if (parsed.port) port = parsed.port;
       if (parsed.pathname) database = parsed.pathname.substring(1);
+
+      const search_ssl = parsed.searchParams.get("ssl");
+      const search_sslmode = parsed.searchParams.get("sslmode");
+      if (search_ssl) ssl = search_ssl === "true";
+      if (search_sslmode) {
+        ssl = search_sslmode === "true" || search_sslmode === "required";
+      }
     }
 
     if (dialect === "postgresql") dialect = "postgres";
     if (dialect === "psql") dialect = "postgres";
+
+    if (process.env.DATABASE_SSL) {
+      ssl = process.env.DATABASE_SSL.toLowerCase() === "true";
+    }
 
     return {
       autoMigrate: true,
@@ -57,9 +69,7 @@ export const DEFAULT = {
         acquire: 30000,
         idle: 10000,
       },
-      dialectOptions: {
-        ssl: process.env.DATABASE_SSL?.toLowerCase() === "true",
-      },
+      dialectOptions: { ssl },
     };
   },
 };


### PR DESCRIPTION
This PR allows the Grouparoo Postgres Database to be connected to via SSL.
* You can include the `?ssl=true` query param in your `DATABASE_URL` environment variable
  * `DATABASE_URL="postgresql://localhost:5432/grouparoo?ssl=true"`
* You can include the `?sslmode=true` or `?sslmode=required` query param in your `DATABASE_URL` environment variable
  * `DATABASE_URL="postgresql://localhost:5432/grouparoo?sslmode=required"`
* If you cannot include either of the above in your `DATABASE_URL` (for example, you are running on Heroku), you can set an additional environment variable `DATABASE_SSL`=`true`

Closes https://github.com/grouparoo/grouparoo/issues/882
Closes T-653