### PR TITLE
Use Setting to configure Event assocation batch size

### DIFF
--- a/core/api/src/initializers/settings.ts
+++ b/core/api/src/initializers/settings.ts
@@ -65,7 +65,7 @@ export class Plugins extends Initializer {
         title: "Runs: Profile Batch Size",
         defaultValue: 100,
         description:
-          "How many Imports should a Run enqueue in each batch before deferring to associate those Imports already enqueued?",
+          "How many Imports and should a Run enqueue in each batch before deferring to associate those Imports already enqueued? Also applies to un-associated Events.",
         type: "number",
       },
       {

--- a/core/api/src/tasks/event/associateProfiles.ts
+++ b/core/api/src/tasks/event/associateProfiles.ts
@@ -1,4 +1,5 @@
 import { Task, task, log } from "actionhero";
+import { plugin } from "../../modules/plugin";
 import { Event } from "../../models/Event";
 
 export class EventsAssociateProfiles extends Task {
@@ -7,36 +8,31 @@ export class EventsAssociateProfiles extends Task {
     this.name = "event:associateProfiles";
     this.description =
       "ensure that events are associated to profiles, even if they were created outside of the Grouparoo API";
-    this.frequency = 60 * 1000;
+    this.frequency = 30 * 1000;
     this.queue = "events";
     this.inputs = {};
   }
 
   async run() {
-    const limit = 1000;
-    let offset = 0;
-    let events: Event[] = [];
+    const limit = parseInt(
+      (await plugin.readSetting("core", "runs-profile-batch-size")).value
+    );
 
-    while (events.length > 0 || offset === 0) {
-      events = await Event.findAll({
-        attributes: ["guid"],
-        where: { profileGuid: null },
-        limit,
-        offset,
-        order: [["createdAt", "asc"]],
+    const events = await Event.findAll({
+      attributes: ["guid"],
+      where: { profileGuid: null },
+      limit,
+      order: [["createdAt", "asc"]],
+    });
+
+    for (const i in events) {
+      await task.enqueue("event:associateProfile", {
+        eventGuid: events[i].guid,
       });
+    }
 
-      for (const i in events) {
-        await task.enqueue("event:associateProfile", {
-          eventGuid: events[i].guid,
-        });
-      }
-
-      if (events.length > 0) {
-        log(`enqueued ${events.length} events for association`);
-      }
-
-      offset = offset + limit;
+    if (events.length > 0) {
+      log(`enqueued ${events.length} events for association`);
     }
   }
 }


### PR DESCRIPTION
Jus like with Runs and Imports, we don't want to enqueue too many Events for association at once - it might blow up your Redis queue.  This PR re-uses the `"core", "runs-profile-batch-size"` setting to limit the number of events considered in one batch (default: 100).

Closes T-735