### PR TITLE
Fix bug with Profile Details page not showing properties

### DIFF
--- a/core/src/modules/ops/property.ts
+++ b/core/src/modules/ops/property.ts
@@ -3,7 +3,6 @@ import { Group } from "../../models/Group";
 import { GroupRule } from "../../models/GroupRule";
 import { App } from "../../models/App";
 import { internalRun } from "../internalRun";
-import { task } from "actionhero";
 import { Op, Transaction } from "sequelize";
 import Mustache from "mustache";
 

--- a/ui/pages/profile/[guid]/edit.tsx
+++ b/ui/pages/profile/[guid]/edit.tsx
@@ -156,9 +156,6 @@ export default function Page(props) {
     setLoading(false);
   }
 
-  const keys = Object.keys(properties);
-  keys.sort();
-
   const updateExistingProperty = async (event) => {
     const _profileProperties = Object.assign({}, profileProperties);
     _profileProperties[event.target.id].values = [event.target.value];
@@ -279,91 +276,83 @@ export default function Page(props) {
               </tr>
             </thead>
             <tbody>
-              {keys.map((key) => {
-                return (
-                  <tr key={`property-${key}`}>
-                    <td>
-                      <span style={{ fontWeight: "bold" }}>
-                        {properties[key].key}
-                      </span>
-                    </td>
-                    <td>
-                      {manualProperties.includes(key) ? (
-                        <Form>
-                          <Form.Group controlId={key}>
-                            <Form.Control
-                              required
-                              type="text"
-                              disabled={loading}
-                              value={
-                                properties[key].values.length === 0
-                                  ? ""
-                                  : properties[key].values.join(", ")
-                              }
-                              onChange={(e) => updateExistingProperty(e)}
-                            />
-                          </Form.Group>
+              {Object.keys(profileProperties)
+                .sort()
+                .map((key) => {
+                  const profileProperty = profileProperties[key];
+                  return (
+                    <tr key={`property-${key}`}>
+                      <td>
+                        <span style={{ fontWeight: "bold" }}>{key}</span>
+                      </td>
+                      <td>
+                        {manualProperties.includes(key) ? (
+                          <Form>
+                            <Form.Group controlId={key}>
+                              <Form.Control
+                                required
+                                type="text"
+                                disabled={loading}
+                                value={
+                                  profileProperty.values.length === 0
+                                    ? ""
+                                    : profileProperty.values.join(", ")
+                                }
+                                onChange={(e) => updateExistingProperty(e)}
+                              />
+                            </Form.Group>
 
-                          <LoadingButton
-                            size="sm"
-                            type="submit"
-                            variant="info"
-                            disabled={loading}
-                            onClick={() => {
-                              handleUpdate(key);
-                            }}
-                          >
-                            Update
-                          </LoadingButton>
-                        </Form>
-                      ) : (
-                        <span>
-                          <strong>
-                            <ArrayProfilePropertyList
-                              type={profileProperties[properties[key].key].type}
-                              values={
-                                profileProperties[properties[key].key].values
-                              }
-                            />
-                          </strong>
-                        </span>
-                      )}
-                    </td>
-                    <td>
-                      <code>
-                        {properties[key].type}
-                        {properties[key].isArray ? "[]" : null}
-                      </code>
-                    </td>
-                    <td>
-                      <StateBadge
-                        state={profileProperties[properties[key].key].state}
-                      />
-                    </td>
-                    <td>
-                      {profileProperties[properties[key].key].valueChangedAt ? (
-                        <Moment fromNow>
-                          {
-                            profileProperties[properties[key].key]
-                              .valueChangedAt
-                          }
-                        </Moment>
-                      ) : (
-                        "Never"
-                      )}
-                    </td>
-                    <td>
-                      {profileProperties[properties[key].key].confirmedAt ? (
-                        <Moment fromNow>
-                          {profileProperties[properties[key].key].confirmedAt}
-                        </Moment>
-                      ) : (
-                        "Never"
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
+                            <LoadingButton
+                              size="sm"
+                              type="submit"
+                              variant="info"
+                              disabled={loading}
+                              onClick={() => {
+                                handleUpdate(key);
+                              }}
+                            >
+                              Update
+                            </LoadingButton>
+                          </Form>
+                        ) : (
+                          <span>
+                            <strong>
+                              <ArrayProfilePropertyList
+                                type={profileProperty.type}
+                                values={profileProperty.values}
+                              />
+                            </strong>
+                          </span>
+                        )}
+                      </td>
+                      <td>
+                        <code>
+                          {profileProperty.type}
+                          {profileProperty.isArray ? "[]" : null}
+                        </code>
+                      </td>
+                      <td>
+                        <StateBadge state={profileProperty.state} />
+                      </td>
+                      <td>
+                        {profileProperty.valueChangedAt ? (
+                          <Moment fromNow>
+                            {profileProperty.valueChangedAt}
+                          </Moment>
+                        ) : (
+                          "Never"
+                        )}
+                      </td>
+                      <td>
+                        {profileProperty.confirmedAt ? (
+                          <Moment fromNow>{profileProperty.confirmedAt}</Moment>
+                        ) : (
+                          "Never"
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
             </tbody>
           </LoadingTable>
         </Col>

--- a/ui/pages/profile/[guid]/edit.tsx
+++ b/ui/pages/profile/[guid]/edit.tsx
@@ -283,7 +283,9 @@ export default function Page(props) {
                 return (
                   <tr key={`property-${key}`}>
                     <td>
-                      <span style={{ fontWeight: "bold" }}>{key}</span>
+                      <span style={{ fontWeight: "bold" }}>
+                        {properties[key].key}
+                      </span>
                     </td>
                     <td>
                       {manualProperties.includes(key) ? (
@@ -318,8 +320,10 @@ export default function Page(props) {
                         <span>
                           <strong>
                             <ArrayProfilePropertyList
-                              type={properties[key].type}
-                              values={properties[key].values}
+                              type={profileProperties[properties[key].key].type}
+                              values={
+                                profileProperties[properties[key].key].values
+                              }
                             />
                           </strong>
                         </span>
@@ -332,20 +336,27 @@ export default function Page(props) {
                       </code>
                     </td>
                     <td>
-                      <StateBadge state={properties[key].state} />
+                      <StateBadge
+                        state={profileProperties[properties[key].key].state}
+                      />
                     </td>
                     <td>
-                      {properties[key].valueChangedAt ? (
+                      {profileProperties[properties[key].key].valueChangedAt ? (
                         <Moment fromNow>
-                          {properties[key].valueChangedAt}
+                          {
+                            profileProperties[properties[key].key]
+                              .valueChangedAt
+                          }
                         </Moment>
                       ) : (
                         "Never"
                       )}
                     </td>
                     <td>
-                      {properties[key].confirmedAt ? (
-                        <Moment fromNow>{properties[key].confirmedAt}</Moment>
+                      {profileProperties[properties[key].key].confirmedAt ? (
+                        <Moment fromNow>
+                          {profileProperties[properties[key].key].confirmedAt}
+                        </Moment>
                       ) : (
                         "Never"
                       )}


### PR DESCRIPTION
All of the values in this table were pointing at the `property`, not the `profileProperties`

![2020-12-18_15-56-13](https://user-images.githubusercontent.com/633226/102674097-96999e00-4149-11eb-838d-aea2fe908a0f.png)
