### PR TITLE
Destroying Destinations happens via task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage
 *.sqlite
 *.sqlite-journal
 apps/*/config/*
+apps/*/*.log
 
 # API
 log

--- a/core/__tests__/models/group/calculatedGroup.ts
+++ b/core/__tests__/models/group/calculatedGroup.ts
@@ -83,7 +83,7 @@ describe("models/group", () => {
       await group.setRules([
         { key: "firstName", match: "nobody", operation: { op: "eq" } },
       ]);
-      expect(group.state).toBe("initializing");
+      expect(group.state).toBe("updating");
 
       let foundTasks = await specHelper.findEnqueuedTasks("group:run");
       expect(foundTasks.length).toBe(1);

--- a/core/__tests__/models/group/group.ts
+++ b/core/__tests__/models/group/group.ts
@@ -192,7 +192,7 @@ describe("models/group", () => {
         });
 
         const destination = await helper.factories.destination();
-        await destination.trackGroup(trackedGroup);
+        const run = await destination.trackGroup(trackedGroup);
         const destinationGroupMemberships = {};
         destinationGroupMemberships[taggedGroup.guid] = "remote-tagged-group";
         await destination.setDestinationGroupMemberships(
@@ -205,11 +205,15 @@ describe("models/group", () => {
 
         const foundTasks = await specHelper.findEnqueuedTasks("group:run");
         expect(foundTasks.length).toBe(1);
-        expect(foundTasks[0].args[0]).toEqual({
-          destinationGuid: destination.guid,
-          groupGuid: trackedGroup.guid,
-          force: false,
-        });
+        expect(foundTasks[0].args[0]).toEqual(
+          expect.objectContaining({
+            destinationGuid: destination.guid,
+            groupGuid: trackedGroup.guid,
+            force: false,
+          })
+        );
+        expect(foundTasks[0].args[0].runGuid).toBeTruthy();
+        expect(foundTasks[0].args[0].runGuid).not.toEqual(run.guid);
       });
     });
   });

--- a/core/__tests__/models/properties/property.ts
+++ b/core/__tests__/models/properties/property.ts
@@ -244,7 +244,7 @@ describe("models/property", () => {
     );
     expect(foundInternalRunTasks.length).toBe(1);
 
-    expect(group.state).toBe("initializing");
+    expect(group.state).toBe("updating");
     foundGroupRunTasks = await specHelper.findEnqueuedTasks("group:run");
     expect(foundGroupRunTasks.length).toBe(2); // + the one from the profile property change
   });

