### PR TITLE
Filter profiles list by state

### DIFF
--- a/core/api/__tests__/actions/profiles.ts
+++ b/core/api/__tests__/actions/profiles.ts
@@ -156,17 +156,38 @@ describe("actions/profiles", () => {
       connection.params = {
         csrfToken,
       };
-      const {
-        error,
-        profiles,
-        total,
-        pendingTotal,
-      } = await specHelper.runAction("profiles:list", connection);
+      const { error, profiles, total } = await specHelper.runAction(
+        "profiles:list",
+        connection
+      );
       expect(error).toBeUndefined();
       expect(profiles.length).toBe(1);
       expect(simpleProfileValues(profiles[0].properties).userId).toEqual([999]);
       expect(total).toBe(1);
+    });
+
+    test("a writer can list all the profiles with a certain state", async () => {
+      connection.params = {
+        csrfToken,
+        state: "pending",
+      };
+      const {
+        profiles: pendingProfiles,
+        total: pendingTotal,
+      } = await specHelper.runAction("profiles:list", connection);
+      expect(pendingProfiles.length).toBe(1);
       expect(pendingTotal).toBe(1);
+
+      connection.params = {
+        csrfToken,
+        state: "ready",
+      };
+      const {
+        profiles: readyProfiles,
+        total: readyTotal,
+      } = await specHelper.runAction("profiles:list", connection);
+      expect(readyProfiles.length).toBe(0);
+      expect(readyTotal).toBe(0);
     });
 
     test("a writer can get autocomplete results from profile properties", async () => {

--- a/core/web/components/profile/list.tsx
+++ b/core/web/components/profile/list.tsx
@@ -4,7 +4,7 @@ import { useOffset, updateURLParams } from "../../hooks/URLParams";
 import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Form, Col, Badge } from "react-bootstrap";
+import { Form, Col, Badge, Button, ButtonGroup } from "react-bootstrap";
 import Moment from "react-moment";
 import Pagination from "../pagination";
 import LoadingTable from "../loadingTable";
@@ -35,10 +35,12 @@ export default function ProfilesList(props) {
   const [searchValue, setSearchValue] = useState<string>(
     router.query.searchValue || props.searchValue || ""
   );
+  const [state, setState] = useState(router.query.state?.toString() || null);
+  const states = ["pending", "ready"];
 
   useSecondaryEffect(() => {
     load();
-  }, [offset, limit]);
+  }, [offset, limit, state]);
 
   let groupGuid: string;
   if (router.query.guid) {
@@ -58,6 +60,7 @@ export default function ProfilesList(props) {
       searchValue,
       limit,
       offset,
+      state,
       groupGuid,
     });
     setLoading(false);
@@ -69,7 +72,7 @@ export default function ProfilesList(props) {
       }
     }
 
-    updateURLParams(router, { offset, searchKey, searchValue });
+    updateURLParams(router, { offset, searchKey, searchValue, state });
   }
 
   async function autocompleteProfilePropertySearch(
@@ -186,8 +189,42 @@ export default function ProfilesList(props) {
         </Form.Row>
       </Form>
 
+      <ButtonGroup id="profile-states">
+        <Button
+          size="sm"
+          variant={state ? "info" : "secondary"}
+          onClick={() => {
+            setState(null);
+            setOffset(0);
+          }}
+        >
+          All
+        </Button>
+        {states.map((t) => {
+          const variant = t === state ? "secondary" : "info";
+          return (
+            <Button
+              key={`state-${t}`}
+              size="sm"
+              variant={variant}
+              onClick={() => {
+                setState(t);
+                setOffset(0);
+              }}
+            >
+              {t}
+            </Button>
+          );
+        })}
+      </ButtonGroup>
+
+      <br />
+      <br />
+
       <p>
-        <strong>{total} matching profiles</strong>
+        <strong>
+          {total} matching profiles {state ? ` in the ${state} state` : ""}
+        </strong>
       </p>
 
       <Pagination

--- a/core/web/components/visualizations/totals.tsx
+++ b/core/web/components/visualizations/totals.tsx
@@ -137,9 +137,11 @@ function PendingProfiles({ execApi }) {
   }
 
   async function load() {
-    const response: Actions.ProfilesList = await execApi("get", `/profiles`);
-    if (response) {
-      setCount(response.pendingTotal);
+    const response: Actions.ProfilesList = await execApi("get", `/profiles`, {
+      state: "pending",
+    });
+    if (response.total) {
+      setCount(response.total);
     }
   }
 


### PR DESCRIPTION
When viewing a list of Profiles, allows filtering to "all", "pending" or "ready" states, in addition to pagination or search params. 

<img width="1310" alt="Screen Shot 2020-11-05 at 10 40 04 AM" src="https://user-images.githubusercontent.com/303226/98282689-72944b80-1f53-11eb-8bac-b72bac8348c9.png">

Closes t-672