### PR TITLE
Code Config Logic Updates

### DIFF
--- a/core/api/__tests__/actions/profilePropertyRules.ts
+++ b/core/api/__tests__/actions/profilePropertyRules.ts
@@ -255,6 +255,19 @@ describe("actions/profilePropertyRules", () => {
       expect(error.message).toMatch("column is required");
     });
 
+    test("a rule can be made identifying", async () => {
+      connection.params = {
+        csrfToken,
+        guid,
+      };
+      const { error, profilePropertyRule } = await specHelper.runAction(
+        "profilePropertyRule:makeIdentifying",
+        connection
+      );
+      expect(error).toBeFalsy();
+      expect(profilePropertyRule.identifying).toEqual(true);
+    });
+
     test("an administrator can list all the profilePropertyRules with examples", async () => {
       const profile = await helper.factories.profile();
       await profile.addOrUpdateProperties({ email: ["person@example.com"] });

--- a/core/api/__tests__/fixtures/codeConfig/empty/config.js
+++ b/core/api/__tests__/fixtures/codeConfig/empty/config.js
@@ -1,11 +1,1 @@
-module.exports = async function getConfig() {
-  return [
-    {
-      id: "setting_cluster_name", // this is actually ignored
-      class: "Setting",
-      pluginName: "core",
-      key: "cluster-name",
-      value: "Test Cluster!!!",
-    },
-  ];
-};
+exports.default = [];

--- a/core/api/__tests__/fixtures/codeConfig/partially-empty/config.js
+++ b/core/api/__tests__/fixtures/codeConfig/partially-empty/config.js
@@ -1,0 +1,57 @@
+module.exports = async function getConfig() {
+  return [
+    {
+      id: "setting_cluster_name", // this is actually ignored
+      class: "Setting",
+      pluginName: "core",
+      key: "cluster-name",
+      value: "Test Cluster",
+    },
+
+    {
+      id: "data_warehouse", // guid -> `app_data_warehouse`
+      name: "Data Warehouse",
+      class: "App",
+      type: "test-plugin-app",
+      options: {
+        fileGuid: "test-file-path.db",
+      },
+    },
+
+    {
+      id: "users_table", // guid -> `src_data_warehouse`
+      name: "Users Table",
+      class: "Source",
+      type: "test-plugin-import",
+      appId: "data_warehouse", // appGuid -> `app_data_warehouse`
+      options: {
+        table: "users",
+      },
+      mapping: {
+        id: "user_id",
+      },
+      bootstrappedProfilePropertyRule: {
+        name: "User Id",
+        type: "integer",
+        id: "user_id", // guid -> `rul_user_id`
+        options: {
+          column: "id",
+        },
+      },
+    },
+
+    {
+      id: "email", // guid -> `rul_email`
+      name: "email",
+      class: "ProfilePropertyRule",
+      type: "email",
+      unique: true,
+      isArray: false,
+      sourceId: "users_table", // sourceGuid -> `src_users_table`
+      options: {
+        column: "email",
+      },
+      filters: [],
+    },
+  ];
+};

--- a/core/api/__tests__/models/group/calculatedGroup.ts
+++ b/core/api/__tests__/models/group/calculatedGroup.ts
@@ -467,6 +467,25 @@ describe("models/group", () => {
 
         expect(group.fromConvenientRules(convenientRules)).toEqual(rules);
       });
+
+      test("convenientRules work with rulesAreEqual", async () => {
+        await group.setRules(
+          group.fromConvenientRules([
+            { key: "firstName", operation: { op: "exists" } },
+          ])
+        );
+        const rules = await group.getRules();
+
+        expect(
+          GroupOps.rulesAreEqual(rules, [
+            {
+              key: "firstName",
+              operation: { op: "ne" },
+              match: "null",
+            },
+          ])
+        ).toBe(true);
+      });
     });
 
     describe("#updateProfileMembership", () => {

--- a/core/api/__tests__/models/group/calculatedGroup.ts
+++ b/core/api/__tests__/models/group/calculatedGroup.ts
@@ -57,6 +57,16 @@ describe("models/group", () => {
       expect(group.state).toBe("draft");
     });
 
+    test("setting rules outside of the dictionary will fail", async () => {
+      await expect(
+        group.setRules([
+          { key: "firstName", match: "nobody", operation: { op: "wacky" } },
+        ])
+      ).rejects.toThrow(
+        /invalid group rule operation "wacky" for profile property rule of type string/
+      );
+    });
+
     test("changing group rules changes the state to initializing and enquires a run, and then back to ready when complete", async () => {
       await api.resque.queue.connection.redis.flushdb();
 

--- a/core/api/__tests__/models/profilePropertyRules/profilePropertyRule.ts
+++ b/core/api/__tests__/models/profilePropertyRules/profilePropertyRule.ts
@@ -204,6 +204,19 @@ describe("models/profilePropertyRule", () => {
         })
       ).rejects.toThrow(/only one profile property rule can be identifying/);
     });
+
+    test("the identifying rule can be changed", async () => {
+      const rule = await ProfilePropertyRule.create({
+        key: "New Rule",
+        type: "string",
+        sourceGuid: source.guid,
+      });
+      expect(rule.identifying).toBe(false);
+
+      await rule.makeIdentifying();
+      expect(rule.identifying).toBe(true);
+      await rule.destroy();
+    });
   });
 
   test("updating a profile property rule with new options enqueued an internalRun and update groups relying on it", async () => {

--- a/core/api/__tests__/modules/codeConfig.ts
+++ b/core/api/__tests__/modules/codeConfig.ts
@@ -14,6 +14,7 @@ import path from "path";
 import { api } from "actionhero";
 import { Op } from "sequelize";
 import { CodeConfig } from "../../src/initializers/codeConfig";
+import { validateConfigObjectKeys } from "../../src/classes/codeConfig";
 
 let actionhero;
 const initializer = new CodeConfig();
@@ -442,6 +443,46 @@ describe("modules/codeConfig", () => {
           /TeamMember.firstName cannot be null/
         );
       });
+    });
+  });
+
+  describe("validations", () => {
+    test("id is always required", async () => {
+      const configObject = {
+        name: "Marketing Team",
+        class: "team",
+      };
+
+      expect(() => validateConfigObjectKeys(Team, configObject)).toThrow(
+        /id is required for a Team/
+      );
+    });
+
+    test("extraneous keys throw an error", async () => {
+      const configObject = {
+        id: "marketing_team",
+        name: "Marketing Team",
+        class: "team",
+        cool: true,
+      };
+
+      expect(() => validateConfigObjectKeys(Team, configObject)).toThrow(
+        /cool is not a valid property of a Team/
+      );
+    });
+
+    test("multiple errors can be returned", async () => {
+      const configObject = {
+        id: "marketing_team",
+        name: "Marketing Team",
+        class: "team",
+        cool: true,
+        thing: "stuff",
+      };
+
+      expect(() => validateConfigObjectKeys(Team, configObject)).toThrow(
+        /cool is not a valid property of a Team, thing is not a valid property of a Team/
+      );
     });
   });
 });

--- a/core/api/src/actions/profilePropertyRules.ts
+++ b/core/api/src/actions/profilePropertyRules.ts
@@ -137,7 +137,6 @@ export class ProfilePropertyRuleCreate extends AuthenticatedAction {
       type: { required: true },
       unique: { required: false },
       isArray: { required: false },
-      identifying: { required: false },
       state: { required: false },
       sourceGuid: { required: false },
       options: { required: false },
@@ -151,7 +150,6 @@ export class ProfilePropertyRuleCreate extends AuthenticatedAction {
       type: params.type,
       unique: params.unique,
       isArray: params.isArray,
-      identifying: params.identifying,
       sourceGuid: params.sourceGuid,
     });
 
@@ -182,7 +180,6 @@ export class ProfilePropertyRuleEdit extends AuthenticatedAction {
       type: { required: false },
       unique: { required: false },
       isArray: { required: false },
-      identifying: { required: false },
       state: { required: false },
       sourceGuid: { required: false },
       options: { required: false },
@@ -207,6 +204,27 @@ export class ProfilePropertyRuleEdit extends AuthenticatedAction {
       pluginOptions: await profilePropertyRule.pluginOptions(),
       source: source.apiData(),
     };
+  }
+}
+
+export class ProfilePropertyRuleMakeIdentifying extends AuthenticatedAction {
+  constructor() {
+    super();
+    this.name = "profilePropertyRule:makeIdentifying";
+    this.description = "make a profilePropertyRule identifying for the cluster";
+    this.outputExample = {};
+    this.permission = { topic: "profilePropertyRule", mode: "write" };
+    this.inputs = {
+      guid: { required: true },
+    };
+  }
+
+  async run({ params }) {
+    const profilePropertyRule = await ProfilePropertyRule.findByGuid(
+      params.guid
+    );
+    await profilePropertyRule.makeIdentifying();
+    return { profilePropertyRule: await profilePropertyRule.apiData() };
   }
 }
 

--- a/core/api/src/classes/codeConfig.ts
+++ b/core/api/src/classes/codeConfig.ts
@@ -53,7 +53,7 @@ export async function getParentByName(model: any, id: string) {
   return instance;
 }
 
