### PR TITLE
Grouparoo can use SQLite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,6 +240,29 @@ jobs:
           command: cd core/web && ./../node_modules/.bin/jest --ci --maxWorkers 2
           environment:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
+  test-core-local:
+    docker:
+      - image: circleci/node:12
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: redis:latest
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+    steps:
+      - checkout
+      - restore_cache:
+          <<: *node-module-cache-options
+      - restore_cache:
+          <<: *dist-cache-options
+      - restore_cache:
+          <<: *core-cache-options
+      - run:
+          name: test-api
+          command: cd core/api && ./../node_modules/.bin/jest __tests__/models --ci
+          environment:
+            DB_DIALECT: sqlite
   test-plugin-app-templates:
     docker:
       - image: circleci/node:12
@@ -1164,6 +1187,11 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
+      - test-core-local:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
       - test-plugin-app-templates:
           filters:
             <<: *ignored-branches
@@ -1293,6 +1321,7 @@ workflows:
             - linter
             - test-core-api
             - test-core-web
+            - test-core-local
             - test-plugin-app-templates
             - test-plugin-bigquery
             - test-plugin-csv
@@ -1363,6 +1392,11 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
+      - test-core-local:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
       - test-plugin-app-templates:
           filters:
             <<: *ignored-branches
@@ -1492,6 +1526,7 @@ workflows:
             - linter
             - test-core-api
             - test-core-web
+            - test-core-local
             - test-plugin-app-templates
             - test-plugin-bigquery
             - test-plugin-csv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,7 @@ jobs:
           <<: *core-cache-options
       - run:
           name: test-api
-          command: cd core/api && ./../node_modules/.bin/jest __tests__/models --ci
+          command: cd core/api && ./../node_modules/.bin/jest __tests__/models --ci --maxWorkers 2
           environment:
             DB_DIALECT: sqlite
   test-plugin-app-templates:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dump.rdb
 newrelic_agent.log
 *.retry
 coverage
+*.sqlite
 
 # API
 log

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ newrelic_agent.log
 *.retry
 coverage
 *.sqlite
+*.sqlite-journal
 
 # API
 log

--- a/apps/staging-public/.env.example
+++ b/apps/staging-public/.env.example
@@ -28,7 +28,13 @@ REDIS_URL="redis://localhost:6379/0"
 ## DATABASE ##
 ##############
 
-DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
+# To use sqlite
+DATABASE_URL="sqlite://grouparoo_development.sqlite"
+
+# To use Postgres
+# DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
+
+# With custom SSL options:
 # DATABASE_SSL=true
 # DATABASE_SSL_SELF_SIGNED=true
 

--- a/apps/staging-public/.env.example
+++ b/apps/staging-public/.env.example
@@ -29,10 +29,10 @@ REDIS_URL="redis://localhost:6379/0"
 ##############
 
 # To use sqlite
-DATABASE_URL="sqlite://grouparoo_development.sqlite"
+# DATABASE_URL="sqlite://grouparoo_development.sqlite"
 
 # To use Postgres
-# DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
+DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
 
 # With custom SSL options:
 # DATABASE_SSL=true

