### PR TITLE
Count run totals with task

### DIFF
--- a/core/api/__tests__/integration/runs/internalRun.ts
+++ b/core/api/__tests__/integration/runs/internalRun.ts
@@ -96,7 +96,7 @@ describe("integration/runs/internalRun", () => {
       expect(foundSendTasks.length).toBe(0);
 
       // check the results of the run
-      await run.reload();
+      await run.updateTotals();
       expect(run.state).toBe("complete");
       expect(run.importsCreated).toBe(1);
       expect(run.profilesCreated).toBe(0);

--- a/core/api/__tests__/modules/groupExport.ts
+++ b/core/api/__tests__/modules/groupExport.ts
@@ -94,7 +94,6 @@ describe("modules/groupExport", () => {
 
     test("the run is complete", async () => {
       const run = await Run.findOne({ where: { guid: runGuid } });
-      expect(run.profilesImported).toBe(4);
       expect(run.state).toBe("complete");
       expect(run.completedAt).toBeTruthy();
     });

--- a/core/api/__tests__/tasks/export/send.ts
+++ b/core/api/__tests__/tasks/export/send.ts
@@ -60,6 +60,8 @@ describe("tasks/export:send", () => {
         where: { creatorGuid: group.guid },
       });
 
+      await run.updateTotals();
+
       expect(run.importsCreated).toBe(1);
       expect(run.profilesCreated).toBe(0);
       expect(run.profilesImported).toBe(0);

--- a/core/api/__tests__/tasks/export/sendBatch.ts
+++ b/core/api/__tests__/tasks/export/sendBatch.ts
@@ -62,6 +62,8 @@ describe("tasks/export:sendBatch", () => {
         where: { creatorGuid: group.guid },
       });
 
+      await run.updateTotals();
+
       expect(run.importsCreated).toBe(1);
       expect(run.profilesCreated).toBe(0);
       expect(run.profilesImported).toBe(0);

--- a/core/api/__tests__/tasks/import/associateProfile.ts
+++ b/core/api/__tests__/tasks/import/associateProfile.ts
@@ -65,8 +65,9 @@ describe("tasks/import:associateProfile", () => {
       expect(_import.newProfileProperties).toEqual({});
       expect(_import.newGroupGuids).toEqual([]);
 
-      await run.reload();
-      expect(run.importsCreated).toBe(0);
+      await run.updateTotals();
+
+      expect(run.importsCreated).toBe(1);
       expect(run.profilesCreated).toBe(1);
       expect(run.profilesImported).toBe(0);
     });

--- a/core/api/__tests__/tasks/profile/completeImport.ts
+++ b/core/api/__tests__/tasks/profile/completeImport.ts
@@ -102,7 +102,7 @@ describe("tasks/profile:completeImport", () => {
       });
 
       await _import.reload();
-      await run.reload();
+      await run.updateTotals();
 
       expect(_import.newProfileProperties.email).toEqual(["mario@example.com"]);
       expect(_import.newProfileProperties.firstName).toEqual(["Mario"]);

--- a/core/api/__tests__/tasks/run/updateCounts.ts
+++ b/core/api/__tests__/tasks/run/updateCounts.ts
@@ -1,0 +1,98 @@
+import { helper } from "@grouparoo/spec-helper";
+import { api, specHelper } from "actionhero";
+import { internalRun } from "../../../src/modules/internalRun";
+import { Import } from "../../../src/models/Import";
+import { Run } from "../../../src/models/Run";
+
+let actionhero;
+let profile;
+
+describe("tasks/runs:updateCounts", () => {
+  beforeAll(async () => {
+    const env = await helper.prepareForAPITest();
+    actionhero = env.actionhero;
+    await helper.factories.profilePropertyRules();
+  }, 1000 * 30);
+
+  beforeEach(async () => {
+    await api.resque.queue.connection.redis.flushdb();
+  });
+
+  afterAll(async () => {
+    await helper.shutdown(actionhero);
+  });
+
+  describe("runs:updateCounts", () => {
+    beforeEach(async () => {
+      await Run.truncate();
+    });
+
+    test("it will find running schedule", async () => {
+      const schedule = await helper.factories.schedule();
+      await Run.create({
+        creatorGuid: schedule.guid,
+        creatorType: "schedule",
+        state: "running",
+      });
+
+      const runsChecked = await specHelper.runTask("runs:updateCounts", {});
+      expect(runsChecked).toBe(1);
+    });
+
+    test("it will not find stopped", async () => {
+      const schedule = await helper.factories.schedule();
+      await Run.create({
+        creatorGuid: schedule.guid,
+        creatorType: "schedule",
+        state: "stopped",
+      });
+
+      const runsChecked = await specHelper.runTask("runs:updateCounts", {});
+      expect(runsChecked).toBe(0);
+    });
+
+    test("it will not find running schedules which are over 1 day old", async () => {
+      const schedule = await helper.factories.schedule();
+      const run = await Run.create({
+        creatorGuid: schedule.guid,
+        creatorType: "schedule",
+        state: "running",
+      });
+
+      await api.sequelize.query(
+        `UPDATE runs set "updatedAt" = '1900-01-01' where guid='${run.guid}'`
+      );
+
+      const runsChecked = await specHelper.runTask("runs:updateCounts", {});
+      expect(runsChecked).toBe(0);
+    });
+
+    test("it will find runs in the complete state that have un-imported profiles", async () => {
+      const schedule = await helper.factories.schedule();
+      const run = await Run.create({
+        creatorGuid: schedule.guid,
+        creatorType: "schedule",
+        state: "complete",
+        importsCreated: 1,
+        profilesImported: 0,
+      });
+
+      const runsChecked = await specHelper.runTask("runs:updateCounts", {});
+      expect(runsChecked).toBe(1);
+    });
+
+    test("it will not find runs in the complete state that have all their profiles imported", async () => {
+      const schedule = await helper.factories.schedule();
+      const run = await Run.create({
+        creatorGuid: schedule.guid,
+        creatorType: "schedule",
+        state: "complete",
+        importsCreated: 1,
+        profilesImported: 1,
+      });
+
+      const runsChecked = await specHelper.runTask("runs:updateCounts", {});
+      expect(runsChecked).toBe(0);
+    });
+  });
+});

--- a/core/api/src/migrations/000048-addImportCreatedProfile.ts
+++ b/core/api/src/migrations/000048-addImportCreatedProfile.ts
@@ -1,0 +1,18 @@
+module.exports = {
+  up: async function (migration, DataTypes) {
+    await migration.addColumn("imports", "createdProfile", {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: true,
+    });
+
+    await migration.changeColumn("imports", "createdProfile", {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+    });
+  },
+
+  down: async function (migration) {
+    await migration.removeColumn("imports", "createdProfile");
+  },
+};

--- a/core/api/src/models/Import.ts
+++ b/core/api/src/models/Import.ts
@@ -10,6 +10,7 @@ import {
   BelongsTo,
   DataType,
   AfterCreate,
+  Default,
 } from "sequelize-typescript";
 import * as uuid from "uuid";
 import { task, config } from "actionhero";
@@ -83,6 +84,11 @@ export class Import extends Model<Import> {
 
   @Column
   profileAssociatedAt: Date;
+
+  @AllowNull(false)
+  @Default(false)
+  @Column
+  createdProfile: boolean;
 
   @Column(DataType.TEXT)
   // oldProfileProperties: string;
@@ -166,6 +172,7 @@ export class Import extends Model<Import> {
 
       // lifecycle timestamps
       createdAt: this.createdAt.getTime(),
+      createdProfile: this.createdProfile,
       profileAssociatedAt: this.profileAssociatedAt
         ? this.profileAssociatedAt.getTime()
         : null,

--- a/core/api/src/models/Run.ts
+++ b/core/api/src/models/Run.ts
@@ -173,20 +173,7 @@ export class Run extends Model<Run> {
   }
 
   async updateTotals() {
-    const importsCreated = await Import.count({
-      where: { creatorGuid: this.guid },
-    });
-    const profilesCreated = await Import.count({
-      where: { creatorGuid: this.guid, createdProfile: true },
-    });
-    const profilesImported = await Import.count({
-      where: { creatorGuid: this.guid, profileUpdatedAt: { [Op.ne]: null } },
-      distinct: true,
-      col: "profileGuid",
-    });
-
-    await this.update({ importsCreated, profilesCreated, profilesImported });
-    await this.determinePercentComplete(false);
+    return RunOps.updateTotals(this);
   }
 
   async buildErrorMessage() {

--- a/core/api/src/models/Run.ts
+++ b/core/api/src/models/Run.ts
@@ -172,6 +172,23 @@ export class Run extends Model<Run> {
     }
   }
 
+  async updateTotals() {
+    const importsCreated = await Import.count({
+      where: { creatorGuid: this.guid },
+    });
+    const profilesCreated = await Import.count({
+      where: { creatorGuid: this.guid, createdProfile: true },
+    });
+    const profilesImported = await Import.count({
+      where: { creatorGuid: this.guid, profileUpdatedAt: { [Op.ne]: null } },
+      distinct: true,
+      col: "profileGuid",
+    });
+
+    await this.update({ importsCreated, profilesCreated, profilesImported });
+    await this.determinePercentComplete(false);
+  }
+
   async buildErrorMessage() {
     const importErrorCounts = await Import.findAll({
       attributes: [

--- a/core/api/src/modules/groupExport.ts
+++ b/core/api/src/modules/groupExport.ts
@@ -101,8 +101,6 @@ export async function groupExportToCSV(group: Group, limit = 1000) {
       csvStream.write(row);
     }
 
-    await run.incrementWithLock("profilesImported", profiles.length);
-
     offset = limit + offset;
     profiles = await getProfiles();
   }

--- a/core/api/src/modules/ops/group.ts
+++ b/core/api/src/modules/ops/group.ts
@@ -332,10 +332,6 @@ export namespace GroupOps {
 
       await transaction.commit();
 
-      await run.incrementWithLock(
-        "importsCreated",
-        profilesNeedingGroupMembership.length
-      );
       await group.update({ calculatedAt: new Date() });
 
       return {
@@ -397,7 +393,6 @@ export namespace GroupOps {
 
       await transaction.commit();
 
-      await run.incrementWithLock("importsCreated", groupMembersCount);
       await group.update({ calculatedAt: new Date() });
       return groupMembersCount;
     } catch (error) {

--- a/core/api/src/modules/ops/runs.ts
+++ b/core/api/src/modules/ops/runs.ts
@@ -97,6 +97,26 @@ export namespace RunOps {
   }
 
   /**
+   * Count up the totals from imports for `importsCreated`, `profilesCreated` and `profilesImported`
+   */
+  export async function updateTotals(run: Run) {
+    const importsCreated = await Import.count({
+      where: { creatorGuid: run.guid },
+    });
+    const profilesCreated = await Import.count({
+      where: { creatorGuid: run.guid, createdProfile: true },
+    });
+    const profilesImported = await Import.count({
+      where: { creatorGuid: run.guid, profileUpdatedAt: { [Op.ne]: null } },
+      distinct: true,
+      col: "profileGuid",
+    });
+
+    await run.update({ importsCreated, profilesCreated, profilesImported });
+    await run.determinePercentComplete(false);
+  }
+
+  /**
    * Make a guess to what percent complete this Run is
    */
   export async function determinePercentComplete(run: Run) {

--- a/core/api/src/modules/ops/runs.ts
+++ b/core/api/src/modules/ops/runs.ts
@@ -3,6 +3,7 @@ import { Profile } from "../../models/Profile";
 import { Group } from "../../models/Group";
 import { Schedule } from "../../models/Schedule";
 import { GroupMember } from "../../models/GroupMember";
+import { Import } from "../../models/Import";
 import { Op } from "sequelize";
 import { log } from "actionhero";
 
@@ -14,9 +15,25 @@ export namespace RunOps {
   export async function quantizedTimeline(run: Run, steps = 25) {
     const data = [];
     const start = run.createdAt.getTime();
-    const end = run.completedAt
-      ? run.completedAt.getTime()
-      : new Date().getTime();
+
+    const lastExportedImport = await Import.findOne({
+      where: { creatorGuid: run.guid },
+      order: [["exportedAt", "desc"]],
+      limit: 1,
+    });
+
+    const lastImportedImport = await Import.findOne({
+      where: { creatorGuid: run.guid },
+      order: [["profileUpdatedAt", "desc"]],
+      limit: 1,
+    });
+
+    const end =
+      lastExportedImport?.exportedAt?.getTime() ||
+      lastImportedImport?.exportedAt?.getTime() ||
+      run?.completedAt?.getTime() ||
+      new Date().getTime();
+
     const stepSize = Math.floor((end - start) / steps);
     const boundaries = [start - stepSize * 2];
     let i = 1;
@@ -38,7 +55,7 @@ export namespace RunOps {
               },
             },
           }),
-          update: await run.$count("imports", {
+          profilesUpdated: await run.$count("imports", {
             where: {
               profileUpdatedAt: {
                 [Op.gte]: lastBoundary,
@@ -46,9 +63,17 @@ export namespace RunOps {
               },
             },
           }),
-          groups: await run.$count("imports", {
+          groupsUpdated: await run.$count("imports", {
             where: {
               groupsUpdatedAt: {
+                [Op.gte]: lastBoundary,
+                [Op.lt]: nextBoundary,
+              },
+            },
+          }),
+          exported: await run.$count("imports", {
+            where: {
+              exportedAt: {
                 [Op.gte]: lastBoundary,
                 [Op.lt]: nextBoundary,
               },

--- a/core/api/src/modules/plugin.ts
+++ b/core/api/src/modules/plugin.ts
@@ -187,8 +187,6 @@ export namespace plugin {
       creatorGuid: run.guid,
     });
 
-    await run.incrementWithLock("importsCreated");
-
     return _import;
   }
 

--- a/core/api/src/tasks/import/associateProfile.ts
+++ b/core/api/src/tasks/import/associateProfile.ts
@@ -1,8 +1,6 @@
-import { Task, api, log, env } from "actionhero";
+import { Task, log, env } from "actionhero";
 import { Import } from "../../models/Import";
-import { Run } from "../../models/Run";
 import { ProfilePropertyType } from "../../modules/ops/profile";
-import { Transaction } from "sequelize";
 
 export class ImportAssociateProfile extends Task {
   constructor() {
@@ -36,18 +34,12 @@ export class ImportAssociateProfile extends Task {
       const oldProfileProperties = await profile.properties();
       const oldGroups = await profile.$get("groups");
 
+      _import.createdProfile = isNew;
       _import.oldProfileProperties = this.simplifyProfileProperties(
         oldProfileProperties
       );
       _import.oldGroupGuids = oldGroups.map((g) => g.guid);
       await _import.save();
-
-      if (_import.creatorType === "run") {
-        if (isNew) {
-          const run = await Run.findByGuid(_import.creatorGuid);
-          await run.incrementWithLock("profilesCreated");
-        }
-      }
     } catch (error) {
       if (env !== "test") {
         log(`[ASSOCIATE PROFILE ERROR] ${error}`, "alert");

--- a/core/api/src/tasks/profile/completeImport.ts
+++ b/core/api/src/tasks/profile/completeImport.ts
@@ -1,7 +1,7 @@
-import { api, task } from "actionhero";
+import { task } from "actionhero";
 import { Profile } from "../../models/Profile";
 import { Run } from "../../models/Run";
-import { Op, Transaction } from "sequelize";
+import { Op } from "sequelize";
 import { ProfilePropertyType } from "../../modules/ops/profile";
 import { RetryableTask } from "../../classes/retryableTask";
 
@@ -88,12 +88,6 @@ export class ProfileCompleteImport extends RetryableTask {
           },
         },
       });
-
-      for (const i in runs) {
-        const run = runs[i];
-        if (run.force) force = true;
-        await run.incrementWithLock("profilesImported");
-      }
 
       await task.enqueue("profile:export", {
         profileGuid: profile.guid,

--- a/core/api/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/api/src/tasks/profileProperty/importProfileProperties.ts
@@ -7,7 +7,7 @@ import { log, task } from "actionhero";
 import { ProfilePropertiesPluginMethodResponse } from "../../classes/plugin";
 import { ProfilePropertyRuleOps } from "../../modules/ops/profilePropertyRule";
 
-export class ProfilePropertyImport extends RetryableTask {
+export class ImportProfileProperties extends RetryableTask {
   constructor() {
     super();
     this.name = "profileProperty:importProfileProperties";

--- a/core/api/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/api/src/tasks/profileProperty/importProfileProperty.ts
@@ -5,7 +5,7 @@ import { log } from "actionhero";
 import { ProfileProperty } from "../../models/ProfileProperty";
 import { ProfilePropertyRuleOps } from "../../modules/ops/profilePropertyRule";
 
-export class ProfilePropertyImport extends RetryableTask {
+export class ImportProfileProperty extends RetryableTask {
   constructor() {
     super();
     this.name = "profileProperty:importProfileProperty";

--- a/core/api/src/tasks/run/internalRun.ts
+++ b/core/api/src/tasks/run/internalRun.ts
@@ -116,7 +116,6 @@ export class RunInternalRun extends Task {
 
       await transaction.commit();
 
-      await run.incrementWithLock("importsCreated", profiles.length);
       await run.afterBatch();
 
       if (profiles.length > 0) {

--- a/core/api/src/tasks/run/updateCounts.ts
+++ b/core/api/src/tasks/run/updateCounts.ts
@@ -1,0 +1,54 @@
+import { api, Task } from "actionhero";
+import { Run } from "../../models/Run";
+import { Op } from "sequelize";
+import { Import } from "../../models/Import";
+import Moment from "moment";
+
+export class UpdateRunCounts extends Task {
+  constructor() {
+    super();
+    this.name = "runs:updateCounts";
+    this.description = "Update the counts of imports and profiles for runs";
+    this.frequency = 1000 * 10;
+    this.queue = "runs";
+    this.inputs = {};
+  }
+
+  async run() {
+    const since = Moment().subtract(1, "day");
+
+    const runs = await Run.findAll({
+      where: {
+        state: { [Op.ne]: "stopped" },
+        error: { [Op.eq]: null },
+        updatedAt: { [Op.gte]: since.toDate() },
+        [Op.or]: [
+          { importsCreated: 0 },
+          {
+            profilesImported: {
+              [Op.lt]: api.sequelize.col("importsCreated"),
+            },
+          },
+        ],
+      },
+    });
+
+    for (const i in runs) {
+      const run = runs[i];
+      const importsCreated = await Import.count({
+        where: { creatorGuid: run.guid },
+      });
+      const profilesCreated = await Import.count({
+        where: { creatorGuid: run.guid, createdProfile: true },
+      });
+      const profilesImported = await Import.count({
+        where: { creatorGuid: run.guid, profileUpdatedAt: { [Op.ne]: null } },
+      });
+
+      await run.update({ importsCreated, profilesCreated, profilesImported });
+      await run.determinePercentComplete(false);
+    }
+
+    return runs.length;
+  }
+}

--- a/core/api/src/tasks/run/updateCounts.ts
+++ b/core/api/src/tasks/run/updateCounts.ts
@@ -1,7 +1,6 @@
 import { api, Task } from "actionhero";
 import { Run } from "../../models/Run";
 import { Op } from "sequelize";
-import { Import } from "../../models/Import";
 import Moment from "moment";
 
 export class UpdateRunCounts extends Task {
@@ -34,19 +33,7 @@ export class UpdateRunCounts extends Task {
     });
 
     for (const i in runs) {
-      const run = runs[i];
-      const importsCreated = await Import.count({
-        where: { creatorGuid: run.guid },
-      });
-      const profilesCreated = await Import.count({
-        where: { creatorGuid: run.guid, createdProfile: true },
-      });
-      const profilesImported = await Import.count({
-        where: { creatorGuid: run.guid, profileUpdatedAt: { [Op.ne]: null } },
-      });
-
-      await run.update({ importsCreated, profilesCreated, profilesImported });
-      await run.determinePercentComplete(false);
+      await runs[i].updateTotals();
     }
 
     return runs.length;

--- a/plugins/@grouparoo/csv/__tests__/integration/csv.ts
+++ b/plugins/@grouparoo/csv/__tests__/integration/csv.ts
@@ -294,7 +294,7 @@ describe("integration/runs/csv", () => {
         const profilesCount = await Profile.count();
         expect(profilesCount).toBe(10);
 
-        await run.reload();
+        await run.updateTotals();
         expect(run.state).toBe("complete");
         expect(run.importsCreated).toBe(10);
         expect(run.profilesCreated).toBe(10);
@@ -387,6 +387,7 @@ describe("integration/runs/csv", () => {
         const profilesCount = await Profile.count();
         expect(profilesCount).toBe(10);
 
+        await run.updateTotals();
         await run.reload();
         expect(run.state).toBe("complete");
         expect(run.importsCreated).toBe(10);

--- a/plugins/@grouparoo/csv/__tests__/integration/csv.ts
+++ b/plugins/@grouparoo/csv/__tests__/integration/csv.ts
@@ -388,7 +388,6 @@ describe("integration/runs/csv", () => {
         expect(profilesCount).toBe(10);
 
         await run.updateTotals();
-        await run.reload();
         expect(run.state).toBe("complete");
         expect(run.importsCreated).toBe(10);
         expect(run.profilesCreated).toBe(0);

--- a/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
+++ b/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
@@ -311,7 +311,7 @@ describe("integration/runs/google-sheets", () => {
         const profilesCount = await Profile.count();
         expect(profilesCount).toBe(10);
 
-        await run.reload();
+        await run.updateTotals();
         expect(run.state).toBe("complete");
         expect(run.importsCreated).toBe(10);
         expect(run.profilesCreated).toBe(10);
@@ -414,7 +414,7 @@ describe("integration/runs/google-sheets", () => {
         const profilesCount = await Profile.count();
         expect(profilesCount).toBe(10);
 
-        await run.reload();
+        await run.updateTotals();
         expect(run.state).toBe("complete");
         expect(run.importsCreated).toBe(10);
         expect(run.profilesCreated).toBe(0);

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -438,7 +438,7 @@ describe("integration/runs/mysql", () => {
       const profilesCount = await Profile.count();
       expect(profilesCount).toBe(10);
 
-      await run.reload();
+      await run.updateTotals();
       expect(run.state).toBe("complete");
       expect(run.importsCreated).toBe(11);
       expect(run.profilesCreated).toBe(10);
@@ -564,6 +564,7 @@ describe("integration/runs/mysql", () => {
       const profilesCount = await Profile.count();
       expect(profilesCount).toBe(10);
 
+      await run.updateTotals();
       await run.reload();
       expect(run.state).toBe("complete");
       expect(run.importsCreated).toBe(1);

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -565,7 +565,6 @@ describe("integration/runs/mysql", () => {
       expect(profilesCount).toBe(10);
 
       await run.updateTotals();
-      await run.reload();
       expect(run.state).toBe("complete");
       expect(run.importsCreated).toBe(1);
       expect(run.profilesCreated).toBe(0);

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
@@ -562,7 +562,6 @@ describe("integration/runs/postgres", () => {
       expect(profilesCount).toBe(10);
 
       await run.updateTotals();
-      await run.reload();
       expect(run.state).toBe("complete");
       expect(run.importsCreated).toBe(1);
       expect(run.profilesCreated).toBe(0);

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
@@ -435,7 +435,7 @@ describe("integration/runs/postgres", () => {
       const profilesCount = await Profile.count();
       expect(profilesCount).toBe(10);
 
-      await run.reload();
+      await run.updateTotals();
       expect(run.state).toBe("complete");
       expect(run.importsCreated).toBe(11);
       expect(run.profilesCreated).toBe(10);
@@ -561,6 +561,7 @@ describe("integration/runs/postgres", () => {
       const profilesCount = await Profile.count();
       expect(profilesCount).toBe(10);
 
+      await run.updateTotals();
       await run.reload();
       expect(run.state).toBe("complete");
       expect(run.importsCreated).toBe(1);


### PR DESCRIPTION
Moves the incrementing of `Run.importsCreated`, `Run.profilesCreated`, and `Run.profilesImported` to a task.  This removes the need for the `run.incrementWithLock `method.  

This adds some lag to the calculation of run's completion percentages.

This PR also extends the "run detail chart" past the completion time (as runs are complete now when the imports are created) to show the lifecycle of those imports past that time - completing the profile import and export

<img width="1517" alt="Screen Shot 2020-11-04 at 3 35 49 PM" src="https://user-images.githubusercontent.com/303226/98180321-75406380-1eb5-11eb-9702-94992ad2cccc.png">

Closes T-670
