### PR TITLE
Do not display Import or Export diff until complete

### DIFF
--- a/core/web/components/export/diff.tsx
+++ b/core/web/components/export/diff.tsx
@@ -1,0 +1,126 @@
+import { Badge } from "react-bootstrap";
+import Link from "next/link";
+import { Models } from "../../utils/apiData";
+
+export function ExportProfilePropertiesDiff({
+  _export,
+}: {
+  _export: Models.ExportType;
+}) {
+  const complete = _export.completedAt;
+
+  if (!complete) {
+    return (
+      <ul>
+        {Object.keys(_export.oldProfileProperties).map((k) => {
+          return (
+            <li key={`${_export.guid}-prp-${k}`}>
+              {k}: {_export.oldProfileProperties[k]?.toString()}
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+
+  return (
+    <ul>
+      {Object.keys(_export.oldProfileProperties).map((k) => {
+        return (
+          <li key={`${_export.guid}-prp-${k}`}>
+            {k}:{" "}
+            {JSON.stringify(_export.oldProfileProperties[k]) !==
+            JSON.stringify(_export.newProfileProperties[k]) ? (
+              <>
+                <Badge variant="danger">-</Badge>&nbsp;
+                {_export.oldProfileProperties[k]?.toString()}
+                {_export.newProfileProperties[k] !== null &&
+                _export.newProfileProperties[k] !== undefined ? (
+                  <>
+                    {" "}
+                    | <Badge variant="success">+</Badge>&nbsp;
+                    {_export.newProfileProperties[k].toString()}
+                  </>
+                ) : null}
+              </>
+            ) : (
+              <>{_export.oldProfileProperties[k]?.toString()}</>
+            )}
+          </li>
+        );
+      })}
+
+      {Object.keys(_export.newProfileProperties).map((k) =>
+        _export.oldProfileProperties[k] === undefined ? (
+          <li key={`${_export.guid}-prp-${k}`}>
+            {k}: <Badge variant="success">+</Badge>&nbsp;
+            {_export.newProfileProperties[k]?.toString()}
+          </li>
+        ) : null
+      )}
+    </ul>
+  );
+}
+
+export function ExportGroupsDiff({
+  _export,
+  groups,
+}: {
+  _export: Models.ExportType;
+  groups: Models.GroupType[];
+}) {
+  const complete = _export.completedAt;
+
+  if (!complete) {
+    return (
+      <>
+        <ul>
+          {_export.oldGroups.map((g) => (
+            <li key={`${_export.guid}-grp-${g}`}>{groupLink(groups, g)}</li>
+          ))}
+        </ul>
+      </>
+    );
+  }
+
+  return (
+    <ul>
+      {_export.oldGroups.map((g) => {
+        return (
+          <li key={`${_export.guid}-grp-${g}`}>
+            {!_export.newGroups.includes(g) ? (
+              <Badge variant={"danger"}>
+                {!_export.newGroups.includes(g) ? "-" : "+"}
+              </Badge>
+            ) : null}
+            &nbsp;
+            {groupLink(groups, g)}
+          </li>
+        );
+      })}
+
+      {_export.newGroups.map((g) =>
+        !_export.oldGroups.includes(g) ? (
+          <li key={`${_export.guid}-grp-${g}`}>
+            <Badge variant="success">+</Badge>&nbsp;
+            {groupLink(groups, g)}
+          </li>
+        ) : null
+      )}
+    </ul>
+  );
+}
+
+function groupLink(groups: Models.GroupType[], groupName: string) {
+  const group = groups.find((g) => g.name === groupName);
+
+  if (group) {
+    return (
+      <Link href="/group/[guid]/edit" as={`/group/${group.guid}/edit`}>
+        <a>{group.name}</a>
+      </Link>
+    );
+  } else {
+    return <span>{groupName} (deleted)</span>;
+  }
+}

--- a/core/web/components/export/list.tsx
+++ b/core/web/components/export/list.tsx
@@ -10,6 +10,7 @@ import Moment from "react-moment";
 import LoadingTable from "../loadingTable";
 import { Models, Actions } from "../../utils/apiData";
 import { ErrorHandler } from "../../utils/errorHandler";
+import { ExportGroupsDiff, ExportProfilePropertiesDiff } from "./diff";
 
 export default function ExportsList(props) {
   const {
@@ -59,20 +60,6 @@ export default function ExportsList(props) {
       if (response.total === 0 && offset > 0) {
         setOffset(0);
       }
-    }
-  }
-
-  function groupLink(groupName) {
-    const group = groups.filter((g) => g.name === groupName)[0];
-
-    if (group) {
-      return (
-        <Link href="/group/[guid]/edit" as={`/group/${group.guid}/edit`}>
-          <a>{groupName}</a>
-        </Link>
-      );
-    } else {
-      return <span>{groupName}</span>;
     }
   }
 
@@ -218,68 +205,10 @@ export default function ExportsList(props) {
                     ) : null}
                   </td>
                   <td>
-                    <ul>
-                      {Object.keys(_export.oldProfileProperties).map((k) => {
-                        return (
-                          <li key={`${_export.guid}-prp-${k}`}>
-                            {k}:{" "}
-                            {JSON.stringify(_export.oldProfileProperties[k]) !==
-                            JSON.stringify(_export.newProfileProperties[k]) ? (
-                              <>
-                                <Badge variant="danger">-</Badge>&nbsp;
-                                {_export.oldProfileProperties[k]?.toString()}
-                                {_export.newProfileProperties[k] !== null &&
-                                _export.newProfileProperties[k] !==
-                                  undefined ? (
-                                  <>
-                                    {" "}
-                                    | <Badge variant="success">+</Badge>&nbsp;
-                                    {_export.newProfileProperties[k].toString()}
-                                  </>
-                                ) : null}
-                              </>
-                            ) : (
-                              <>{_export.oldProfileProperties[k]?.toString()}</>
-                            )}
-                          </li>
-                        );
-                      })}
-
-                      {Object.keys(_export.newProfileProperties).map((k) =>
-                        _export.oldProfileProperties[k] === undefined ? (
-                          <li key={`${_export.guid}-prp-${k}`}>
-                            {k}: <Badge variant="success">+</Badge>&nbsp;
-                            {_export.newProfileProperties[k]?.toString()}
-                          </li>
-                        ) : null
-                      )}
-                    </ul>
+                    <ExportProfilePropertiesDiff _export={_export} />
                   </td>
                   <td>
-                    <ul>
-                      {_export.oldGroups.map((g) => {
-                        return (
-                          <li key={`${_export.guid}-grp-${g}`}>
-                            {!_export.newGroups.includes(g) ? (
-                              <Badge variant={"danger"}>
-                                {!_export.newGroups.includes(g) ? "-" : "+"}
-                              </Badge>
-                            ) : null}
-                            &nbsp;
-                            {groupLink(g)}
-                          </li>
-                        );
-                      })}
-
-                      {_export.newGroups.map((g) =>
-                        !_export.oldGroups.includes(g) ? (
-                          <li key={`${_export.guid}-grp-${g}`}>
-                            <Badge variant="success">+</Badge>&nbsp;
-                            {groupLink(g)}
-                          </li>
-                        ) : null
-                      )}
-                    </ul>
+                    <ExportGroupsDiff _export={_export} groups={groups} />
                   </td>
                 </tr>
 

--- a/core/web/components/import/diff.tsx
+++ b/core/web/components/import/diff.tsx
@@ -1,0 +1,129 @@
+import { Badge } from "react-bootstrap";
+import Link from "next/link";
+import { Models } from "../../utils/apiData";
+
+export function ImportProfilePropertiesDiff({
+  _import,
+}: {
+  _import: Models.ImportType;
+}) {
+  const complete = _import.profileUpdatedAt && _import.groupsUpdatedAt;
+
+  if (!complete) {
+    return (
+      <>
+        <ul>
+          {Object.keys(_import.oldProfileProperties).map((k) => {
+            return (
+              <li key={`${_import.guid}-prp-${k}`}>
+                {k}: {_import.oldProfileProperties[k]?.toString()}
+              </li>
+            );
+          })}
+        </ul>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <ul>
+        {Object.keys(_import.oldProfileProperties).map((k) => {
+          return (
+            <li key={`${_import.guid}-prp-${k}`}>
+              {k}:{" "}
+              {JSON.stringify(_import.oldProfileProperties[k]) !==
+              JSON.stringify(_import.newProfileProperties[k]) ? (
+                <>
+                  <Badge variant="danger">-</Badge>&nbsp;
+                  {_import.oldProfileProperties[k]?.toString()}
+                  {_import.newProfileProperties[k] !== null &&
+                  _import.newProfileProperties[k] !== undefined ? (
+                    <>
+                      {" "}
+                      | <Badge variant="success">+</Badge>&nbsp;
+                      {_import.newProfileProperties[k].toString()}
+                    </>
+                  ) : null}
+                </>
+              ) : (
+                _import.oldProfileProperties[k]?.toString()
+              )}
+            </li>
+          );
+        })}
+
+        {Object.keys(_import.newProfileProperties).map((k) =>
+          _import.oldProfileProperties[k] === undefined ? (
+            <li key={`${_import.guid}-prp-${k}`}>
+              {k}: <Badge variant="success">+</Badge>&nbsp;
+              {_import.newProfileProperties[k]?.toString()}
+            </li>
+          ) : null
+        )}
+      </ul>
+    </>
+  );
+}
+
+export function ImportGroupsDiff({
+  _import,
+  groups,
+}: {
+  _import: Models.ImportType;
+  groups: Models.GroupType[];
+}) {
+  const complete = _import.profileUpdatedAt && _import.groupsUpdatedAt;
+
+  if (!complete) {
+    return (
+      <>
+        <ul>
+          {_import.oldGroupGuids.map((g) => (
+            <li key={`${_import.guid}-grp-${g}`}>{groupLink(groups, g)}</li>
+          ))}
+        </ul>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <ul>
+        {_import.oldGroupGuids.map((g) => {
+          return (
+            <li key={`${_import.guid}-grp-${g}`}>
+              {!_import.newGroupGuids.includes(g) ? (
+                <Badge variant="danger">-</Badge>
+              ) : null}{" "}
+              {groupLink(groups, g)}
+            </li>
+          );
+        })}
+
+        {_import.newGroupGuids.map((g) =>
+          !_import.oldGroupGuids.includes(g) ? (
+            <li key={`${_import.guid}-grp-${g}`}>
+              <Badge variant="success">+</Badge>&nbsp;
+              {groupLink(groups, g)}
+            </li>
+          ) : null
+        )}
+      </ul>
+    </>
+  );
+}
+
+function groupLink(groups: Models.GroupType[], groupGuid: string) {
+  const group = groups.find((g) => g.guid === groupGuid);
+
+  if (group) {
+    return (
+      <Link href="/group/[guid]/edit" as={`/group/${group.guid}/edit`}>
+        <a>{group.name}</a>
+      </Link>
+    );
+  } else {
+    return <span>{groupGuid} (deleted)</span>;
+  }
+}

--- a/core/web/components/import/list.tsx
+++ b/core/web/components/import/list.tsx
@@ -6,10 +6,11 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import Pagination from "../pagination";
 import LoadingTable from "../loadingTable";
-import { Alert, Badge } from "react-bootstrap";
+import { Alert } from "react-bootstrap";
 import Moment from "react-moment";
 import { Models, Actions } from "../../utils/apiData";
 import { ErrorHandler } from "../../utils/errorHandler";
+import { ImportProfilePropertiesDiff, ImportGroupsDiff } from "./diff";
 
 export default function ImportList(props) {
   const {
@@ -54,20 +55,6 @@ export default function ImportList(props) {
     if (response?.imports) {
       setImports(response.imports);
       setTotal(response.total);
-    }
-  }
-
-  function groupLink(groupGuid) {
-    const group = groups.filter((g) => g.guid === groupGuid)[0];
-
-    if (group) {
-      return (
-        <Link href="/group/[guid]/edit" as={`/group/${group.guid}/edit`}>
-          <a>{group.name}</a>
-        </Link>
-      );
-    } else {
-      return <span>{groupGuid} (deleted)</span>;
     }
   }
 
@@ -156,65 +143,10 @@ export default function ImportList(props) {
                     )}
                   </td>
                   <td>
-                    <ul>
-                      {Object.keys(_import.oldProfileProperties).map((k) => {
-                        return (
-                          <li key={`${_import.guid}-prp-${k}`}>
-                            {k}:{" "}
-                            {JSON.stringify(_import.oldProfileProperties[k]) !==
-                            JSON.stringify(_import.newProfileProperties[k]) ? (
-                              <>
-                                <Badge variant="danger">-</Badge>&nbsp;
-                                {_import.oldProfileProperties[k]?.toString()}
-                                {_import.newProfileProperties[k] !== null &&
-                                _import.newProfileProperties[k] !==
-                                  undefined ? (
-                                  <>
-                                    {" "}
-                                    | <Badge variant="success">+</Badge>&nbsp;
-                                    {_import.newProfileProperties[k].toString()}
-                                  </>
-                                ) : null}
-                              </>
-                            ) : (
-                              _import.oldProfileProperties[k]?.toString()
-                            )}
-                          </li>
-                        );
-                      })}
-
-                      {Object.keys(_import.newProfileProperties).map((k) =>
-                        _import.oldProfileProperties[k] === undefined ? (
-                          <li key={`${_import.guid}-prp-${k}`}>
-                            {k}: <Badge variant="success">+</Badge>&nbsp;
-                            {_import.newProfileProperties[k]?.toString()}
-                          </li>
-                        ) : null
-                      )}
-                    </ul>
+                    <ImportProfilePropertiesDiff _import={_import} />
                   </td>
                   <td>
-                    <ul>
-                      {_import.oldGroupGuids.map((g) => {
-                        return (
-                          <li key={`${_import.guid}-grp-${g}`}>
-                            {!_import.newGroupGuids.includes(g) ? (
-                              <Badge variant="danger">-</Badge>
-                            ) : null}{" "}
-                            {groupLink(g)}
-                          </li>
-                        );
-                      })}
-
-                      {_import.newGroupGuids.map((g) =>
-                        !_import.oldGroupGuids.includes(g) ? (
-                          <li key={`${_import.guid}-grp-${g}`}>
-                            <Badge variant="success">+</Badge>&nbsp;
-                            {groupLink(g)}
-                          </li>
-                        ) : null
-                      )}
-                    </ul>
+                    <ImportGroupsDiff _import={_import} groups={groups} />
                   </td>
                   <td>
                     {Object.keys(_import.data).map((k) => (

--- a/core/web/pages/export/[guid]/edit.tsx
+++ b/core/web/pages/export/[guid]/edit.tsx
@@ -5,6 +5,10 @@ import Head from "next/head";
 import Moment from "react-moment";
 import ExportTabs from "../../../components/tabs/export";
 import { Models } from "../../../utils/apiData";
+import {
+  ExportGroupsDiff,
+  ExportProfilePropertiesDiff,
+} from "../../../components/export/diff";
 
 export default function Page({
   _export,
@@ -65,75 +69,11 @@ export default function Page({
           <Row>
             <Col>
               <strong>Profile Properties</strong>
-              <ul>
-                {Object.keys(_export.oldProfileProperties).map((k) => {
-                  return (
-                    <li key={`old-${k}`}>
-                      {k}:{" "}
-                      {_export.oldProfileProperties[k] !==
-                      _export.newProfileProperties[k] ? (
-                        <>
-                          <Badge variant="danger">-</Badge>{" "}
-                          {_export.oldProfileProperties[k]?.toString()}
-                          {_export.newProfileProperties[k] !== null &&
-                          _export.newProfileProperties[k] !== undefined ? (
-                            <>
-                              {" "}
-                              | <Badge variant="success">+</Badge>{" "}
-                              {_export.newProfileProperties[k]?.toString()}
-                            </>
-                          ) : null}
-                        </>
-                      ) : (
-                        _export.oldProfileProperties[k]?.toString()
-                      )}
-                    </li>
-                  );
-                })}
-
-                {Object.keys(_export.newProfileProperties).map((k) =>
-                  _export.oldProfileProperties[k] === undefined ? (
-                    <li key={`old-${k}`}>
-                      {k}: <Badge variant="success">+</Badge>{" "}
-                      {_export.newProfileProperties[k]?.toString()}
-                    </li>
-                  ) : null
-                )}
-              </ul>
+              <ExportProfilePropertiesDiff _export={_export} />
             </Col>
             <Col>
               <strong>Groups</strong>
-              <ul>
-                {_export.oldGroups.map((groupGuid) => {
-                  return (
-                    <li key={`grp-${groupGuid}`}>
-                      {!_export.newGroups.includes(groupGuid) ? (
-                        <Badge variant="danger">-</Badge>
-                      ) : null}{" "}
-                      <Link
-                        href="/group/[guid]/edit"
-                        as={`/group/${getGroupGuid(groupGuid)}/edit`}
-                      >
-                        <a>{groupGuid}</a>
-                      </Link>
-                    </li>
-                  );
-                })}
-
-                {_export.newGroups.map((groupGuid) =>
-                  !_export.oldGroups.includes(groupGuid) ? (
-                    <li key={`grp-${groupGuid}`}>
-                      <Badge variant="success">+</Badge>{" "}
-                      <Link
-                        href="/group/[guid]/edit"
-                        as={`/group/${getGroupGuid(groupGuid)}/edit`}
-                      >
-                        <a>{groupGuid}</a>
-                      </Link>
-                    </li>
-                  ) : null
-                )}
-              </ul>
+              <ExportGroupsDiff _export={_export} groups={groups} />
             </Col>
           </Row>
         </Col>

--- a/core/web/pages/import/[guid]/edit.tsx
+++ b/core/web/pages/import/[guid]/edit.tsx
@@ -1,10 +1,14 @@
 import ImportTabs from "../../../components/tabs/import";
 import Head from "next/head";
 import { useApi } from "../../../hooks/useApi";
-import { Row, Col, Table, Badge, Alert } from "react-bootstrap";
+import { Row, Col, Table, Alert } from "react-bootstrap";
 import Link from "next/link";
 import Moment from "react-moment";
 import { Models } from "../../../utils/apiData";
+import {
+  ImportProfilePropertiesDiff,
+  ImportGroupsDiff,
+} from "../../../components/import/diff";
 
 export default function Page(props) {
   const {
@@ -72,75 +76,11 @@ export default function Page(props) {
           <Row>
             <Col>
               <strong>Profile Properties</strong>
-              <ul>
-                {Object.keys(_import.oldProfileProperties).map((k) => {
-                  return (
-                    <li key={`${_import.guid}-prp-${k}`}>
-                      {k}:{" "}
-                      {JSON.stringify(_import.oldProfileProperties[k]) !==
-                      JSON.stringify(_import.newProfileProperties[k]) ? (
-                        <>
-                          <Badge variant="danger">-</Badge>&nbsp;
-                          {_import.oldProfileProperties[k]?.toString()}
-                          {_import.newProfileProperties[k] !== null &&
-                          _import.newProfileProperties[k] !== undefined ? (
-                            <>
-                              {" "}
-                              | <Badge variant="success">+</Badge>&nbsp;
-                              {_import.newProfileProperties[k].toString()}
-                            </>
-                          ) : null}
-                        </>
-                      ) : (
-                        _import.oldProfileProperties[k]?.toString()
-                      )}
-                    </li>
-                  );
-                })}
-
-                {Object.keys(_import.newProfileProperties).map((k) =>
-                  _import.oldProfileProperties[k] === undefined ? (
-                    <li key={`old-${k}`}>
-                      {k}: <Badge variant="success">+</Badge>{" "}
-                      {_import.newProfileProperties[k]?.toString()}
-                    </li>
-                  ) : null
-                )}
-              </ul>
+              <ImportProfilePropertiesDiff _import={_import} />
             </Col>
             <Col>
               <strong>Groups</strong>
-              <ul>
-                {_import.oldGroupGuids.map((groupGuid) => {
-                  return (
-                    <li key={`grp-${groupGuid}`}>
-                      {!_import.newGroupGuids.includes(groupGuid) ? (
-                        <Badge variant="danger">-</Badge>
-                      ) : null}{" "}
-                      <Link
-                        href="/group/[guid]/edit"
-                        as={`/group/${groupGuid}/edit`}
-                      >
-                        <a>{groupName(groupGuid)}</a>
-                      </Link>
-                    </li>
-                  );
-                })}
-
-                {_import.newGroupGuids.map((groupGuid) =>
-                  !_import.oldGroupGuids.includes(groupGuid) ? (
-                    <li key={`grp-${groupGuid}`}>
-                      <Badge variant="success">+</Badge>{" "}
-                      <Link
-                        href="/group/[guid]/edit"
-                        as={`/group/${groupGuid}/edit`}
-                      >
-                        <a>{groupName(groupGuid)}</a>
-                      </Link>
-                    </li>
-                  ) : null
-                )}
-              </ul>
+              <ImportGroupsDiff _import={_import} groups={groups} />
             </Col>
           </Row>
 


### PR DESCRIPTION
As Profile Properties and Group Memberships change, we show a diff of what happened on each Export and Import.  However, until those Imports and Exports are complete, we shouldn't show the diff, as it's misleading.

<img width="1139" alt="Screen Shot 2020-11-11 at 3 04 50 PM" src="https://user-images.githubusercontent.com/303226/98874516-408d5880-242f-11eb-95ea-b28977fbffa0.png">

Closes T-697