--- a/cli/src/lib/generate.ts
+++ b/cli/src/lib/generate.ts
@@ -27,15 +27,17 @@ export default async function Generate(workDir: string = process.cwd()) {
   if (!fs.existsSync(envFile)) {
     log.info("Creating .env");
     fs.copyFileSync(getTemplatePath(".env"), envFile);
-    log.info(
+    log.warn(
       "Please check the options in .env to ensure that they pertain to your environment"
     );
   } else {
     log.warn(".env already exists, not modifying");
   }
 
+  log.info("");
   log.info("Installing dependencies...");
-  await SpawnCommand("npm", ["install"], workDir, log);
+  log.info("");
+  await SpawnCommand("npm", ["install"], workDir, log, " >     ");
 
   log.success("Grouparoo project created!");
   log.info(

--- a/cli/src/lib/spawnCommand.ts
+++ b/cli/src/lib/spawnCommand.ts
@@ -5,16 +5,17 @@ export default async function spawnCommand(
   command: string,
   args: string[],
   cwd: string,
-  log: Logger
+  log: Logger,
+  messagePrefix = ""
 ) {
   return new Promise((resolve, reject) => {
     const process = spawn(command, args, { cwd });
 
     process.stdout.on("data", (message) =>
-      log.debug(message.toString().replace("\n", ""))
+      log.debug(messagePrefix + message.toString().replace("\n", ""))
     );
     process.stderr.on("data", (message) =>
-      log.warn(message.toString().replace("\n", ""))
+      log.warn(messagePrefix + message.toString().replace("\n", ""))
     );
 
     process.on("exit", function (code) {

--- a/cli/templates/.env
+++ b/cli/templates/.env
@@ -28,6 +28,12 @@ REDIS_URL="redis://localhost:6379/0"
 ## DATABASE ##
 ##############
 
-DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
+# To use sqlite
+DATABASE_URL="sqlite://grouparoo_development.sqlite"
+
+# To use Postgres
+# DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
+
+# With custom SSL options:
 # DATABASE_SSL=true
 # DATABASE_SSL_SELF_SIGNED=true

--- a/core/api/__tests__/models/group/calculatedGroup.ts
+++ b/core/api/__tests__/models/group/calculatedGroup.ts
@@ -557,7 +557,7 @@ describe("models/group", () => {
             match: new Date(0).getTime(),
             operation: { op: "gt" },
           },
-          { key: "lastName", match: "mario", operation: { op: "like" } },
+          { key: "lastName", match: "Mario", operation: { op: "like" } },
         ]);
         const count = await group.countPotentialMembers();
         expect(count).toBe(3);
@@ -572,7 +572,7 @@ describe("models/group", () => {
             match: new Date(100000).getTime(),
             operation: { op: "gte" },
           },
-          { key: "lastName", match: "mario", operation: { op: "like" } },
+          { key: "lastName", match: "Mario", operation: { op: "like" } },
         ];
         const count = await group.countPotentialMembers(rules);
         expect(count).toBe(1);
@@ -597,7 +597,7 @@ describe("models/group", () => {
           },
           {
             key: "lastName",
-            match: "mario",
+            match: "Mario",
             operation: { op: "like" },
           },
         ];

--- a/core/api/__tests__/models/group/calculatedGroup.ts
+++ b/core/api/__tests__/models/group/calculatedGroup.ts
@@ -557,7 +557,7 @@ describe("models/group", () => {
             match: new Date(0).getTime(),
             operation: { op: "gt" },
           },
-          { key: "lastName", match: "mario", operation: { op: "iLike" } },
+          { key: "lastName", match: "mario", operation: { op: "like" } },
         ]);
         const count = await group.countPotentialMembers();
         expect(count).toBe(3);
@@ -572,7 +572,7 @@ describe("models/group", () => {
             match: new Date(100000).getTime(),
             operation: { op: "gte" },
           },
-          { key: "lastName", match: "mario", operation: { op: "iLike" } },
+          { key: "lastName", match: "mario", operation: { op: "like" } },
         ];
         const count = await group.countPotentialMembers(rules);
         expect(count).toBe(1);
@@ -588,7 +588,7 @@ describe("models/group", () => {
           {
             key: "firstName",
             match: "%",
-            operation: { op: "iLike" },
+            operation: { op: "like" },
           },
           {
             key: "lastLoginAt",
@@ -598,7 +598,7 @@ describe("models/group", () => {
           {
             key: "lastName",
             match: "mario",
-            operation: { op: "iLike" },
+            operation: { op: "like" },
           },
         ];
 

--- a/core/api/__tests__/models/group/rules/booleans.ts
+++ b/core/api/__tests__/models/group/rules/booleans.ts
@@ -42,7 +42,7 @@ describe("model/group", () => {
       test("multiple matches (ALL)", async () => {
         await group.setRules([
           { key: "isVIP", match: true, operation: { op: "eq" } },
-          { key: "lastName", match: "mario", operation: { op: "like" } },
+          { key: "lastName", match: "Mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(1);
       });
@@ -51,7 +51,7 @@ describe("model/group", () => {
         await group.update({ matchType: "any" });
         await group.setRules([
           { key: "isVIP", match: true, operation: { op: "eq" } },
-          { key: "lastName", match: "mario", operation: { op: "like" } },
+          { key: "lastName", match: "Mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(3);
       });

--- a/core/api/__tests__/models/group/rules/booleans.ts
+++ b/core/api/__tests__/models/group/rules/booleans.ts
@@ -1,5 +1,6 @@
 import { SharedGroupTests } from "../../../utils/prepareSharedGroupTest";
 import { Group } from "../../../../src/models/Group";
+import { config } from "actionhero";
 
 describe("model/group", () => {
   let group: Group;
@@ -41,7 +42,7 @@ describe("model/group", () => {
       test("multiple matches (ALL)", async () => {
         await group.setRules([
           { key: "isVIP", match: true, operation: { op: "eq" } },
-          { key: "lastName", match: "mario", operation: { op: "iLike" } },
+          { key: "lastName", match: "mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(1);
       });
@@ -50,7 +51,7 @@ describe("model/group", () => {
         await group.update({ matchType: "any" });
         await group.setRules([
           { key: "isVIP", match: true, operation: { op: "eq" } },
-          { key: "lastName", match: "mario", operation: { op: "iLike" } },
+          { key: "lastName", match: "mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(3);
       });

--- a/core/api/__tests__/models/group/rules/dates.ts
+++ b/core/api/__tests__/models/group/rules/dates.ts
@@ -71,7 +71,7 @@ describe("model/group", () => {
             match: new Date(0).getTime(),
             operation: { op: "gt" },
           },
-          { key: "lastName", match: "mario", operation: { op: "iLike" } },
+          { key: "lastName", match: "mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(1);
       });
@@ -84,7 +84,7 @@ describe("model/group", () => {
             match: new Date(0).getTime(),
             operation: { op: "gt" },
           },
-          { key: "lastName", match: "mario", operation: { op: "iLike" } },
+          { key: "lastName", match: "mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(3);
       });
@@ -187,7 +187,7 @@ describe("model/group", () => {
             relativeMatchDirection: "subtract",
             operation: { op: "gt" },
           },
-          { key: "lastName", match: "mario", operation: { op: "iLike" } },
+          { key: "lastName", match: "mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(1);
       });
@@ -202,7 +202,7 @@ describe("model/group", () => {
             relativeMatchDirection: "subtract",
             operation: { op: "gt" },
           },
-          { key: "lastName", match: "mario", operation: { op: "iLike" } },
+          { key: "lastName", match: "mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(3);
       });

--- a/core/api/__tests__/models/group/rules/dates.ts
+++ b/core/api/__tests__/models/group/rules/dates.ts
@@ -71,7 +71,7 @@ describe("model/group", () => {
             match: new Date(0).getTime(),
             operation: { op: "gt" },
           },
-          { key: "lastName", match: "mario", operation: { op: "like" } },
+          { key: "lastName", match: "Mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(1);
       });
@@ -84,7 +84,7 @@ describe("model/group", () => {
             match: new Date(0).getTime(),
             operation: { op: "gt" },
           },
-          { key: "lastName", match: "mario", operation: { op: "like" } },
+          { key: "lastName", match: "Mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(3);
       });
@@ -187,7 +187,7 @@ describe("model/group", () => {
             relativeMatchDirection: "subtract",
             operation: { op: "gt" },
           },
-          { key: "lastName", match: "mario", operation: { op: "like" } },
+          { key: "lastName", match: "Mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(1);
       });
@@ -202,7 +202,7 @@ describe("model/group", () => {
             relativeMatchDirection: "subtract",
             operation: { op: "gt" },
           },
-          { key: "lastName", match: "mario", operation: { op: "like" } },
+          { key: "lastName", match: "Mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(3);
       });

--- a/core/api/__tests__/models/group/rules/emails.ts
+++ b/core/api/__tests__/models/group/rules/emails.ts
@@ -48,8 +48,8 @@ describe("model/group", () => {
 
       test("multiple rules with same key", async () => {
         await group.setRules([
-          { key: "email", match: "mario%", operation: { op: "iLike" } },
-          { key: "email", match: "%@example.com", operation: { op: "iLike" } },
+          { key: "email", match: "mario%", operation: { op: "like" } },
+          { key: "email", match: "%@example.com", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(1);
       });

--- a/core/api/__tests__/models/group/rules/floats.ts
+++ b/core/api/__tests__/models/group/rules/floats.ts
@@ -48,7 +48,7 @@ describe("model/group", () => {
       test("multiple matches (ALL)", async () => {
         await group.setRules([
           { key: "ltv", match: 1, operation: { op: "gte" } },
-          { key: "lastName", match: "mario", operation: { op: "like" } },
+          { key: "lastName", match: "Mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(2);
       });
@@ -57,7 +57,7 @@ describe("model/group", () => {
         await group.update({ matchType: "any" });
         await group.setRules([
           { key: "ltv", match: 1, operation: { op: "gte" } },
-          { key: "lastName", match: "%toad%", operation: { op: "like" } },
+          { key: "lastName", match: "%Toad%", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(4);
       });

--- a/core/api/__tests__/models/group/rules/floats.ts
+++ b/core/api/__tests__/models/group/rules/floats.ts
@@ -48,7 +48,7 @@ describe("model/group", () => {
       test("multiple matches (ALL)", async () => {
         await group.setRules([
           { key: "ltv", match: 1, operation: { op: "gte" } },
-          { key: "lastName", match: "mario", operation: { op: "iLike" } },
+          { key: "lastName", match: "mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(2);
       });
@@ -57,7 +57,7 @@ describe("model/group", () => {
         await group.update({ matchType: "any" });
         await group.setRules([
           { key: "ltv", match: 1, operation: { op: "gte" } },
-          { key: "lastName", match: "%toad%", operation: { op: "iLike" } },
+          { key: "lastName", match: "%toad%", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(4);
       });

--- a/core/api/__tests__/models/group/rules/integers.ts
+++ b/core/api/__tests__/models/group/rules/integers.ts
@@ -48,7 +48,7 @@ describe("model/group", () => {
       test("multiple matches (ALL)", async () => {
         await group.setRules([
           { key: "userId", match: 1, operation: { op: "eq" } },
-          { key: "lastName", match: "mario", operation: { op: "like" } },
+          { key: "lastName", match: "Mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(1);
       });
@@ -57,7 +57,7 @@ describe("model/group", () => {
         await group.update({ matchType: "any" });
         await group.setRules([
           { key: "userId", match: 1, operation: { op: "eq" } },
-          { key: "lastName", match: "mario", operation: { op: "like" } },
+          { key: "lastName", match: "Mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(2);
       });

--- a/core/api/__tests__/models/group/rules/integers.ts
+++ b/core/api/__tests__/models/group/rules/integers.ts
@@ -48,7 +48,7 @@ describe("model/group", () => {
       test("multiple matches (ALL)", async () => {
         await group.setRules([
           { key: "userId", match: 1, operation: { op: "eq" } },
-          { key: "lastName", match: "mario", operation: { op: "iLike" } },
+          { key: "lastName", match: "mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(1);
       });
@@ -57,7 +57,7 @@ describe("model/group", () => {
         await group.update({ matchType: "any" });
         await group.setRules([
           { key: "userId", match: 1, operation: { op: "eq" } },
-          { key: "lastName", match: "mario", operation: { op: "iLike" } },
+          { key: "lastName", match: "mario", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(2);
       });

--- a/core/api/__tests__/models/group/rules/phoneNumbers.ts
+++ b/core/api/__tests__/models/group/rules/phoneNumbers.ts
@@ -75,8 +75,8 @@ describe("model/group", () => {
 
       test("multiple rules with same key", async () => {
         await group.setRules([
-          { key: "phoneNumber", match: "+1 412%", operation: { op: "iLike" } },
-          { key: "phoneNumber", match: "%000%", operation: { op: "iLike" } },
+          { key: "phoneNumber", match: "+1 412%", operation: { op: "like" } },
+          { key: "phoneNumber", match: "%000%", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(3);
       });

--- a/core/api/__tests__/models/group/rules/strings.ts
+++ b/core/api/__tests__/models/group/rules/strings.ts
@@ -33,7 +33,7 @@ describe("model/group", () => {
 
       test("partial matches", async () => {
         await group.setRules([
-          { key: "lastName", match: "%toad%", operation: { op: "like" } },
+          { key: "lastName", match: "%Toad%", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(2);
       });
@@ -48,7 +48,7 @@ describe("model/group", () => {
 
       test("multiple matches (ALL)", async () => {
         await group.setRules([
-          { key: "lastName", match: "%toad%", operation: { op: "like" } },
+          { key: "lastName", match: "%Toad%", operation: { op: "like" } },
           { key: "firstName", match: "Peach", operation: { op: "eq" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(1);
@@ -57,7 +57,7 @@ describe("model/group", () => {
       test("multiple matches (ANY)", async () => {
         await group.update({ matchType: "any" });
         await group.setRules([
-          { key: "lastName", match: "%toad%", operation: { op: "like" } },
+          { key: "lastName", match: "%Toad%", operation: { op: "like" } },
           { key: "firstName", match: "Peach", operation: { op: "eq" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(2);

--- a/core/api/__tests__/models/group/rules/strings.ts
+++ b/core/api/__tests__/models/group/rules/strings.ts
@@ -1,5 +1,6 @@
 import { SharedGroupTests } from "../../../utils/prepareSharedGroupTest";
 import { Group } from "../../../../src/models/Group";
+import { config } from "actionhero";
 
 describe("model/group", () => {
   let group: Group;
@@ -32,7 +33,7 @@ describe("model/group", () => {
 
       test("partial matches", async () => {
         await group.setRules([
-          { key: "lastName", match: "%toad%", operation: { op: "iLike" } },
+          { key: "lastName", match: "%toad%", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(2);
       });
@@ -40,14 +41,14 @@ describe("model/group", () => {
       test("multiple rules with same key", async () => {
         await group.setRules([
           { key: "lastName", match: "Mario", operation: { op: "eq" } },
-          { key: "lastName", match: "%a%", operation: { op: "iLike" } },
+          { key: "lastName", match: "%a%", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(2);
       });
 
       test("multiple matches (ALL)", async () => {
         await group.setRules([
-          { key: "lastName", match: "%toad%", operation: { op: "iLike" } },
+          { key: "lastName", match: "%toad%", operation: { op: "like" } },
           { key: "firstName", match: "Peach", operation: { op: "eq" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(1);
@@ -56,7 +57,7 @@ describe("model/group", () => {
       test("multiple matches (ANY)", async () => {
         await group.update({ matchType: "any" });
         await group.setRules([
-          { key: "lastName", match: "%toad%", operation: { op: "iLike" } },
+          { key: "lastName", match: "%toad%", operation: { op: "like" } },
           { key: "firstName", match: "Peach", operation: { op: "eq" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(2);
@@ -132,19 +133,21 @@ describe("model/group", () => {
         expect(await group.countPotentialMembers()).toBe(3);
       });
 
-      test("array property iLike", async () => {
-        await group.setRules([
-          { key: "purchases", match: "MUSH%", operation: { op: "iLike" } },
-        ]);
-        expect(await group.countPotentialMembers()).toBe(2);
-      });
+      if (config.sequelize.dialect === "postgres") {
+        test("array property iLike", async () => {
+          await group.setRules([
+            { key: "purchases", match: "MUSH%", operation: { op: "iLike" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(2);
+        });
 
-      test("array property not iLike", async () => {
-        await group.setRules([
-          { key: "purchases", match: "STA%", operation: { op: "notILike" } },
-        ]);
-        expect(await group.countPotentialMembers()).toBe(3);
-      });
+        test("array property not iLike", async () => {
+          await group.setRules([
+            { key: "purchases", match: "STA%", operation: { op: "notILike" } },
+          ]);
+          expect(await group.countPotentialMembers()).toBe(3);
+        });
+      }
     });
   });
 });

--- a/core/api/__tests__/models/group/rules/topLevelGroupRules.ts
+++ b/core/api/__tests__/models/group/rules/topLevelGroupRules.ts
@@ -133,8 +133,8 @@ describe("model/group", () => {
 
         test("multiple rules with same key", async () => {
           await group.setRules([
-            { key: "guid", match: "pro%", operation: { op: "iLike" } },
-            { key: "guid", match: "pro_%", operation: { op: "iLike" } },
+            { key: "guid", match: "pro%", operation: { op: "like" } },
+            { key: "guid", match: "pro_%", operation: { op: "like" } },
           ]);
           expect(await group.countPotentialMembers()).toBe(4);
         });

--- a/core/api/__tests__/models/group/rules/urls.ts
+++ b/core/api/__tests__/models/group/rules/urls.ts
@@ -75,8 +75,8 @@ describe("model/group", () => {
 
       test("multiple rules with same key", async () => {
         await group.setRules([
-          { key: "url", match: "https%", operation: { op: "iLike" } },
-          { key: "url", match: "%.com", operation: { op: "iLike" } },
+          { key: "url", match: "https%", operation: { op: "like" } },
+          { key: "url", match: "%.com", operation: { op: "like" } },
         ]);
         expect(await group.countPotentialMembers()).toBe(3);
       });

--- a/core/api/__tests__/models/profile.ts
+++ b/core/api/__tests__/models/profile.ts
@@ -813,7 +813,7 @@ describe("models/profile", () => {
 
         await group.update({ matchType: "all" });
         await group.setRules([
-          { key: "email", match: "%@example.com", operation: { op: "iLike" } },
+          { key: "email", match: "%@example.com", operation: { op: "like" } },
         ]);
 
         const groupMemberships = await profile.updateGroupMembership();
@@ -1076,7 +1076,7 @@ describe("models/profile", () => {
     });
 
     test("only profile B has an anonymousId", async () => {
-      expect(profileA.anonymousId).toBeNull();
+      expect(profileA.anonymousId).toBeFalsy();
       expect(profileB.anonymousId).toEqual("abc123");
     });
 

--- a/core/api/__tests__/models/profilePropertyRules/dependsOn.ts
+++ b/core/api/__tests__/models/profilePropertyRules/dependsOn.ts
@@ -1,12 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
-import { api, specHelper } from "actionhero";
 import { ProfilePropertyRule } from "../../../src/models/ProfilePropertyRule";
-import { Log } from "../../../src/models/Log";
-import { App } from "../../../src/models/App";
 import { Source } from "../../../src/models/Source";
-import { Option } from "../../../src/models/Option";
-import { plugin } from "../../../src/modules/plugin";
-import { ProfilePropertyRuleFilter } from "../../../src/models/ProfilePropertyRuleFilter";
 import { ProfilePropertyRuleOps } from "../../../src/modules/ops/profilePropertyRule";
 
 let actionhero;

--- a/core/api/__tests__/models/profilePropertyRules/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRules/profilePropertyRule.ts
@@ -331,7 +331,7 @@ describe("models/profilePropertyRule", () => {
 
     const group = await helper.factories.group({ type: "calculated" });
     await group.setRules([
-      { key: "thing", match: "%", operation: { op: "iLike" } },
+      { key: "thing", match: "%", operation: { op: "like" } },
     ]);
 
     await expect(rule.destroy()).rejects.toThrow(

--- a/core/api/src/actions/profiles.ts
+++ b/core/api/src/actions/profiles.ts
@@ -1,4 +1,4 @@
-import { api } from "actionhero";
+import { api, config } from "actionhero";
 import { AuthenticatedAction } from "../classes/authenticatedAction";
 import { Profile } from "../models/Profile";
 import { ProfileProperty } from "../models/ProfileProperty";
@@ -148,6 +148,10 @@ export class ProfileAutocompleteProfileProperty extends AuthenticatedAction {
   }
 
   async run({ params }) {
+    const op = config.sequelize.dialect === "postgres" ? Op.iLike : Op.like;
+    const rawValueWhereClause = {};
+    rawValueWhereClause[op] = `%${params.match}%`;
+
     const profileProperties = await ProfileProperty.findAll({
       attributes: [
         [
@@ -158,7 +162,7 @@ export class ProfileAutocompleteProfileProperty extends AuthenticatedAction {
       ],
       where: {
         profilePropertyRuleGuid: params.profilePropertyRuleGuid,
-        rawValue: { [Op.iLike]: `%${params.match}%` },
+        rawValue: rawValueWhereClause,
       },
       group: ["rawValue", "profilePropertyRuleGuid"],
       limit: params.limit,

--- a/core/api/src/actions/teams.ts
+++ b/core/api/src/actions/teams.ts
@@ -29,21 +29,27 @@ export class TeamInitialize extends Action {
       throw new Error("an administration team already exists, please sign in");
     }
 
-    team = await Team.create({
-      name: "Administrators",
-      locked: true,
-      permissionAllRead: true,
-      permissionAllWrite: true,
-    });
+    try {
+      team = await Team.create({
+        name: "Administrators",
+        locked: true,
+        permissionAllRead: true,
+        permissionAllWrite: true,
+      });
 
-    teamMember = await TeamMember.create({
-      teamGuid: team.guid,
-      email: params.email,
-      firstName: params.firstName,
-      lastName: params.lastName,
-    });
+      teamMember = await TeamMember.create({
+        teamGuid: team.guid,
+        email: params.email,
+        firstName: params.firstName,
+        lastName: params.lastName,
+      });
 
-    await teamMember.updatePassword(params.password);
+      await teamMember.updatePassword(params.password);
+    } catch (error) {
+      if (teamMember) await teamMember.destroy();
+      if (team) await team.destroy();
+      throw error;
+    }
 
     if (params.subscribe) {
       await GrouparooSubscription(teamMember);

--- a/core/api/src/classes/loggedModel.ts
+++ b/core/api/src/classes/loggedModel.ts
@@ -43,7 +43,7 @@ export abstract class LoggedModel<T> extends Model<T> {
 
   @AfterCreate
   static async logCreate(instance) {
-    await Log.create({
+    Log.create({
       topic: modelName(instance),
       verb: "create",
       ownerGuid: instance.guid,
@@ -64,7 +64,7 @@ export abstract class LoggedModel<T> extends Model<T> {
   static async logBulkCreate(instances) {
     for (const i in instances) {
       const instance = instances[i];
-      await Log.create({
+      Log.create({
         topic: modelName(instance),
         verb: "create",
         ownerGuid: instance.guid,
@@ -76,7 +76,7 @@ export abstract class LoggedModel<T> extends Model<T> {
 
   @AfterUpdate
   static async logUpdate(instance) {
-    await Log.create({
+    Log.create({
       topic: modelName(instance),
       verb: "update",
       ownerGuid: instance.guid,
@@ -87,7 +87,7 @@ export abstract class LoggedModel<T> extends Model<T> {
 
   @AfterDestroy
   static async logDestroy(instance) {
-    await Log.create({
+    Log.create({
       topic: modelName(instance),
       verb: "destroy",
       ownerGuid: instance.guid,

--- a/core/api/src/classes/loggedModel.ts
+++ b/core/api/src/classes/loggedModel.ts
@@ -12,6 +12,7 @@ import {
 import * as uuid from "uuid";
 import { Log } from "../models/Log";
 import { config, chatRoom } from "actionhero";
+import { Transaction } from "sequelize";
 
 function modelName(instance): string {
   let name = instance.constructor.name;
@@ -42,14 +43,20 @@ export abstract class LoggedModel<T> extends Model<T> {
   updatedAt: Date;
 
   @AfterCreate
-  static async logCreate(instance) {
-    Log.create({
-      topic: modelName(instance),
-      verb: "create",
-      ownerGuid: instance.guid,
-      data: await instance.filteredDataForLogging(),
-      message: await instance.logMessage("create"),
-    });
+  static async logCreate(
+    instance,
+    { transaction }: { transaction?: Transaction } = {}
+  ) {
+    await Log.create(
+      {
+        topic: modelName(instance),
+        verb: "create",
+        ownerGuid: instance.guid,
+        data: await instance.filteredDataForLogging(),
+        message: await instance.logMessage("create"),
+      },
+      { transaction }
+    );
   }
 
   @AfterCreate
@@ -61,39 +68,57 @@ export abstract class LoggedModel<T> extends Model<T> {
   }
 
   @AfterBulkCreate
-  static async logBulkCreate(instances) {
+  static async logBulkCreate(
+    instances,
+    { transaction }: { transaction?: Transaction } = {}
+  ) {
     for (const i in instances) {
       const instance = instances[i];
-      Log.create({
-        topic: modelName(instance),
-        verb: "create",
-        ownerGuid: instance.guid,
-        data: await instance.filteredDataForLogging(),
-        message: await instance.logMessage("create"),
-      });
+      await Log.create(
+        {
+          topic: modelName(instance),
+          verb: "create",
+          ownerGuid: instance.guid,
+          data: await instance.filteredDataForLogging(),
+          message: await instance.logMessage("create"),
+        },
+        { transaction }
+      );
     }
   }
 
   @AfterUpdate
-  static async logUpdate(instance) {
-    Log.create({
-      topic: modelName(instance),
-      verb: "update",
-      ownerGuid: instance.guid,
-      data: await instance.filteredDataForLogging(),
-      message: await instance.logMessage("update"),
-    });
+  static async logUpdate(
+    instance,
+    { transaction }: { transaction?: Transaction } = {}
+  ) {
+    await Log.create(
+      {
+        topic: modelName(instance),
+        verb: "update",
+        ownerGuid: instance.guid,
+        data: await instance.filteredDataForLogging(),
+        message: await instance.logMessage("update"),
+      },
+      { transaction }
+    );
   }
 
   @AfterDestroy
-  static async logDestroy(instance) {
-    Log.create({
-      topic: modelName(instance),
-      verb: "destroy",
-      ownerGuid: instance.guid,
-      data: await instance.filteredDataForLogging(),
-      message: await instance.logMessage("destroy"),
-    });
+  static async logDestroy(
+    instance,
+    { transaction }: { transaction?: Transaction } = {}
+  ) {
+    await Log.create(
+      {
+        topic: modelName(instance),
+        verb: "destroy",
+        ownerGuid: instance.guid,
+        data: await instance.filteredDataForLogging(),
+        message: await instance.logMessage("destroy"),
+      },
+      { transaction }
+    );
   }
 
   async filteredDataForLogging() {

--- a/core/api/src/config/sequelize.ts
+++ b/core/api/src/config/sequelize.ts
@@ -8,7 +8,8 @@ const databaseBaseName = "grouparoo";
 
 export const DEFAULT = {
   sequelize: (config) => {
-    let dialect = "postgres";
+    let dialect = process.env.DB_DIALECT || "postgres";
+    let storage: string; //only for sqlite
     let host = process.env.DB_HOST || "127.0.0.1";
     let port = process.env.DB_PORT || "5432";
     let database =
@@ -55,10 +56,10 @@ export const DEFAULT = {
 
     // sqlite overrides
     if (dialect === "sqlite") {
+      storage = host;
       if (!host) host = ":memory:";
+      if (process.env.NODE_ENV === "test") storage = `${database}.sqlite`;
     }
-
-    // console.log(`grouparoo using ${dialect} database @ ${host}`);
 
     return {
       autoMigrate: true,
@@ -71,7 +72,7 @@ export const DEFAULT = {
       password: password,
       models: [join(__dirname, "..", "models")],
       migrations: [join(__dirname, "..", "migrations")],
-      storage: host, // only used for sqlite
+      storage, // only used for sqlite
       pool: {
         max: process.env.SEQUELIZE_POOL_SIZE
           ? parseInt(process.env.SEQUELIZE_POOL_SIZE)

--- a/core/api/src/config/sequelize.ts
+++ b/core/api/src/config/sequelize.ts
@@ -62,7 +62,7 @@ export const DEFAULT = {
 
     return {
       autoMigrate: true,
-      logging: (...msg) => console.log(msg),
+      logging: false,
       dialect: dialect,
       port: parseInt(port),
       database: database,

--- a/core/api/src/config/sequelize.ts
+++ b/core/api/src/config/sequelize.ts
@@ -53,9 +53,16 @@ export const DEFAULT = {
       ssl = { rejectUnauthorized: false };
     }
 
+    // sqlite overrides
+    if (dialect === "sqlite") {
+      if (!host) host = ":memory:";
+    }
+
+    // console.log(`grouparoo using ${dialect} database @ ${host}`);
+
     return {
       autoMigrate: true,
-      logging: false,
+      logging: (...msg) => console.log(msg),
       dialect: dialect,
       port: parseInt(port),
       database: database,
@@ -64,6 +71,7 @@ export const DEFAULT = {
       password: password,
       models: [join(__dirname, "..", "models")],
       migrations: [join(__dirname, "..", "migrations")],
+      storage: host, // only used for sqlite
       pool: {
         max: process.env.SEQUELIZE_POOL_SIZE
           ? parseInt(process.env.SEQUELIZE_POOL_SIZE)

--- a/core/api/src/migrations/000030-exportRunGuids.ts
+++ b/core/api/src/migrations/000030-exportRunGuids.ts
@@ -5,10 +5,6 @@ module.exports = {
       allowNull: false,
       defaultValue: 0,
     });
-    await migration.changeColumn("runs", "exportsCreated", {
-      type: DataTypes.BIGINT,
-      allowNull: false,
-    });
 
     await migration.addColumn("exports", "runGuids", {
       type: DataTypes.TEXT,

--- a/core/api/src/migrations/000031-runLimitOffsetMethod.ts
+++ b/core/api/src/migrations/000031-runLimitOffsetMethod.ts
@@ -5,19 +5,11 @@ module.exports = {
       allowNull: false,
       defaultValue: 0,
     });
-    await migration.changeColumn("runs", "limit", {
-      type: DataTypes.BIGINT,
-      allowNull: false,
-    });
 
     await migration.addColumn("runs", "offset", {
       type: DataTypes.BIGINT,
       allowNull: false,
       defaultValue: 0,
-    });
-    await migration.changeColumn("runs", "offset", {
-      type: DataTypes.BIGINT,
-      allowNull: false,
     });
 
     await migration.addColumn("runs", "method", {

--- a/core/api/src/migrations/000033-profilePropertyArray.ts
+++ b/core/api/src/migrations/000033-profilePropertyArray.ts
@@ -2,22 +2,14 @@ module.exports = {
   up: async function (migration, DataTypes) {
     await migration.addColumn("profileProperties", "position", {
       type: DataTypes.BIGINT,
-      allowNull: true,
-      defaultValue: 0,
-    });
-    await migration.changeColumn("profileProperties", "position", {
-      type: DataTypes.BIGINT,
       allowNull: false,
+      defaultValue: 0,
     });
 
     await migration.addColumn("profilePropertyRules", "isArray", {
       type: DataTypes.BOOLEAN,
-      allowNull: true,
-      defaultValue: false,
-    });
-    await migration.changeColumn("profilePropertyRules", "isArray", {
-      type: DataTypes.BOOLEAN,
       allowNull: false,
+      defaultValue: false,
     });
 
     await migration.removeIndex(

--- a/core/api/src/migrations/000034-runPercentComplete.ts
+++ b/core/api/src/migrations/000034-runPercentComplete.ts
@@ -5,10 +5,6 @@ module.exports = {
       allowNull: false,
       defaultValue: 100,
     });
-    await migration.changeColumn("runs", "percentComplete", {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-    });
   },
 
   down: async function (migration) {

--- a/core/api/src/migrations/000035-identifyingProfilePropertyRule.ts
+++ b/core/api/src/migrations/000035-identifyingProfilePropertyRule.ts
@@ -5,10 +5,6 @@ module.exports = {
       allowNull: false,
       defaultValue: false,
     });
-    await migration.changeColumn("profilePropertyRules", "identifying", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-    });
 
     // we need to pick one of the existing rules to be identifying - prefer the oldest unique rule.
     const [results] = await migration.sequelize.query(

--- a/core/api/src/migrations/000037-exportHasChanges.ts
+++ b/core/api/src/migrations/000037-exportHasChanges.ts
@@ -5,19 +5,11 @@ module.exports = {
       allowNull: false,
       defaultValue: true,
     });
-    await migration.changeColumn("exports", "hasChanges", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-    });
 
     await migration.addColumn("runs", "force", {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
-    });
-    await migration.changeColumn("runs", "force", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
     });
   },
 

--- a/core/api/src/migrations/000040-addExportForce.ts
+++ b/core/api/src/migrations/000040-addExportForce.ts
@@ -3,11 +3,6 @@ module.exports = {
     await migration.addColumn("exports", "force", {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
-      allowNull: true,
-    });
-
-    await migration.changeColumn("exports", "force", {
-      type: DataTypes.BOOLEAN,
       allowNull: false,
     });
   },

--- a/core/api/src/migrations/000042-addSettingType.ts
+++ b/core/api/src/migrations/000042-addSettingType.ts
@@ -3,11 +3,6 @@ module.exports = {
     await migration.addColumn("settings", "type", {
       type: DataTypes.STRING(191),
       defaultValue: "string",
-      allowNull: true,
-    });
-
-    await migration.changeColumn("settings", "type", {
-      type: DataTypes.STRING(191),
       allowNull: false,
     });
 

--- a/core/api/src/migrations/000044-settingTitleAndVariant.ts
+++ b/core/api/src/migrations/000044-settingTitleAndVariant.ts
@@ -2,22 +2,14 @@ module.exports = {
   up: async function (migration, DataTypes) {
     await migration.addColumn("settings", "title", {
       type: DataTypes.STRING(191),
-      allowNull: true,
-      defaultValue: "",
-    });
-    await migration.changeColumn("settings", "title", {
-      type: DataTypes.STRING(191),
       allowNull: false,
+      defaultValue: "",
     });
 
     await migration.addColumn("settings", "variant", {
       type: DataTypes.STRING(191),
-      allowNull: true,
-      defaultValue: "",
-    });
-    await migration.changeColumn("settings", "variant", {
-      type: DataTypes.STRING(191),
       allowNull: false,
+      defaultValue: "",
     });
   },
 

--- a/core/api/src/migrations/000046-addStateToProfilesAndProfileProperties.ts
+++ b/core/api/src/migrations/000046-addStateToProfilesAndProfileProperties.ts
@@ -2,22 +2,14 @@ module.exports = {
   up: async function (migration, DataTypes) {
     await migration.addColumn("profiles", "state", {
       type: DataTypes.STRING(191),
-      allowNull: true,
-      defaultValue: "ready",
-    });
-    await migration.changeColumn("profiles", "state", {
-      type: DataTypes.STRING(191),
       allowNull: false,
+      defaultValue: "ready",
     });
 
     await migration.addColumn("profileProperties", "state", {
       type: DataTypes.STRING(191),
-      allowNull: true,
-      defaultValue: "ready",
-    });
-    await migration.changeColumn("profileProperties", "state", {
-      type: DataTypes.STRING(191),
       allowNull: false,
+      defaultValue: "ready",
     });
 
     await migration.addColumn("profileProperties", "valueChangedAt", {

--- a/core/api/src/migrations/000048-addImportCreatedProfile.ts
+++ b/core/api/src/migrations/000048-addImportCreatedProfile.ts
@@ -3,11 +3,6 @@ module.exports = {
     await migration.addColumn("imports", "createdProfile", {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
-      allowNull: true,
-    });
-
-    await migration.changeColumn("imports", "createdProfile", {
-      type: DataTypes.BOOLEAN,
       allowNull: false,
     });
   },

--- a/core/api/src/migrations/000050-addDirectlyMappedToRules.ts
+++ b/core/api/src/migrations/000050-addDirectlyMappedToRules.ts
@@ -2,12 +2,8 @@ module.exports = {
   up: async function (migration, DataTypes) {
     await migration.addColumn("profilePropertyRules", "directlyMapped", {
       type: DataTypes.BOOLEAN,
-      allowNull: true,
-      defaultValue: false,
-    });
-    await migration.changeColumn("profilePropertyRules", "directlyMapped", {
-      type: DataTypes.BOOLEAN,
       allowNull: false,
+      defaultValue: false,
     });
   },
 

--- a/core/api/src/models/ApiKey.ts
+++ b/core/api/src/models/ApiKey.ts
@@ -109,13 +109,21 @@ export class ApiKey extends LoggedModel<ApiKey> {
     const topics = Permission.topics();
     for (const i in topics) {
       const topic = topics[i];
-      const [permission] = await Permission.findOrCreate({
+      let permission = await Permission.findOne({
         where: {
           topic,
           ownerGuid: instance.guid,
           ownerType: "apiKey",
         },
       });
+
+      if (!permission) {
+        permission = await Permission.create({
+          topic,
+          ownerGuid: instance.guid,
+          ownerType: "apiKey",
+        });
+      }
 
       if (instance.permissionAllRead !== null) {
         await permission.update({ read: instance.permissionAllRead });

--- a/core/api/src/models/ApiKey.ts
+++ b/core/api/src/models/ApiKey.ts
@@ -10,7 +10,7 @@ import {
 } from "sequelize-typescript";
 import * as UUID from "uuid";
 import { LoggedModel } from "../classes/loggedModel";
-import { Permission } from "./Permission";
+import { Permission, PermissionTopics } from "./Permission";
 import { AsyncReturnType } from "type-fest";
 
 @Table({ tableName: "apiKeys", paranoid: false })
@@ -112,9 +112,8 @@ export class ApiKey extends LoggedModel<ApiKey> {
 
   @AfterSave
   static async buildPermissions(instance: ApiKey, { transaction }) {
-    const topics = Permission.topics();
-    for (const i in topics) {
-      const topic = topics[i];
+    for (const i in PermissionTopics) {
+      const topic = PermissionTopics[i];
       let permission = await Permission.findOne({
         where: {
           topic,

--- a/core/api/src/models/Export.ts
+++ b/core/api/src/models/Export.ts
@@ -98,12 +98,8 @@ export class Export extends Model<Export> {
 
   @Column(DataType.TEXT)
   get oldGroups(): string[] {
-    try {
-      //@ts-ignore
-      return JSON.parse(this.getDataValue("oldGroups"));
-    } catch (e) {
-      return [];
-    }
+    //@ts-ignore
+    return JSON.parse(this.getDataValue("oldGroups") || "[]");
   }
   set oldGroups(value: string[]) {
     //@ts-ignore
@@ -112,12 +108,8 @@ export class Export extends Model<Export> {
 
   @Column(DataType.TEXT)
   get newGroups(): string[] {
-    try {
-      //@ts-ignore
-      return JSON.parse(this.getDataValue("newGroups"));
-    } catch (e) {
-      return [];
-    }
+    //@ts-ignore
+    return JSON.parse(this.getDataValue("newGroups") || "[]");
   }
   set newGroups(value: string[]) {
     //@ts-ignore

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -14,7 +14,7 @@ import {
   DefaultScope,
   Scopes,
 } from "sequelize-typescript";
-import { api } from "actionhero";
+import { api, config } from "actionhero";
 import { Op, Transaction } from "sequelize";
 import Moment from "moment";
 import { LoggedModel } from "../classes/loggedModel";
@@ -449,11 +449,11 @@ export class Group extends LoggedModel<Group> {
         operation,
         type,
         topLevel,
-        match,
         relativeMatchNumber,
         relativeMatchDirection,
         relativeMatchUnit,
       } = rule;
+      let { match } = rule;
       const localWhereGroup = {};
       let rawValueMatch = {};
 
@@ -463,6 +463,14 @@ export class Group extends LoggedModel<Group> {
       }
 
       if (match !== null && match !== undefined) {
+        // special cases for dialects
+        if (config.sequelize.dialect === "sqlite") {
+          if (profilePropertyRule?.type === "boolean") {
+            if (match === "1") match = "true";
+            if (match === "0") match = "false";
+          }
+        }
+
         // rewrite null matches
         rawValueMatch[Op[operation.op]] =
           match.toString().toLocaleLowerCase() === "null" ? null : match;

--- a/core/api/src/models/GroupMember.ts
+++ b/core/api/src/models/GroupMember.ts
@@ -76,32 +76,38 @@ export class GroupMember extends Model<GroupMember> {
   }
 
   @AfterCreate
-  static async logCreate(instance: GroupMember) {
-    const group = await instance.$get("group");
+  static async logCreate(instance: GroupMember, { transaction }) {
+    const group = await instance.$get("group", { transaction });
 
-    await Log.create({
-      topic: "groupMember",
-      verb: "create",
-      data: await instance.apiData(),
-      ownerGuid: instance.profileGuid,
-      message: `added to group ${group ? group.name : ""} (${
-        instance.groupGuid
-      })`,
-    });
+    await Log.create(
+      {
+        topic: "groupMember",
+        verb: "create",
+        data: await instance.apiData(),
+        ownerGuid: instance.profileGuid,
+        message: `added to group ${group ? group.name : ""} (${
+          instance.groupGuid
+        })`,
+      },
+      { transaction }
+    );
   }
 
   @AfterDestroy
-  static async logDestroy(instance: GroupMember) {
-    const group = await instance.$get("group");
+  static async logDestroy(instance: GroupMember, { transaction }) {
+    const group = await instance.$get("group", { transaction });
 
-    await Log.create({
-      topic: "groupMember",
-      verb: "destroy",
-      data: await instance.apiData(),
-      ownerGuid: instance.profileGuid,
-      message: `removed from group ${group ? group.name : ""} (${
-        instance.groupGuid
-      })`,
-    });
+    await Log.create(
+      {
+        topic: "groupMember",
+        verb: "destroy",
+        data: await instance.apiData(),
+        ownerGuid: instance.profileGuid,
+        message: `removed from group ${group ? group.name : ""} (${
+          instance.groupGuid
+        })`,
+      },
+      { transaction }
+    );
   }
 }

--- a/core/api/src/models/Permission.ts
+++ b/core/api/src/models/Permission.ts
@@ -11,7 +11,7 @@ import { LoggedModel } from "../classes/loggedModel";
 import { Team } from "./Team";
 import { ApiKey } from "./ApiKey";
 
-export const topics = [
+export const PermissionTopics = [
   "apiKey",
   "app",
   "destination",
@@ -125,14 +125,10 @@ export class Permission extends LoggedModel<Permission> {
     return permission[mode];
   }
 
-  static topics() {
-    return topics;
-  }
-
   static validateTopic(topic) {
     if (topic === "*") return;
 
-    if (!Permission.topics().includes(topic)) {
+    if (!PermissionTopics.includes(topic)) {
       throw new Error(`cannot determine permission topic for ${topic}`);
     }
   }

--- a/core/api/src/models/Permission.ts
+++ b/core/api/src/models/Permission.ts
@@ -11,6 +11,28 @@ import { LoggedModel } from "../classes/loggedModel";
 import { Team } from "./Team";
 import { ApiKey } from "./ApiKey";
 
+export const topics = [
+  "apiKey",
+  "app",
+  "destination",
+  "event",
+  "export",
+  "export",
+  "file",
+  "group",
+  "import",
+  "log",
+  "notification",
+  "profile",
+  "profilePropertyRule",
+  "resque",
+  "run",
+  "setupStep",
+  "source",
+  "system",
+  "team",
+] as const;
+
 @Table({ tableName: "permissions", paranoid: false })
 export class Permission extends LoggedModel<Permission> {
   guidPrefix() {
@@ -104,33 +126,11 @@ export class Permission extends LoggedModel<Permission> {
   }
 
   static topics() {
-    return [
-      "apiKey",
-      "app",
-      "destination",
-      "event",
-      "export",
-      "export",
-      "file",
-      "group",
-      "import",
-      "log",
-      "notification",
-      "profile",
-      "profilePropertyRule",
-      "resque",
-      "run",
-      "setupStep",
-      "source",
-      "system",
-      "team",
-    ];
+    return topics;
   }
 
   static validateTopic(topic) {
-    if (topic === "*") {
-      return;
-    }
+    if (topic === "*") return;
 
     if (!Permission.topics().includes(topic)) {
       throw new Error(`cannot determine permission topic for ${topic}`);

--- a/core/api/src/models/Profile.ts
+++ b/core/api/src/models/Profile.ts
@@ -108,12 +108,12 @@ export class Profile extends LoggedModel<Profile> {
     return ProfileOps.removeProperties(this, properties);
   }
 
-  async buildNullProperties(transaction?: Transaction) {
-    return ProfileOps.buildNullProperties(this, "ready", transaction);
+  async buildNullProperties() {
+    return ProfileOps.buildNullProperties(this, "ready");
   }
 
-  async markPending(transaction?: Transaction) {
-    return ProfileOps.markPending(this, transaction);
+  async markPending() {
+    return ProfileOps.markPending(this);
   }
 
   async updateGroupMembership() {
@@ -180,11 +180,8 @@ export class Profile extends LoggedModel<Profile> {
   }
 
   @AfterCreate
-  static async buildNullPropertiesForNewProfile(
-    instance: Profile,
-    { transaction }
-  ) {
-    await instance.buildNullProperties(transaction);
+  static async buildNullPropertiesForNewProfile(instance: Profile) {
+    await instance.buildNullProperties();
   }
 
   @AfterDestroy

--- a/core/api/src/models/Profile.ts
+++ b/core/api/src/models/Profile.ts
@@ -108,8 +108,8 @@ export class Profile extends LoggedModel<Profile> {
     return ProfileOps.removeProperties(this, properties);
   }
 
-  async buildNullProperties() {
-    return ProfileOps.buildNullProperties(this);
+  async buildNullProperties(transaction?: Transaction) {
+    return ProfileOps.buildNullProperties(this, "ready", transaction);
   }
 
   async markPending(transaction?: Transaction) {
@@ -180,8 +180,11 @@ export class Profile extends LoggedModel<Profile> {
   }
 
   @AfterCreate
-  static async buildNullPropertiesForNewProfile(instance: Profile) {
-    await instance.buildNullProperties();
+  static async buildNullPropertiesForNewProfile(
+    instance: Profile,
+    { transaction }
+  ) {
+    await instance.buildNullProperties(transaction);
   }
 
   @AfterDestroy
@@ -190,16 +193,18 @@ export class Profile extends LoggedModel<Profile> {
   }
 
   @AfterDestroy
-  static async destroyProfileProperties(instance: Profile) {
+  static async destroyProfileProperties(instance: Profile, { transaction }) {
     await ProfileProperty.destroy({
       where: { profileGuid: instance.guid },
+      transaction,
     });
   }
 
   @AfterDestroy
-  static async destroyGroupMembers(instance: Profile) {
+  static async destroyGroupMembers(instance: Profile, { transaction }) {
     await GroupMember.destroy({
       where: { profileGuid: instance.guid },
+      transaction,
     });
   }
 
@@ -211,14 +216,18 @@ export class Profile extends LoggedModel<Profile> {
   }
 
   @AfterDestroy
-  static async destroyImports(instance: Profile) {
+  static async destroyImports(instance: Profile, { transaction }) {
     await Import.destroy({
       where: { profileGuid: instance.guid },
+      transaction,
     });
   }
 
   @AfterDestroy
-  static async destroyExports(instance: Profile) {
-    await Export.destroy({ where: { profileGuid: instance.guid } });
+  static async destroyExports(instance: Profile, { transaction }) {
+    await Export.destroy({
+      where: { profileGuid: instance.guid },
+      transaction,
+    });
   }
 }

--- a/core/api/src/models/ProfileProperty.ts
+++ b/core/api/src/models/ProfileProperty.ts
@@ -199,27 +199,31 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
   }
 
   @AfterSave
-  static async updateProfileAfterSave(instance: ProfileProperty) {
+  static async updateProfileAfterSave(
+    instance: ProfileProperty,
+    { transaction }
+  ) {
     const changed = instance.changed();
-    if (!changed) {
-      return;
-    }
+    if (!changed) return;
 
-    const profile = await instance.$get("profile");
+    const profile = await instance.$get("profile", { transaction });
     if (profile && changed.indexOf("rawValue") >= 0) {
       profile.updatedAt = new Date();
       profile.changed("updatedAt", true);
-      await profile.save();
+      await profile.save({ transaction });
     }
   }
 
   @AfterDestroy
-  static async updateProfileAfterDestroy(instance: ProfileProperty) {
-    const profile = await instance.$get("profile");
+  static async updateProfileAfterDestroy(
+    instance: ProfileProperty,
+    { transaction }
+  ) {
+    const profile = await instance.$get("profile", { transaction });
     if (profile) {
       profile.updatedAt = new Date();
       profile.changed("updatedAt", true);
-      await profile.save();
+      await profile.save({ transaction });
     }
   }
 }

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -474,37 +474,45 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
   }
 
   @AfterDestroy
-  static async destroyOptions(instance: ProfilePropertyRule) {
+  static async destroyOptions(instance: ProfilePropertyRule, { transaction }) {
     await Option.destroy({
       where: { ownerGuid: instance.guid },
+      transaction,
     });
   }
 
   @AfterDestroy
-  static async stopRuns(instance: ProfilePropertyRule) {
+  static async stopRuns(instance: ProfilePropertyRule, { transaction }) {
     const runs = await Run.findAll({
       where: { creatorGuid: instance.guid, state: "running" },
+      transaction,
     });
 
     for (const i in runs) {
-      await runs[i].update({ state: "stopped" });
+      await runs[i].update({ state: "stopped" }, { transaction });
     }
   }
 
   @AfterDestroy
   static async destroyProfilePropertyRuleFilters(
-    instance: ProfilePropertyRule
+    instance: ProfilePropertyRule,
+    { transaction }
   ) {
     await ProfilePropertyRuleFilter.destroy({
       where: { profilePropertyRuleGuid: instance.guid },
+      transaction,
     });
   }
 
   @AfterDestroy
-  static async clearCacheAfterDestroy(instance: ProfilePropertyRule) {
+  static async clearCacheAfterDestroy(
+    instance: ProfilePropertyRule,
+    { transaction }
+  ) {
     await this.clearCache();
     await ProfileProperty.destroy({
       where: { profilePropertyRuleGuid: instance.guid },
+      transaction,
     });
   }
 

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -18,7 +18,7 @@ import {
   BeforeCreate,
 } from "sequelize-typescript";
 import { Op } from "sequelize";
-import { env, api, cache } from "actionhero";
+import { env, api, cache, config } from "actionhero";
 import { plugin } from "../modules/plugin";
 import { LoggedModel } from "../classes/loggedModel";
 import { Profile } from "./Profile";
@@ -37,7 +37,7 @@ import { ProfilePropertyRuleOps } from "../modules/ops/profilePropertyRule";
 
 export function profilePropertyRuleJSToSQLType(jsType: string) {
   const map = {
-    boolean: "boolean",
+    boolean: config.sequelize.dialect === "sqlite" ? "text" : "boolean", // there is no boolean type in SQLite
     date: "bigint", // we store things via timestamps in the DB
     email: "text",
     float: "float",

--- a/core/api/src/models/Run.ts
+++ b/core/api/src/models/Run.ts
@@ -94,16 +94,8 @@ export class Run extends Model<Run> {
 
   @Column(DataType.STRING)
   get highWaterMark(): HighWaterMark {
-    try {
-      // @ts-ignore
-      return JSON.parse(this.getDataValue("highWaterMark"));
-    } catch (error) {
-      log(
-        `error parsing highWaterMark for run ${this.guid}: ${error}`,
-        "error"
-      );
-      return {};
-    }
+    // @ts-ignore
+    return JSON.parse(this.getDataValue("highWaterMark") || "{}");
   }
   set highWaterMark(value: HighWaterMark) {
     // @ts-ignore

--- a/core/api/src/models/Schedule.ts
+++ b/core/api/src/models/Schedule.ts
@@ -265,22 +265,19 @@ export class Schedule extends LoggedModel<Schedule> {
   }
 
   @AfterDestroy
-  static async destroyAppOptions(instance: Schedule) {
-    return Option.destroy({
-      where: {
-        ownerGuid: instance.guid,
-      },
-    });
+  static async destroyAppOptions(instance: Schedule, { transaction }) {
+    return Option.destroy({ where: { ownerGuid: instance.guid }, transaction });
   }
 
   @AfterDestroy
-  static async stopRuns(instance: Schedule) {
+  static async stopRuns(instance: Schedule, { transaction }) {
     const runs = await Run.findAll({
       where: { creatorGuid: instance.guid, state: "running" },
+      transaction,
     });
 
     for (const i in runs) {
-      await runs[i].update({ state: "stopped" });
+      await runs[i].update({ state: "stopped" }, { transaction });
     }
   }
 }

--- a/core/api/src/models/Source.ts
+++ b/core/api/src/models/Source.ts
@@ -329,30 +329,28 @@ export class Source extends LoggedModel<Source> {
   }
 
   @AfterSave
-  static async updateRuleDirectMappings(instance: Source) {
-    const rules = await instance.$get("profilePropertyRules");
+  static async updateRuleDirectMappings(instance: Source, { transaction }) {
+    const rules = await instance.$get("profilePropertyRules", { transaction });
     for (const i in rules) {
       const rule = rules[i];
       await ProfilePropertyRule.determineDirectlyMapped(rule);
-      if (rule.changed()) await rule.save();
+      if (rule.changed()) await rule.save({ transaction });
     }
   }
 
   @AfterDestroy
-  static async destroyOptions(instance: Source) {
+  static async destroyOptions(instance: Source, { transaction }) {
     return Option.destroy({
-      where: {
-        ownerGuid: instance.guid,
-      },
+      where: { ownerGuid: instance.guid },
+      transaction,
     });
   }
 
   @AfterDestroy
-  static async destroyMappings(instance: Source) {
+  static async destroyMappings(instance: Source, { transaction }) {
     return Mapping.destroy({
-      where: {
-        ownerGuid: instance.guid,
-      },
+      where: { ownerGuid: instance.guid },
+      transaction,
     });
   }
 }

--- a/core/api/src/models/Team.ts
+++ b/core/api/src/models/Team.ts
@@ -127,13 +127,23 @@ export class Team extends LoggedModel<Team> {
     const topics = Permission.topics();
     for (const i in topics) {
       const topic = topics[i];
-      const [permission, isNew] = await Permission.findOrCreate({
+      let isNew = false;
+      let permission = await Permission.findOne({
         where: {
           topic,
           ownerGuid: instance.guid,
           ownerType: "team",
         },
       });
+
+      if (!permission) {
+        isNew = true;
+        permission = await Permission.create({
+          topic,
+          ownerGuid: instance.guid,
+          ownerType: "team",
+        });
+      }
 
       if (isNew) {
         // default new teams to having full 'read' access

--- a/core/api/src/models/Team.ts
+++ b/core/api/src/models/Team.ts
@@ -10,10 +10,12 @@ import {
   AfterDestroy,
   BeforeSave,
 } from "sequelize-typescript";
+import { api } from "actionhero";
 import { LoggedModel } from "../classes/loggedModel";
 import { TeamMember } from "./TeamMember";
 import { Permission } from "./Permission";
 import { AsyncReturnType } from "type-fest";
+import { Transaction } from "sequelize";
 
 @Table({ tableName: "teams", paranoid: false })
 export class Team extends LoggedModel<Team> {
@@ -120,47 +122,66 @@ export class Team extends LoggedModel<Team> {
 
   @AfterSave
   static async buildPermissions(instance: Team) {
+    const transaction: Transaction = await api.sequelize.transaction();
     const permissionsWithStatus: Array<{
       isNew: boolean;
       permission: Permission;
     }> = [];
     const topics = Permission.topics();
-    for (const i in topics) {
-      const topic = topics[i];
-      let isNew = false;
-      let permission = await Permission.findOne({
-        where: {
-          topic,
-          ownerGuid: instance.guid,
-          ownerType: "team",
-        },
-      });
 
-      if (!permission) {
-        isNew = true;
-        permission = await Permission.create({
-          topic,
-          ownerGuid: instance.guid,
-          ownerType: "team",
+    try {
+      for (const i in topics) {
+        const topic = topics[i];
+        let isNew = false;
+        let permission = await Permission.findOne({
+          where: {
+            topic,
+            ownerGuid: instance.guid,
+            ownerType: "team",
+          },
+          transaction,
         });
+
+        if (!permission) {
+          isNew = true;
+          permission = await Permission.create(
+            {
+              topic,
+              ownerGuid: instance.guid,
+              ownerType: "team",
+            },
+            { transaction }
+          );
+        }
+
+        if (isNew) {
+          // default new teams to having full 'read' access
+          await permission.update({ read: true }, { transaction });
+        }
+
+        if (instance.permissionAllRead !== null) {
+          await permission.update(
+            { read: instance.permissionAllRead },
+            { transaction }
+          );
+        }
+        if (instance.permissionAllWrite !== null) {
+          await permission.update(
+            { write: instance.permissionAllWrite },
+            { transaction }
+          );
+        }
+
+        permissionsWithStatus.push({ isNew, permission });
       }
 
-      if (isNew) {
-        // default new teams to having full 'read' access
-        await permission.update({ read: true });
-      }
+      await transaction.commit();
 
-      if (instance.permissionAllRead !== null) {
-        await permission.update({ read: instance.permissionAllRead });
-      }
-      if (instance.permissionAllWrite !== null) {
-        await permission.update({ write: instance.permissionAllWrite });
-      }
-
-      permissionsWithStatus.push({ isNew, permission });
+      return permissionsWithStatus;
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
     }
-
-    return permissionsWithStatus;
   }
 
   @BeforeDestroy
@@ -180,7 +201,10 @@ export class Team extends LoggedModel<Team> {
   }
 
   @AfterDestroy
-  static async deletePermissions(instance: Team) {
-    return Permission.destroy({ where: { ownerGuid: instance.guid } });
+  static async deletePermissions(instance: Team, { transaction }) {
+    return Permission.destroy({
+      where: { ownerGuid: instance.guid },
+      transaction,
+    });
   }
 }

--- a/core/api/src/models/Team.ts
+++ b/core/api/src/models/Team.ts
@@ -13,7 +13,7 @@ import {
 import { api } from "actionhero";
 import { LoggedModel } from "../classes/loggedModel";
 import { TeamMember } from "./TeamMember";
-import { Permission } from "./Permission";
+import { Permission, PermissionTopics } from "./Permission";
 import { AsyncReturnType } from "type-fest";
 import { Transaction } from "sequelize";
 
@@ -127,11 +127,10 @@ export class Team extends LoggedModel<Team> {
       isNew: boolean;
       permission: Permission;
     }> = [];
-    const topics = Permission.topics();
 
     try {
-      for (const i in topics) {
-        const topic = topics[i];
+      for (const i in PermissionTopics) {
+        const topic = PermissionTopics[i];
         let isNew = false;
         let permission = await Permission.findOne({
           where: {

--- a/core/api/src/modules/RuleOpsDictionary.ts
+++ b/core/api/src/modules/RuleOpsDictionary.ts
@@ -1,3 +1,5 @@
+import { config } from "actionhero";
+
 const _boolean_ops = [
   { op: "exists", description: "exists with any value" },
   { op: "notExists", description: "does not exist" },
@@ -21,14 +23,20 @@ const _string_ops = [
   { op: "notExists", description: "does not exist" },
   { op: "eq", description: "is equal to" },
   { op: "ne", description: "is not equal to" },
-  { op: "like", description: "is like" },
-  { op: "iLike", description: "is like (case insensitive)" },
-  { op: "notLike", description: "is not like (case insensitive)" },
-  { op: "notILike", description: "is not like (case insensitive)" },
+  { op: "like", description: "is like (case sensitive)" },
+  { op: "notLike", description: "is not like (case sensitive)" },
   { op: "startsWith", description: "starts with" },
   { op: "endsWith", description: "ends with" },
   { op: "substring", description: "includes the string" },
 ];
+
+if (config.sequelize.dialect === "postgres") {
+  _string_ops.push({ op: "iLike", description: "is like (case insensitive)" });
+  _string_ops.push({
+    op: "notILike",
+    description: "is not like (case insensitive)",
+  });
+}
 
 const _date_ops = [
   { op: "exists", description: "exists with any value" },

--- a/core/api/src/modules/ops/export.ts
+++ b/core/api/src/modules/ops/export.ts
@@ -118,7 +118,6 @@ export namespace ExportOps {
             startedAt: null,
           },
           transaction,
-          returning: true,
         }
       );
 

--- a/core/api/src/modules/ops/export.ts
+++ b/core/api/src/modules/ops/export.ts
@@ -97,10 +97,7 @@ export namespace ExportOps {
 
     let _exports: Export[];
 
-    const transaction: Transaction = await api.sequelize.transaction({
-      lock: Transaction.LOCK.UPDATE,
-      type: Transaction.TYPES.EXCLUSIVE,
-    });
+    const transaction: Transaction = await api.sequelize.transaction({});
 
     try {
       _exports = await Export.findAll({

--- a/core/api/src/modules/ops/export.ts
+++ b/core/api/src/modules/ops/export.ts
@@ -3,11 +3,10 @@ import {
   ExportProfilePropertiesWithType,
 } from "../../models/Export";
 import { ProfilePropertyOps } from "../../modules/ops/profileProperty";
-import { plugin } from "../../modules/plugin";
 import { Export } from "../../models/Export";
 import { Destination } from "../../models/Destination";
 import { api, task } from "actionhero";
-import { Op } from "sequelize";
+import { Op, Transaction } from "sequelize";
 
 export namespace ExportOps {
   /** Count up the exports in each state, optionally filtered for a profile or destination */
@@ -91,40 +90,51 @@ export namespace ExportOps {
 
   export async function processPendingExportsForDestination(
     destination: Destination,
-    limit?: number
+    limit = 100
   ) {
-    if (!limit) {
-      limit = parseInt(
-        (await plugin.readSetting("core", "exports-profile-batch-size")).value
-      );
-    }
     const app = await destination.$get("app");
     const { pluginConnection } = await destination.getPlugin();
 
-    // We use Export#startedAt to denote that this export needs to be worked.  We can update and claim them in one go.
-    // This requires a custom query.
-    const query = `
-UPDATE "exports"
-SET "startedAt" = NOW()
-WHERE guid IN (
-  SELECT guid FROM "exports"
-  WHERE "startedAt" IS NULL
-  AND "destinationGuid" = '${destination.guid}'
-  ORDER BY "createdAt" DESC
-  LIMIT ${limit}
-)
-AND "startedAt" IS NULL
-AND "destinationGuid" = '${destination.guid}'
-RETURNING *
-;
-  `;
+    let _exports: Export[];
 
-    const _exports: Export[] = await api.sequelize.query(query, {
-      model: Export,
-      mapToModel: true,
+    const transaction: Transaction = await api.sequelize.transaction({
+      lock: Transaction.LOCK.UPDATE,
+      type: Transaction.TYPES.EXCLUSIVE,
     });
 
-    if (_exports.length > 0) {
+    try {
+      _exports = await Export.findAll({
+        where: {
+          startedAt: null,
+          destinationGuid: destination.guid,
+        },
+        order: [["createdAt", "asc"]],
+        limit,
+        transaction,
+      });
+
+      const updateResponse = await Export.update(
+        { startedAt: new Date() },
+        {
+          where: {
+            guid: { [Op.in]: _exports.map((e) => e.guid) },
+            startedAt: null,
+          },
+          transaction,
+        }
+      );
+
+      transaction.commit();
+
+      _exports = updateResponse[1];
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+
+    if (!_exports) return _exports?.length || 0;
+
+    if (_exports.length > 0)
       if (pluginConnection.methods.exportProfiles) {
         // the plugin has a batch exportProfiles method
         await task.enqueue(
@@ -150,7 +160,6 @@ RETURNING *
           )
         );
       }
-    }
 
     return _exports.length;
   }

--- a/core/api/src/modules/ops/group.ts
+++ b/core/api/src/modules/ops/group.ts
@@ -294,9 +294,7 @@ export namespace GroupOps {
       },
     });
 
-    const transaction = await api.sequelize.transaction({
-      type: Transaction.TYPES.EXCLUSIVE,
-    });
+    const transaction = await api.sequelize.transaction({});
 
     try {
       const existingGroupMemberProfileGuids = groupMembers.map(
@@ -367,9 +365,7 @@ export namespace GroupOps {
       limit,
     });
 
-    const transaction = await api.sequelize.transaction({
-      type: Transaction.TYPES.EXCLUSIVE,
-    });
+    const transaction = await api.sequelize.transaction({});
 
     try {
       // The offset and order can be ignored as we will keep running this query until the set of results becomes 0.

--- a/core/api/src/modules/ops/group.ts
+++ b/core/api/src/modules/ops/group.ts
@@ -176,9 +176,7 @@ export namespace GroupOps {
     rules?: GroupRuleWithKey[],
     matchType: "any" | "all" = group.matchType
   ) {
-    if (!rules) {
-      rules = await group.getRules();
-    }
+    if (!rules) rules = await group.getRules();
 
     const { where, include } = await group._buildGroupMemberQueryParts(
       rules,
@@ -204,9 +202,7 @@ export namespace GroupOps {
     const funnelCounts = [];
     let funnelStep = 0;
 
-    if (!rules) {
-      rules = await group.getRules();
-    }
+    if (!rules) rules = await group.getRules();
 
     for (const i in rules) {
       const localRule = rules[i];

--- a/core/api/src/modules/ops/profile.ts
+++ b/core/api/src/modules/ops/profile.ts
@@ -282,20 +282,27 @@ export namespace ProfileOps {
     }
   }
 
-  export async function buildNullProperties(profile: Profile, state = "ready") {
+  export async function buildNullProperties(
+    profile: Profile,
+    state = "ready",
+    transaction?: Transaction
+  ) {
     const properties = await profile.properties();
     const rules = await ProfilePropertyRule.cached();
     let newPropertiesCount = 0;
     for (const key in rules) {
       if (!properties[key]) {
-        await ProfileProperty.create({
-          profileGuid: profile.guid,
-          profilePropertyRuleGuid: rules[key].guid,
-          state,
-          stateChangedAt: new Date(),
-          valueChangedAt: new Date(),
-          confirmedAt: new Date(),
-        });
+        await ProfileProperty.create(
+          {
+            profileGuid: profile.guid,
+            profilePropertyRuleGuid: rules[key].guid,
+            state,
+            stateChangedAt: new Date(),
+            valueChangedAt: new Date(),
+            confirmedAt: new Date(),
+          },
+          { transaction }
+        );
         newPropertiesCount++;
       }
     }

--- a/core/api/src/modules/ops/profile.ts
+++ b/core/api/src/modules/ops/profile.ts
@@ -598,7 +598,9 @@ export namespace ProfileOps {
 
       await transaction.commit();
 
-      profiles = updateResponse[1];
+      // For postgres only: we can update our result set with the rows that were updated, filtering out those which are no longer state=pending
+      // in SQLite this isn't possible, but contention is far less likely
+      if (updateResponse[1]) profiles = updateResponse[1];
     } catch (error) {
       await transaction.rollback();
       throw error;

--- a/core/api/src/modules/ops/profile.ts
+++ b/core/api/src/modules/ops/profile.ts
@@ -282,27 +282,20 @@ export namespace ProfileOps {
     }
   }
 
-  export async function buildNullProperties(
-    profile: Profile,
-    state = "ready",
-    transaction?: Transaction
-  ) {
+  export async function buildNullProperties(profile: Profile, state = "ready") {
     const properties = await profile.properties();
     const rules = await ProfilePropertyRule.cached();
     let newPropertiesCount = 0;
     for (const key in rules) {
       if (!properties[key]) {
-        await ProfileProperty.create(
-          {
-            profileGuid: profile.guid,
-            profilePropertyRuleGuid: rules[key].guid,
-            state,
-            stateChangedAt: new Date(),
-            valueChangedAt: new Date(),
-            confirmedAt: new Date(),
-          },
-          { transaction }
-        );
+        await ProfileProperty.create({
+          profileGuid: profile.guid,
+          profilePropertyRuleGuid: rules[key].guid,
+          state,
+          stateChangedAt: new Date(),
+          valueChangedAt: new Date(),
+          confirmedAt: new Date(),
+        });
         newPropertiesCount++;
       }
     }
@@ -471,10 +464,7 @@ export namespace ProfileOps {
   /**
    * Mark the profile and all of its properties as pending
    */
-  export async function markPending(
-    profile: Profile,
-    transaction?: Transaction
-  ) {
+  export async function markPending(profile: Profile) {
     const profilePropertyRuleGuidsToMakePending: string[] = [];
     const cachedProfilePropertyRule = await ProfilePropertyRule.cached();
     for (const guid in cachedProfilePropertyRule) {
@@ -493,11 +483,10 @@ export namespace ProfileOps {
             [Op.in]: profilePropertyRuleGuidsToMakePending,
           },
         },
-        transaction,
       }
     );
 
-    await profile.update({ state: "pending" }, { transaction });
+    await profile.update({ state: "pending" });
   }
 
   /**
@@ -566,10 +555,7 @@ export namespace ProfileOps {
   export async function makeReady(limit = 100) {
     let profiles: Profile[];
 
-    const transaction: Transaction = await api.sequelize.transaction({
-      lock: Transaction.LOCK.UPDATE,
-      type: Transaction.TYPES.EXCLUSIVE,
-    });
+    const transaction: Transaction = await api.sequelize.transaction({});
 
     try {
       const notInQuery = api.sequelize.dialect.QueryGenerator.selectQuery(

--- a/core/api/src/modules/ops/source.ts
+++ b/core/api/src/modules/ops/source.ts
@@ -324,7 +324,7 @@ export namespace SourceOps {
       await ProfilePropertyRule.ensureOneIdentifyingProperty(rule);
 
       // danger zone!
-      await LoggedModel.logCreate(rule);
+      await LoggedModel.logCreate(rule, {});
       // @ts-ignore
       await rule.save({ hooks: false });
       await ProfilePropertyRule.clearCacheAfterSave();

--- a/core/api/src/modules/optionHelper.ts
+++ b/core/api/src/modules/optionHelper.ts
@@ -91,7 +91,7 @@ export namespace OptionHelper {
 
       // @ts-ignore
       instance.changed("updatedAt", true);
-      await LoggedModel.logUpdate(instance);
+      await LoggedModel.logUpdate(instance, { transaction });
       // @ts-ignore
       await instance.save({ transaction, hooks: false });
 

--- a/core/package.json
+++ b/core/package.json
@@ -93,6 +93,7 @@
     "reflect-metadata": "0.1.13",
     "sequelize": "5.22.3",
     "sequelize-typescript": "1.1.0",
+    "sqlite3": "^5.0.0",
     "stacktrace-js": "2.0.2",
     "swagger-ui": "3.36.2",
     "ts-node": "9.0.0",

--- a/core/web/pages/resque/overview.tsx
+++ b/core/web/pages/resque/overview.tsx
@@ -88,7 +88,7 @@ export default function ResqueOverview(props) {
     setWorkers(_workers);
     setStats(_stats);
     setQueues(_queues);
-    setFailedCount(response.failedCount);
+    setFailedCount(response?.failedCount);
 
     timer = setTimeout(() => {
       load();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,7 @@ importers:
       reflect-metadata: 0.1.13
       sequelize: 5.22.3
       sequelize-typescript: 1.1.0_0d818a7f936188802d899b647afea6d0
+      sqlite3: 5.0.0
       stacktrace-js: 2.0.2
       swagger-ui: 3.36.2
       ts-node: 9.0.0_typescript@4.0.5
@@ -170,7 +171,7 @@ importers:
       csv-parse: 4.14.0
       enzyme: 3.11.0
       enzyme-adapter-react-16: 1.15.5_4f82faf5e8cab057bc46d4d95079ec42
-      jest: 26.6.3_ts-node@9.0.0
+      jest: 26.6.3
       jest-environment-webdriver: 0.2.0_jest@26.6.3
       jest-fetch-mock: 3.0.3
       jest-mock-axios: 4.2.1
@@ -246,6 +247,7 @@ importers:
       reflect-metadata: 0.1.13
       sequelize: 5.22.3
       sequelize-typescript: 1.1.0
+      sqlite3: ^5.0.0
       stacktrace-js: 2.0.2
       swagger-ui: 3.36.2
       ts-jest: 26.4.4
@@ -2450,43 +2452,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
-  /@jest/core/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/reporters': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 14.14.6
-      ansi-escapes: 4.3.1
-      chalk: 4.1.0
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      jest-changed-files: 26.6.2
-      jest-config: 26.6.3_ts-node@9.0.0
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-resolve-dependencies: 26.6.3
-      jest-runner: 26.6.3_ts-node@9.0.0
-      jest-runtime: 26.6.3_ts-node@9.0.0
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      jest-watcher: 26.6.2
-      micromatch: 4.0.2
-      p-each-series: 2.1.0
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   /@jest/environment/26.6.2:
     dependencies:
       '@jest/fake-timers': 26.6.2
@@ -2585,20 +2550,6 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
-  /@jest/test-sequencer/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@jest/test-result': 26.6.2
-      graceful-fs: 4.2.4
-      jest-haste-map: 26.6.2
-      jest-runner: 26.6.3_ts-node@9.0.0
-      jest-runtime: 26.6.3_ts-node@9.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
     resolution:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/transform/26.6.2:
@@ -9736,29 +9687,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
-  /jest-cli/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@jest/core': 26.6.3_ts-node@9.0.0
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      chalk: 4.1.0
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      import-local: 3.0.2
-      is-ci: 2.0.0
-      jest-config: 26.6.3_ts-node@9.0.0
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      prompts: 2.3.2
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-config/26.6.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -9779,37 +9707,6 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.2
       pretty-format: 26.6.2
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    resolution:
-      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
-  /jest-config/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@babel/core': 7.12.3
-      '@jest/test-sequencer': 26.6.3_ts-node@9.0.0
-      '@jest/types': 26.6.2
-      babel-jest: 26.6.3_@babel+core@7.12.3
-      chalk: 4.1.0
-      deepmerge: 4.2.2
-      glob: 7.1.6
-      graceful-fs: 4.2.4
-      jest-environment-jsdom: 26.6.2
-      jest-environment-node: 26.6.2
-      jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3_ts-node@9.0.0
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      micromatch: 4.0.2
-      pretty-format: 26.6.2
-      ts-node: 9.0.0_typescript@4.0.5
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -9898,7 +9795,7 @@ packages:
       integrity: sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==
   /jest-environment-webdriver/0.2.0_jest@26.6.3:
     dependencies:
-      jest: 26.6.3_ts-node@9.0.0
+      jest: 26.6.3
       jest-environment-node: 22.1.4
       selenium-webdriver: 4.0.0-alpha.7
     dev: true
@@ -9966,33 +9863,6 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
-  /jest-jasmine2/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@babel/traverse': 7.12.1
-      '@jest/environment': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 14.14.6
-      chalk: 4.1.0
-      co: 4.6.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runtime: 26.6.3_ts-node@9.0.0
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      pretty-format: 26.6.2
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
     resolution:
       integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
   /jest-leak-detector/26.6.2:
@@ -10131,35 +10001,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
-  /jest-runner/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 14.14.6
-      chalk: 4.1.0
-      emittery: 0.7.2
-      exit: 0.1.2
-      graceful-fs: 4.2.4
-      jest-config: 26.6.3_ts-node@9.0.0
-      jest-docblock: 26.0.0
-      jest-haste-map: 26.6.2
-      jest-leak-detector: 26.6.2
-      jest-message-util: 26.6.2
-      jest-resolve: 26.6.2
-      jest-runtime: 26.6.3_ts-node@9.0.0
-      jest-util: 26.6.2
-      jest-worker: 26.6.2
-      source-map-support: 0.5.19
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   /jest-runtime/26.6.3:
     dependencies:
       '@jest/console': 26.6.2
@@ -10193,43 +10034,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
-  /jest-runtime/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/fake-timers': 26.6.2
-      '@jest/globals': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/yargs': 15.0.9
-      chalk: 4.1.0
-      cjs-module-lexer: 0.6.0
-      collect-v8-coverage: 1.0.1
-      exit: 0.1.2
-      glob: 7.1.6
-      graceful-fs: 4.2.4
-      jest-config: 26.6.3_ts-node@9.0.0
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-mock: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      slash: 3.0.0
-      strip-bom: 4.0.0
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
     resolution:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-serializer/26.6.2:
@@ -10357,19 +10161,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
-  /jest/26.6.3_ts-node@9.0.0:
-    dependencies:
-      '@jest/core': 26.6.3_ts-node@9.0.0
-      import-local: 3.0.2
-      jest-cli: 26.6.3_ts-node@9.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
     resolution:
       integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
   /jju/1.4.0:
@@ -11924,6 +11715,10 @@ packages:
     optional: true
     resolution:
       integrity: sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==
+  /node-addon-api/2.0.0:
+    dev: false
+    resolution:
+      integrity: sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA==
   /node-addon-api/3.0.2:
     dev: false
     resolution:
@@ -12073,6 +11868,22 @@ packages:
     optional: true
     resolution:
       integrity: sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==
+  /node-pre-gyp/0.11.0:
+    dependencies:
+      detect-libc: 1.0.3
+      mkdirp: 0.5.5
+      needle: 2.5.2
+      nopt: 4.0.3
+      npm-packlist: 1.4.8
+      npmlog: 4.1.2
+      rc: 1.2.8
+      rimraf: 2.7.1
+      semver: 5.7.1
+      tar: 4.4.13
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==
   /node-pre-gyp/0.15.0:
     dependencies:
       detect-libc: 1.0.3
@@ -15681,6 +15492,19 @@ packages:
   /sprintf-js/1.1.2:
     resolution:
       integrity: sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
+  /sqlite3/5.0.0:
+    dependencies:
+      node-addon-api: 2.0.0
+      node-pre-gyp: 0.11.0
+    dev: false
+    optionalDependencies:
+      node-gyp: 3.8.0
+    peerDependenciesMeta:
+      node-gyp:
+        optional: true
+    requiresBuild: true
+    resolution:
+      integrity: sha512-rjvqHFUaSGnzxDy2AHCwhHy6Zp6MNJzCPGYju4kD8yi6bze4d1/zMTg6C7JI49b7/EM7jKMTvyfN/4ylBKdwfw==
   /sqlstring/2.3.1:
     dev: false
     engines:

--- a/tools/merger/data/ci/core-local/job.yml.template
+++ b/tools/merger/data/ci/core-local/job.yml.template
@@ -20,7 +20,7 @@
 {{{custom_steps}}}
       - run:
           name: test-{{section}}
-          command: cd {{{relative_path}}}/{{section}} && ./../node_modules/.bin/jest __tests__/models --ci
+          command: cd {{{relative_path}}}/{{section}} && ./../node_modules/.bin/jest __tests__/models --ci --maxWorkers 2
           environment:
             DB_DIALECT: sqlite
 {{{custom_test}}}

--- a/tools/merger/data/ci/core-local/job.yml.template
+++ b/tools/merger/data/ci/core-local/job.yml.template
@@ -1,0 +1,26 @@
+  {{{job_name}}}:
+    docker:
+      - image: circleci/node:12
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: redis:latest
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+{{{custom_docker}}}
+    steps:
+      - checkout
+      - restore_cache:
+          <<: *node-module-cache-options
+      - restore_cache:
+          <<: *dist-cache-options
+      - restore_cache:
+          <<: *core-cache-options
+{{{custom_steps}}}
+      - run:
+          name: test-{{section}}
+          command: cd {{{relative_path}}}/{{section}} && ./../node_modules/.bin/jest __tests__/models --ci
+          environment:
+            DB_DIALECT: sqlite
+{{{custom_test}}}

--- a/tools/merger/data/ci/core-local/workflow.yml.template
+++ b/tools/merger/data/ci/core-local/workflow.yml.template
@@ -1,0 +1,5 @@
+      - {{{job_name}}}:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -88,6 +88,13 @@ class Generator {
       relative_path: `core`,
       name: "core",
     });
+    this.jobList.push({
+      type: "core-local",
+      section: "api",
+      job_name: `test-core-local`,
+      relative_path: `core`,
+      name: "core",
+    });
   }
 
   addCLI() {


### PR DESCRIPTION
This PR makes it possible to run Grouparoo against a SQLite database.  This enables both in-memory operation and persisting the SQLite database to disk.  Per #935, this will make it easier to get started with Grouparoo.

## Features

- [x] With the first-time developer experience in mind, this PR changes the output of `grouparoo generate` to use SQLite by default
- [x] This PR removes any custom queries which would only work on Postgres
- [x] This PR removes any custom aggregations that only work on Postgres (or knows how to format things for both PG and SQLite)
- [x] This PR removes all instances of `findOrCreate` globally in the app... they keep causing problems! 
- [x] Re run (some) tests in CI against sqlite

## Questions
* ~~SQLite does not like the creation of new records in @`afterSave`/@`afterCreate` hooks.  This makes the LoggedModel hard to use.  We can choose to not `await` these, so they will be outside of the save transaction... but then we can't guarantee that the logs are written...  See https://github.com/grouparoo/grouparoo/pull/965/commits/1cbe2ac5c2b642b8959330d41027bb80b7807e39 for more info~~
* Hooks which add or create models (like using an `@afterSave` to create a Log record) need to use the transaction of the parent model, if there is a transaction in play.  SQLite only has one transaction available, so can't `await Log.create()` in a hook without the transaction... it will never complete.
* `iLike` (case-insensitive like queries) do not work for sqlite. - there are now a few conditionals scattered about the codebase based on `config.sequelize.dialect`

Part of #935
Closes T-673