--- a/core/__tests__/modules/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig.ts
@@ -146,7 +146,6 @@ describe("modules/codeConfig", () => {
       expect(groups.length).toBe(1);
       expect(groups[0].guid).toBe("grp_email_group");
       expect(groups[0].name).toBe("People with Email Addresses");
-      expect(groups[0].state).toBe("ready");
       expect(groups[0].locked).toBe("config:code");
       const rules = await groups[0].getRules();
       expect(rules).toEqual([
@@ -280,7 +279,6 @@ describe("modules/codeConfig", () => {
       expect(groups.length).toBe(1);
       expect(groups[0].guid).toBe("grp_email_group");
       expect(groups[0].name).toBe("People who have Email Addresses");
-      expect(groups[0].state).toBe("ready");
       expect(groups[0].locked).toBe("config:code");
       const rules = await groups[0].getRules();
       expect(rules).toEqual([

--- a/core/__tests__/tasks/destination/destroy.ts
+++ b/core/__tests__/tasks/destination/destroy.ts
@@ -1,0 +1,175 @@
+import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
+import { api, specHelper, utils } from "actionhero";
+import { Group } from "./../../../src/models/Group";
+import { Destination } from "./../../../src/models/Destination";
+import { Export } from "./../../../src/models/Export";
+import { Profile } from "./../../../src/models/Profile";
+import { Run } from "./../../../src/models/Run";
+
+let actionhero;
+
+describe("tasks/destination:destroy", () => {
+  beforeAll(async () => {
+    const env = await helper.prepareForAPITest();
+    actionhero = env.actionhero;
+  }, helper.setupTime);
+
+  afterAll(async () => {
+    await helper.shutdown(actionhero);
+  });
+
+  beforeAll(async () => {
+    await api.resque.queue.connection.redis.flushdb();
+    await Export.truncate();
+  });
+
+  describe("without tracked group", () => {
+    let destination: Destination;
+
+    beforeAll(async () => {
+      destination = await helper.factories.destination();
+    });
+
+    afterAll(async () => {
+      await destination.destroy();
+    });
+
+    test("deleting a destination with no group tracked works", async () => {
+      await destination.update({ state: "deleted" });
+      await specHelper.runTask("destination:destroy", {
+        destinationGuid: destination.guid,
+      });
+
+      await expect(Destination.findByGuid(destination.guid)).rejects.toThrow(
+        /cannot find Destination/
+      );
+    });
+  });
+
+  describe("with tracked group", () => {
+    let group: Group;
+    let destination: Destination;
+    let mario: Profile;
+    let luigi: Profile;
+    let run: Run;
+
+    beforeAll(async () => {
+      destination = await helper.factories.destination();
+      group = await helper.factories.group();
+      mario = await helper.factories.profile();
+      luigi = await helper.factories.profile();
+      await group.addProfile(mario);
+      await group.addProfile(luigi);
+      await destination.trackGroup(group);
+
+      await api.resque.queue.connection.redis.flushdb();
+      await Run.truncate();
+    });
+
+    test("a destination tracking a group cannot be deleted", async () => {
+      await expect(destination.destroy()).rejects.toThrow(
+        "cannot delete a destination that is tracking a group"
+      );
+    });
+
+    test("the task can be enqueued and create a run for the group", async () => {
+      await destination.update({ state: "deleted" });
+      await specHelper.runTask("destination:destroy", {
+        destinationGuid: destination.guid,
+      });
+
+      run = await Run.findOne({ where: { creatorGuid: group.guid } });
+
+      const foundTasks = await specHelper.findEnqueuedTasks(
+        "destination:destroy"
+      );
+      expect(foundTasks.length).toBe(1);
+      expect(foundTasks[0].args[0]).toEqual({
+        destinationGuid: destination.guid,
+        runGuid: run.guid,
+      });
+
+      destination = await Destination.findByGuid(destination.guid);
+      expect(destination.state).toBe("deleted");
+      expect(destination.groupGuid).toBeNull();
+    });
+
+    test("the destination will not be deleted yet (running run)", async () => {
+      await utils.sleep(1000);
+      await specHelper.runTask("destination:destroy", {
+        destinationGuid: destination.guid,
+        runGuid: run.guid,
+      });
+
+      destination = await Destination.findByGuid(destination.guid);
+      expect(destination.state).toBe("deleted");
+    });
+
+    test("the group run can be completed and create exports", async () => {
+      // add
+      let foundTasks = await specHelper.findEnqueuedTasks("group:run");
+      await specHelper.deleteEnqueuedTasks("group:run", foundTasks[0].args[0]);
+      await specHelper.runTask("group:run", foundTasks[0].args[0]);
+      // remove
+      foundTasks = await specHelper.findEnqueuedTasks("group:run");
+      await specHelper.deleteEnqueuedTasks("group:run", foundTasks[0].args[0]);
+      await specHelper.runTask("group:run", foundTasks[0].args[0]);
+      // removeOld
+      foundTasks = await specHelper.findEnqueuedTasks("group:run");
+      await specHelper.deleteEnqueuedTasks("group:run", foundTasks[0].args[0]);
+      await specHelper.runTask("group:run", foundTasks[0].args[0]);
+
+      await ImportWorkflow();
+
+      // complete
+      foundTasks = await specHelper.findEnqueuedTasks("group:run");
+      await specHelper.deleteEnqueuedTasks("group:run", foundTasks[0].args[0]);
+      await specHelper.runTask("group:run", foundTasks[0].args[0]);
+
+      run = await Run.findByGuid(run.guid);
+      group = await Group.findByGuid(group.guid);
+      expect(group.state).toBe("ready");
+      expect(run.state).toBe("complete");
+
+      // create exports
+      const exportTasks = await specHelper.findEnqueuedTasks("profile:export");
+      await Promise.all(
+        exportTasks.map((t) => specHelper.runTask("profile:export", t.args[0]))
+      );
+    });
+
+    test("the destination will not be deleted yet (pending exports)", async () => {
+      await utils.sleep(1000);
+      await specHelper.runTask("destination:destroy", {
+        destinationGuid: destination.guid,
+        runGuid: run.guid,
+      });
+
+      destination = await Destination.findByGuid(destination.guid);
+      expect(destination.state).toBe("deleted");
+    });
+
+    test("the exports can be exported", async () => {
+      await specHelper.runTask("export:enqueue", {});
+      const foundExportSendTasks = await specHelper.findEnqueuedTasks(
+        "export:send"
+      );
+      await Promise.all(
+        foundExportSendTasks.map((t) =>
+          specHelper.runTask("export:send", t.args[0])
+        )
+      );
+    });
+
+    test("now the destination can be deleted", async () => {
+      await specHelper.runTask("destination:destroy", {
+        destinationGuid: destination.guid,
+        runGuid: run.guid,
+      });
+
+      await expect(Destination.findByGuid(destination.guid)).rejects.toThrow(
+        /cannot find Destination/
+      );
+    });
+  });
+});

--- a/core/__tests__/tasks/export/send.ts
+++ b/core/__tests__/tasks/export/send.ts
@@ -38,10 +38,12 @@ describe("tasks/export:send", () => {
       group = await helper.factories.group({ type: "manual" });
       await group.addProfile(profile);
 
-      await api.resque.queue.connection.redis.flushdb();
-
       destination = await helper.factories.destination();
       await destination.trackGroup(group);
+
+      await api.resque.queue.connection.redis.flushdb();
+      await Run.truncate();
+
       const destinationGroupMemberships = {};
       destinationGroupMemberships[group.guid] = group.name;
       await destination.setDestinationGroupMemberships(

--- a/core/__tests__/tasks/export/sendBatch.ts
+++ b/core/__tests__/tasks/export/sendBatch.ts
@@ -38,12 +38,14 @@ describe("tasks/export:sendBatch", () => {
       group = await helper.factories.group({ type: "manual" });
       await group.addProfile(profile);
 
-      await api.resque.queue.connection.redis.flushdb();
-
       destination = await helper.factories.destination(null, {
         type: "test-plugin-export-batch",
       });
       await destination.trackGroup(group);
+
+      await api.resque.queue.connection.redis.flushdb();
+      await Run.truncate();
+
       const destinationGroupMemberships = {};
       destinationGroupMemberships[group.guid] = group.name;
       await destination.setDestinationGroupMemberships(

--- a/core/__tests__/tasks/group/run.ts
+++ b/core/__tests__/tasks/group/run.ts
@@ -76,7 +76,7 @@ describe("tasks/group:run", () => {
     });
 
     test("can be enqueued", async () => {
-      await task.enqueue("group:run", { groupGuid: "abc123" });
+      await group.run();
       const found = await specHelper.findEnqueuedTasks("group:run");
       expect(found.length).toEqual(1);
     });
@@ -102,7 +102,7 @@ describe("tasks/group:run", () => {
         { key: "email", match: "%@%", operation: { op: "like" } },
       ]);
 
-      expect(group.state).toBe("initializing");
+      expect(group.state).toBe("updating");
 
       foundTasks = await specHelper.findEnqueuedTasks("group:run");
       expect(foundTasks.length).toBe(1);
@@ -179,7 +179,7 @@ describe("tasks/group:run", () => {
         },
       ]);
 
-      expect(group.state).toBe("initializing");
+      expect(group.state).toBe("updating");
 
       imports = await Import.findAll();
       expect(imports.length).toBe(0); // no imports to add profiles to the group
@@ -266,6 +266,9 @@ describe("tasks/group:run", () => {
 
       expect((await group.$get("groupMembers")).length).toBe(1);
 
+      await api.resque.queue.connection.redis.flushdb();
+      await group.run();
+
       foundTasks = await specHelper.findEnqueuedTasks("group:run");
       expect(foundTasks.length).toBe(1);
       expect(foundTasks[0].args[0].method).toBeUndefined();
@@ -311,10 +314,7 @@ describe("tasks/group:run", () => {
 
     it("will pass destinationGuid to all run steps", async () => {
       let foundTasks = [];
-      await task.enqueue("group:run", {
-        groupGuid: group.guid,
-        destinationGuid: "abc123",
-      });
+      await group.run(false, "abc123");
 
       foundTasks = await specHelper.findEnqueuedTasks("group:run");
       expect(foundTasks.length).toBe(1);
@@ -345,7 +345,7 @@ describe("tasks/group:run", () => {
 
     it("will set run.force if that option is provided to the task", async () => {
       const group = await helper.factories.group();
-      await task.enqueue("group:run", { groupGuid: group.guid, force: true });
+      await group.run(true);
       const foundTasks = await specHelper.findEnqueuedTasks("group:run");
       await specHelper.runTask("group:run", foundTasks[0].args[0]);
       const run = await Run.findOne({ where: { creatorGuid: group.guid } });
@@ -358,7 +358,7 @@ describe("tasks/group:run", () => {
         { key: "email", match: "%@%", operation: { op: "like" } },
       ]);
 
-      expect(group.state).toBe("initializing");
+      expect(group.state).toBe("updating");
 
       let foundTasks = await specHelper.findEnqueuedTasks("group:run");
       await api.resque.queue.connection.redis.flushdb();

--- a/core/bin/dev
+++ b/core/bin/dev
@@ -21,7 +21,7 @@ for p in $GROUPAROO_PIDS; do
   sleep 1
 done
 
-"$NODEMON" -e js,jsx,ts,tsx --signal SIGTERM --ignore dist --watch ./src --watch ../../plugins/**/*.js \
+"$NODEMON" -e js,jsx,ts,tsx --signal SIGTERM --ignore dist --watch ./src --watch ../plugins/**/*.js \
 --exec "$TS_NODE" --transpile-only --log-error src/grouparoo.ts \
 || exit 0
 

--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -72,12 +72,6 @@ export const DEFAULT = {
       if (storage !== ":memory:" && !isAbsolute(storage)) {
         storage = join(getParentPath(), storage);
       }
-
-      if (config?.tasks?.maxTaskProcessors > 1) {
-        throw new Error(
-          "Only one task worker can be used with a SQLite database"
-        );
-      }
     }
 
     return {

--- a/core/src/initializers/environment.ts
+++ b/core/src/initializers/environment.ts
@@ -17,6 +17,12 @@ export class Environment extends Initializer {
 
     if (config.sequelize.dialect === "sqlite") {
       log(`using SQLite database: ${config.sequelize.storage}`);
+
+      if (config.tasks.maxTaskProcessors > 1) {
+        throw new Error(
+          "Only one task worker can be used with a SQLite database"
+        );
+      }
     }
   }
 }

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -69,6 +69,7 @@ const STATE_TRANSITIONS = [
   { from: "ready", to: "updating", checks: [] },
   { from: "updating", to: "ready", checks: [] },
   { from: "updating", to: "initializing", checks: [] },
+  { from: "updating", to: "deleted", checks: [] },
   { from: "ready", to: "deleted", checks: [] },
 ];
 

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -2,29 +2,23 @@ import {
   Destination,
   SimpleDestinationOptions,
 } from "../../models/Destination";
-import { App } from "../../models/App";
 import { Profile } from "../../models/Profile";
-import { Run } from "../../models/Run";
-import { Import } from "../../models/Import";
 import { Export, ExportProfilePropertiesWithType } from "../../models/Export";
 import { Group } from "../../models/Group";
 import { Property } from "../../models/Property";
 import { MappingHelper } from "../mappingHelper";
 import {
   ExportedProfile,
-  ExportProfilePluginMethod,
   ExportProfilesPluginMethod,
   ErrorWithProfileGuid,
   DestinationMappingOptionsResponseTypes,
   DestinationMappingOptionsMethodResponse,
 } from "../../classes/plugin";
-import { api, task, log, config, cache } from "actionhero";
+import { config, cache } from "actionhero";
 import { deepStrictEqual } from "assert";
 import { ProfilePropertyOps } from "./profileProperty";
 import { destinationTypeConversions } from "../destinationTypeConversions";
 import { GroupMember } from "../../models/GroupMember";
-import { Op } from "sequelize";
-import { PluginConnection } from "../../classes/plugin";
 
 function deepStrictEqualBoolean(a: any, b: any): boolean {
   try {
@@ -59,7 +53,7 @@ export namespace DestinationOps {
         const oldGroup = await Group.findByGuid(oldGroupGuid);
         await oldGroup.run(true, destination.guid);
       }
-      await group.run(true, destination.guid);
+      return group.run(true, destination.guid);
     }
   }
 
@@ -72,7 +66,7 @@ export namespace DestinationOps {
 
     if (oldGroupGuid) {
       const oldGroup = await Group.findByGuid(oldGroupGuid);
-      await oldGroup.run(true, destination.guid);
+      return oldGroup.run(true, destination.guid);
     }
   }
 

--- a/core/src/modules/ops/property.ts
+++ b/core/src/modules/ops/property.ts
@@ -26,7 +26,7 @@ export namespace PropertyOps {
     for (const i in groups) {
       const group = groups[i];
       await group.update({ state: "initializing" });
-      await task.enqueue("group:run", { groupGuid: group.guid });
+      await group.run();
     }
   }
 

--- a/core/src/tasks/destination/destroy.ts
+++ b/core/src/tasks/destination/destroy.ts
@@ -1,0 +1,61 @@
+import { Task, task, config } from "actionhero";
+import { Destination } from "../../models/Destination";
+import { Run } from "../../models/Run";
+
+export class DestinationDestroy extends Task {
+  constructor() {
+    super();
+    this.name = "destination:destroy";
+    this.description =
+      "untrack the group, wait for the exports, and then delete the destination";
+    this.frequency = 0;
+    this.queue = "destinations";
+    this.inputs = {
+      destinationGuid: { required: true },
+      runGuid: { required: false },
+    };
+  }
+
+  async run(params) {
+    const destination = await Destination.scope(null).findOne({
+      where: { guid: params.destinationGuid, state: "deleted" },
+    });
+
+    // the destination may have been force-deleted
+    if (!destination) return;
+
+    let run: Run;
+    // untrack the group, if we are still tracking one
+    // this will trigger a run to export all group members one last time
+    if (destination.groupGuid) {
+      run = await destination.unTrackGroup();
+    } else if (params.runGuid) {
+      run = await Run.scope(null).findOne({ where: { guid: params.runGuid } });
+    }
+
+    // the run is not yet complete
+    if (run) {
+      if (run.state === "running" || run.state === "draft") {
+        return task.enqueueIn(config.tasks.timeout + 1, this.name, {
+          destinationGuid: destination.guid,
+          runGuid: run.guid,
+        });
+      }
+    }
+
+    // ensure that all the exports are complete
+    try {
+      await Destination.waitForPendingExports(destination);
+    } catch (error) {
+      if (error.message.match(/cannot delete destination until/)) {
+        return task.enqueueIn(config.tasks.timeout * 2, this.name, {
+          destinationGuid: destination.guid,
+          runGuid: run.guid,
+        });
+      } else throw error;
+    }
+
+    // the run is done (complete or stopped) or there was not a tracked group for this destination
+    await destination.destroy();
+  }
+}

--- a/core/src/tasks/export/enqueue.ts
+++ b/core/src/tasks/export/enqueue.ts
@@ -20,9 +20,7 @@ export class EnqueueExports extends RetryableTask {
       (await plugin.readSetting("core", "exports-profile-batch-size")).value
     );
 
-    const destinations = await Destination.findAll({
-      where: { state: "ready" },
-    });
+    const destinations = await Destination.scope(null).findAll();
 
     let totalEnqueued = 0;
 

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -14,7 +14,7 @@ export class RunGroup extends Task {
     this.queue = "groups";
     this.inputs = {
       groupGuid: { required: true },
-      runGuid: { required: false },
+      runGuid: { required: true },
       method: { required: false },
       offset: { required: false },
       highWaterMark: { required: false },
@@ -44,23 +44,7 @@ export class RunGroup extends Task {
       );
 
     const group = await Group.findByGuid(params.groupGuid);
-
-    let run: Run;
-    if (params.runGuid) {
-      run = await Run.findByGuid(params.runGuid);
-    } else {
-      run = await Run.create({
-        creatorGuid: group.guid,
-        creatorType: "group",
-        state: "running",
-        force,
-      });
-      await group.update({ state: "updating" });
-      log(
-        `[ run ] starting run ${run.guid} for group ${group.name} (${group.guid})`,
-        "notice"
-      );
-    }
+    const run = await Run.findByGuid(params.runGuid);
 
     if (run.state === "stopped") return;
 

--- a/core/src/tasks/group/updateCalculatedGroups.ts
+++ b/core/src/tasks/group/updateCalculatedGroups.ts
@@ -1,4 +1,4 @@
-import { task, Task } from "actionhero";
+import { Task } from "actionhero";
 import { Group } from "../../models/Group";
 import { plugin } from "../../modules/plugin";
 import { Op } from "sequelize";
@@ -35,10 +35,6 @@ export class GroupsUpdateCalculatedGroups extends Task {
       },
     });
 
-    await Promise.all(
-      calculatedGroups.map(async (group) => {
-        return task.enqueue("group:run", { groupGuid: group.guid });
-      })
-    );
+    await Promise.all(calculatedGroups.map((group) => group.run()));
   }
 }

--- a/core/src/tasks/profile/export.ts
+++ b/core/src/tasks/profile/export.ts
@@ -70,7 +70,7 @@ export class ProfileExport extends RetryableTask {
             .map((d) => d.guid)
             .includes(_import.data?._meta?.destinationGuid)
         ) {
-          const destination = await Destination.findOne({
+          const destination = await Destination.scope(null).findOne({
             where: { guid: _import.data._meta.destinationGuid },
           });
           if (destination) destinations.push(destination);

--- a/plugins/@grouparoo/logger/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/logger/src/initializers/plugin.ts
@@ -28,7 +28,8 @@ export class Plugins extends Initializer {
               key: "filename",
               displayName: "File Name",
               required: true,
-              description: "The name of the file to log to, in /log.",
+              description:
+                "The name of the file to log to, relative to your application root.",
               placeholder: "/path/to/grouparoo.log",
             },
             {

--- a/plugins/@grouparoo/logger/src/lib/export/exportProfiles.ts
+++ b/plugins/@grouparoo/logger/src/lib/export/exportProfiles.ts
@@ -1,13 +1,13 @@
 import { ExportProfilesPluginMethod } from "@grouparoo/core";
-import * as fs from "fs";
-import * as path from "path";
-import { config, log } from "actionhero";
+import fs from "fs";
+import { getFilePath } from "../utils/getFilePath";
+import { log } from "actionhero";
 
 export const exportProfiles: ExportProfilesPluginMethod = async ({
   appOptions,
   exports,
 }) => {
-  const filePath = path.join(config.general.paths.log[0], appOptions.filename);
+  const filePath = getFilePath(appOptions.filename);
   let lines = [];
 
   exports.map((_export) => {

--- a/plugins/@grouparoo/logger/src/lib/test.ts
+++ b/plugins/@grouparoo/logger/src/lib/test.ts
@@ -1,10 +1,10 @@
 import { TestPluginMethod } from "@grouparoo/core";
-import * as fs from "fs";
-import * as path from "path";
-import { config } from "actionhero";
+import fs from "fs";
+import { getFilePath } from "./utils/getFilePath";
 
 export const test: TestPluginMethod = async ({ appOptions }) => {
-  const filePath = path.join(config.general.paths.log[0], appOptions.filename);
+  const filePath = getFilePath(appOptions.filename);
+
   const now = new Date();
   try {
     // touch the file
@@ -16,6 +16,6 @@ export const test: TestPluginMethod = async ({ appOptions }) => {
 
   return {
     success: true,
-    message: `Access to ${appOptions.filename} confirmed`,
+    message: `Access to ${filePath} confirmed`,
   };
 };

--- a/plugins/@grouparoo/logger/src/lib/utils/getFilePath.ts
+++ b/plugins/@grouparoo/logger/src/lib/utils/getFilePath.ts
@@ -1,0 +1,13 @@
+import { getParentPath } from "@grouparoo/core/dist/utils/pluginDetails";
+import path from "path";
+
+export function getFilePath(filename: string) {
+  let filePath: string;
+  if (path.isAbsolute(filename)) {
+    filePath = filename;
+  } else {
+    filePath = path.join(getParentPath(), filename);
+  }
+
+  return filePath;
+}

--- a/ui/components/visualizations/homepageWidgets.tsx
+++ b/ui/components/visualizations/homepageWidgets.tsx
@@ -464,8 +464,7 @@ export function PendingExports({ execApi }) {
   async function load() {
     const { destinations }: Actions.DestinationsList = await execApi(
       "get",
-      `/destinations`,
-      { state: "ready" }
+      `/destinations`
     );
 
     const { exports: _exports }: Actions.ExportsList = await execApi(


### PR DESCRIPTION

<img width="1524" alt="Screen Shot 2020-12-15 at 10 50 33 AM" src="https://user-images.githubusercontent.com/303226/102282360-5934d680-3ee5-11eb-8f42-0a94ebb74cee.png">


This PR moves the destruction of a Destination to a background task.  This means that the UX/DX of deleting a Destination is synchronous and the server will sort it out for you.  This means that you can click "delete" on a Destination and have immediate feedback... and have a similar experience in Code-Config.

This is similar to how we destroy Groups.

Part of T-805