### PR TITLE
Fix Locked string migration (#000054)

### DIFF
--- a/core/api/src/migrations/000054-lockedString.ts
+++ b/core/api/src/migrations/000054-lockedString.ts
@@ -23,16 +23,19 @@ module.exports = {
       });
       if (table !== "teams") {
         await migration.sequelize.query(
-          `UPDATE "${table}" SET locked='config:code' where locked IS NOT NULL`
+          `UPDATE "${table}" SET locked='config:code' WHERE (locked = '1' OR locked = 'true')`
         );
       } else {
         await migration.sequelize.query(
-          `UPDATE "${table}" SET locked='team:initialize' where locked IS NOT NULL and name = 'Administrators' and "permissionAllWrite" = true and "permissionAllRead" = true`
+          `UPDATE "${table}" SET locked='team:initialize' WHERE (locked = '1' OR locked = 'true') AND name = 'Administrators' AND "permissionAllWrite" = true AND "permissionAllRead" = true`
         );
         await migration.sequelize.query(
-          `UPDATE "${table}" SET locked='config:code' where locked IS NOT NULL and name != 'Administrators'`
+          `UPDATE "${table}" SET locked='config:code' WHERE (locked = '1' OR locked = 'true') AND name != 'Administrators'`
         );
       }
+      await migration.sequelize.query(
+        `UPDATE "${table}" SET locked=NULL WHERE (locked = '0' OR locked = 'false')`
+      );
     }
   },
 


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/grouparoo/grouparoo/pull/1039 which improperly migrated all models which could be configured by code (Apps, Groups, Profile Property Rules, etc) to be "locked" by `code:config`.

<img width="1392" alt="Screen Shot 2020-12-02 at 2 02 33 PM" src="https://user-images.githubusercontent.com/303226/100937013-377c2e00-34a7-11eb-8328-1563124fd915.png">

<img width="1392" alt="Screen Shot 2020-12-02 at 2 02 47 PM" src="https://user-images.githubusercontent.com/303226/100937020-39de8800-34a7-11eb-9c72-4f09cbafe9ca.png">

Closes T-825

