### PR TITLE
CLI checks for valid node.js version

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -33,9 +33,10 @@
     "chalk": "4.1.0",
     "commander": "6.1.0",
     "fs-extra": "9.0.1",
-    "glob": "^7.1.6",
+    "glob": "7.1.6",
     "npm-check-updates": "10.2.3",
-    "ora": "5.1.0"
+    "ora": "5.1.0",
+    "semver": "7.3.4"
   },
   "devDependencies": {
     "@types/fs-extra": "*",

--- a/cli/src/grouparoo.ts
+++ b/cli/src/grouparoo.ts
@@ -3,6 +3,7 @@
 import { program } from "commander";
 import Ora from "ora";
 import { loadLocalCommands } from "./utils/loadLocalCommands";
+import { checkNodeVersion } from "./utils/checkNodeVersion";
 
 import Generate from "./lib/generate";
 import Upgrade from "./lib/upgrade";
@@ -12,6 +13,7 @@ const Package = require("../package.json");
 if (!process.env.INIT_CWD) process.env.INIT_CWD = process.cwd(); // used for monorepo app determination
 
 async function main() {
+  checkNodeVersion();
   program.storeOptionsAsProperties(false);
   program.version(Package.version);
 

--- a/cli/src/utils/checkNodeVersion.ts
+++ b/cli/src/utils/checkNodeVersion.ts
@@ -1,0 +1,19 @@
+import * as semver from "semver";
+import path from "path";
+import { readPackageJSON } from "./readPackageJSON";
+import Ora from "ora";
+
+export function checkNodeVersion() {
+  const requiredVersions: string = readPackageJSON(
+    path.join(__dirname, "..", "..", "package.json")
+  ).engines.node;
+  const currentVersion = process.version;
+  const match = semver.satisfies(currentVersion, requiredVersions);
+
+  if (!match) {
+    Ora().fail(
+      `current node.js version ${currentVersion} does not match ${requiredVersions}`
+    );
+    process.exit(1);
+  }
+}

--- a/cli/src/utils/ensureNoTsHeaderFiles.ts
+++ b/cli/src/utils/ensureNoTsHeaderFiles.ts
@@ -1,0 +1,9 @@
+export function ensureNoTsHeaderFiles(files: Array<string>): Array<string> {
+  return files.filter((f) => {
+    if (f.match(/.*\.d\.ts$/)) {
+      return false;
+    } else {
+      return true;
+    }
+  });
+}

--- a/cli/src/utils/loadLocalCommands.ts
+++ b/cli/src/utils/loadLocalCommands.ts
@@ -1,6 +1,8 @@
 import fs from "fs-extra";
 import path from "path";
 import * as glob from "glob";
+import { readPackageJSON } from "./readPackageJSON";
+import { ensureNoTsHeaderFiles } from "./ensureNoTsHeaderFiles";
 
 export async function loadLocalCommands(program) {
   // are we in a grouparoo project directory?
@@ -161,18 +163,4 @@ async function runCommand(instance, _program) {
   if (toStop || toStop === null || toStop === undefined) {
     setTimeout(process.exit, 500, 0);
   }
-}
-
-function ensureNoTsHeaderFiles(files: Array<string>): Array<string> {
-  return files.filter((f) => {
-    if (f.match(/.*\.d\.ts$/)) {
-      return false;
-    } else {
-      return true;
-    }
-  });
-}
-
-function readPackageJSON(file: string) {
-  return JSON.parse(fs.readFileSync(file).toString());
 }

--- a/cli/src/utils/readPackageJSON.ts
+++ b/cli/src/utils/readPackageJSON.ts
@@ -1,0 +1,5 @@
+import fs from "fs-extra";
+
+export function readPackageJSON(file: string) {
+  return JSON.parse(fs.readFileSync(file).toString());
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,7 @@ importers:
       glob: 7.1.6
       npm-check-updates: 10.2.3
       ora: 5.1.0
+      semver: 7.3.4
     devDependencies:
       '@types/fs-extra': 9.0.2
       '@types/node': 14.14.7
@@ -82,10 +83,11 @@ importers:
       chalk: 4.1.0
       commander: 6.1.0
       fs-extra: 9.0.1
-      glob: ^7.1.6
+      glob: 7.1.6
       npm-check-updates: 10.2.3
       ora: 5.1.0
       prettier: 2.2.1
+      semver: 7.3.4
       ts-node: 9.1.1
       typescript: 4.1.2
   clients/@grouparoo/web:


### PR DESCRIPTION
```
➜  nvm use v12
Now using node v12.18.4 (npm v6.14.9)

➜ grouparoo
Usage: grouparoo [options] [command]

Options:
  -V, --version                  output the version number
  -h, --help                     display help for command

Commands:
  console                        Start an interactive REPL session with the api object in-scope
  start                          Run the Grouparoo server
  status                         Display the status of your Grouparoo cluster
  demo-config                    Writes config to current app
  demo-data-purchases [options]  Load eCommerce users and purchases into a source database.
  demo-event-stream              Makes a continuous stream of user browsing events
  demo-setup                     Start from empty bootstrap
  generate [options] [path]      Generate a new Grouparoo project
  upgrade [path]                 Upgrade an existing Grouparoo project
  help [command]                 display help for command

➜  nvm use v15
Now using node v15.0.0 (npm v7.0.2)

➜  grouparoo
✖ current node.js version v15.0.0 does not match >=12.0.0 <15.0.0
```

Closes T-871