### PR TITLE
When checking Profile Property dependencies rely on state

### DIFF
--- a/core/api/__tests__/models/profileProperty.ts
+++ b/core/api/__tests__/models/profileProperty.ts
@@ -480,7 +480,7 @@ describe("models/profileProperty", () => {
           email: ["mario@example.com"],
         })
       ).rejects.toThrow(
-        /another profile already has the value mario@example.com for property email/
+        /Another profile already has the value mario@example.com for property email/
       );
     });
 

--- a/core/api/__tests__/tasks/profileProperty/importProfileProperties.ts
+++ b/core/api/__tests__/tasks/profileProperty/importProfileProperties.ts
@@ -97,9 +97,9 @@ describe("tasks/profileProperty:importProfileProperties", () => {
       expect(property.rawValue).toBe(`${profile.guid}@example.com`);
     });
 
-    test("will not import profile properties that are missing dependencies", async () => {
-      const ltvRule = await ProfilePropertyRule.findOne({
-        where: { key: "ltv" },
+    test("will not import profile properties that have pending dependencies", async () => {
+      const userIdRule = await ProfilePropertyRule.findOne({
+        where: { key: "userId" },
       });
 
       const profile = await helper.factories.profile();
@@ -112,13 +112,13 @@ describe("tasks/profileProperty:importProfileProperties", () => {
       });
       await property.update({ state: "pending" });
 
-      const ltvProperty = await ProfileProperty.findOne({
+      const userIdProperty = await ProfileProperty.findOne({
         where: {
           profileGuid: profile.guid,
-          profilePropertyRuleGuid: ltvRule.guid,
+          profilePropertyRuleGuid: userIdRule.guid,
         },
       });
-      await ltvProperty.update({ rawValue: null });
+      await userIdProperty.update({ state: "pending" });
 
       await specHelper.runTask("profileProperty:importProfileProperties", {
         profileGuids: [profile.guid],

--- a/core/api/__tests__/tasks/profileProperty/importProfileProperty.ts
+++ b/core/api/__tests__/tasks/profileProperty/importProfileProperty.ts
@@ -53,9 +53,9 @@ describe("tasks/profileProperty:importProfileProperty", () => {
       expect(property.rawValue).toBe(`${profile.guid}@example.com`);
     });
 
-    test("will not import profile properties that are missing dependencies", async () => {
-      const ltvRule = await ProfilePropertyRule.findOne({
-        where: { key: "ltv" },
+    test("will not import profile properties that have pending dependencies", async () => {
+      const userIdRule = await ProfilePropertyRule.findOne({
+        where: { key: "userId" },
       });
 
       const profile = await helper.factories.profile();
@@ -68,16 +68,16 @@ describe("tasks/profileProperty:importProfileProperty", () => {
       });
       await property.update({ state: "pending" });
 
-      const ltvProperty = await ProfileProperty.findOne({
+      const userIdProperty = await ProfileProperty.findOne({
         where: {
           profileGuid: profile.guid,
-          profilePropertyRuleGuid: ltvRule.guid,
+          profilePropertyRuleGuid: userIdRule.guid,
         },
       });
-      await ltvProperty.update({ rawValue: null });
+      await userIdProperty.update({ state: "pending" });
 
-      await specHelper.runTask("profileProperty:importProfileProperty", {
-        profileGuid: profile.guid,
+      await specHelper.runTask("profileProperty:importProfileProperties", {
+        profileGuids: [profile.guid],
         profilePropertyRuleGuid: property.profilePropertyRuleGuid,
       });
 

--- a/core/api/src/models/ProfileProperty.ts
+++ b/core/api/src/models/ProfileProperty.ts
@@ -179,7 +179,7 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
 
       if (count > 0) {
         throw new Error(
-          `another profile already has the value ${this.rawValue} for property ${rule.key}`
+          `Another profile already has the value ${this.rawValue} for property ${rule.key}`
         );
       }
     }

--- a/core/api/src/modules/ops/event.ts
+++ b/core/api/src/modules/ops/event.ts
@@ -108,7 +108,17 @@ export namespace EventOps {
 
     const profileProperties = {};
     profileProperties[profilePropertyRule.key] = event.userId;
-    await profile.addOrUpdateProperties(profileProperties);
+
+    try {
+      await profile.addOrUpdateProperties(profileProperties);
+    } catch (error) {
+      // the profile was created in the middle of this task; try again!
+      if (error.toString().match(/Another profile already has the value/)) {
+        return associateEventWithUserId(event, profilePropertyRule);
+      } else {
+        throw error;
+      }
+    }
 
     event.profileGuid = profile.guid;
     event.profileAssociatedAt = new Date();

--- a/core/api/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/api/src/tasks/profileProperty/importProfileProperties.ts
@@ -42,15 +42,7 @@ export class ImportProfileProperties extends RetryableTask {
       const properties = await profile.properties();
 
       dependencies.forEach((dep) => {
-        if (
-          properties[dep.key].values.length === 0 ||
-          properties[dep.key].values.filter((v) => v === null).length ===
-            properties[dep.key].values.length ||
-          properties[dep.key].values.filter((v) => v === undefined).length ===
-            properties[dep.key].values.length
-        ) {
-          ok = false;
-        }
+        if (properties[dep.key].state !== "ready") ok = false;
       });
 
       if (ok) profilesWithDependenciesMet.push(profile);

--- a/core/api/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/api/src/tasks/profileProperty/importProfileProperty.ts
@@ -45,15 +45,7 @@ export class ImportProfileProperty extends RetryableTask {
 
     let ok = true;
     dependencies.forEach((dep) => {
-      if (
-        properties[dep.key].values.length === 0 ||
-        properties[dep.key].values.filter((v) => v === null).length ===
-          properties[dep.key].values.length ||
-        properties[dep.key].values.filter((v) => v === undefined).length ===
-          properties[dep.key].values.length
-      ) {
-        ok = false;
-      }
+      if (properties[dep.key].state !== "ready") ok = false;
     });
 
     // there's a dependency we don't have yet

--- a/plugins/@grouparoo/spec-helper/src/lib/workflows/import.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/workflows/import.ts
@@ -1,30 +1,45 @@
+import { Profile } from "@grouparoo/core/api/src";
 import { specHelper } from "actionhero";
 
 export async function ImportWorkflow() {
+  const maxAttempts = 5;
+  let attempts = 0;
   let importTasks = [];
-  await specHelper.runTask("profileProperties:enqueue", {});
+  let pendingProfiles = 1;
 
-  // batch
-  importTasks = await specHelper.findEnqueuedTasks(
-    "profileProperty:importProfileProperties"
-  );
-  await Promise.all(
-    importTasks.map((t) =>
-      specHelper.runTask("profileProperty:importProfileProperties", t.args[0])
-    )
-  );
+  async function _import() {
+    await specHelper.runTask("profileProperties:enqueue", {});
 
-  // single
-  importTasks = await specHelper.findEnqueuedTasks(
-    "profileProperty:importProfileProperty"
-  );
-  await Promise.all(
-    importTasks.map((t) =>
-      specHelper.runTask("profileProperty:importProfileProperty", t.args[0])
-    )
-  );
+    // batch
+    importTasks = await specHelper.findEnqueuedTasks(
+      "profileProperty:importProfileProperties"
+    );
+    await Promise.all(
+      importTasks.map((t) =>
+        specHelper.runTask("profileProperty:importProfileProperties", t.args[0])
+      )
+    );
 
-  await specHelper.runTask("profiles:checkReady", {});
+    // single
+    importTasks = await specHelper.findEnqueuedTasks(
+      "profileProperty:importProfileProperty"
+    );
+    await Promise.all(
+      importTasks.map((t) =>
+        specHelper.runTask("profileProperty:importProfileProperty", t.args[0])
+      )
+    );
+
+    await specHelper.runTask("profiles:checkReady", {});
+
+    pendingProfiles = await Profile.count({ where: { state: "pending" } });
+  }
+
+  // we'll need to loop more than once to get dependent profiles first before secondary ones
+  while (pendingProfiles > 0 && attempts < maxAttempts) {
+    await _import();
+    attempts++;
+  }
 
   const completeTasks = await specHelper.findEnqueuedTasks(
     "profile:completeImport"


### PR DESCRIPTION
When checking to see if a Profile's Property is ready to be imported, we check that Property Rules's dependencies (ie: `email` likely relies on `userId`).  Rather than checking for an array of non-null values for `userId`, we can simply rely on the `userId` Profile Property being in the `ready` state. 

This removes a class of errors for Profiles which will always be in the incomplete state, i.e.: profiles which are created only by events (without being identified) and will never get a `userId`. 

Closes T-680