### PR TITLE
Allow the Grouparoo Database to use a self-signed SSL cert with DATABASE_SSL_SELF_SIGNED

### DIFF
--- a/apps/local-public/.env.example
+++ b/apps/local-public/.env.example
@@ -30,4 +30,5 @@ REDIS_URL="redis://localhost:6379/0"
 
 DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
 # DATABASE_SSL=true
+# DATABASE_SSL_SELF_SIGNED=true
 

--- a/apps/staging-public/.env.example
+++ b/apps/staging-public/.env.example
@@ -30,6 +30,7 @@ REDIS_URL="redis://localhost:6379/0"
 
 DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
 # DATABASE_SSL=true
+# DATABASE_SSL_SELF_SIGNED=true
 
 ########
 ## S3 ##

--- a/cli/templates/.env
+++ b/cli/templates/.env
@@ -30,3 +30,4 @@ REDIS_URL="redis://localhost:6379/0"
 
 DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
 # DATABASE_SSL=true
+# DATABASE_SSL_SELF_SIGNED=true

--- a/core/api/src/config/sequelize.ts
+++ b/core/api/src/config/sequelize.ts
@@ -19,7 +19,7 @@ export const DEFAULT = {
     let username =
       process.env.DB_USER || process.env.CI ? "postgres" : undefined;
     let password = process.env.DB_PASS || undefined;
-    let ssl = false;
+    let ssl: boolean | { [key: string]: any } = false;
 
     // if your environment provides database information via a single JDBC-style URL
     // like mysql://username:password@hostname:port/default_schema
@@ -46,8 +46,11 @@ export const DEFAULT = {
     if (dialect === "postgresql") dialect = "postgres";
     if (dialect === "psql") dialect = "postgres";
 
-    if (process.env.DATABASE_SSL) {
-      ssl = process.env.DATABASE_SSL.toLowerCase() === "true";
+    if (process.env.DATABASE_SSL?.toLowerCase() === "true") {
+      ssl = true;
+    }
+    if (process.env.DATABASE_SSL_SELF_SIGNED?.toLowerCase() === "true") {
+      ssl = { rejectUnauthorized: false };
     }
 
     return {


### PR DESCRIPTION
You can set the environment variable `DATABASE_SSL_SELF_SIGNED=true` to use self-signed SSL certificates when connecting to a Grouparoo Database.