### PR TITLE
Test that Group Rule comparisons are valid SQL before saving

### DIFF
--- a/core/__tests__/models/group/calculatedGroup.ts
+++ b/core/__tests__/models/group/calculatedGroup.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { api, specHelper } from "actionhero";
+import { api, specHelper, config } from "actionhero";
 import { Log } from "../../../src/models/Log";
 import { Profile } from "../../../src/models/Profile";
 import { Group } from "../../../src/models/Group";
@@ -67,11 +67,15 @@ describe("models/group", () => {
       );
     });
 
-    test("setting rules that fail a SQL comparison", async () => {
-      await expect(
-        group.setRules([{ key: "ltv", match: "fish", operation: { op: "gt" } }])
-      ).rejects.toThrow(/fish/); // the error message is dependant on the database, but should contain the column name
-    });
+    if (config.sequelize.dialect !== "sqlite") {
+      test("setting rules that fail a SQL comparison", async () => {
+        await expect(
+          group.setRules([
+            { key: "ltv", match: "fish", operation: { op: "gt" } },
+          ])
+        ).rejects.toThrow(/fish/); // the error message is dependant on the database, but should contain the column name
+      });
+    }
 
     test("changing group rules changes the state to initializing and enquires a run, and then back to ready when complete", async () => {
       await api.resque.queue.connection.redis.flushdb();

--- a/core/__tests__/models/group/calculatedGroup.ts
+++ b/core/__tests__/models/group/calculatedGroup.ts
@@ -67,6 +67,12 @@ describe("models/group", () => {
       );
     });
 
+    test("setting rules that fail a SQL comparison", async () => {
+      await expect(
+        group.setRules([{ key: "ltv", match: "fish", operation: { op: "gt" } }])
+      ).rejects.toThrow(/fish/); // the error message is dependant on the database, but should contain the column name
+    });
+
     test("changing group rules changes the state to initializing and enquires a run, and then back to ready when complete", async () => {
       await api.resque.queue.connection.redis.flushdb();
 

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -156,7 +156,7 @@ export class Group extends LoggedModel<Group> {
     return this.$count("groupMembers", queryOptions);
   }
 
-  async getRules() {
+  async getRules(transaction?: Transaction) {
     if (this.type === "manual") return [];
 
     // We won't be deleting the model for GroupRule until the group is really deleted (to validate other models)
@@ -166,11 +166,14 @@ export class Group extends LoggedModel<Group> {
     const rulesWithKey: GroupRuleWithKey[] = [];
     const rules = await this.$get("groupRules", {
       order: [["position", "asc"]],
+      transaction,
     });
 
     for (const i in rules) {
       const rule: GroupRule = rules[i];
-      const profilePropertyRule = await rule.$get("profilePropertyRule");
+      const profilePropertyRule = await rule.$get("profilePropertyRule", {
+        transaction,
+      });
       const type = profilePropertyRule
         ? profilePropertyRule.type
         : TopLevelGroupRules.find((tlgr) => tlgr.key === rule.profileColumn)
@@ -249,8 +252,6 @@ export class Group extends LoggedModel<Group> {
           );
         }
 
-        await this.countPotentialMembers([rule]); // test out the new rule
-
         await GroupRule.create(
           {
             position: parseInt(i) + 1,
@@ -268,6 +269,10 @@ export class Group extends LoggedModel<Group> {
           { transaction }
         );
       }
+
+      // test the rules
+      const savedRules = await this.getRules(transaction);
+      await this.countPotentialMembers(savedRules);
 
       if (this.state !== "deleted" && rules.length > 0) {
         this.state = "initializing";

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -249,6 +249,8 @@ export class Group extends LoggedModel<Group> {
           );
         }
 
+        await this.countPotentialMembers([rule]); // test out the new rule
+
         await GroupRule.create(
           {
             position: parseInt(i) + 1,


### PR DESCRIPTION
If you try to add a Group Rule comparison that makes no sense, like ` group.setRules([{ key: "ltv", match: "fish", operation: { op: "gt" } }])` (comparing a number column to a string), the Group Rule will not be saved and the transaction reverted. 

Closes T-763.