### PR TITLE
Properly consider alpha versions in semver ranges

### DIFF
--- a/core/api/__tests__/actions/plugins.ts
+++ b/core/api/__tests__/actions/plugins.ts
@@ -39,8 +39,9 @@ describe("actions/plugins", () => {
     expect(plugins.length).toBeGreaterThanOrEqual(1);
     expect(plugins[0]).toEqual({
       name: "@grouparoo/core",
-      version: coreVersion,
+      currentVersion: coreVersion,
       latestVersion: "0.1.17", // from nock recording
+      upToDate: true,
       license: "MPL-2.0",
       url: "https://github.com/grouparoo/grouparoo",
     });

--- a/core/api/__tests__/notifiers/newVersionNotifier.ts
+++ b/core/api/__tests__/notifiers/newVersionNotifier.ts
@@ -8,22 +8,25 @@ jest.mock("../../src/modules/pluginVersions.ts", () => ({
     return [
       {
         name: "@grouparoo/core",
-        version: "1.2.3",
+        currentVersion: "1.2.3",
         latestVersion: "99.0.1",
+        upToDate: false,
         license: "MPL-2.0",
         url: "https://github.com/grouparoo/grouparoo",
       },
       {
         name: "@grouparoo/postgres",
-        version: "1.2.3",
+        currentVersion: "1.2.3",
         latestVersion: "99.0.1",
+        upToDate: false,
         license: "MPL-2.0",
         url: "https://github.com/grouparoo/grouparoo",
       },
       {
         name: "@grouparoo/mysql",
-        version: "1.2.3",
+        currentVersion: "1.2.3",
         latestVersion: "99.0.1",
+        upToDate: false,
         license: "MPL-2.0",
         url: "https://github.com/grouparoo/grouparoo",
       },

--- a/core/api/src/notifiers/newVersionNotifier.ts
+++ b/core/api/src/notifiers/newVersionNotifier.ts
@@ -20,9 +20,7 @@ export class NewVersionNotifier extends Notifier {
       return;
     }
 
-    if (core.latestVersion === "unknown") {
-      return;
-    }
+    if (core.latestVersion === "unknown") return;
 
     const notification: NotifierMessagePayload = {
       subject: "There's a new version of Grouparoo!",

--- a/core/api/src/notifiers/newVersionNotifier.ts
+++ b/core/api/src/notifiers/newVersionNotifier.ts
@@ -13,15 +13,14 @@ export class NewVersionNotifier extends Notifier {
     const core = plugins.find((p) => p.name === "@grouparoo/core");
     const otherPluginsWithUpdates = plugins
       .filter((p) => p.name !== "@grouparoo/core")
-      .filter((p) => p.version !== p.latestVersion)
-      .filter((p) => p.latestVersion !== "unknown");
+      .filter((p) => p.upToDate === false);
 
-    if (core.version === core.latestVersion) {
+    if (core.upToDate) {
       await this.clearNotifications();
       return;
     }
 
-    if (core.version === "unknown") {
+    if (core.latestVersion === "unknown") {
       return;
     }
 
@@ -31,7 +30,7 @@ export class NewVersionNotifier extends Notifier {
 **There is a new version of Grouparoo available!**
 
 You are currently running version **${
-        core.version
+        core.currentVersion
       }** of @grouparoo/core, but the latest version is **${
         core.latestVersion
       }**.  We suggest that you upgrade your server as soon as possible to take advantage of all the new features and fixes.
@@ -43,7 +42,7 @@ ${
   otherPluginsWithUpdates
     ? `There are also other plugins with updates available:
 ${otherPluginsWithUpdates
-  .map((p) => ` * ${p.name} (${p.version} -> ${p.latestVersion})`)
+  .map((p) => ` * ${p.name} (${p.currentVersion} -> ${p.latestVersion})`)
   .join("\r\n")}`
     : null
 }

--- a/core/package.json
+++ b/core/package.json
@@ -58,6 +58,7 @@
     "axios": "0.21.0",
     "bcrypt": "5.0.0",
     "bootstrap": "4.5.3",
+    "compare-versions": "3.6.0",
     "csv-stringify": "5.5.1",
     "date-fns": "2.16.1",
     "dotenv": "8.2.0",

--- a/core/web/pages/about.tsx
+++ b/core/web/pages/about.tsx
@@ -22,9 +22,7 @@ export default function Page({
 }: {
   plugins: Actions.PluginsList["plugins"];
 }) {
-  const hasOutOfDatePlugin = plugins.find((p) => p.version !== p.latestVersion)
-    ? true
-    : false;
+  const hasOutOfDatePlugin = plugins.find((p) => !p.upToDate) ? true : false;
 
   return (
     <>
@@ -86,9 +84,8 @@ export default function Page({
             <tr key={`plugin-${plugin.name}`}>
               <td>{plugin.name}</td>
               <td>
-                {plugin.version}{" "}
-                {plugin.version !== plugin.latestVersion &&
-                plugin.latestVersion !== "unknown" ? (
+                {plugin.currentVersion}{" "}
+                {!plugin.upToDate ? (
                   <Badge variant={"warning"}>Out of Date</Badge>
                 ) : null}
               </td>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,7 @@ importers:
       axios: 0.21.0
       bcrypt: 5.0.0
       bootstrap: 4.5.3
+      compare-versions: 3.6.0
       csv-stringify: 5.5.1
       date-fns: 2.16.1
       dotenv: 8.2.0
@@ -202,6 +203,7 @@ importers:
       axios: 0.21.0
       bcrypt: 5.0.0
       bootstrap: 4.5.3
+      compare-versions: 3.6.0
       csv-parse: 4.12.0
       csv-stringify: 5.5.1
       date-fns: 2.16.1
@@ -5928,6 +5930,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==
+  /compare-versions/3.6.0:
+    dev: false
+    resolution:
+      integrity: sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
   /component-emitter/1.3.0:
     resolution:
       integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==


### PR DESCRIPTION
We now use the [`compare-versions`](https://www.npmjs.com/package/compare-versions) package to determine if a package is out of date for the `/about` page and new-version notifier.  `compare-versions` knows how to support alpha releases with "extended" patch semver names like `1.2.3-alpha.4`