-export async function validateAndFormatGuid(model, id: string) {
+export async function validateAndFormatGuid(model: any, id: string) {
   if (!id) throw new Error("id is required");
   let guid = `${id}`;
 
@@ -73,6 +73,41 @@ export async function validateAndFormatGuid(model, id: string) {
   }
 
   return guid;
+}
+
+export function validateConfigObjectKeys(
+  model: any,
+  configObject,
+  additionalAllowedKeys: string[] = []
+) {
+  const errors: string[] = [];
+  const modelKeys = Object.keys(model.rawAttributes).concat(
+    additionalAllowedKeys
+  );
+  let idFound = false;
+  const configKeys = Object.keys(configObject)
+    .filter((k) => k !== "class")
+    .filter((k) => typeof configObject[k] !== "object")
+    .map((k) => {
+      if (k === "id") {
+        idFound = true;
+        return "guid";
+      } else if (k.match(/.+Id$/)) {
+        return k.replace(/Id$/, "Guid");
+      } else {
+        return k;
+      }
+    });
+
+  if (!idFound) errors.push(`id is required for a ${model.name}`);
+
+  configKeys.forEach((k) => {
+    if (!modelKeys.includes(k)) {
+      errors.push(`${k} is not a valid property of a ${model.name}`);
+    }
+  });
+
+  if (errors.length > 0) throw new Error(errors.join(", "));
 }
 
 export function logModel(instance, mode: "created" | "updated" | "deleted") {

--- a/core/api/src/classes/codeConfig.ts
+++ b/core/api/src/classes/codeConfig.ts
@@ -214,6 +214,15 @@ function getParentIds(configObject: ConfigurationObject) {
     });
   }
 
+  if (configObject["destinationGroupMemberships"]) {
+    const groupIds: string[] = Object.values(
+      configObject["destinationGroupMemberships"]
+    );
+    groupIds.forEach((v) => {
+      prerequisiteIds.push(v);
+    });
+  }
+
   return { prerequisiteIds, providedIds };
 }
 

