### PR TITLE
Support CLI commands when Grouparoo is at the same level as Actionhero

### DIFF
--- a/cli/src/utils/loadLocalCommands.ts
+++ b/cli/src/utils/loadLocalCommands.ts
@@ -48,7 +48,18 @@ function getActionhero() {
   process.chdir(
     path.join(process.env.INIT_CWD, "node_modules", "@grouparoo", "core")
   );
-  return require(path.join(process.cwd(), "node_modules", "actionhero"));
+
+  try {
+    try {
+      // we are in a client project with flat install, or we can resolve the package directly
+      return require("actionhero");
+    } catch (e) {
+      // the actionhero package is a child of grouparoo/core
+      return require(path.join(process.cwd(), "node_modules", "actionhero"));
+    }
+  } catch (error) {
+    throw new Error(`cannot find actionhero package - ${error}`);
+  }
 }
 
 async function loadDirectory(


### PR DESCRIPTION
In client installs with NPM,`actionhero` may not be a child of `grouparoo/core` (depending on if you use NPM or Yarn)