### PR TITLE
Code Config for the events App & The Events App is No Longer Created Automatically

### DIFF
--- a/core/api/__tests__/actions/apps.ts
+++ b/core/api/__tests__/actions/apps.ts
@@ -169,9 +169,9 @@ describe("actions/apps", () => {
         connection
       );
       expect(error).toBeUndefined();
-      expect(apps.length).toBe(2); // this app and the events app
+      expect(apps.length).toBe(1);
       expect(apps[0].name).toBe("test app");
-      expect(total).toBe(2);
+      expect(total).toBe(1);
     });
 
     test("an administrator can edit an app", async () => {

--- a/core/api/__tests__/actions/cluster.ts
+++ b/core/api/__tests__/actions/cluster.ts
@@ -73,11 +73,9 @@ describe("actions/cluster", () => {
         expect(counts).toEqual(expect.objectContaining({ Source: 1 }));
       });
 
-      test("only the event app remains, and it has been moved back to draft", async () => {
+      test("there are no apps", async () => {
         const apps = await App.scope(null).findAll();
-        expect(apps.length).toBe(1);
-        expect(apps[0].type).toBe("events");
-        expect(apps[0].state).toBe("draft");
+        expect(apps.length).toBe(0);
       });
 
       test("all the SetupSteps will be set to incomplete", async () => {

--- a/core/api/__tests__/fixtures/codeConfig/changes/config.js
+++ b/core/api/__tests__/fixtures/codeConfig/changes/config.js
@@ -19,6 +19,16 @@ module.exports = async function getConfig() {
     },
 
     {
+      id: "events", // guid -> `app_events`
+      name: "Grouparoo Events",
+      class: "App",
+      type: "events",
+      options: {
+        identifyingProfilePropertyRuleGuid: "rul_user_id",
+      },
+    },
+
+    {
       id: "users_table", // guid -> `src_data_warehouse`
       name: "Users Table",
       class: "Source",

--- a/core/api/__tests__/fixtures/codeConfig/initial/config.js
+++ b/core/api/__tests__/fixtures/codeConfig/initial/config.js
@@ -19,6 +19,16 @@ module.exports = async function getConfig() {
     },
 
     {
+      id: "events", // guid -> `app_events`
+      name: "Grouparoo Events",
+      class: "App",
+      type: "events",
+      options: {
+        identifyingProfilePropertyRuleGuid: "rul_user_id",
+      },
+    },
+
+    {
       id: "users_table", // guid -> `src_data_warehouse`
       name: "Users Table",
       class: "Source",

--- a/core/api/__tests__/integration/events.ts
+++ b/core/api/__tests__/integration/events.ts
@@ -47,6 +47,17 @@ describe("integration/events", () => {
     csrfToken = sessionResponse.csrfToken;
   });
 
+  test("an events app can be created", async () => {
+    connection.params = {
+      csrfToken,
+      type: "events",
+      name: "Grouparoo Events",
+    };
+    const { app, error } = await specHelper.runAction("app:create", connection);
+    expect(error).toBeFalsy();
+    expect(app.type).toBe("events");
+  });
+
   test("the events app is present and can be configured", async () => {
     connection.params = {
       csrfToken,

--- a/core/api/__tests__/integration/events.ts
+++ b/core/api/__tests__/integration/events.ts
@@ -68,7 +68,7 @@ describe("integration/events", () => {
     const { error, app } = await specHelper.runAction("app:edit", connection);
 
     expect(error).toBeUndefined();
-    expect(app.name).toBe("events");
+    expect(app.name).toBe("Grouparoo Events");
     expect(app.state).toBe("ready");
     appGuid = app.guid;
   });
@@ -389,7 +389,7 @@ describe("integration/events", () => {
 
       expect(error).toBeUndefined();
       expect(source.guid).toBeTruthy();
-      expect(source.app.name).toBe("events");
+      expect(source.app.name).toBe("Grouparoo Events");
     });
 
     describe("profilePropertyRules", () => {

--- a/core/api/__tests__/models/app.ts
+++ b/core/api/__tests__/models/app.ts
@@ -293,7 +293,7 @@ describe("models/app", () => {
     test("the events app should be created automatically", async () => {
       eventApp = await App.scope(null).findOne({ where: { type: "events" } });
       expect(eventApp.guid).toBeTruthy();
-      expect(eventApp.name).toBe("events");
+      expect(eventApp.name).toBe("Grouparoo Events");
     });
 
     test("another events app cannot be created", async () => {
@@ -302,12 +302,12 @@ describe("models/app", () => {
           name: "events 2",
           type: "events",
         })
-      ).rejects.toThrow(/cannot create a new events app/);
+      ).rejects.toThrow(/cannot create a new events app, only 1 allowed/);
     });
 
     test("the events app cannot be deleted", async () => {
       await expect(eventApp.destroy()).rejects.toThrow(
-        /this app cannot be deleted/
+        /cannot delete this events app, at least 1 required/
       );
     });
 

--- a/core/api/__tests__/models/app/app.ts
+++ b/core/api/__tests__/models/app/app.ts
@@ -1,8 +1,8 @@
 import { helper } from "@grouparoo/spec-helper";
-import { App } from "./../../src/models/App";
-import { Option } from "./../../src/models/Option";
-import { Log } from "./../../src/models/Log";
-import { plugin } from "./../../src/modules/plugin";
+import { App } from "../../../src/models/App";
+import { Option } from "../../../src/models/Option";
+import { Log } from "../../../src/models/Log";
+import { plugin } from "../../../src/modules/plugin";
 import { api, redis, utils } from "actionhero";
 let actionhero;
 
@@ -280,42 +280,6 @@ describe("models/app", () => {
       // doesn't throw
       await source.destroy();
       await app.destroy();
-    });
-  });
-
-  describe("events app", () => {
-    let eventApp: App;
-
-    beforeAll(async () => {
-      await helper.factories.profilePropertyRules();
-    });
-
-    test("the events app should be created automatically", async () => {
-      eventApp = await App.scope(null).findOne({ where: { type: "events" } });
-      expect(eventApp.guid).toBeTruthy();
-      expect(eventApp.name).toBe("Grouparoo Events");
-    });
-
-    test("another events app cannot be created", async () => {
-      await expect(
-        App.create({
-          name: "events 2",
-          type: "events",
-        })
-      ).rejects.toThrow(/cannot create a new events app, only 1 allowed/);
-    });
-
-    test("the events app cannot be deleted", async () => {
-      await expect(eventApp.destroy()).rejects.toThrow(
-        /cannot delete this events app, at least 1 required/
-      );
-    });
-
-    test("the appOptions for the events app only include unique profile property rules", async () => {
-      const appOptions = await eventApp.appOptions();
-      expect(
-        appOptions.identifyingProfilePropertyRuleGuid.descriptions.sort()
-      ).toEqual(["email", "userId"]);
     });
   });
 

--- a/core/api/__tests__/models/app/eventsApp.ts
+++ b/core/api/__tests__/models/app/eventsApp.ts
@@ -1,0 +1,60 @@
+import { helper } from "@grouparoo/spec-helper";
+import { ProfilePropertyRule } from "../../../src/models/ProfilePropertyRule";
+import { App } from "../../../src/models/App";
+let actionhero;
+
+describe("models/app", () => {
+  beforeAll(async () => {
+    const env = await helper.prepareForAPITest();
+    actionhero = env.actionhero;
+  }, helper.setupTime);
+
+  afterAll(async () => {
+    await helper.shutdown(actionhero);
+  });
+
+  describe("events app", () => {
+    beforeAll(async () => {
+      await helper.factories.profilePropertyRules();
+    });
+
+    test("an events app can be created", async () => {
+      await App.create({ name: "events", type: "events" });
+    });
+
+    test("more than one events app cannot be created", async () => {
+      await expect(
+        App.create({ name: "events 2", type: "events" })
+      ).rejects.toThrow(/cannot create a new events app, only 1 allowed/);
+    });
+
+    test("the appOptions for the events app only include unique profile property rules", async () => {
+      const app = await App.scope(null).findOne({ where: { type: "events" } });
+      const appOptions = await app.appOptions();
+      expect(
+        appOptions.identifyingProfilePropertyRuleGuid.descriptions.sort()
+      ).toEqual(["email", "userId"]);
+    });
+
+    test("the events app tests that there is a valid identifyingProfilePropertyRuleGuid", async () => {
+      const app = await App.scope(null).findOne({ where: { type: "events" } });
+
+      await app.setOptions({ identifyingProfilePropertyRuleGuid: "missing" });
+      expect(await app.test()).toEqual({
+        error: "cannot find identifying profile property rule (missing)",
+        message: undefined,
+        success: false,
+      });
+
+      const rule = await ProfilePropertyRule.findOne({
+        where: { key: "userId" },
+      });
+      await app.setOptions({ identifyingProfilePropertyRuleGuid: rule.guid });
+      expect(await app.test()).toEqual({
+        error: undefined,
+        message: "Events App OK",
+        success: true,
+      });
+    });
+  });
+});

--- a/core/api/__tests__/modules/codeConfig.ts
+++ b/core/api/__tests__/modules/codeConfig.ts
@@ -52,14 +52,24 @@ describe("modules/codeConfig", () => {
 
     test("apps are created", async () => {
       const apps = await App.findAll({
-        where: { type: { [Op.ne]: "events" } },
+        order: [["type", "asc"]],
       });
-      expect(apps.length).toBe(1);
-      expect(apps[0].guid).toBe("app_data_warehouse");
-      expect(apps[0].name).toBe("Data Warehouse");
+      expect(apps.length).toBe(2);
+
+      expect(apps[0].guid).toBe("app_events");
+      expect(apps[0].name).toBe("Grouparoo Events");
       expect(apps[0].state).toBe("ready");
       expect(apps[0].locked).toBe("config:code");
-      const options = await apps[0].getOptions();
+      let options = await apps[0].getOptions();
+      expect(options).toEqual({
+        identifyingProfilePropertyRuleGuid: "rul_user_id",
+      });
+
+      expect(apps[1].guid).toBe("app_data_warehouse");
+      expect(apps[1].name).toBe("Data Warehouse");
+      expect(apps[1].state).toBe("ready");
+      expect(apps[1].locked).toBe("config:code");
+      options = await apps[1].getOptions();
       expect(options).toEqual({ fileGuid: "test-file-path.db" });
     });
 

--- a/core/api/__tests__/tasks/event/associateProfile.ts
+++ b/core/api/__tests__/tasks/event/associateProfile.ts
@@ -17,9 +17,7 @@ describe("tasks/event:associateProfile", () => {
     const userIdRule = await ProfilePropertyRule.findOne({
       where: { key: "userId" },
     });
-    const eventApp = await App.scope(null).findOne({
-      where: { type: "events" },
-    });
+    const eventApp = await App.create({ type: "events", name: "events" });
     await eventApp.setOptions({
       identifyingProfilePropertyRuleGuid: userIdRule.guid,
     });

--- a/core/api/src/actions/apps.ts
+++ b/core/api/src/actions/apps.ts
@@ -59,14 +59,18 @@ export class AppOptions extends AuthenticatedAction {
     const types: Array<{
       name: string;
       maxInstances: number;
+      minInstances: number;
+      addible: boolean;
       options: PluginApp["options"];
       plugin: { name: string; icon: string };
       provides: { source: boolean; destination: boolean };
     }> = [];
 
-    api.plugins.plugins.map((plugin: GrouparooPlugin) => {
+    for (const i in api.plugins.plugins) {
+      const plugin = api.plugins.plugins[i];
       if (plugin.apps) {
-        plugin.apps.map((app) => {
+        for (const j in plugin.apps) {
+          const app = plugin.apps[j];
           const source = api.plugins.plugins.find((p) =>
             p?.connections?.find(
               (c) => c.app === app.name && c.direction === "import"
@@ -83,16 +87,24 @@ export class AppOptions extends AuthenticatedAction {
             ? true
             : false;
 
+          const appsOfThisType = await App.count({ where: { type: app.name } });
+          let addible = true;
+          if (app.maxInstances && app.maxInstances === appsOfThisType) {
+            addible = false;
+          }
+
           types.push({
             name: app.name,
-            addible: app.addible,
+            maxInstances: app.maxInstances,
+            minInstances: app.minInstances,
+            addible,
             options: app.options,
             plugin: { name: plugin.name, icon: plugin.icon },
             provides: { source, destination },
           });
-        });
+        }
       }
-    });
+    }
 
     const environmentVariableOptions = OptionHelper.getEnvironmentVariableOptionsForTopic(
       "app"

--- a/core/api/src/actions/apps.ts
+++ b/core/api/src/actions/apps.ts
@@ -58,7 +58,7 @@ export class AppOptions extends AuthenticatedAction {
   async run() {
     const types: Array<{
       name: string;
-      addible: boolean;
+      maxInstances: number;
       options: PluginApp["options"];
       plugin: { name: string; icon: string };
       provides: { source: boolean; destination: boolean };

--- a/core/api/src/actions/cluster.ts
+++ b/core/api/src/actions/cluster.ts
@@ -77,19 +77,7 @@ export class ClusterReset extends AuthenticatedAction {
       const modelName = model.name;
       const count = await model.count();
 
-      if (model === App) {
-        await model
-          .scope(null)
-          .destroy({ where: { type: { [Op.ne]: "events" } } });
-
-        const models = await model.findAll();
-        await Promise.all(
-          // @ts-ignore
-          models.map((m) => m.update({ state: "draft" }, { hooks: false }))
-        );
-      } else {
-        await model.truncate();
-      }
+      await model.truncate();
 
       counts[modelName] = count;
 

--- a/core/api/src/classes/codeConfig.ts
+++ b/core/api/src/classes/codeConfig.ts
@@ -28,6 +28,12 @@ export interface ConfigurationObject {
   mapping?: { [key: string]: any };
 }
 
+interface orderedConfigObject {
+  configObject: ConfigurationObject;
+  providedIds: string[];
+  prerequisiteIds: string[];
+}
+
 // Utils
 
 export const codeConfigLockKey = "config:code";
@@ -95,25 +101,123 @@ export function extractNonNullParts(
   return cleanedOptions;
 }
 
-export function sortConfigurationObject(
-  a: ConfigurationObject,
-  b: ConfigurationObject
-) {
-  const klass = a.class.toLocaleLowerCase();
-  const otherKlass = b.class.toLocaleLowerCase();
+export function sortConfigurationObject(configObjects: ConfigurationObject[]) {
+  const configObjectsWithIds: orderedConfigObject[] = [];
 
-  const points = {
-    setting: 10,
-    app: 9,
-    source: 8,
-    profilepropertyrule: 7,
-    group: 7,
-    destination: 5,
-    schedule: 4,
-    apikey: 3,
-    team: 2,
-    teammember: 1,
-  };
+  for (const i in configObjects) {
+    const configObject = configObjects[i];
+    const { providedIds, prerequisiteIds } = getParentIds(configObject);
+    configObjectsWithIds.push({
+      configObject,
+      providedIds,
+      prerequisiteIds,
+    });
+  }
 
-  return points[otherKlass] - points[klass];
+  const sortedConfigObjectsWithIds = sortConfigObjectsWithIds(
+    configObjectsWithIds
+  );
+  console.log(sortedConfigObjectsWithIds);
+  return sortedConfigObjectsWithIds.map((o) => o.configObject);
+}
+
+function getParentIds(configObject: ConfigurationObject) {
+  const keys = Object.keys(configObject);
+  const prerequisiteIds: string[] = [];
+  const providedIds: string[] = [];
+
+  providedIds.push(configObject.id);
+
+  // special cases
+  // - Bootstrapped profile property rules
+  if (configObject?.bootstrappedProfilePropertyRule?.id) {
+    providedIds.push(configObject.bootstrappedProfilePropertyRule.id);
+  }
+
+  // prerequisites
+  for (const i in keys) {
+    if (keys[i].match(/.+Id$/)) {
+      prerequisiteIds.push(configObject[keys[i]]);
+    }
+  }
+
+  const objectContainers = ["options"];
+  objectContainers.map((_container) => {
+    if (configObject[_container]) {
+      const containerKeys = Object.keys(configObject[_container]);
+      for (const i in containerKeys) {
+        if (containerKeys[i].match(/.+Id$/)) {
+          prerequisiteIds.push(configObject[_container][containerKeys[i]]);
+        } else if (containerKeys[i].match(/.+Guid$/)) {
+          prerequisiteIds.push(
+            configObject[_container][containerKeys[i]].replace(/^.{3}_/, "")
+          );
+        }
+      }
+    }
+  });
+
+  const arrayContainers = ["rules"];
+  arrayContainers.map((_container) => {
+    for (const i in configObject[_container]) {
+      const record = configObject[_container][i];
+      const recordKeys = Object.keys(record);
+      for (const j in recordKeys) {
+        if (recordKeys[j].match(/.+Id$/)) {
+          prerequisiteIds.push(record[recordKeys[j]]);
+        }
+      }
+    }
+  });
+
+  if (configObject["mapping"]) {
+    const mappingValues = Object.keys(configObject["mapping"]);
+    mappingValues.forEach((v) => {
+      prerequisiteIds.push(v);
+    });
+  }
+
+  return { prerequisiteIds, providedIds };
+}
+
+function sortConfigObjectsWithIds(configObjectsWithIds: orderedConfigObject[]) {
+  const sortedConfigObjectsWithIds: orderedConfigObject[] = [];
+
+  configObjectsWithIds.forEach((c) => {
+    if (sortedConfigObjectsWithIds.length === 0) {
+      sortedConfigObjectsWithIds.push(c);
+    } else if (c.prerequisiteIds.length === 0) {
+      sortedConfigObjectsWithIds.unshift(c);
+    } else {
+      let indexOfLastDependency: number;
+      let indexOfFirstDependent: number;
+
+      sortedConfigObjectsWithIds.forEach((listedConfigObject, idx) => {
+        c.prerequisiteIds.forEach((id) => {
+          if (listedConfigObject.providedIds.includes(id)) {
+            indexOfLastDependency = idx;
+          }
+        });
+
+        c.providedIds.map((id) => {
+          if (
+            !indexOfFirstDependent &&
+            listedConfigObject.prerequisiteIds.includes(id)
+          ) {
+            indexOfFirstDependent = idx;
+          }
+        });
+      });
+
+      if (indexOfLastDependency) {
+        sortedConfigObjectsWithIds.splice(indexOfLastDependency + 1, 0, c);
+      } else if (indexOfFirstDependent) {
+        sortedConfigObjectsWithIds.splice(indexOfFirstDependent, 0, c);
+      } else {
+        sortedConfigObjectsWithIds.push(c);
+      }
+    }
+  });
+
+  return sortedConfigObjectsWithIds;
 }

--- a/core/api/src/classes/codeConfig.ts
+++ b/core/api/src/classes/codeConfig.ts
@@ -117,7 +117,6 @@ export function sortConfigurationObject(configObjects: ConfigurationObject[]) {
   const sortedConfigObjectsWithIds = sortConfigObjectsWithIds(
     configObjectsWithIds
   );
-  console.log(sortedConfigObjectsWithIds);
   return sortedConfigObjectsWithIds.map((o) => o.configObject);
 }
 

--- a/core/api/src/classes/plugin.ts
+++ b/core/api/src/classes/plugin.ts
@@ -43,7 +43,8 @@ export interface GrouparooPlugin {
 export interface PluginApp {
   name: string;
   options: AppOption[];
-  addible?: boolean;
+  minInstances?: number;
+  maxInstances?: number;
   methods: {
     connect?: ConnectPluginAppMethod;
     disconnect?: DisconnectPluginAppMethod;

--- a/core/api/src/initializers/events.ts
+++ b/core/api/src/initializers/events.ts
@@ -40,7 +40,8 @@ export class Events extends Initializer {
                 "The profile property rule which will map to the event field 'userId'.  Only unique profile property rules can be used.",
             },
           ],
-          addible: false,
+          maxInstances: 1,
+          minInstances: 1,
           methods: {
             test: async () => {
               return { success: (await Event.count()) >= 0 };
@@ -405,10 +406,11 @@ async function addEventsApp() {
   let eventsApp = await App.scope(null).findOne({
     where: { type: "events" },
   });
+
   if (!eventsApp) {
     eventsApp = App.build({
       type: "events",
-      name: "events",
+      name: "Grouparoo Events",
       state: "draft",
     });
     App.generateGuid(eventsApp);

--- a/core/api/src/initializers/events.ts
+++ b/core/api/src/initializers/events.ts
@@ -2,11 +2,10 @@
 // This is important to prevent a circular-dependency tree that won't load.
 // You can test this with `npm prepare && npm start` if you change the import statements back to the models.
 
-import { api, Initializer, log } from "actionhero";
+import { api, Initializer } from "actionhero";
 import { ProfilePropertyRule } from "../index";
 import { plugin } from "../modules/plugin";
 import { SourceOptionsMethodResponse } from "../classes/plugin";
-import { App } from "../models/App";
 import { Event } from "../models/Event";
 import { EventData } from "../models/EventData";
 import {
@@ -15,6 +14,7 @@ import {
   PluginConnectionProfilePropertyRuleOption,
   SourceFilterMethod,
   ProfilePropertyPluginMethod,
+  TestPluginMethod,
 } from "./../index";
 
 export class Events extends Initializer {
@@ -41,11 +41,8 @@ export class Events extends Initializer {
             },
           ],
           maxInstances: 1,
-          minInstances: 1,
           methods: {
-            test: async () => {
-              return { success: (await Event.count()) >= 0 };
-            },
+            test: testEventsApp,
             appOptions: async () => {
               const uniqueRules = await ProfilePropertyRule.findAll({
                 where: { unique: true },
@@ -86,10 +83,6 @@ export class Events extends Initializer {
         },
       ],
     });
-  }
-
-  async start() {
-    await addEventsApp();
   }
 }
 
@@ -140,6 +133,19 @@ const eventSourcePreview: SourcePreviewMethod = async ({ sourceOptions }) => {
   }
 
   return eventPreviews;
+};
+
+const testEventsApp: TestPluginMethod = async ({ appOptions }) => {
+  const identifyingProfilePropertyRule = await ProfilePropertyRule.findOne({
+    where: { guid: appOptions.identifyingProfilePropertyRuleGuid },
+  });
+  if (!identifyingProfilePropertyRule) {
+    throw new Error(
+      `cannot find identifying profile property rule (${appOptions.identifyingProfilePropertyRuleGuid})`
+    );
+  }
+
+  return { success: true, message: "Events App OK" };
 };
 
 const eventProfilePropertyRuleOptionOptions = async (args) => {
@@ -401,21 +407,3 @@ const eventProfileProperty: ProfilePropertyPluginMethod = async ({
     }
   }
 };
-
-async function addEventsApp() {
-  let eventsApp = await App.scope(null).findOne({
-    where: { type: "events" },
-  });
-
-  if (!eventsApp) {
-    eventsApp = App.build({
-      type: "events",
-      name: "Grouparoo Events",
-      state: "draft",
-    });
-    App.generateGuid(eventsApp);
-    // @ts-ignore
-    await eventsApp.save({ hooks: false });
-    log(`created events app (${eventsApp.guid})`);
-  }
-}

--- a/core/api/src/models/App.ts
+++ b/core/api/src/models/App.ts
@@ -221,7 +221,7 @@ export class App extends LoggedModel<App> {
     if (
       pluginApp &&
       pluginApp.maxInstances &&
-      pluginApp.maxInstances > count + 1
+      pluginApp.maxInstances < count + 1
     ) {
       throw new Error(
         `cannot create a new ${instance.type} app, only ${pluginApp.maxInstances} allowed`

--- a/core/api/src/models/App.ts
+++ b/core/api/src/models/App.ts
@@ -215,11 +215,16 @@ export class App extends LoggedModel<App> {
   }
 
   @BeforeCreate
-  static async checkAddibleCreate(instance: App) {
+  static async checkMaxInstances(instance: App) {
+    const count = await App.count({ where: { type: instance.type } });
     const { pluginApp } = await instance.getPlugin();
-    if (pluginApp && pluginApp.addible === false) {
+    if (
+      pluginApp &&
+      pluginApp.maxInstances &&
+      pluginApp.maxInstances > count + 1
+    ) {
       throw new Error(
-        `cannot create a new ${instance.type} app, it is not addible`
+        `cannot create a new ${instance.type} app, only ${pluginApp.maxInstances} allowed`
       );
     }
   }
@@ -284,10 +289,17 @@ export class App extends LoggedModel<App> {
   }
 
   @BeforeDestroy
-  static async checkAddibleDestroy(instance: App) {
+  static async checkMinInstances(instance: App) {
+    const count = await App.count({ where: { type: instance.type } });
     const { pluginApp } = await instance.getPlugin();
-    if (pluginApp && pluginApp.addible === false) {
-      throw new Error(`this app cannot be deleted`);
+    if (
+      pluginApp &&
+      pluginApp.minInstances &&
+      pluginApp.minInstances > count - 1
+    ) {
+      throw new Error(
+        `cannot delete this ${instance.type} app, at least ${pluginApp.minInstances} required`
+      );
     }
   }
 

--- a/core/api/src/models/App.ts
+++ b/core/api/src/models/App.ts
@@ -216,7 +216,9 @@ export class App extends LoggedModel<App> {
 
   @BeforeCreate
   static async checkMaxInstances(instance: App) {
-    const count = await App.count({ where: { type: instance.type } });
+    const count = await App.scope(null).count({
+      where: { type: instance.type },
+    });
     const { pluginApp } = await instance.getPlugin();
     if (
       pluginApp &&
@@ -290,7 +292,9 @@ export class App extends LoggedModel<App> {
 
   @BeforeDestroy
   static async checkMinInstances(instance: App) {
-    const count = await App.count({ where: { type: instance.type } });
+    const count = await App.scope(null).count({
+      where: { type: instance.type },
+    });
     const { pluginApp } = await instance.getPlugin();
     if (
       pluginApp &&

--- a/core/api/src/models/DestinationGroupMembership.ts
+++ b/core/api/src/models/DestinationGroupMembership.ts
@@ -62,7 +62,7 @@ export class DestinationGroupMembership extends LoggedModel<DestinationGroupMemb
     instance: DestinationGroupMembership,
     { transaction }: { transaction?: Transaction } = {}
   ) {
-    const existing = await DestinationGroupMembership.findOne({
+    const existing = await DestinationGroupMembership.scope(null).findOne({
       where: {
         guid: { [Op.ne]: instance.guid },
         destinationGuid: instance.destinationGuid,
@@ -82,7 +82,7 @@ export class DestinationGroupMembership extends LoggedModel<DestinationGroupMemb
     instance: DestinationGroupMembership,
     { transaction }: { transaction?: Transaction } = {}
   ) {
-    const existing = await DestinationGroupMembership.findOne({
+    const existing = await DestinationGroupMembership.scope(null).findOne({
       where: {
         guid: { [Op.ne]: instance.guid },
         destinationGuid: instance.destinationGuid,

--- a/core/api/src/models/GroupMember.ts
+++ b/core/api/src/models/GroupMember.ts
@@ -82,7 +82,7 @@ export class GroupMember extends Model<GroupMember> {
     instance: GroupMember,
     { transaction }: { transaction?: Transaction } = {}
   ) {
-    const existing = await GroupMember.findOne({
+    const existing = await GroupMember.scope(null).findOne({
       where: {
         guid: { [Op.ne]: instance.guid },
         profileGuid: instance.profileGuid,

--- a/core/api/src/models/Mapping.ts
+++ b/core/api/src/models/Mapping.ts
@@ -73,7 +73,7 @@ export class Mapping extends LoggedModel<Mapping> {
     instance: Mapping,
     { transaction }: { transaction?: Transaction } = {}
   ) {
-    const existing = await Mapping.findOne({
+    const existing = await Mapping.scope(null).findOne({
       where: {
         guid: { [Op.ne]: instance.guid },
         ownerGuid: instance.ownerGuid,
@@ -93,7 +93,7 @@ export class Mapping extends LoggedModel<Mapping> {
     instance: Mapping,
     { transaction }: { transaction?: Transaction } = {}
   ) {
-    const existing = await Mapping.findOne({
+    const existing = await Mapping.scope(null).findOne({
       where: {
         guid: { [Op.ne]: instance.guid },
         ownerGuid: instance.ownerGuid,

--- a/core/api/src/models/Option.ts
+++ b/core/api/src/models/Option.ts
@@ -69,7 +69,7 @@ export class Option extends LoggedModel<Option> {
     instance: Option,
     { transaction }: { transaction?: Transaction } = {}
   ) {
-    const existing = await Option.findOne({
+    const existing = await Option.scope(null).findOne({
       where: {
         guid: { [Op.ne]: instance.guid },
         ownerGuid: instance.ownerGuid,

--- a/core/api/src/models/Permission.ts
+++ b/core/api/src/models/Permission.ts
@@ -103,7 +103,7 @@ export class Permission extends LoggedModel<Permission> {
     instance: Permission,
     { transaction }: { transaction?: Transaction } = {}
   ) {
-    const existing = await Permission.findOne({
+    const existing = await Permission.scope(null).findOne({
       where: {
         guid: { [Op.ne]: instance.guid },
         ownerGuid: instance.ownerGuid,

--- a/core/api/src/models/ProfileProperty.ts
+++ b/core/api/src/models/ProfileProperty.ts
@@ -185,7 +185,7 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
     instance: ProfileProperty,
     { transaction }: { transaction?: Transaction } = {}
   ) {
-    const existing = await ProfileProperty.findOne({
+    const existing = await ProfileProperty.scope(null).findOne({
       where: {
         guid: { [Op.ne]: instance.guid },
         profileGuid: instance.profileGuid,

--- a/core/api/src/models/Setting.ts
+++ b/core/api/src/models/Setting.ts
@@ -105,7 +105,7 @@ export class Setting extends LoggedModel<Setting> {
     instance: Setting,
     { transaction }: { transaction?: Transaction } = {}
   ) {
-    const existing = await Setting.findOne({
+    const existing = await Setting.scope(null).findOne({
       where: {
         guid: { [Op.ne]: instance.guid },
         pluginName: instance.pluginName,

--- a/core/api/src/modules/configLoaders/all.ts
+++ b/core/api/src/modules/configLoaders/all.ts
@@ -42,7 +42,8 @@ export async function loadConfigDirectory(configDir: string) {
   }
 
   if (configFiles.length > 0) {
-    const seenGuids = await processConfigObjects(configObjects);
+    const sortedConfigObjects = sortConfigurationObject(configObjects);
+    const seenGuids = await processConfigObjects(sortedConfigObjects);
     await deleteLockedObjects(seenGuids);
   }
 }
@@ -77,10 +78,8 @@ async function processConfigObjects(configObjects: Array<ConfigurationObject>) {
     teammember: [],
   };
 
-  const sortedConfigObjects = configObjects.sort(sortConfigurationObject);
-
-  for (const i in sortedConfigObjects) {
-    const configObject = sortedConfigObjects[i];
+  for (const i in configObjects) {
+    const configObject = configObjects[i];
     if (Object.keys(configObject).length === 0) continue;
     let klass = configObject?.class?.toLocaleLowerCase();
     let object;

--- a/core/api/src/modules/configLoaders/all.ts
+++ b/core/api/src/modules/configLoaders/all.ts
@@ -81,7 +81,8 @@ async function processConfigObjects(configObjects: Array<ConfigurationObject>) {
 
   for (const i in sortedConfigObjects) {
     const configObject = sortedConfigObjects[i];
-    let klass = configObject.class.toLocaleLowerCase();
+    if (Object.keys(configObject).length === 0) continue;
+    let klass = configObject?.class?.toLocaleLowerCase();
     let object;
     try {
       switch (klass) {

--- a/core/api/src/modules/configLoaders/all.ts
+++ b/core/api/src/modules/configLoaders/all.ts
@@ -55,7 +55,11 @@ async function loadConfigFile(file: string): Promise<ConfigurationObject> {
     payload = require(file);
   }
 
-  if (Object.keys(payload) === ["default"]) payload = payload.default;
+  const payloadKeys = Object.keys(payload);
+  if (payloadKeys.length === 1 && payloadKeys[0] === "default") {
+    payload = payload.default;
+  }
+
   if (typeof payload === "function") payload = await payload(config);
   return payload;
 }

--- a/core/api/src/modules/configLoaders/all.ts
+++ b/core/api/src/modules/configLoaders/all.ts
@@ -55,6 +55,7 @@ async function loadConfigFile(file: string): Promise<ConfigurationObject> {
     payload = require(file);
   }
 
+  if (Object.keys(payload) === ["default"]) payload = payload.default;
   if (typeof payload === "function") payload = await payload(config);
   return payload;
 }

--- a/plugins/@grouparoo/demo/config/events/pageviews.json
+++ b/plugins/@grouparoo/demo/config/events/pageviews.json
@@ -1,5 +1,14 @@
 [
   {
+    "id": "events",
+    "name": "Grouparoo Events",
+    "class": "App",
+    "type": "events",
+    "options": {
+      "identifyingProfilePropertyRuleGuid": "rul_user_id"
+    }
+  },
+  {
     "id": "event_pageviews",
     "name": "Pageview Events",
     "class": "Source",

--- a/plugins/@grouparoo/demo/src/bin/grouparoo/demo/dataPurchases.ts
+++ b/plugins/@grouparoo/demo/src/bin/grouparoo/demo/dataPurchases.ts
@@ -2,7 +2,7 @@ import { CLI, log } from "actionhero";
 import { users, purchases } from "../../../sample_data";
 import { loadConfigFiles } from "../../../configFiles";
 import { groups } from "../../../groups";
-import { events, enableEventsApp } from "../../../events";
+import { events } from "../../../events";
 import { init, finalize } from "../../../util/shared";
 
 export class Console extends CLI {
@@ -22,12 +22,11 @@ export class Console extends CLI {
       log(`Using scale = ${params.scale}`);
     }
     await init({ reset: true });
-    await loadConfigFiles("setup");
-    await loadConfigFiles("purchases");
     await users({ scale });
     await purchases({ scale });
-    await enableEventsApp();
     await events({ scale });
+    await loadConfigFiles("setup");
+    await loadConfigFiles("purchases");
     await loadConfigFiles("events");
     await groups();
     await finalize();

--- a/plugins/@grouparoo/demo/src/events.ts
+++ b/plugins/@grouparoo/demo/src/events.ts
@@ -1,8 +1,5 @@
-import { runAction } from "./util/runAction";
 import { MockSession, getApiKey } from "./util/MockSession";
-import { App, ProfilePropertyRule } from "@grouparoo/core";
 import { getPurchaseCategories, getPurchases } from "./sample_data";
-import { log } from "./util/shared";
 
 interface DataOptions {
   scale?: number;
@@ -44,57 +41,4 @@ async function generatePurchaseEvents(purchases, apiKey) {
     );
     await session.run();
   }
-}
-
-const EVENTS_GUID = "app_events";
-// mostly copied from initializer/events.ts
-async function addEventsApp() {
-  let eventsApp = await App.scope(null).findOne({
-    where: {
-      type: "events",
-      guid: EVENTS_GUID,
-    },
-  });
-  if (!eventsApp) {
-    eventsApp = App.build({
-      type: "events",
-      name: "Events",
-      state: "draft",
-    });
-    eventsApp.guid = EVENTS_GUID;
-
-    // @ts-ignore
-    await eventsApp.save({ hooks: false });
-    log(1, `created events app (${eventsApp.guid})`);
-  }
-}
-
-export async function enableEventsApp() {
-  await addEventsApp();
-  const where = { guid: EVENTS_GUID };
-  const found = await App.scope(null).findOne({ where });
-  if (!found) {
-    throw new Error(`Events App not found!`);
-  }
-
-  const ruleGuid = await findIdentifyingRuleGuid();
-
-  const params = {
-    guid: found.guid,
-    state: "ready",
-    options: { identifyingProfilePropertyRuleGuid: ruleGuid },
-  };
-
-  await runAction("app:edit", params);
-
-  return found.reload();
-}
-
-async function findIdentifyingRuleGuid() {
-  const where = { key: "userId" };
-  const found = await ProfilePropertyRule.findOne({ where });
-  if (!found) {
-    throw new Error(`Identifying rule not found: ${where.key}`);
-  }
-  return found.guid;
 }

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -140,15 +140,7 @@ export namespace helper {
   export async function truncate() {
     await Promise.all(
       models.map(async (model) => {
-        if (model === App) {
-          return model.scope(null).destroy({
-            where: {
-              type: { [Op.ne]: "events" },
-            },
-          });
-        } else {
-          return model.truncate();
-        }
+        return model.truncate();
       })
     );
 


### PR DESCRIPTION
This PR adds the optional `minInstances` and `maxInstances` for a Grouparoo Plugin's App.  The `events` App definition now has `minInstances  =  0` and `maxInstances =  1`.  

The Event App is no longer created automatically.  Either CodeConfig can create the app, or you can via the UI/API, whichever comes first. 

This PR also enhances the order in which we attempt to load code-config objects.  We order every object against the prerequisite Ids requires against the other objects and what they provide (see https://github.com/grouparoo/grouparoo/pull/1040/commits/a6239547b85c8677195991b5aae610a5e97c4ef4 for more info)

Closes T-765
Closes T-813
Closes T-809
Closes T-811
Closes T-761