### PR TITLE
Directly mapped profile properties will not be marked as pending

### DIFF
--- a/core/api/__tests__/models/profile.ts
+++ b/core/api/__tests__/models/profile.ts
@@ -301,7 +301,7 @@ describe("models/profile", () => {
         }
       });
 
-      test("a profile can be marked as pending", async () => {
+      test("a profile can be marked as pending and it's properties will be marked as pending as well", async () => {
         const newProfile = await Profile.create();
         await newProfile.update({ state: "ready" });
         await ProfileProperty.update(
@@ -315,7 +315,11 @@ describe("models/profile", () => {
         expect(newProfile.state).toBe("pending");
         const properties = await newProfile.properties();
         for (const k in properties) {
-          expect(properties[k].state).toEqual("pending");
+          if (k === "userId") {
+            expect(properties[k].state).toEqual("ready");
+          } else {
+            expect(properties[k].state).toEqual("pending");
+          }
         }
       });
 

--- a/core/api/__tests__/models/profilePropertyRules/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRules/profilePropertyRule.ts
@@ -367,19 +367,19 @@ describe("models/profilePropertyRule", () => {
     expect(optionsCount).toBe(0);
   });
 
-  test("profile property rules can determine if they are directly mapped", async () => {
-    const userIdRule = await ProfilePropertyRule.findOne({
-      where: { key: "userId" },
-    });
-    const emailRule = await ProfilePropertyRule.findOne({
-      where: { key: "email" },
+  describe("cache and directlyMapping", () => {
+    let userIdRule: ProfilePropertyRule;
+    let emailRule: ProfilePropertyRule;
+
+    beforeAll(async () => {
+      userIdRule = await ProfilePropertyRule.findOne({
+        where: { key: "userId" },
+      });
+      emailRule = await ProfilePropertyRule.findOne({
+        where: { key: "email" },
+      });
     });
 
-    expect(await userIdRule.directlyMapped()).toBe(true);
-    expect(await emailRule.directlyMapped()).toBe(false);
-  });
-
-  describe("cache", () => {
     test("cached data can be returned", async () => {
       const rules = await ProfilePropertyRule.cached();
       const keys = Object.keys(rules);
@@ -411,6 +411,18 @@ describe("models/profilePropertyRule", () => {
         "purchases",
         "userId",
       ]);
+    });
+
+    test("directlyMapping will be determined as on save", async () => {
+      expect(userIdRule.directlyMapped).toBe(true);
+      expect(emailRule.directlyMapped).toBe(false);
+    });
+
+    test("profile property rules include if they are directly mapped", async () => {
+      const rules = await ProfilePropertyRule.cached();
+
+      expect(rules["userId"].directlyMapped).toBe(true);
+      expect(rules["email"].directlyMapped).toBe(false);
     });
   });
 

--- a/core/api/__tests__/models/profilePropertyRules/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRules/profilePropertyRule.ts
@@ -367,11 +367,23 @@ describe("models/profilePropertyRule", () => {
     expect(optionsCount).toBe(0);
   });
 
+  test("profile property rules can determine if they are directly mapped", async () => {
+    const userIdRule = await ProfilePropertyRule.findOne({
+      where: { key: "userId" },
+    });
+    const emailRule = await ProfilePropertyRule.findOne({
+      where: { key: "email" },
+    });
+
+    expect(await userIdRule.directlyMapped()).toBe(true);
+    expect(await emailRule.directlyMapped()).toBe(false);
+  });
+
   describe("cache", () => {
     test("cached data can be returned", async () => {
       const rules = await ProfilePropertyRule.cached();
       const keys = Object.keys(rules);
-      expect(keys).toEqual([
+      expect(keys.sort()).toEqual([
         "email",
         "firstName",
         "isVIP",
@@ -388,7 +400,7 @@ describe("models/profilePropertyRule", () => {
       await ProfilePropertyRule.clearCache();
       const rules = await ProfilePropertyRule.cached();
       const keys = Object.keys(rules);
-      expect(keys).toEqual([
+      expect(keys.sort()).toEqual([
         "email",
         "firstName",
         "isVIP",

--- a/core/api/__tests__/tasks/profileProperty/enqueue.ts
+++ b/core/api/__tests__/tasks/profileProperty/enqueue.ts
@@ -75,7 +75,7 @@ describe("tasks/profileProperties:enqueue", () => {
 
       expect(importProfilePropertiesTasks.length).toBe(0);
       expect(importProfilePropertyTasks.length).toBe(
-        profilePropertyRulesCount * 2
+        (profilePropertyRulesCount - 1) * 2
       );
     });
 
@@ -127,7 +127,7 @@ describe("tasks/profileProperties:enqueue", () => {
 
         expect(importProfilePropertyTasks.length).toBe(0);
         expect(importProfilePropertiesTasks.length).toBe(
-          profilePropertyRulesCount
+          profilePropertyRulesCount - 1
         );
         importProfilePropertiesTasks.forEach((t) =>
           expect(t.args[0].profileGuids.length).toBe(2)
@@ -168,7 +168,7 @@ describe("tasks/profileProperties:enqueue", () => {
 
         expect(importProfilePropertyTasks.length).toBe(0);
         expect(importProfilePropertiesTasks.length).toBe(
-          profilePropertyRulesCount
+          profilePropertyRulesCount - 1
         );
         importProfilePropertiesTasks.forEach((t) =>
           expect(t.args[0].profileGuids.length).toBe(1)

--- a/core/api/src/migrations/000050-addDirectlyMappedToRules.ts
+++ b/core/api/src/migrations/000050-addDirectlyMappedToRules.ts
@@ -1,0 +1,17 @@
+module.exports = {
+  up: async function (migration, DataTypes) {
+    await migration.addColumn("profilePropertyRules", "directlyMapped", {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      defaultValue: false,
+    });
+    await migration.changeColumn("profilePropertyRules", "directlyMapped", {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+    });
+  },
+
+  down: async function (migration) {
+    await migration.removeColumn("profilePropertyRules", "directlyMapped");
+  },
+};

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -14,6 +14,7 @@ import {
   Default,
   DataType,
   DefaultScope,
+  AfterSave,
 } from "sequelize-typescript";
 import { Op } from "sequelize";
 import { LoggedModel } from "../classes/loggedModel";
@@ -324,6 +325,16 @@ export class Source extends LoggedModel<Source> {
       throw new Error(
         "you cannot delete a source that has profile property rules"
       );
+    }
+  }
+
+  @AfterSave
+  static async updateRuleDirectMappings(instance: Source) {
+    const rules = await instance.$get("profilePropertyRules");
+    for (const i in rules) {
+      const rule = rules[i];
+      await ProfilePropertyRule.determineDirectlyMapped(rule);
+      if (rule.changed()) await rule.save();
     }
   }
 

--- a/core/api/src/modules/mappingHelper.ts
+++ b/core/api/src/modules/mappingHelper.ts
@@ -7,7 +7,7 @@ import { Transaction } from "sequelize";
 
 export namespace MappingHelper {
   export interface Mappings {
-    [key: string]: any;
+    [remoteKey: string]: any;
   }
 
   export async function getMapping(instance: Source | Destination) {

--- a/core/api/src/modules/ops/profilePropertyRule.ts
+++ b/core/api/src/modules/ops/profilePropertyRule.ts
@@ -129,6 +129,18 @@ export namespace ProfilePropertyRuleOps {
   }
 
   /**
+   * Determine if this profile property rule is directly mapped (ie: used in the mapping) and therefore profile property values for this rule will never change
+   */
+  export async function directlyMapped(
+    profilePropertyRule: ProfilePropertyRule
+  ) {
+    const source = await profilePropertyRule.$get("source");
+    const mapping = await source.getMapping();
+    const mappingValues = Object.values(mapping);
+    return mappingValues.includes(profilePropertyRule.key);
+  }
+
+  /**
    * Get the options for a Profile Property Rule's Filter from its plugin
    */
   export async function pluginFilterOptions(

--- a/core/api/src/modules/ops/profilePropertyRule.ts
+++ b/core/api/src/modules/ops/profilePropertyRule.ts
@@ -129,18 +129,6 @@ export namespace ProfilePropertyRuleOps {
   }
 
   /**
-   * Determine if this profile property rule is directly mapped (ie: used in the mapping) and therefore profile property values for this rule will never change
-   */
-  export async function directlyMapped(
-    profilePropertyRule: ProfilePropertyRule
-  ) {
-    const source = await profilePropertyRule.$get("source");
-    const mapping = await source.getMapping();
-    const mappingValues = Object.values(mapping);
-    return mappingValues.includes(profilePropertyRule.key);
-  }
-
-  /**
    * Get the options for a Profile Property Rule's Filter from its plugin
    */
   export async function pluginFilterOptions(


### PR DESCRIPTION
When `profile.markPending()` as part of creating an import, there are some Profile Properties that we know will never change.  This is commonly `userId` - the primary key used in a source.  By not marking this Profile Property as pending, we can speed up the import process as subsequent Profile Properties won't need to wait for `userId` to become ready.

We can tell if a Profile Property isn't going to change if it's the key used directly in the parent source's mapping. 

Closes T-688