### PR TITLE
Only allow one task worker when using a SQLite database

### DIFF
--- a/core/api/src/config/sequelize.ts
+++ b/core/api/src/config/sequelize.ts
@@ -59,6 +59,11 @@ export const DEFAULT = {
       storage = host;
       if (!host) host = ":memory:";
       if (process.env.NODE_ENV === "test") storage = `${database}.sqlite`;
+      if (config?.tasks?.maxTaskProcessors > 1) {
+        throw new Error(
+          "Only one task worker can be used with a SQLite database"
+        );
+      }
     }
 
     return {


### PR DESCRIPTION
If you have more than one WORKER enabled, the app will crash with the message `Error: Only one task worker can be used with a SQLite database`.  This is important because SQLite only allows one query at a time.  Having more workers is more likely to result in a deadlock.

Closes T-673