--- a/core/api/src/config/routes.ts
+++ b/core/api/src/config/routes.ts
@@ -117,6 +117,7 @@ export const DEFAULT = {
         { path: "/v:apiVersion/profile/:guid", action: "profile:edit" },
         { path: "/v:apiVersion/profiles/importAndUpdate", action: "profiles:importAndUpdate" },
         { path: "/v:apiVersion/profilePropertyRule/:guid", action: "profilePropertyRule:edit" },
+        { path: "/v:apiVersion/profilePropertyRule/:guid/makeIdentifying", action: "profilePropertyRule:makeIdentifying" },
         { path: "/v:apiVersion/account", action: "account:edit" },
         { path: "/v:apiVersion/setting/:guid", action: "setting:edit" },
         { path: "/v:apiVersion/app/:guid/test", action: "app:test" },

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -234,6 +234,15 @@ export class Group extends LoggedModel<Group> {
           throw new Error(`cannot find Profile Property Rule ${key}`);
         }
 
+        const dictionaryEntries = ProfilePropertyRuleOpsDictionary[
+          profilePropertyRule.type
+        ].filter((operation) => operation.op === rule.operation.op);
+        if (!dictionaryEntries || dictionaryEntries.length === 0) {
+          throw new Error(
+            `invalid group rule operation "${rule.operation.op}" for profile property rule of type ${profilePropertyRule.type}`
+          );
+        }
+
         await GroupRule.create(
           {
             position: parseInt(i) + 1,

--- a/core/api/src/models/Group.ts
+++ b/core/api/src/models/Group.ts
@@ -173,18 +173,17 @@ export class Group extends LoggedModel<Group> {
       const profilePropertyRule = await rule.$get("profilePropertyRule");
       const type = profilePropertyRule
         ? profilePropertyRule.type
-        : TopLevelGroupRules.filter(
-            (tlgr) => tlgr.key === rule.profileColumn
-          )[0].type;
+        : TopLevelGroupRules.find((tlgr) => tlgr.key === rule.profileColumn)
+            .type;
       rulesWithKey.push({
         key: profilePropertyRule ? profilePropertyRule.key : rule.profileColumn,
         topLevel: profilePropertyRule ? false : true,
         type: type,
         operation: {
           op: rule.op,
-          description: ProfilePropertyRuleOpsDictionary[type].filter(
+          description: ProfilePropertyRuleOpsDictionary[type].find(
             (operation) => operation.op === rule.op
-          )[0].description,
+          ).description,
         },
         match: rule.match,
         relativeMatchNumber: rule.relativeMatchNumber,
@@ -234,9 +233,16 @@ export class Group extends LoggedModel<Group> {
           throw new Error(`cannot find Profile Property Rule ${key}`);
         }
 
-        const dictionaryEntries = ProfilePropertyRuleOpsDictionary[
-          profilePropertyRule.type
-        ].filter((operation) => operation.op === rule.operation.op);
+        let type = profilePropertyRule?.type;
+        if (topLevelRuleKeys.includes(key)) {
+          type = TopLevelGroupRules.find((tlgr) => tlgr.key === key).type as
+            | "string"
+            | "date";
+        }
+
+        const dictionaryEntries = ProfilePropertyRuleOpsDictionary[type].filter(
+          (operation) => operation.op === rule.operation.op
+        );
         if (!dictionaryEntries || dictionaryEntries.length === 0) {
           throw new Error(
             `invalid group rule operation "${rule.operation.op}" for profile property rule of type ${profilePropertyRule.type}`

--- a/core/api/src/models/ProfilePropertyRule.ts
+++ b/core/api/src/models/ProfilePropertyRule.ts
@@ -342,6 +342,10 @@ export class ProfilePropertyRule extends LoggedModel<ProfilePropertyRule> {
     }
   }
 
+  async makeIdentifying() {
+    return ProfilePropertyRuleOps.makeIdentifying(this);
+  }
+
   async apiData() {
     const options = await this.getOptions();
     const filters = await this.getFilters();

--- a/core/api/src/modules/configLoaders/apiKey.ts
+++ b/core/api/src/modules/configLoaders/apiKey.ts
@@ -3,6 +3,7 @@ import {
   validateAndFormatGuid,
   codeConfigLockKey,
   logModel,
+  validateConfigObjectKeys,
 } from "../../classes/codeConfig";
 import { ApiKey, Permission } from "../..";
 import { Op } from "sequelize";
@@ -11,6 +12,8 @@ export async function loadApiKey(configObject: ConfigurationObject) {
   let isNew = false;
 
   const guid = await validateAndFormatGuid(ApiKey, configObject.id);
+  validateConfigObjectKeys(ApiKey, configObject);
+
   let apiKey = await ApiKey.scope(null).findOne({
     where: { locked: codeConfigLockKey, guid },
   });

--- a/core/api/src/modules/configLoaders/app.ts
+++ b/core/api/src/modules/configLoaders/app.ts
@@ -4,6 +4,7 @@ import {
   extractNonNullParts,
   codeConfigLockKey,
   logModel,
+  validateConfigObjectKeys,
 } from "../../classes/codeConfig";
 import { App } from "../..";
 import { Op } from "sequelize";
@@ -11,6 +12,7 @@ import { Op } from "sequelize";
 export async function loadApp(configObject: ConfigurationObject) {
   let isNew = false;
   const guid = await validateAndFormatGuid(App, configObject.id);
+  validateConfigObjectKeys(App, configObject);
 
   let app = await App.scope(null).findOne({
     where: { guid, locked: codeConfigLockKey },

--- a/core/api/src/modules/configLoaders/destination.ts
+++ b/core/api/src/modules/configLoaders/destination.ts
@@ -5,6 +5,7 @@ import {
   getParentByName,
   codeConfigLockKey,
   validateAndFormatGuid,
+  validateConfigObjectKeys,
 } from "../../classes/codeConfig";
 import { App, Destination, Group, ProfilePropertyRule } from "../..";
 import { Op } from "sequelize";
@@ -15,6 +16,8 @@ export async function loadDestination(configObject: ConfigurationObject) {
   const app: App = await getParentByName(App, configObject.appId);
 
   const guid = await validateAndFormatGuid(Destination, configObject.id);
+  validateConfigObjectKeys(Destination, configObject);
+
   let destination = await Destination.scope(null).findOne({
     where: { guid, appGuid: app.guid },
   });

--- a/core/api/src/modules/configLoaders/destination.ts
+++ b/core/api/src/modules/configLoaders/destination.ts
@@ -36,7 +36,6 @@ export async function loadDestination(configObject: ConfigurationObject) {
 
   await destination.update({
     name: configObject.name,
-    groupGuid: group?.guid,
   });
 
   await destination.setOptions(extractNonNullParts(configObject, "options"));
@@ -58,13 +57,17 @@ export async function loadDestination(configObject: ConfigurationObject) {
     "destinationGroupMemberships"
   );
   for (const remoteName in sanitizedDestinationGroupMemberships) {
-    const group = await getParentByName(
+    const membershipGroup = await getParentByName(
       Group,
       sanitizedDestinationGroupMemberships[remoteName]
     );
-    destinationGroupMemberships[group.guid] = remoteName;
+    destinationGroupMemberships[membershipGroup.guid] = remoteName;
   }
   await destination.setDestinationGroupMemberships(destinationGroupMemberships);
+
+  if (destination.groupGuid !== group.guid) {
+    await destination.trackGroup(group);
+  }
 
   await destination.update({ state: "ready" });
 

--- a/core/api/src/modules/configLoaders/group.ts
+++ b/core/api/src/modules/configLoaders/group.ts
@@ -3,6 +3,7 @@ import {
   validateAndFormatGuid,
   codeConfigLockKey,
   logModel,
+  validateConfigObjectKeys,
 } from "../../classes/codeConfig";
 import { Group } from "../..";
 import { ProfilePropertyRule } from "../../models/ProfilePropertyRule";
@@ -11,6 +12,7 @@ import { Op } from "sequelize";
 export async function loadGroup(configObject: ConfigurationObject) {
   let isNew = false;
   const guid = await validateAndFormatGuid(Group, configObject.id);
+  validateConfigObjectKeys(Group, configObject);
 
   let group = await Group.scope(null).findOne({
     where: { guid, locked: codeConfigLockKey },

--- a/core/api/src/modules/configLoaders/profilePropertyRule.ts
+++ b/core/api/src/modules/configLoaders/profilePropertyRule.ts
@@ -37,7 +37,6 @@ export async function loadProfilePropertyRule(
     key: configObject.key || configObject.name,
     unique: configObject.unique,
     isArray: configObject.isArray,
-    identifying: configObject.identifying,
   });
 
   await profilePropertyRule.setOptions(
@@ -46,6 +45,10 @@ export async function loadProfilePropertyRule(
 
   if (configObject.filters) {
     await profilePropertyRule.setFilters(configObject.filters);
+  }
+
+  if (configObject.identifying === true) {
+    await profilePropertyRule.makeIdentifying();
   }
 
   await profilePropertyRule.update({ state: "ready" });

--- a/core/api/src/modules/configLoaders/profilePropertyRule.ts
+++ b/core/api/src/modules/configLoaders/profilePropertyRule.ts
@@ -5,6 +5,7 @@ import {
   getParentByName,
   codeConfigLockKey,
   validateAndFormatGuid,
+  validateConfigObjectKeys,
 } from "../../classes/codeConfig";
 import { ProfilePropertyRule, Source } from "../..";
 import { Op } from "sequelize";
@@ -19,6 +20,8 @@ export async function loadProfilePropertyRule(
     ProfilePropertyRule,
     configObject.id
   );
+  validateConfigObjectKeys(ProfilePropertyRule, configObject, ["name"]);
+
   let profilePropertyRule = await ProfilePropertyRule.scope(null).findOne({
     where: { locked: codeConfigLockKey, guid },
   });

--- a/core/api/src/modules/configLoaders/schedule.ts
+++ b/core/api/src/modules/configLoaders/schedule.ts
@@ -5,6 +5,7 @@ import {
   getParentByName,
   codeConfigLockKey,
   extractNonNullParts,
+  validateConfigObjectKeys,
 } from "../../classes/codeConfig";
 import { Schedule, Source } from "../..";
 import { Op } from "sequelize";
@@ -12,6 +13,7 @@ import { Op } from "sequelize";
 export async function loadSchedule(configObject: ConfigurationObject) {
   let isNew = false;
   const guid = await validateAndFormatGuid(Schedule, configObject.id);
+  validateConfigObjectKeys(Schedule, configObject);
   const source: Source = await getParentByName(Source, configObject.sourceId);
 
   let schedule = await Schedule.scope(null).findOne({

--- a/core/api/src/modules/configLoaders/setting.ts
+++ b/core/api/src/modules/configLoaders/setting.ts
@@ -2,10 +2,14 @@ import {
   ConfigurationObject,
   logModel,
   codeConfigLockKey,
+  validateConfigObjectKeys,
 } from "../../classes/codeConfig";
 import { plugin } from "../..";
+import { Setting } from "../../models/Setting";
 
 export async function loadSetting(configObject: ConfigurationObject) {
+  validateConfigObjectKeys(Setting, configObject);
+
   const setting = await plugin.updateSetting(
     configObject.pluginName,
     configObject.key,

--- a/core/api/src/modules/configLoaders/source.ts
+++ b/core/api/src/modules/configLoaders/source.ts
@@ -5,6 +5,7 @@ import {
   getParentByName,
   codeConfigLockKey,
   validateAndFormatGuid,
+  validateConfigObjectKeys,
 } from "../../classes/codeConfig";
 import { App, Source, ProfilePropertyRule } from "../..";
 import { Op } from "sequelize";
@@ -15,6 +16,8 @@ export async function loadSource(configObject: ConfigurationObject) {
   const app: App = await getParentByName(App, configObject.appId);
 
   const guid = await validateAndFormatGuid(Source, configObject.id);
+  validateConfigObjectKeys(Source, configObject);
+
   let source = await Source.scope(null).findOne({
     where: { guid, locked: codeConfigLockKey, appGuid: app.guid },
   });

--- a/core/api/src/modules/configLoaders/team.ts
+++ b/core/api/src/modules/configLoaders/team.ts
@@ -3,6 +3,7 @@ import {
   logModel,
   codeConfigLockKey,
   validateAndFormatGuid,
+  validateConfigObjectKeys,
 } from "../../classes/codeConfig";
 import { Team, Permission } from "../..";
 import { Op } from "sequelize";
@@ -11,6 +12,8 @@ export async function loadTeam(configObject: ConfigurationObject) {
   let isNew = false;
 
   const guid = await validateAndFormatGuid(Team, configObject.id);
+  validateConfigObjectKeys(Team, configObject);
+
   let team = await Team.scope(null).findOne({
     where: { locked: codeConfigLockKey, guid },
   });

--- a/core/api/src/modules/configLoaders/teamMember.ts
+++ b/core/api/src/modules/configLoaders/teamMember.ts
@@ -4,6 +4,7 @@ import {
   getParentByName,
   logModel,
   validateAndFormatGuid,
+  validateConfigObjectKeys,
 } from "../../classes/codeConfig";
 import { Team, TeamMember } from "../..";
 import { Op } from "sequelize";
@@ -14,6 +15,8 @@ export async function loadTeamMember(configObject: ConfigurationObject) {
   const team: Team = await getParentByName(Team, configObject.teamId);
 
   const guid = await validateAndFormatGuid(TeamMember, configObject.id);
+  validateConfigObjectKeys(TeamMember, configObject);
+
   let teamMember = await TeamMember.scope(null).findOne({
     where: { locked: codeConfigLockKey, guid },
   });

--- a/core/api/src/modules/ops/profilePropertyRule.ts
+++ b/core/api/src/modules/ops/profilePropertyRule.ts
@@ -7,6 +7,7 @@ import { GroupRule } from "../../models/GroupRule";
 import { App } from "../../models/App";
 import { internalRun } from "../internalRun";
 import { task } from "actionhero";
+import { Op } from "sequelize";
 import Mustache from "mustache";
 
 export namespace ProfilePropertyRuleOps {
@@ -131,6 +132,17 @@ export namespace ProfilePropertyRuleOps {
     return dependencies.filter(
       (v, i, a) => a.findIndex((t) => t.guid === v.guid) === i
     );
+  }
+
+  /** Make this rule identifying */
+  export async function makeIdentifying(rule: ProfilePropertyRule) {
+    if (rule.identifying === true) return;
+
+    await ProfilePropertyRule.update(
+      { identifying: false },
+      { where: { guid: { [Op.ne]: rule.guid } } }
+    );
+    await rule.update({ identifying: true });
   }
 
   /**

--- a/core/web/components/events/list.tsx
+++ b/core/web/components/events/list.tsx
@@ -91,6 +91,8 @@ export default function EventsList(props) {
 
   return (
     <>
+      {props.header ? props.header : <h1>Events</h1>}
+
       {hideSearch ? null : (
         <Form id="search" onSubmit={load}>
           <Form.Group>

--- a/core/web/components/export/list.tsx
+++ b/core/web/components/export/list.tsx
@@ -70,7 +70,7 @@ export default function ExportsList(props) {
 
   return (
     <>
-      <h1>Exports</h1>
+      {props.header ? props.header : <h1>Exports</h1>}
 
       <Row>
         <Col md={3}>

--- a/core/web/components/import/list.tsx
+++ b/core/web/components/import/list.tsx
@@ -60,7 +60,7 @@ export default function ImportList(props) {
 
   return (
     <>
-      <h1>Imports</h1>
+      {props.header ? props.header : <h1>Imports</h1>}
 
       <p>
         {total} imports {creatorGuid ? `for ${creatorGuid}` : null}{" "}

--- a/core/web/components/lockedBadge.tsx
+++ b/core/web/components/lockedBadge.tsx
@@ -1,0 +1,17 @@
+import { Badge } from "react-bootstrap";
+
+export default function LockedBadge({
+  object,
+}: {
+  object: { locked?: string };
+}) {
+  if (!object.locked || object.locked == "") return null;
+
+  return (
+    <>
+      <Badge style={{ marginBottom: 20 }} variant="light">
+        Locked ({object.locked})
+      </Badge>
+    </>
+  );
+}

--- a/core/web/components/log/list.tsx
+++ b/core/web/components/log/list.tsx
@@ -106,7 +106,7 @@ export default function LogsList(props) {
 
   return (
     <>
-      <h1>Logs</h1>
+      {props.header ? props.header : <h1>Logs</h1>}
 
       <ButtonGroup id="log-types">
         <Button

--- a/core/web/components/profile/list.tsx
+++ b/core/web/components/profile/list.tsx
@@ -116,78 +116,80 @@ export default function ProfilesList(props) {
 
   return (
     <>
-      <h1>Profiles</h1>
+      {props.header ? props.header : <h1>Profiles</h1>}
 
-      <Form id="search" onSubmit={load}>
-        <Form.Row>
-          <Col md={3}>
-            <Form.Group>
-              <Form.Label>Search Property</Form.Label>
-              <Form.Control
-                name="searchKey"
-                as="select"
-                value={searchKey}
-                disabled={props.searchKey || loading ? true : false}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                  setSearchKey(event.target.value);
-                  setSearchValue("");
-                  autocompleteProfilePropertySearch("%", event.target.value);
-                }}
-              >
-                <option value="">Show All</option>
-                {profilePropertyRules.map((rule) => (
-                  <option key={`rule-${rule.key}`}>{rule.key}</option>
-                ))}
-              </Form.Control>
-            </Form.Group>
-          </Col>
-          {searchKey !== "" ? (
-            <Col md={7}>
-              <>
-                <Form.Label>
-                  Search Term (use <code>%</code> for wildcards and{" "}
-                  <code>null</code> for empty values)
-                </Form.Label>
-                <AsyncTypeahead
-                  key={`typeahead-search-${searchKey}`}
-                  id={`typeahead-search-${searchKey}`}
-                  minLength={0}
+      {groupGuid ? null : (
+        <Form id="search" onSubmit={load}>
+          <Form.Row>
+            <Col md={3}>
+              <Form.Group>
+                <Form.Label>Search Property</Form.Label>
+                <Form.Control
+                  name="searchKey"
+                  as="select"
+                  value={searchKey}
                   disabled={props.searchKey || loading ? true : false}
-                  isLoading={searchLoading}
-                  allowNew={true}
-                  onChange={(selected) => {
-                    if (!selected[0]) {
-                      return;
-                    }
-
-                    setSearchValue(
-                      selected[0].label
-                        ? selected[0].label // when a new custom option is set
-                        : selected[0] // when a list option is chosen);
-                    );
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    setSearchKey(event.target.value);
+                    setSearchValue("");
+                    autocompleteProfilePropertySearch("%", event.target.value);
                   }}
-                  onBlur={(e) => {
-                    const value = e.target.value;
-                    if (value && value.length > 0) setSearchValue(value);
-                  }}
-                  options={autocompleteResults}
-                  onSearch={autocompleteProfilePropertySearch}
-                  placeholder={`name@example.com`}
-                  defaultSelected={
-                    searchValue ? [searchValue.toString()] : undefined
-                  }
-                />
-              </>
+                >
+                  <option value="">Show All</option>
+                  {profilePropertyRules.map((rule) => (
+                    <option key={`rule-${rule.key}`}>{rule.key}</option>
+                  ))}
+                </Form.Control>
+              </Form.Group>
             </Col>
-          ) : null}
+            {searchKey !== "" ? (
+              <Col md={7}>
+                <>
+                  <Form.Label>
+                    Search Term (use <code>%</code> for wildcards and{" "}
+                    <code>null</code> for empty values)
+                  </Form.Label>
+                  <AsyncTypeahead
+                    key={`typeahead-search-${searchKey}`}
+                    id={`typeahead-search-${searchKey}`}
+                    minLength={0}
+                    disabled={props.searchKey || loading ? true : false}
+                    isLoading={searchLoading}
+                    allowNew={true}
+                    onChange={(selected) => {
+                      if (!selected[0]) {
+                        return;
+                      }
 
-          <Col md={2} style={{ marginTop: 33 }}>
-            <LoadingButton size="sm" type="submit" disabled={loading}>
-              Search
-            </LoadingButton>
-          </Col>
-        </Form.Row>
-      </Form>
+                      setSearchValue(
+                        selected[0].label
+                          ? selected[0].label // when a new custom option is set
+                          : selected[0] // when a list option is chosen);
+                      );
+                    }}
+                    onBlur={(e) => {
+                      const value = e.target.value;
+                      if (value && value.length > 0) setSearchValue(value);
+                    }}
+                    options={autocompleteResults}
+                    onSearch={autocompleteProfilePropertySearch}
+                    placeholder={`name@example.com`}
+                    defaultSelected={
+                      searchValue ? [searchValue.toString()] : undefined
+                    }
+                  />
+                </>
+              </Col>
+            ) : null}
+
+            <Col md={2} style={{ marginTop: 33 }}>
+              <LoadingButton size="sm" type="submit" disabled={loading}>
+                Search
+              </LoadingButton>
+            </Col>
+          </Form.Row>
+        </Form>
+      )}
 
       <ButtonGroup id="profile-states">
         <Button

--- a/core/web/components/runs/list.tsx
+++ b/core/web/components/runs/list.tsx
@@ -70,7 +70,7 @@ export default function RunsList(props) {
 
   return (
     <>
-      <h1>Runs</h1>
+      {props.header ? props.header : <h1>Runs</h1>}
 
       <Row>
         <Col>

--- a/core/web/components/settings/identifyingProfilePropertyRule.tsx
+++ b/core/web/components/settings/identifyingProfilePropertyRule.tsx
@@ -42,21 +42,10 @@ export default function IdentifyingProfilePropertyRule(props) {
 
     setLoading(true);
 
-    for (const i in profilePropertyRules) {
-      if (profilePropertyRules[i].identifying) {
-        await execApi(
-          "put",
-          `/profilePropertyRule/${profilePropertyRules[i].guid}`,
-          { identifying: false }
-        );
-      }
-    }
-
     if (identifyingProfilePropertyGuid !== "") {
       await execApi(
         "put",
-        `/profilePropertyRule/${identifyingProfilePropertyGuid}`,
-        { identifying: true }
+        `/profilePropertyRule/${identifyingProfilePropertyGuid}/makeIdentifying`
       );
     }
 

--- a/core/web/components/stateBadge.tsx
+++ b/core/web/components/stateBadge.tsx
@@ -34,5 +34,9 @@ export default function StateBadge({ state }: { state: string }) {
       variant = "primary";
   }
 
-  return <Badge variant={variant}>{state}</Badge>;
+  return (
+    <Badge style={{ marginBottom: 20 }} variant={variant}>
+      {state}
+    </Badge>
+  );
 }

--- a/core/web/components/visualizations/homepageWidgets.tsx
+++ b/core/web/components/visualizations/homepageWidgets.tsx
@@ -442,6 +442,7 @@ export function PendingExports({ execApi }) {
   const [destinations, setDestinations] = useState<Models.DestinationType[]>(
     []
   );
+  const [pendingExportsCount, setPendingExportsCount] = useState(0);
   const [mostRecentExport, setMostRecentExport] = useState<Models.ExportType>();
   let timer;
 
@@ -471,10 +472,13 @@ export function PendingExports({ execApi }) {
       { limit: 1 }
     );
 
+    let _pendingExportsCount = 0;
     const sample = { time: new Date() };
     for (const i in destinations) {
       const destination = destinations[i];
       sample[destination.name] =
+        destination.exportTotals.created + destination.exportTotals.started;
+      _pendingExportsCount +=
         destination.exportTotals.created + destination.exportTotals.started;
     }
 
@@ -485,6 +489,7 @@ export function PendingExports({ execApi }) {
 
     if (destinations) setDestinations(destinations);
     if (_exports) setMostRecentExport(_exports[0]);
+    if (destinations) setPendingExportsCount(_pendingExportsCount);
   }
 
   if (destinations.length === 0) {
@@ -498,7 +503,7 @@ export function PendingExports({ execApi }) {
   return (
     <Card>
       <Card.Body>
-        <Card.Title>Pending Exports</Card.Title>
+        <Card.Title>Pending Exports ({pendingExportsCount})</Card.Title>
         <div style={{ height: 200 }}>
           <RollingChart
             data={pendingExportSamples}

--- a/core/web/pages/apiKey/[guid]/edit.tsx
+++ b/core/web/pages/apiKey/[guid]/edit.tsx
@@ -6,6 +6,7 @@ import PermissionsList from "../../../components/permissions";
 import { useRouter } from "next/router";
 import ApiKeyTabs from "../../../components/tabs/apiKey";
 import LoadingButton from "../../../components/loadingButton";
+import LockedBadge from "../../../components/lockedBadge";
 
 import { Models, Actions } from "../../../utils/apiData";
 
@@ -89,6 +90,8 @@ export default function Page(props) {
 
       <ApiKeyTabs apiKey={apiKey} />
 
+      <h1>{apiKey.name}</h1>
+      <LockedBadge object={apiKey} />
       <Form id="form" onSubmit={updateApiKey} autoComplete="off">
         <fieldset disabled={apiKey.locked !== null}>
           <Form.Group>

--- a/core/web/pages/app/[guid]/edit.tsx
+++ b/core/web/pages/app/[guid]/edit.tsx
@@ -9,6 +9,7 @@ import { Typeahead } from "react-bootstrap-typeahead";
 import AppTabs from "../../../components/tabs/app";
 import Loader from "../../../components/loader";
 import LoadingButton from "../../../components/loadingButton";
+import LockedBadge from "../../../components/lockedBadge";
 
 import { Actions, Models } from "../../../utils/apiData";
 import { ErrorHandler } from "../../../utils/errorHandler";
@@ -128,24 +129,24 @@ export default function Page(props) {
 
       <AppTabs app={app} />
 
-      <p>
-        <span className="text-muted">{app.guid}</span>
-      </p>
-
       <Row>
         <Col md={1} style={{ textAlign: "center" }}>
-          <br />
           <AppIcon src={app.icon} fluid size={100} />
-          <br />
-          <br />
-          {app.provides.source ? <Badge variant="primary">source</Badge> : null}
-          <br />
+        </Col>
+        <Col>
+          <h1>{app.name}</h1>
+          {app.provides.source ? (
+            <Badge variant="primary">source</Badge>
+          ) : null}{" "}
           {app.provides.destination ? (
             <Badge variant="info">destination</Badge>
-          ) : null}
+          ) : null}{" "}
+          <LockedBadge object={app} />{" "}
         </Col>
-
+      </Row>
+      <Row>
         <Col>
+          <br />
           <Form id="form" onSubmit={edit} autoComplete="off">
             <fieldset disabled={app.locked !== null}>
               <Form.Group controlId="name">

--- a/core/web/pages/destination/[guid]/data.tsx
+++ b/core/web/pages/destination/[guid]/data.tsx
@@ -7,6 +7,9 @@ import { useRouter } from "next/router";
 import { Typeahead } from "react-bootstrap-typeahead";
 import DestinationTabs from "../../../components/tabs/destination";
 import LoadingButton from "../../../components/loadingButton";
+import StateBadge from "../../../components/stateBadge";
+import AppIcon from "../../../components/appIcon";
+import LockedBadge from "../../../components/lockedBadge";
 import { Models, Actions } from "../../../utils/apiData";
 import { ErrorHandler } from "../../../utils/errorHandler";
 import { SuccessHandler } from "../../../utils/successHandler";
@@ -289,7 +292,16 @@ export default function Page(props) {
 
       <DestinationTabs destination={destination} />
 
-      <h1>Destination Data</h1>
+      <Row>
+        <Col md={1}>
+          <AppIcon src={destination.app.icon} fluid size={100} />
+        </Col>
+        <Col>
+          <h1>{destination.name} - Data</h1>
+          <StateBadge state={destination.state} />{" "}
+          <LockedBadge object={destination} />
+        </Col>
+      </Row>
       <Row>
         <Col>
           <Form id="form" onSubmit={update}>

--- a/core/web/pages/destination/[guid]/edit.tsx
+++ b/core/web/pages/destination/[guid]/edit.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import Head from "next/head";
 import AppIcon from "./../../../components/appIcon";
 import StateBadge from "./../../../components/stateBadge";
+import LockedBadge from "../../../components/lockedBadge";
 import { Typeahead } from "react-bootstrap-typeahead";
 import DestinationTabs from "./../../../components/tabs/destination";
 import LoadingButton from "../../../components/loadingButton";
@@ -126,16 +127,18 @@ export default function Page(props) {
 
       <DestinationTabs destination={destination} />
 
-      <h1>Edit Destination</h1>
-
       <Row>
         <Col md={1}>
-          <br />
           <AppIcon src={destination.app.icon} fluid size={100} />
         </Col>
         <Col>
-          <StateBadge state={destination.state} />
-
+          <h1>{destination.name}</h1>
+          <StateBadge state={destination.state} />{" "}
+          <LockedBadge object={destination} />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
           <Form id="form" onSubmit={onSubmit} autoComplete="off">
             <fieldset disabled={destination.locked !== null}>
               <Form.Group controlId="name">

--- a/core/web/pages/destination/[guid]/exports.tsx
+++ b/core/web/pages/destination/[guid]/exports.tsx
@@ -1,7 +1,11 @@
 import Head from "next/head";
 import { useApi } from "../../../hooks/useApi";
+import { Row, Col } from "react-bootstrap";
 import ExportsList from "../../../components/export/list";
 import DestinationTabs from "../../../components/tabs/destination";
+import AppIcon from "./../../../components/appIcon";
+import StateBadge from "./../../../components/stateBadge";
+import LockedBadge from "../../../components/lockedBadge";
 
 export default function Page(props) {
   const { destination } = props;
@@ -14,7 +18,21 @@ export default function Page(props) {
 
       <DestinationTabs destination={destination} />
 
-      <ExportsList {...props} />
+      <ExportsList
+        header={
+          <Row>
+            <Col md={1}>
+              <AppIcon src={destination.app.icon} fluid size={100} />
+            </Col>
+            <Col>
+              <h1>{destination.name} - Exports</h1>
+              <StateBadge state={destination.state} />{" "}
+              <LockedBadge object={destination} />
+            </Col>
+          </Row>
+        }
+        {...props}
+      />
     </>
   );
 }

--- a/core/web/pages/events/overview.tsx
+++ b/core/web/pages/events/overview.tsx
@@ -24,7 +24,13 @@ export default function Page(props) {
       <h2>Stream</h2>
       <Button href="/events/stream">See Full Stream</Button>
       <br />
-      <EventsList {...props} hideSearch hidePagination limit={25} />
+      <EventsList
+        header={" "}
+        {...props}
+        hideSearch
+        hidePagination
+        limit={25}
+      />
 
       <br />
       <br />

--- a/core/web/pages/events/stream.tsx
+++ b/core/web/pages/events/stream.tsx
@@ -16,8 +16,6 @@ export default function Page(props) {
         </Link>
       </Alert>
 
-      <h1>Event Stream</h1>
-
       <EventsList {...props} />
     </>
   );

--- a/core/web/pages/group/[guid]/destinations.tsx
+++ b/core/web/pages/group/[guid]/destinations.tsx
@@ -59,7 +59,7 @@ export default function Page(props) {
 
       <GroupTabs group={group} />
 
-      <h1>Group Destination</h1>
+      <h1>{group.name} - Destinations</h1>
       <p>{destinations.length} destinations interested in this group</p>
 
       <LoadingTable loading={loading}>

--- a/core/web/pages/group/[guid]/edit.tsx
+++ b/core/web/pages/group/[guid]/edit.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useApi } from "../../../hooks/useApi";
 import { Row, Col, Form } from "react-bootstrap";
 import StateBadge from "../../../components/stateBadge";
+import LockedBadge from "../../../components/lockedBadge";
 import Moment from "react-moment";
 import { useRouter } from "next/router";
 import Head from "next/head";
@@ -76,12 +77,9 @@ export default function Page(props) {
       <Head>
         <title>Grouparoo: {group.name}</title>
       </Head>
-
       <GroupTabs group={group} />
-
-      <StateBadge state={group.state} />
-      <br />
-      <br />
+      <h1>{group.name}</h1>
+      <StateBadge state={group.state} /> <LockedBadge object={group} />
       <Row>
         <Col md={group.type === "calculated" ? 8 : 12}>
           <Form id="form" onSubmit={submit} autoComplete="off">

--- a/core/web/pages/group/[guid]/logs.tsx
+++ b/core/web/pages/group/[guid]/logs.tsx
@@ -14,7 +14,7 @@ export default function Page(props) {
 
       <GroupTabs group={group} />
 
-      <LogsList {...props} />
+      <LogsList header={<h1>{group.name} - Logs</h1>} {...props} />
     </>
   );
 }

--- a/core/web/pages/group/[guid]/members.tsx
+++ b/core/web/pages/group/[guid]/members.tsx
@@ -61,9 +61,9 @@ export default function Page(props) {
         <title>Grouparoo: {group.name}</title>
       </Head>
       <GroupTabs group={group} />
-      <p>
-        <StateBadge state={group.state} />
-      </p>
+      <h1>{group.name} - Members</h1>
+      <StateBadge state={group.state} />
+      <br />
       <Button
         disabled={group.state !== "ready"}
         variant="outline-secondary"
@@ -85,7 +85,7 @@ export default function Page(props) {
         Recalculate Members
       </Button>
       <br />
-      <br />
+      <hr />
       <ProfilesList {...props} />
     </>
   );

--- a/core/web/pages/group/[guid]/rules.tsx
+++ b/core/web/pages/group/[guid]/rules.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useState } from "react";
 import { useApi } from "../../../hooks/useApi";
 import StateBadge from "../../../components/stateBadge";
+import LockedBadge from "../../../components/lockedBadge";
 import Head from "next/head";
 import GroupTabs from "../../../components/tabs/group";
 import DatePicker from "../../../components/datePicker";
@@ -160,14 +161,13 @@ export default function Page(props) {
         <title>Grouparoo: {group.name}</title>
       </Head>
       <GroupTabs group={group} />
-      <h1>Group Rules for {group.name}</h1>
+      <h1>{group.name} - Rules</h1>
+      <StateBadge state={group.state} /> <LockedBadge object={group} />
       <p>
         Total Profiles in this group: &nbsp;
         <Badge style={{ fontSize: 16 }} variant="info">
           {countPotentialMembers}
         </Badge>
-        <br />
-        <StateBadge state={group.state} />
       </p>
       <p>
         Define the profile properties that you want to segment by. Profiles in

--- a/core/web/pages/group/[guid]/runs.tsx
+++ b/core/web/pages/group/[guid]/runs.tsx
@@ -14,7 +14,7 @@ export default function Page(props) {
 
       <GroupTabs group={group} />
 
-      <RunsList {...props} />
+      <RunsList header={<h1>{group.name} - Runs</h1>} {...props} />
     </>
   );
 }

--- a/core/web/pages/profile/[guid]/edit.tsx
+++ b/core/web/pages/profile/[guid]/edit.tsx
@@ -201,10 +201,7 @@ export default function Page(props) {
       <Row>
         <Col md={9}>
           <Row>
-            <Col md={2}>
-              <ProfileImageFromEmail loading={loading} email={email} />
-            </Col>
-            <Col md={10}>
+            <Col>
               <span className="text-muted">Created At: </span>
               <Moment fromNow>{profile.createdAt}</Moment>
               <br />
@@ -212,8 +209,13 @@ export default function Page(props) {
               <Moment fromNow>{profile.updatedAt}</Moment>
               <br />
               <StateBadge state={profile.state} />
-              <br />
-              <br />
+            </Col>
+          </Row>
+          <Row>
+            <Col md={2}>
+              <ProfileImageFromEmail loading={loading} email={email} />
+            </Col>
+            <Col>
               {uniqueProfileProperties.map((key) => {
                 return (
                   <h3 key={`profileHeader-${key}`}>
@@ -224,7 +226,11 @@ export default function Page(props) {
                   </h3>
                 );
               })}
-              <br />
+            </Col>
+          </Row>
+          <br />
+          <Row>
+            <Col>
               <LoadingButton
                 disabled={loading}
                 onClick={() => {
@@ -249,78 +255,6 @@ export default function Page(props) {
               </LoadingButton>
             </Col>
           </Row>
-        </Col>
-        <Col md={3}>
-          <h3>Groups</h3>
-
-          {groups.length > 0 ? null : <p>None</p>}
-
-          <ListGroup>
-            {groups.map((group) => (
-              <ListGroup.Item key={`groupMember-${group.guid}`} variant="info">
-                {group.type === "manual" ? (
-                  <>
-                    <LoadingButton
-                      disabled={loading}
-                      size="sm"
-                      variant="danger"
-                      onClick={() => {
-                        handleRemove(group);
-                      }}
-                    >
-                      X
-                    </LoadingButton>
-                    &nbsp; &nbsp;
-                  </>
-                ) : null}
-                <Link
-                  href="/group/[guid]/members"
-                  as={`/group/${group.guid}/members`}
-                >
-                  <a>{group.name}</a>
-                </Link>
-              </ListGroup.Item>
-            ))}
-          </ListGroup>
-
-          <hr />
-
-          <Form onSubmit={(event) => handleAdd(event)} autoComplete="off">
-            <Row>
-              <Col md={9}>
-                <Form.Group controlId="groupGuid">
-                  <Form.Label>Add Group</Form.Label>
-                  <Form.Control as="select" disabled={loading}>
-                    {allGroups.map((group) => {
-                      const disabled =
-                        group.type !== "manual" ||
-                        groupMembershipGuids.includes(group.guid);
-                      return (
-                        <option
-                          disabled={disabled}
-                          value={group.guid}
-                          key={`group-${group.guid}`}
-                        >
-                          {group.name}
-                        </option>
-                      );
-                    })}
-                  </Form.Control>
-                </Form.Group>
-              </Col>
-              <Col md={3}>
-                <div style={{ paddingTop: 34 }} />
-                <LoadingButton
-                  variant="outline-primary"
-                  size="sm"
-                  type="submit"
-                  disabled={loading}
-                >
-                  Add
-                </LoadingButton>
-              </Col>
-            </Row>
-          </Form>
         </Col>
       </Row>
 
@@ -418,6 +352,81 @@ export default function Page(props) {
               })}
             </tbody>
           </LoadingTable>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <h3>Groups</h3>
+
+          {groups.length > 0 ? null : <p>None</p>}
+
+          <ListGroup>
+            {groups.map((group) => (
+              <ListGroup.Item key={`groupMember-${group.guid}`} variant="info">
+                {group.type === "manual" ? (
+                  <>
+                    <LoadingButton
+                      disabled={loading}
+                      size="sm"
+                      variant="danger"
+                      onClick={() => {
+                        handleRemove(group);
+                      }}
+                    >
+                      X
+                    </LoadingButton>
+                    &nbsp; &nbsp;
+                  </>
+                ) : null}
+                <Link
+                  href="/group/[guid]/members"
+                  as={`/group/${group.guid}/members`}
+                >
+                  <a>{group.name}</a>
+                </Link>
+              </ListGroup.Item>
+            ))}
+          </ListGroup>
+
+          <hr />
+
+          <Form onSubmit={(event) => handleAdd(event)} autoComplete="off">
+            <Row>
+              <Col md={9}>
+                <Form.Group controlId="groupGuid">
+                  <Form.Label>Add Group</Form.Label>
+                  <Form.Control as="select" disabled={loading}>
+                    {allGroups.map((group) => {
+                      const disabled =
+                        group.type !== "manual" ||
+                        groupMembershipGuids.includes(group.guid);
+                      return (
+                        <option
+                          disabled={disabled}
+                          value={group.guid}
+                          key={`group-${group.guid}`}
+                        >
+                          {group.name}
+                        </option>
+                      );
+                    })}
+                  </Form.Control>
+                </Form.Group>
+              </Col>
+              <Col md={3}>
+                <div style={{ paddingTop: 34 }} />
+                <LoadingButton
+                  variant="outline-primary"
+                  size="sm"
+                  type="submit"
+                  disabled={loading}
+                >
+                  Add
+                </LoadingButton>
+              </Col>
+            </Row>
+          </Form>
         </Col>
       </Row>
     </>

--- a/core/web/pages/profile/[guid]/events.tsx
+++ b/core/web/pages/profile/[guid]/events.tsx
@@ -15,9 +15,10 @@ export default function Page(props) {
 
       <ProfileTabs profile={profile} />
 
-      <h1>Events</h1>
-
-      <EventsList {...props} />
+      <EventsList
+        header={<h1>{getProfileDisplayName(profile)} - Events</h1>}
+        {...props}
+      />
     </>
   );
 }

--- a/core/web/pages/profile/[guid]/exports.tsx
+++ b/core/web/pages/profile/[guid]/exports.tsx
@@ -15,7 +15,10 @@ export default function Page(props) {
 
       <ProfileTabs profile={profile} />
 
-      <ExportsList {...props} />
+      <ExportsList
+        header={<h1>{getProfileDisplayName(profile)} - Exports</h1>}
+        {...props}
+      />
     </>
   );
 }

--- a/core/web/pages/profile/[guid]/imports.tsx
+++ b/core/web/pages/profile/[guid]/imports.tsx
@@ -15,7 +15,10 @@ export default function Page(props) {
 
       <ProfileTabs profile={profile} />
 
-      <ImportList {...props} />
+      <ImportList
+        header={<h1>{getProfileDisplayName(profile)} - Imports</h1>}
+        {...props}
+      />
     </>
   );
 }

--- a/core/web/pages/profile/[guid]/logs.tsx
+++ b/core/web/pages/profile/[guid]/logs.tsx
@@ -2,6 +2,7 @@ import Head from "next/head";
 import { useApi } from "../../../hooks/useApi";
 import LogsList from "../../../components/log/list";
 import ProfileTabs from "../../../components/tabs/profile";
+import getProfileDisplayName from "../../../components/profile/getProfileDisplayName";
 
 export default function Page(props) {
   const { profile } = props;
@@ -14,7 +15,10 @@ export default function Page(props) {
 
       <ProfileTabs profile={profile} />
 
-      <LogsList {...props} />
+      <LogsList
+        header={<h1>{getProfileDisplayName(profile)} - Logs</h1>}
+        {...props}
+      />
     </>
   );
 }

--- a/core/web/pages/profilePropertyRule/[guid]/edit.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/edit.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import Loader from "../../../components/loader";
 import AppIcon from "../../../components/appIcon";
 import StateBadge from "../../../components/stateBadge";
+import LockedBadge from "../../../components/lockedBadge";
 import ProfilePreview from "../../../components/profilePropertyRule/profilePreview";
 import { Typeahead } from "react-bootstrap-typeahead";
 import DatePicker from "../../../components/datePicker";
@@ -176,13 +177,16 @@ export default function Page(props) {
         <fieldset disabled={profilePropertyRule.locked !== null}>
           <Row>
             <Col md={1}>
-              <br />
               <AppIcon src={source.app.icon} fluid size={100} />
             </Col>
             <Col md={8}>
-              <strong>State</strong>:{" "}
-              <StateBadge state={profilePropertyRule.state} />
-              <br />
+              <h1>{profilePropertyRule.key}</h1>
+              <StateBadge state={profilePropertyRule.state} />{" "}
+              <LockedBadge object={profilePropertyRule} />
+            </Col>
+          </Row>
+          <Row>
+            <Col>
               <Form.Group controlId="key">
                 <p>
                   <strong>Source</strong>:{" "}

--- a/core/web/pages/profilePropertyRule/[guid]/groups.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/groups.tsx
@@ -1,7 +1,11 @@
 import { useApi } from "../../../hooks/useApi";
 import Head from "next/head";
 import Link from "next/link";
+import { Row, Col } from "react-bootstrap";
 import LoadingTable from "../../../components/loadingTable";
+import AppIcon from "../../../components/appIcon";
+import StateBadge from "../../../components/stateBadge";
+import LockedBadge from "../../../components/lockedBadge";
 import ProfilePropertyRuleTabs from "../../../components/tabs/profilePropertyRule";
 import { Models } from "../../../utils/apiData";
 
@@ -24,6 +28,17 @@ export default function Page({
         profilePropertyRule={profilePropertyRule}
         source={source}
       />
+
+      <Row>
+        <Col md={1}>
+          <AppIcon src={source.app.icon} fluid size={100} />
+        </Col>
+        <Col md={8}>
+          <h1>{profilePropertyRule.key} - Groups</h1>
+          <StateBadge state={profilePropertyRule.state} />{" "}
+          <LockedBadge object={profilePropertyRule} />
+        </Col>
+      </Row>
 
       <LoadingTable loading={false}>
         <thead>

--- a/core/web/pages/profilePropertyRule/[guid]/logs.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/logs.tsx
@@ -2,6 +2,10 @@ import Head from "next/head";
 import { useApi } from "../../../hooks/useApi";
 import LogsList from "../../../components/log/list";
 import ProfilePropertyRuleTabs from "../../../components/tabs/profilePropertyRule";
+import { Row, Col } from "react-bootstrap";
+import AppIcon from "../../../components/appIcon";
+import StateBadge from "../../../components/stateBadge";
+import LockedBadge from "../../../components/lockedBadge";
 import { Models } from "../../../utils/apiData";
 
 export default function Page(props) {
@@ -24,7 +28,21 @@ export default function Page(props) {
         source={source}
       />
 
-      <LogsList {...props} />
+      <LogsList
+        header={
+          <Row>
+            <Col md={1}>
+              <AppIcon src={source.app.icon} fluid size={100} />
+            </Col>
+            <Col md={8}>
+              <h1>{profilePropertyRule.key} - Logs</h1>
+              <StateBadge state={profilePropertyRule.state} />{" "}
+              <LockedBadge object={profilePropertyRule} />
+            </Col>
+          </Row>
+        }
+        {...props}
+      />
     </>
   );
 }

--- a/core/web/pages/profilePropertyRule/[guid]/profiles.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/profiles.tsx
@@ -2,6 +2,10 @@ import { useApi } from "../../../hooks/useApi";
 import Head from "next/head";
 import ProfilePropertyRuleTabs from "../../../components/tabs/profilePropertyRule";
 import ProfilesList from "../../../components/profile/list";
+import { Row, Col } from "react-bootstrap";
+import AppIcon from "../../../components/appIcon";
+import StateBadge from "../../../components/stateBadge";
+import LockedBadge from "../../../components/lockedBadge";
 import { Models } from "../../../utils/apiData";
 
 export default function Page(props) {
@@ -26,6 +30,18 @@ export default function Page(props) {
 
       <ProfilesList
         {...props}
+        header={
+          <Row>
+            <Col md={1}>
+              <AppIcon src={source.app.icon} fluid size={100} />
+            </Col>
+            <Col md={8}>
+              <h1>{profilePropertyRule.key} - Profiles</h1>
+              <StateBadge state={profilePropertyRule.state} />{" "}
+              <LockedBadge object={profilePropertyRule} />
+            </Col>
+          </Row>
+        }
         searchKey={profilePropertyRule.key}
         searchValue="%"
       />

--- a/core/web/pages/profilePropertyRule/[guid]/runs.tsx
+++ b/core/web/pages/profilePropertyRule/[guid]/runs.tsx
@@ -1,6 +1,10 @@
 import Head from "next/head";
 import RunsList from "../../../components/runs/list";
 import { useApi } from "../../../hooks/useApi";
+import { Row, Col } from "react-bootstrap";
+import AppIcon from "../../../components/appIcon";
+import StateBadge from "../../../components/stateBadge";
+import LockedBadge from "../../../components/lockedBadge";
 import ProfilePropertyRuleTabs from "../../../components/tabs/profilePropertyRule";
 import { Models } from "../../../utils/apiData";
 
@@ -24,7 +28,21 @@ export default function Page(props) {
         source={source}
       />
 
-      <RunsList {...props} />
+      <RunsList
+        header={
+          <Row>
+            <Col md={1}>
+              <AppIcon src={source.app.icon} fluid size={100} />
+            </Col>
+            <Col md={8}>
+              <h1>{profilePropertyRule.key} - Runs</h1>
+              <StateBadge state={profilePropertyRule.state} />{" "}
+              <LockedBadge object={profilePropertyRule} />
+            </Col>
+          </Row>
+        }
+        {...props}
+      />
     </>
   );
 }

--- a/core/web/pages/settings/[tab].tsx
+++ b/core/web/pages/settings/[tab].tsx
@@ -8,6 +8,7 @@ import { capitalize } from "../../components/tabs";
 import { useRouter } from "next/router";
 import { Models, Actions } from "../../utils/apiData";
 import LoadingButton from "../../components/loadingButton";
+import LockedBadge from "../../components/lockedBadge";
 
 import ImportAndUpdateAllProfiles from "../../components/settings/importAndUpdate";
 import IdentifyingProfilePropertyRule from "../../components/settings/identifyingProfilePropertyRule";
@@ -149,6 +150,7 @@ function SettingCard({
               {setting.description}
             </Card.Subtitle>
           ) : null}
+          <LockedBadge object={setting} />
 
           <Form onSubmit={handleSubmit(onSubmit)} autoComplete="off">
             <fieldset disabled={setting.locked !== null}>

--- a/core/web/pages/source/[guid]/edit.tsx
+++ b/core/web/pages/source/[guid]/edit.tsx
@@ -6,6 +6,7 @@ import { Row, Col, Form, Badge, Alert } from "react-bootstrap";
 import { useRouter } from "next/router";
 import AppIcon from "./../../../components/appIcon";
 import StateBadge from "./../../../components/stateBadge";
+import LockedBadge from "./../../../components/lockedBadge";
 import { Typeahead } from "react-bootstrap-typeahead";
 import { Models, Actions } from "../../../utils/apiData";
 import LoadingTable from "../../../components/loadingTable";
@@ -152,20 +153,18 @@ export default function Page(props) {
       <Head>
         <title>Grouparoo: {source.name}</title>
       </Head>
-
       <SourceTabs source={source} />
-
-      <h2>Edit this {source.app.name} Source</h2>
-
       <Row>
         <Col md={1}>
-          <br />
           <AppIcon src={source.app.icon} fluid size={100} />
         </Col>
         <Col>
-          <StateBadge state={source.state} />
-          <br />
-          <br />
+          <h1>Edit this {source.app.name} Source</h1>
+          <StateBadge state={source.state} /> <LockedBadge object={source} />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
           <Form id="form" onSubmit={onSubmit} autoComplete="off">
             <fieldset disabled={source.locked !== null}>
               <Form.Group controlId="name">

--- a/core/web/pages/source/[guid]/mapping.tsx
+++ b/core/web/pages/source/[guid]/mapping.tsx
@@ -5,6 +5,9 @@ import { useState } from "react";
 import { Row, Col, Table, Form, Button } from "react-bootstrap";
 import { createSchedule } from "../../../components/schedule/add";
 import LoadingButton from "../../../components/loadingButton";
+import AppIcon from "../../../components/appIcon";
+import StateBadge from "../../../components/stateBadge";
+import LockedBadge from "../../../components/lockedBadge";
 import { useRouter } from "next/router";
 import { Actions } from "../../../utils/apiData";
 
@@ -127,11 +130,25 @@ export default function Page(props) {
       return self.indexOf(value) === index;
     });
 
+  const Header = function () {
+    return (
+      <Row>
+        <Col md={1}>
+          <AppIcon src={source.app.icon} fluid size={100} />
+        </Col>
+        <Col>
+          <h1>{source.name} - Profile Identification</h1>
+          <StateBadge state={source.state} /> <LockedBadge object={source} />
+        </Col>
+      </Row>
+    );
+  };
+
   if (!source.previewAvailable) {
     return (
       <>
-        <h2>Profile Identification</h2>
         <SourceTabs source={source} />
+        <Header />
         <p>Mapping not available for a {source.type} source</p>
       </>
     );
@@ -140,8 +157,8 @@ export default function Page(props) {
   if (previewColumns.length === 0) {
     return (
       <>
-        <h2>Profile Identification</h2>
         <SourceTabs source={source} />
+        <Header />
         <p>Set the options first!</p>
       </>
     );
@@ -154,8 +171,7 @@ export default function Page(props) {
       </Head>
 
       <SourceTabs source={source} />
-
-      <h1>Profile Identification</h1>
+      <Header />
 
       <Form>
         <fieldset disabled={source.locked !== null}>

--- a/core/web/pages/source/[guid]/overview.tsx
+++ b/core/web/pages/source/[guid]/overview.tsx
@@ -2,6 +2,7 @@ import { useApi } from "../../../hooks/useApi";
 import { Row, Col, Table, Badge, Alert } from "react-bootstrap";
 import AppIcon from "./../../../components/appIcon";
 import StateBadge from "./../../../components/stateBadge";
+import LockedBadge from "./../../../components/lockedBadge";
 import Link from "next/link";
 import Moment from "react-moment";
 import ScheduleAddButton from "../../../components/schedule/add";
@@ -43,9 +44,11 @@ export default function Page({
         </Col>
         <Col>
           <h1>{source.name}</h1>
-          <StateBadge state={source.state} />
-          <br />
-          <br />
+          <StateBadge state={source.state} /> <LockedBadge object={source} />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
           <p>
             <strong>App</strong>:{" "}
             <Link href="/app/[guid]" as={`/app/${source.app.guid}`}>
@@ -55,7 +58,6 @@ export default function Page({
             <strong>Connection</strong>: {source.connection.name}:{" "}
             {source.connection.description}
           </p>
-
           <p>
             <strong>Options</strong>
             <br />
@@ -66,11 +68,8 @@ export default function Page({
               </span>
             ))}
           </p>
-
           <hr />
-
           <h2>Profile Property Rules</h2>
-
           <Table>
             <thead>
               <tr>
@@ -111,15 +110,12 @@ export default function Page({
               ))}
             </tbody>
           </Table>
-
           <ProfilePropertyRuleAddButton
             errorHandler={errorHandler}
             successHandler={successHandler}
             source={source}
           />
-
           <hr />
-
           <h2>Schedule</h2>
           <br />
           {source.scheduleAvailable ? (
@@ -241,9 +237,7 @@ export default function Page({
               Schedule not available for this connection type
             </Alert>
           )}
-
           <hr />
-
           <h2>Profile Identification</h2>
           {source.previewAvailable && !source.connection.skipSourceMapping ? (
             Object.keys(source.mapping).length === 1 ? (

--- a/core/web/pages/source/[guid]/runs.tsx
+++ b/core/web/pages/source/[guid]/runs.tsx
@@ -3,7 +3,10 @@ import RunsList from "../../../components/runs/list";
 import { useApi } from "../../../hooks/useApi";
 import { useState } from "react";
 import SourceTabs from "../../../components/tabs/source";
-import { Button } from "react-bootstrap";
+import AppIcon from "../../../components/appIcon";
+import StateBadge from "../../../components/stateBadge";
+import LockedBadge from "../../../components/lockedBadge";
+import { Button, Row, Col } from "react-bootstrap";
 
 export default function Page(props) {
   const { errorHandler, successHandler, runsHandler, source } = props;
@@ -29,20 +32,39 @@ export default function Page(props) {
 
       <SourceTabs source={source} />
 
-      <Button
-        size="sm"
-        variant="outline-primary"
-        disabled={loading}
-        onClick={() => {
-          enqueueScheduleRun();
-        }}
-      >
-        Run Now
-      </Button>
-      <br />
-      <br />
-
-      <RunsList {...props} />
+      <RunsList
+        header={
+          <>
+            <Row>
+              <Col md={1}>
+                <AppIcon src={source?.app?.icon} fluid size={100} />
+              </Col>
+              <Col>
+                <h1>{source.name} - Runs</h1>
+                <StateBadge state={source.state} />{" "}
+                <LockedBadge object={source} />
+              </Col>
+            </Row>
+            <Row>
+              <Col>
+                <Button
+                  size="sm"
+                  variant="outline-primary"
+                  disabled={loading}
+                  onClick={() => {
+                    enqueueScheduleRun();
+                  }}
+                >
+                  Run Now
+                </Button>
+                <br />
+                <br />
+              </Col>
+            </Row>
+          </>
+        }
+        {...props}
+      />
     </>
   );
 }

--- a/core/web/pages/source/[guid]/schedule.tsx
+++ b/core/web/pages/source/[guid]/schedule.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/router";
 import Link from "next/link";
 import AppIcon from "../../../components/appIcon";
 import StateBadge from "../../../components/stateBadge";
+import LockedBadge from "../../../components/lockedBadge";
 import { Models, Actions } from "../../../utils/apiData";
 import { ErrorHandler } from "../../../utils/errorHandler";
 import { SuccessHandler } from "../../../utils/successHandler";
@@ -110,16 +111,16 @@ export default function Page(props) {
         <fieldset disabled={schedule.locked !== null}>
           <Row>
             <Col md={1}>
-              <br />
               <AppIcon src={source?.app?.icon} fluid size={100} />
             </Col>
             <Col>
-              <h2>
-                Schedule for source <Badge variant="info">{source.name}</Badge>
-              </h2>
-              <StateBadge state={schedule.state} />
-              <br />
-              <br />
+              <h1>{source.name} - Schedule</h1>
+              <StateBadge state={schedule.state} />{" "}
+              <LockedBadge object={source} />
+            </Col>
+          </Row>
+          <Row>
+            <Col>
               <Form.Group controlId="recurring">
                 <Form.Check
                   type="checkbox"
@@ -337,16 +338,12 @@ export default function Page(props) {
                   </div>
                 ))}
               </>
-
               <hr />
-
               <LoadingButton variant="primary" type="submit" disabled={loading}>
                 Update
               </LoadingButton>
-
               <br />
               <br />
-
               <LoadingButton
                 variant="danger"
                 disabled={loading}

--- a/core/web/pages/team/[guid]/edit.tsx
+++ b/core/web/pages/team/[guid]/edit.tsx
@@ -6,6 +6,7 @@ import PermissionsList from "../../../components/permissions";
 import { useRouter } from "next/router";
 import { Models, Actions } from "../../../utils/apiData";
 import TeamTabs from "../../../components/tabs/team";
+import LockedBadge from "../../../components/lockedBadge";
 
 export default function Page(props) {
   const { errorHandler, successHandler, teamHandler } = props;
@@ -82,6 +83,9 @@ export default function Page(props) {
   return (
     <>
       <TeamTabs team={team} />
+
+      <h1>{team.name}</h1>
+      <LockedBadge object={team} />
 
       <Form id="form" onSubmit={updateTeam} autoComplete="off">
         <fieldset disabled={team.locked !== null}>

--- a/core/web/pages/team/[guid]/members.tsx
+++ b/core/web/pages/team/[guid]/members.tsx
@@ -51,6 +51,8 @@ export default function Page(props) {
     <>
       <TeamTabs team={team} />
 
+      <h1>{team.name} - Members</h1>
+
       <LoadingTable loading={loading}>
         <thead>
           <tr>

--- a/core/web/pages/teamMember/[guid]/edit.tsx
+++ b/core/web/pages/teamMember/[guid]/edit.tsx
@@ -62,6 +62,8 @@ export default function Page(props) {
 
       <TeamMemberTabs teamMember={teamMember} />
 
+      <h1>{teamMember.email}</h1>
+
       <Row>
         <Col md={2}>
           <p>

--- a/core/web/utils/apiData.ts
+++ b/core/web/utils/apiData.ts
@@ -158,6 +158,7 @@ import {
   ProfilePropertyRuleCreate,
   ProfilePropertyRuleDestroy,
   ProfilePropertyRuleEdit,
+  ProfilePropertyRuleMakeIdentifying,
   ProfilePropertyRuleFilterOptions,
   ProfilePropertyRuleGroups,
   ProfilePropertyRulePluginOptions,
@@ -392,6 +393,9 @@ export namespace Actions {
   >;
   export type ProfilePropertyRuleEdit = AsyncReturnType<
     typeof ProfilePropertyRuleEdit.prototype.run
+  >;
+  export type ProfilePropertyRuleMakeIdentifying = AsyncReturnType<
+    typeof ProfilePropertyRuleMakeIdentifying.prototype.run
   >;
   export type ProfilePropertyRuleFilterOptions = AsyncReturnType<
     typeof ProfilePropertyRuleFilterOptions.prototype.run


### PR DESCRIPTION
* use `destination.trackGroup` method to assign group to destination in codeConfig
* Actions and Code Config Helpers to make a Profile Property Rule identifying
* Config Objects are validated not to have extra properties
* display locked status and fixup headers
* validate that group rule ops are in the dictionary for this type

This PR also includes a review of all page headers in the UI, and provide a more consistent page header:

<img width="1347" alt="Screen Shot 2020-12-03 at 12 24 00 PM" src="https://user-images.githubusercontent.com/303226/101084373-b71b0300-3562-11eb-8387-1e05acfb45c3.png">
<img width="1347" alt="Screen Shot 2020-12-03 at 12 24 03 PM" src="https://user-images.githubusercontent.com/303226/101084381-b97d5d00-3562-11eb-98af-e507e45adb88.png">
<img width="1347" alt="Screen Shot 2020-12-03 at 12 24 06 PM" src="https://user-images.githubusercontent.com/303226/101084384-bb472080-3562-11eb-9857-b34b33ce078d.png">


Closes T-816
Closes T-760
Closes T-762
Closes T-833
Closes T-763
Closes T-764
Closes T-834