### PR TITLE
Sweep un-associated  profileProperties

### DIFF
--- a/core/api/__tests__/actions/groups.ts
+++ b/core/api/__tests__/actions/groups.ts
@@ -227,7 +227,7 @@ describe("actions/groups", () => {
       });
 
       beforeAll(async () => {
-        await Profile.destroy({ truncate: true });
+        await Profile.truncate();
 
         mario = await Profile.create();
         luigi = await Profile.create();

--- a/core/api/__tests__/actions/profilePropertyRules.ts
+++ b/core/api/__tests__/actions/profilePropertyRules.ts
@@ -25,7 +25,7 @@ describe("actions/profilePropertyRules", () => {
       email: "mario@example.com",
     });
 
-    await ProfilePropertyRule.destroy({ truncate: true });
+    await ProfilePropertyRule.truncate();
 
     source = await helper.factories.source();
     await source.setOptions({ table: "test table" });

--- a/core/api/__tests__/actions/runs.ts
+++ b/core/api/__tests__/actions/runs.ts
@@ -20,7 +20,7 @@ describe("actions/runs", () => {
 
   beforeAll(async () => {
     await helper.factories.profilePropertyRules();
-    await Run.destroy({ truncate: true });
+    await Run.truncate();
 
     await specHelper.runAction("team:initialize", {
       firstName: "Mario",

--- a/core/api/__tests__/actions/settings.ts
+++ b/core/api/__tests__/actions/settings.ts
@@ -29,7 +29,7 @@ describe("actions/settings", () => {
     let guid;
 
     beforeAll(async () => {
-      await Setting.destroy({ truncate: true });
+      await Setting.truncate();
 
       await plugin.registerSetting(
         "testPlugin",

--- a/core/api/__tests__/integration/runs/internalRun.ts
+++ b/core/api/__tests__/integration/runs/internalRun.ts
@@ -40,7 +40,7 @@ describe("integration/runs/internalRun", () => {
       await profile.addOrUpdateProperties({ userId: [1] });
 
       await api.resque.queue.connection.redis.flushdb();
-      await Run.destroy({ truncate: true });
+      await Run.truncate();
 
       rule = await ProfilePropertyRule.create({
         sourceGuid: source.guid,

--- a/core/api/__tests__/models/app.ts
+++ b/core/api/__tests__/models/app.ts
@@ -103,7 +103,7 @@ describe("models/app", () => {
   });
 
   test("the app options will not be logged", async () => {
-    await Log.destroy({ truncate: true });
+    await Log.truncate();
 
     const app = await App.create({
       name: "test log app",

--- a/core/api/__tests__/models/group/calculatedGroup.ts
+++ b/core/api/__tests__/models/group/calculatedGroup.ts
@@ -264,7 +264,7 @@ describe("models/group", () => {
 
       let imports = await Import.findAll();
       expect(imports.length).toBe(2);
-      await Import.destroy({ truncate: true });
+      await Import.truncate();
 
       await group.run(true);
       const foundTasks = await specHelper.findEnqueuedTasks("group:run");
@@ -291,7 +291,7 @@ describe("models/group", () => {
 
       let imports = await Import.findAll();
       expect(imports.length).toBe(2);
-      await Import.destroy({ truncate: true });
+      await Import.truncate();
 
       await group.run(true, "abc123");
       const foundTasks = await specHelper.findEnqueuedTasks("group:run");
@@ -337,7 +337,7 @@ describe("models/group", () => {
     });
 
     test("adding and removing members from a calculated group produces log entries", async () => {
-      await Log.destroy({ truncate: true });
+      await Log.truncate();
 
       await group.update({ matchType: "all" });
       await group.setRules([

--- a/core/api/__tests__/models/profile.ts
+++ b/core/api/__tests__/models/profile.ts
@@ -69,7 +69,7 @@ describe("models/profile", () => {
     let houseRule: ProfilePropertyRule;
 
     beforeAll(async () => {
-      await Profile.destroy({ truncate: true });
+      await Profile.truncate();
 
       source = await helper.factories.source();
       await source.setOptions({ table: "test table" });
@@ -219,7 +219,7 @@ describe("models/profile", () => {
   describe("profile property helpers", () => {
     let profile: Profile;
     beforeAll(async () => {
-      await Profile.destroy({ truncate: true });
+      await Profile.truncate();
     });
 
     test("it cannot add a profile property that is not defined", async () => {
@@ -285,7 +285,7 @@ describe("models/profile", () => {
 
       afterAll(async () => {
         await source.setMapping({});
-        await ProfilePropertyRule.destroy({ truncate: true });
+        await ProfilePropertyRule.truncate();
         await source.destroy();
       });
 
@@ -800,7 +800,7 @@ describe("models/profile", () => {
       await Promise.all(members.map((m) => m.destroy()));
       await group.destroy();
       await source.setMapping({});
-      await ProfilePropertyRule.destroy({ truncate: true });
+      await ProfilePropertyRule.truncate();
       await source.destroy();
       await app.destroy();
     });
@@ -904,9 +904,9 @@ describe("models/profile", () => {
     });
 
     afterAll(async () => {
-      await ProfilePropertyRule.destroy({ truncate: true });
-      await Source.destroy({ truncate: true });
-      await App.destroy({ truncate: true });
+      await ProfilePropertyRule.truncate();
+      await Source.truncate();
+      await App.truncate();
     });
 
     test("it can pull profile properties in from all connected apps", async () => {
@@ -1017,7 +1017,7 @@ describe("models/profile", () => {
     let profileB: Profile;
 
     beforeAll(async () => {
-      await Profile.destroy({ truncate: true });
+      await Profile.truncate();
       await helper.factories.profilePropertyRules();
 
       // create the profiles and events
@@ -1060,9 +1060,9 @@ describe("models/profile", () => {
     });
 
     afterAll(async () => {
-      await ProfilePropertyRule.destroy({ truncate: true });
-      await Source.destroy({ truncate: true });
-      await App.destroy({ truncate: true });
+      await ProfilePropertyRule.truncate();
+      await Source.truncate();
+      await App.truncate();
     });
 
     test("the profiles both have properties and events", async () => {

--- a/core/api/__tests__/models/run.ts
+++ b/core/api/__tests__/models/run.ts
@@ -221,7 +221,7 @@ describe("models/run", () => {
     let profile: Profile;
 
     beforeEach(async () => {
-      Import.destroy({ truncate: true });
+      Import.truncate();
 
       profile = await helper.factories.profile();
 
@@ -311,7 +311,7 @@ describe("models/run", () => {
     let run: Run;
 
     beforeAll(async () => {
-      Import.destroy({ truncate: true });
+      Import.truncate();
 
       run = await Run.create({
         creatorGuid: schedule.guid,

--- a/core/api/__tests__/models/setupStep.ts
+++ b/core/api/__tests__/models/setupStep.ts
@@ -39,7 +39,7 @@ describe("models/setupStep", () => {
 
   test("setup steps have unique keys", async () => {
     await expect(
-      SetupStep.create({ position: 1, key: "create_team" })
+      SetupStep.create({ position: 1, key: "create_a_team" })
     ).rejects.toThrow();
   });
 

--- a/core/api/__tests__/models/setupStep.ts
+++ b/core/api/__tests__/models/setupStep.ts
@@ -59,7 +59,7 @@ describe("models/setupStep", () => {
   });
 
   test("complete checks will remain complete and not check again", async () => {
-    await Team.destroy({ truncate: true });
+    await Team.truncate();
 
     const teamStep = await SetupStep.findOne({
       where: { key: "create_a_team" },

--- a/core/api/__tests__/models/teamMember.ts
+++ b/core/api/__tests__/models/teamMember.ts
@@ -60,7 +60,7 @@ describe("models/teamMember", () => {
   });
 
   test("creating and updating a team member creates a log entry but does not include passwordHash", async () => {
-    await Log.destroy({ truncate: true });
+    await Log.truncate();
 
     const teamMember = await TeamMember.create({
       teamGuid: team.guid,
@@ -77,7 +77,7 @@ describe("models/teamMember", () => {
     expect(createLog.data.email).toBe("luigi@example.com");
     expect(createLog.message).toBe('teamMember "luigi@example.com" created');
 
-    await Log.destroy({ truncate: true });
+    await Log.truncate();
     await teamMember.update({ firstName: "Luigi!" });
 
     let updateNameLog = await Log.findOne({
@@ -89,7 +89,7 @@ describe("models/teamMember", () => {
       'teamMember "luigi@example.com" updated: firstName -> Luigi!'
     );
 
-    await Log.destroy({ truncate: true });
+    await Log.truncate();
     await teamMember.updatePassword("gold-coins");
 
     let updateLog = await Log.findOne({

--- a/core/api/__tests__/modules/codeConfig.ts
+++ b/core/api/__tests__/modules/codeConfig.ts
@@ -325,7 +325,9 @@ describe("modules/codeConfig", () => {
     });
 
     test("all objects will be deleted with an empty config file", async () => {
-      expect(await App.count()).toBe(0);
+      expect(await App.count({ where: { type: { [Op.ne]: "events" } } })).toBe(
+        0
+      );
       expect(await Source.count()).toBe(0);
       expect(await Schedule.count()).toBe(0);
       expect(await Destination.count()).toBe(0);

--- a/core/api/__tests__/modules/internalRun.ts
+++ b/core/api/__tests__/modules/internalRun.ts
@@ -11,7 +11,7 @@ describe("modules/internalRun", () => {
     actionhero = env.actionhero;
     await helper.factories.profilePropertyRules();
     await api.resque.queue.connection.redis.flushdb();
-    await Run.destroy({ truncate: true });
+    await Run.truncate();
   }, helper.setupTime);
 
   afterAll(async () => {

--- a/core/api/__tests__/tasks/group/destroy.ts
+++ b/core/api/__tests__/tasks/group/destroy.ts
@@ -23,14 +23,14 @@ describe("tasks/group:destroy", () => {
 
     beforeEach(async () => {
       await api.resque.queue.connection.redis.flushdb();
-      await Import.destroy({ truncate: true });
+      await Import.truncate();
     });
 
     beforeAll(async () => {
       await helper.factories.profilePropertyRules();
       helper.disableTestPluginImport();
 
-      await Profile.destroy({ truncate: true });
+      await Profile.truncate();
 
       mario = await Profile.create();
       luigi = await Profile.create();
@@ -74,7 +74,7 @@ describe("tasks/group:destroy", () => {
       expect(groupMemberCount).toBe(2);
       _imports = await Import.findAll();
       expect(_imports.length).toBe(2);
-      await Import.destroy({ truncate: true });
+      await Import.truncate();
 
       await task.enqueue("group:destroy", {
         groupGuid: group.guid,

--- a/core/api/__tests__/tasks/group/exportToCSV.ts
+++ b/core/api/__tests__/tasks/group/exportToCSV.ts
@@ -26,14 +26,14 @@ describe("tasks/group:exportToCSV", () => {
 
     beforeEach(async () => {
       await api.resque.queue.connection.redis.flushdb();
-      await Import.destroy({ truncate: true });
+      await Import.truncate();
     });
 
     beforeAll(async () => {
       await helper.factories.profilePropertyRules();
       helper.disableTestPluginImport();
 
-      await Profile.destroy({ truncate: true });
+      await Profile.truncate();
 
       mario = await Profile.create();
       luigi = await Profile.create();

--- a/core/api/__tests__/tasks/group/run.ts
+++ b/core/api/__tests__/tasks/group/run.ts
@@ -27,7 +27,7 @@ describe("tasks/group:run", () => {
 
     beforeEach(async () => {
       await api.resque.queue.connection.redis.flushdb();
-      await Import.destroy({ truncate: true });
+      await Import.truncate();
     });
 
     beforeAll(async () => {
@@ -39,7 +39,7 @@ describe("tasks/group:run", () => {
         type: "calculated",
       });
 
-      await Profile.destroy({ truncate: true });
+      await Profile.truncate();
 
       mario = await Profile.create();
       luigi = await Profile.create();

--- a/core/api/__tests__/tasks/profile/export.ts
+++ b/core/api/__tests__/tasks/profile/export.ts
@@ -144,8 +144,8 @@ describe("tasks/profile:export", () => {
 
       beforeEach(async () => {
         await api.resque.queue.connection.redis.flushdb();
-        await Import.destroy({ truncate: true });
-        await Export.destroy({ truncate: true });
+        await Import.truncate();
+        await Export.truncate();
       });
 
       it("updates the run and imports", async () => {

--- a/core/api/__tests__/tasks/profileProperty/sweep.ts
+++ b/core/api/__tests__/tasks/profileProperty/sweep.ts
@@ -1,0 +1,84 @@
+import { helper } from "@grouparoo/spec-helper";
+import { api, task, specHelper } from "actionhero";
+import { ProfilePropertyRule, ProfileProperty, Profile } from "../../../src";
+
+let actionhero;
+
+describe("tasks/profileProperties:sweep", () => {
+  let emailRule: ProfilePropertyRule;
+  let mario: Profile;
+
+  beforeAll(async () => {
+    const env = await helper.prepareForAPITest();
+    await helper.factories.profilePropertyRules();
+    actionhero = env.actionhero;
+  }, helper.setupTime);
+
+  beforeAll(async () => {
+    emailRule = await ProfilePropertyRule.findOne({ where: { key: "email" } });
+    mario = await helper.factories.profile();
+    await mario.addOrUpdateProperties({
+      firstName: ["Mario"],
+      lastName: ["Mario"],
+      email: ["mario@example.com"],
+    });
+  });
+
+  beforeEach(async () => {
+    await api.resque.queue.connection.redis.flushdb();
+  });
+
+  afterAll(async () => {
+    await helper.shutdown(actionhero);
+  });
+
+  test("a profile property with a missing profile", async () => {
+    const profileProperty = await ProfileProperty.create({
+      profileGuid: "missing",
+      profilePropertyRuleGuid: emailRule.guid,
+      rawValue: "person@example.com",
+      position: 0,
+    });
+
+    await specHelper.runTask("profileProperties:sweep", {});
+
+    await expect(profileProperty.reload()).rejects.toThrow(
+      /does not exist anymore/
+    );
+
+    // other profiles' properties are OK
+    const marioProperties = await mario.properties();
+    expect(marioProperties["email"].values).toEqual(["mario@example.com"]);
+  });
+
+  test("a profile property with a missing profile property rule", async () => {
+    const luigi = await helper.factories.profile();
+    await luigi.addOrUpdateProperties({
+      firstName: ["Luigi"],
+      lastName: ["Mario"],
+      email: ["luigi@example.com"],
+    });
+
+    const profileProperty = await ProfileProperty.create(
+      {
+        guid: "rule_missing",
+        profileGuid: luigi.guid,
+        profilePropertyRuleGuid: "missing",
+        rawValue: "green-hat",
+        position: 0,
+      },
+      //@ts-ignore
+      { hooks: false } // we need to skip validations
+    );
+
+    await specHelper.runTask("profileProperties:sweep", {});
+
+    await expect(profileProperty.reload()).rejects.toThrow(
+      /does not exist anymore/
+    );
+
+    // Luigi's other properties are OK
+    const luigiProperties = await luigi.properties();
+    expect(luigiProperties["email"].values).toEqual(["luigi@example.com"]);
+  });
+});

--- a/core/api/__tests__/tasks/schedule/updateSchedules.ts
+++ b/core/api/__tests__/tasks/schedule/updateSchedules.ts
@@ -13,7 +13,7 @@ describe("tasks/schedule:updateSchedules", () => {
 
   beforeEach(async () => {
     await api.resque.queue.connection.redis.flushdb();
-    await Run.destroy({ truncate: true });
+    await Run.truncate();
   });
 
   afterAll(async () => {

--- a/core/api/__tests__/tasks/sweeper.ts
+++ b/core/api/__tests__/tasks/sweeper.ts
@@ -22,7 +22,7 @@ describe("tasks/sweeper", () => {
   describe("sweeper", () => {
     beforeAll(async () => {
       await helper.factories.profilePropertyRules();
-      await Log.destroy({ truncate: true });
+      await Log.truncate();
     });
 
     test("settings are loaded at boot", async () => {

--- a/core/api/__tests__/tasks/telemetry.ts
+++ b/core/api/__tests__/tasks/telemetry.ts
@@ -26,7 +26,7 @@ describe("tasks/telemetry", () => {
   describe("telemetry", () => {
     beforeAll(async () => {
       await helper.factories.profilePropertyRules();
-      await Log.destroy({ truncate: true });
+      await Log.truncate();
     });
 
     test("settings are loaded at boot", async () => {

--- a/core/api/__tests__/utils/prepareSharedGroupTest.ts
+++ b/core/api/__tests__/utils/prepareSharedGroupTest.ts
@@ -24,7 +24,7 @@ export namespace SharedGroupTests {
       actionhero = env.actionhero;
     }
 
-    await Profile.destroy({ truncate: true });
+    await Profile.truncate();
     await helper.factories.profilePropertyRules();
     helper.disableTestPluginImport();
 
@@ -111,6 +111,6 @@ export namespace SharedGroupTests {
     await Promise.all(members.map((m) => m.destroy()));
     await group.destroy();
     await run.destroy();
-    await Import.destroy({ truncate: true });
+    await Import.truncate();
   }
 }

--- a/core/api/src/actions/cluster.ts
+++ b/core/api/src/actions/cluster.ts
@@ -88,7 +88,7 @@ export class ClusterReset extends AuthenticatedAction {
           models.map((m) => m.update({ state: "draft" }, { hooks: false }))
         );
       } else {
-        await model.destroy({ truncate: true, force: true });
+        await model.truncate();
       }
 
       counts[modelName] = count;

--- a/core/api/src/classes/loggedModel.ts
+++ b/core/api/src/classes/loggedModel.ts
@@ -109,13 +109,20 @@ export abstract class LoggedModel<T> extends Model<T> {
     instance,
     { transaction }: { transaction?: Transaction } = {}
   ) {
+    let message = `${modelName(this)} "${instance.guid}" destroyed`;
+    try {
+      message = await instance.logMessage("destroy");
+    } catch (error) {
+      message += ` (${error})`;
+    }
+
     await Log.create(
       {
         topic: modelName(instance),
         verb: "destroy",
         ownerGuid: instance.guid,
         data: await instance.filteredDataForLogging(),
-        message: await instance.logMessage("destroy"),
+        message,
       },
       { transaction }
     );

--- a/core/api/src/classes/loggedModel.ts
+++ b/core/api/src/classes/loggedModel.ts
@@ -47,13 +47,20 @@ export abstract class LoggedModel<T> extends Model<T> {
     instance,
     { transaction }: { transaction?: Transaction } = {}
   ) {
+    let message = `${modelName(this)} "${instance.guid}" created`;
+    try {
+      message = await instance.logMessage("create");
+    } catch (error) {
+      message += ` (${error})`;
+    }
+
     await Log.create(
       {
         topic: modelName(instance),
         verb: "create",
         ownerGuid: instance.guid,
         data: await instance.filteredDataForLogging(),
-        message: await instance.logMessage("create"),
+        message,
       },
       { transaction }
     );
@@ -61,10 +68,12 @@ export abstract class LoggedModel<T> extends Model<T> {
 
   @AfterCreate
   static async broadcast(instance) {
-    await chatRoom.broadcast({}, `model:${modelName(instance)}`, {
-      model: await instance.apiData(),
-      verb: "create",
-    });
+    try {
+      await chatRoom.broadcast({}, `model:${modelName(instance)}`, {
+        model: await instance.apiData(),
+        verb: "create",
+      });
+    } catch {}
   }
 
   @AfterBulkCreate
@@ -74,13 +83,21 @@ export abstract class LoggedModel<T> extends Model<T> {
   ) {
     for (const i in instances) {
       const instance = instances[i];
+
+      let message = `${modelName(this)} "${instance.guid}" created`;
+      try {
+        message = await instance.logMessage("create");
+      } catch (error) {
+        message += ` (${error})`;
+      }
+
       await Log.create(
         {
           topic: modelName(instance),
           verb: "create",
           ownerGuid: instance.guid,
           data: await instance.filteredDataForLogging(),
-          message: await instance.logMessage("create"),
+          message,
         },
         { transaction }
       );
@@ -92,13 +109,20 @@ export abstract class LoggedModel<T> extends Model<T> {
     instance,
     { transaction }: { transaction?: Transaction } = {}
   ) {
+    let message = `${modelName(this)} "${instance.guid}" updated`;
+    try {
+      message = await instance.logMessage("update");
+    } catch (error) {
+      message += ` (${error})`;
+    }
+
     await Log.create(
       {
         topic: modelName(instance),
         verb: "update",
         ownerGuid: instance.guid,
         data: await instance.filteredDataForLogging(),
-        message: await instance.logMessage("update"),
+        message,
       },
       { transaction }
     );
@@ -132,9 +156,7 @@ export abstract class LoggedModel<T> extends Model<T> {
     let apiData = {};
     try {
       apiData = await this.apiData();
-    } catch (error) {
-      log(error, "error");
-    }
+    } catch {}
 
     config.general.filteredParams.forEach((p) => {
       if (apiData[p]) apiData[p] = "** filtered **";

--- a/core/api/src/classes/retryableTask.ts
+++ b/core/api/src/classes/retryableTask.ts
@@ -1,4 +1,4 @@
-import { Task, config } from "actionhero";
+import { Task, env } from "actionhero";
 
 export abstract class RetryableTask extends Task {
   constructor() {
@@ -7,13 +7,10 @@ export abstract class RetryableTask extends Task {
     this.plugins = ["QueueLock", "Retry"];
     this.pluginOptions = {
       Retry: {
-        retryLimit:
-          config.process.env === "development" || config.process.env === "test"
-            ? 1
-            : 7,
+        retryLimit: env === "development" || env === "test" ? 1 : 7,
         backoffStrategy:
-          config.process.env === "development" || config.process.env === "test"
-            ? [1]
+          env === "development" || env === "test"
+            ? [1000]
             : [
                 1000, // 1 second
                 10 * 1000, // 10 seconds

--- a/core/api/src/modules/ops/profile.ts
+++ b/core/api/src/modules/ops/profile.ts
@@ -43,62 +43,47 @@ export namespace ProfileOps {
     const hash: ProfilePropertyType = {};
 
     for (const i in profileProperties) {
-      try {
-        const rule = rules.find(
-          (r) => r.guid === profileProperties[i].profilePropertyRuleGuid
-        );
-        if (!rule) {
-          await removeOrphanProperties(profile);
-          return properties(profile);
-        }
-
-        const key = rule.key;
-        if (!hash[key]) {
-          hash[key] = {
-            guid: profileProperties[i].profilePropertyRuleGuid,
-            state: profileProperties[i].state,
-            values: [],
-            type: rule.type,
-            unique: rule.unique,
-            isArray: rule.isArray,
-            identifying: rule.identifying,
-            valueChangedAt: profileProperties[i].valueChangedAt,
-            confirmedAt: profileProperties[i].confirmedAt,
-            stateChangedAt: profileProperties[i].stateChangedAt,
-            createdAt: profileProperties[i].createdAt,
-            updatedAt: profileProperties[i].updatedAt,
-          };
-        }
-
-        hash[key].values.push(await profileProperties[i].getValue());
-
-        const timeFields = [
-          "valueChangedAt",
-          "confirmedAt",
-          "stateChangedAt",
-          "createdAt",
-          "updatedAt",
-        ];
-
-        timeFields.forEach((field) => {
-          if (hash[key][field] < profileProperties[i][field]) {
-            hash[key][field] = profileProperties[i][field];
-          }
-        });
-      } catch (error) {
-        if (
-          error
-            .toString()
-            .match(
-              /cached profile property rule not found for this profilePropertyRuleGuid/
-            )
-        ) {
-          // it's ok, we are in the middle of creating or destroying a profile property
-          log(error, "info");
-        } else {
-          throw error;
-        }
+      const rule = rules.find(
+        (r) => r.guid === profileProperties[i].profilePropertyRuleGuid
+      );
+      if (!rule) {
+        await profileProperties[i].destroy();
+        continue;
       }
+
+      const key = rule.key;
+      if (!hash[key]) {
+        hash[key] = {
+          guid: profileProperties[i].profilePropertyRuleGuid,
+          state: profileProperties[i].state,
+          values: [],
+          type: rule.type,
+          unique: rule.unique,
+          isArray: rule.isArray,
+          identifying: rule.identifying,
+          valueChangedAt: profileProperties[i].valueChangedAt,
+          confirmedAt: profileProperties[i].confirmedAt,
+          stateChangedAt: profileProperties[i].stateChangedAt,
+          createdAt: profileProperties[i].createdAt,
+          updatedAt: profileProperties[i].updatedAt,
+        };
+      }
+
+      hash[key].values.push(await profileProperties[i].getValue());
+
+      const timeFields = [
+        "valueChangedAt",
+        "confirmedAt",
+        "stateChangedAt",
+        "createdAt",
+        "updatedAt",
+      ];
+
+      timeFields.forEach((field) => {
+        if (hash[key][field] < profileProperties[i][field]) {
+          hash[key][field] = profileProperties[i][field];
+        }
+      });
     }
 
     return hash;
@@ -307,20 +292,6 @@ export namespace ProfileOps {
     }
 
     return newPropertiesCount;
-  }
-
-  /**
-   * remove any orphan profile properties for this profile
-   */
-  export async function removeOrphanProperties(profile: Profile) {
-    const orphanProperties = await ProfileProperty.findAll({
-      include: [{ model: ProfilePropertyRule, required: false }],
-      where: { profileGuid: profile.guid, "$profilePropertyRule.guid$": null },
-    });
-
-    for (const i in orphanProperties) await orphanProperties[i].destroy();
-
-    return orphanProperties.length;
   }
 
   /**

--- a/core/api/src/tasks/profile/completeImport.ts
+++ b/core/api/src/tasks/profile/completeImport.ts
@@ -76,6 +76,7 @@ export class ProfileCompleteImport extends RetryableTask {
       const newProfileProperties = this.simplifyProfileProperties(
         await profile.properties()
       );
+
       const newGroups = await profile.$get("groups");
       const newGroupGuids = newGroups.map((g) => g.guid);
       const now = new Date();

--- a/core/api/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/api/src/tasks/profileProperty/importProfileProperties.ts
@@ -26,9 +26,10 @@ export class ImportProfileProperties extends RetryableTask {
       where: { guid: { [Op.in]: params.profileGuids } },
       include: [ProfileProperty],
     });
-    const profilePropertyRule = await ProfilePropertyRule.findByGuid(
-      params.profilePropertyRuleGuid
-    );
+    const profilePropertyRule = await ProfilePropertyRule.findOne({
+      where: { guid: params.profilePropertyRuleGuid },
+    });
+    if (!profilePropertyRule) return;
     const source = await profilePropertyRule.$get("source");
 
     const profilesWithDependenciesMet: Profile[] = [];

--- a/core/api/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/api/src/tasks/profileProperty/importProfileProperty.ts
@@ -34,10 +34,11 @@ export class ImportProfileProperty extends RetryableTask {
       });
     }
 
+    const profilePropertyRule = await ProfilePropertyRule.findOne({
+      where: { guid: params.profilePropertyRuleGuid },
+    });
+    if (!profilePropertyRule) return;
     const properties = await profile.properties();
-    const profilePropertyRule = await ProfilePropertyRule.findByGuid(
-      params.profilePropertyRuleGuid
-    );
     const source = await profilePropertyRule.$get("source");
     const dependencies = await ProfilePropertyRuleOps.dependencies(
       profilePropertyRule

--- a/core/api/src/tasks/profileProperty/sweep.ts
+++ b/core/api/src/tasks/profileProperty/sweep.ts
@@ -1,0 +1,56 @@
+import { Task } from "actionhero";
+import { Profile } from "../../models/Profile";
+import { ProfileProperty } from "../../models/ProfileProperty";
+import { ProfilePropertyRule } from "../../models/ProfilePropertyRule";
+import { plugin } from "../../modules/plugin";
+
+export class ProfilePropertySweep extends Task {
+  constructor() {
+    super();
+    this.name = "profileProperties:sweep";
+    this.description =
+      "Double check that all profile properties are removed that don't belong to a profile or profile property rule";
+    this.frequency = 1000 * 30;
+    this.queue = "profileProperties";
+    this.inputs = {};
+  }
+
+  async run() {
+    let count = 0;
+
+    const limit = parseInt(
+      (
+        await plugin.readSetting(
+          "core",
+          "imports-profile-properties-batch-size"
+        )
+      ).value
+    );
+
+    // delete those profile properties who have no profile
+    const profilePropertiesMissingProfile = await ProfileProperty.findAll({
+      include: [{ model: Profile, required: false }],
+      where: { "$profile.guid$": null },
+      limit,
+    });
+
+    // delete those profile properties who have no profile property rule
+    const profilePropertiesMissingRule = await ProfileProperty.findAll({
+      include: [{ model: ProfilePropertyRule, required: false }],
+      where: { "$profilePropertyRule.guid$": null },
+      limit,
+    });
+
+    for (const i in profilePropertiesMissingProfile) {
+      await profilePropertiesMissingProfile[i].destroy();
+    }
+
+    for (const i in profilePropertiesMissingRule) {
+      await profilePropertiesMissingRule[i].destroy();
+    }
+
+    count += profilePropertiesMissingProfile.length;
+    count += profilePropertiesMissingRule.length;
+    return count;
+  }
+}

--- a/core/api/src/tasks/run/internalRun.ts
+++ b/core/api/src/tasks/run/internalRun.ts
@@ -60,7 +60,7 @@ export class RunInternalRun extends Task {
           },
         });
 
-        await property.update({ state: "pending" });
+        await property?.update({ state: "pending" });
         await profile.update({ state: "pending" });
       } else {
         await profile.markPending();
@@ -82,6 +82,7 @@ export class RunInternalRun extends Task {
       where: { guid: params.runGuid },
     });
 
+    if (!run) return;
     if (run.state === "stopped") return;
 
     await run.update(

--- a/core/test.ts
+++ b/core/test.ts
@@ -1,4 +1,0 @@
-// I am an index file to make using specHelper easier from within plugins, i.e.:
-// import { helper } from `@grouparoo/core/test`
-
-export { helper } from "./api/__tests__/utils/specHelper";

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -146,7 +146,7 @@ export namespace helper {
             },
           });
         } else {
-          return model.destroy({ truncate: true, force: true });
+          return model.truncate();
         }
       })
     );


### PR DESCRIPTION
There are rare occurrences when it is possible to leave an un-associated Profile Property around after the deletion of it's parent, either a Profile or Profile Property Rule.  These may occur when an import task is running as a Profile Property Rule is deleted, or a 2 Profiles have been merged.

This PR introduces a new periodic task `profileProperties:sweep` to clean these up.

An alternative approach was attempted using foreign key constraints, but that was not possible (see https://github.com/RobinBuschmann/sequelize-typescript/issues/755 for similar issue)

Closes T-772