### PR TITLE
Homepage group chart fixes

### DIFF
--- a/core/api/src/actions/groups.ts
+++ b/core/api/src/actions/groups.ts
@@ -76,13 +76,14 @@ export class GroupsListByNewestMember extends AuthenticatedAction {
 
     const groupGuids = newGroupMembers.map((mem) => mem.groupGuid);
 
-    const groups = await Group.findAll({
-      where: { guid: { [Op.in]: groupGuids } },
-    });
-
-    groups.sort(
-      (a, b) => groupGuids.indexOf(a.guid) - groupGuids.indexOf(b.guid)
-    );
+    let groups = await Group.findAll();
+    groups = groups
+      .sort((a, b) => {
+        if (groupGuids.indexOf(a.guid) < 0) return 1;
+        if (groupGuids.indexOf(b.guid) < 0) return -1;
+        return groupGuids.indexOf(a.guid) - groupGuids.indexOf(b.guid);
+      })
+      .slice(0, params.limit);
 
     const newestMembersAdded: { [guid: string]: number } = {};
     newGroupMembers.forEach((g) => {

--- a/core/api/src/actions/groups.ts
+++ b/core/api/src/actions/groups.ts
@@ -87,10 +87,10 @@ export class GroupsListByNewestMember extends AuthenticatedAction {
 
     const newestMembersAdded: { [guid: string]: number } = {};
     newGroupMembers.forEach((g) => {
-      newestMembersAdded[g.groupGuid] = g
-        // @ts-ignore
-        .getDataValue("newestMemberAdded")
-        .getTime();
+      // @ts-ignore
+      const value: Date | string = g.getDataValue("newestMemberAdded"); // this may be a string if SQLite is used
+      newestMembersAdded[g.groupGuid] =
+        value instanceof Date ? value.getTime() : new Date(value).getTime();
     });
 
     return {

--- a/core/web/components/visualizations/homepageWidgets.tsx
+++ b/core/web/components/visualizations/homepageWidgets.tsx
@@ -127,7 +127,11 @@ export function GroupsByNewestMember({ execApi }) {
                   </td>
                   <td>{group.profilesCount}</td>
                   <td>
-                    <Moment fromNow>{newestMembersAdded[group.guid]}</Moment>
+                    {newestMembersAdded[group.guid] ? (
+                      <Moment fromNow>{newestMembersAdded[group.guid]}</Moment>
+                    ) : (
+                      "No Group Members"
+                    )}
                   </td>
                 </tr>
               );


### PR DESCRIPTION
* Always show N groups, even if they don't have any members
* Display "no members" if there are no group members
* Handle when SQLLite returns newestMemberAdded as a string

Closes T-743