### PR TITLE
Run NPM though CLI subshell

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -34,7 +34,6 @@
     "commander": "6.2.1",
     "fs-extra": "9.0.1",
     "glob": "7.1.6",
-    "npm": "6.14.10",
     "npm-check-updates": "10.2.5",
     "ora": "5.1.0",
     "semver": "7.3.4"

--- a/cli/src/lib/initialize.ts
+++ b/cli/src/lib/initialize.ts
@@ -59,9 +59,8 @@ export default async function Initialize(workDir: string, program) {
 
   logger.succeed("Grouparoo project created!");
 
-  console.log("");
-  console.log(
-    "- Ensure that Postgres and Redis are running if you have enabled them in .env or your environment"
+  console.info(
+    "    - Ensure that Postgres and Redis are running if you have enabled them in .env or your environment"
   );
-  console.log(`- type "npm start" to start the Grouparoo application.`);
+  console.info(`    - Type "npm start" to start the Grouparoo application.`);
 }

--- a/cli/src/utils/spawnPromise.ts
+++ b/cli/src/utils/spawnPromise.ts
@@ -1,0 +1,41 @@
+import { spawn } from "child_process";
+
+export async function spawnPromise(
+  command: string,
+  args: Array<string> = [],
+  cwd: string = process.cwd(),
+  extraEnv = {},
+  logger?: any
+) {
+  const {
+    exitCode,
+    stdout,
+    stderr,
+  }: { exitCode: number; stdout: string; stderr: string } = await new Promise(
+    (resolve) => {
+      let stdout = "";
+      let stderr = "";
+
+      const spawnProcess = spawn(command, args, {
+        cwd,
+        env: Object.assign(extraEnv, process.env),
+      });
+
+      spawnProcess.stdout.on("data", (data) => {
+        stdout += String(data);
+        if (logger) logger.text = String(data);
+      });
+
+      spawnProcess.stderr.on("data", (data) => {
+        stderr += String(data);
+        if (logger) logger.text = String(data);
+      });
+
+      spawnProcess.on("close", (exitCode) => {
+        resolve({ exitCode, stdout, stderr });
+      });
+    }
+  );
+
+  return { exitCode, stdout, stderr };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,6 @@ importers:
       commander: 6.2.1
       fs-extra: 9.0.1
       glob: 7.1.6
-      npm: 6.14.10
       npm-check-updates: 10.2.5
       ora: 5.1.0
       semver: 7.3.4
@@ -87,7 +86,6 @@ importers:
       commander: 6.2.1
       fs-extra: 9.0.1
       glob: 7.1.6
-      npm: 6.14.10
       npm-check-updates: 10.2.5
       ora: 5.1.0
       prettier: 2.2.1
@@ -101,20 +99,20 @@ importers:
       jest-fetch-mock: 3.0.3
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
-      ts-loader: 8.0.12_typescript@4.1.3+webpack@4.44.2
+      ts-loader: 8.0.13_typescript@4.1.3+webpack@4.44.2
       typescript: 4.1.3
-      webpack: 4.44.2_webpack-cli@4.3.0
-      webpack-cli: 4.3.0_webpack@4.44.2
+      webpack: 4.44.2_webpack-cli@4.3.1
+      webpack-cli: 4.3.1_webpack@4.44.2
     specifiers:
       '@types/jest': '*'
       jest: 26.6.3
       jest-fetch-mock: 3.0.3
       prettier: 2.2.1
       ts-jest: 26.4.4
-      ts-loader: 8.0.12
+      ts-loader: 8.0.13
       typescript: 4.1.3
       webpack: 4.44.2
-      webpack-cli: 4.3.0
+      webpack-cli: 4.3.1
   core:
     dependencies:
       '@grouparoo/client-web': 'link:../clients/@grouparoo/web'
@@ -166,7 +164,7 @@ importers:
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       type-fest: 0.20.2
-      typedoc: 0.20.2_typescript@4.1.3
+      typedoc: 0.20.10_typescript@4.1.3
       typescript: 4.1.3
     specifiers:
       '@grouparoo/client-web': ^0.2.0-alpha.10
@@ -212,7 +210,7 @@ importers:
       ts-jest: 26.4.4
       ts-node: 9.1.0
       type-fest: 0.20.2
-      typedoc: 0.20.2
+      typedoc: 0.20.10
       typescript: 4.1.3
       umzug: 2.3.0
       uuid: 8.3.2
@@ -396,7 +394,7 @@ importers:
       typescript: 4.1.3
   plugins/@grouparoo/files-s3:
     dependencies:
-      aws-sdk: 2.818.0
+      aws-sdk: 2.820.0
       fs-extra: 9.0.1
     devDependencies:
       '@grouparoo/core': 'link:../../../core'
@@ -412,7 +410,7 @@ importers:
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 25.0.2
-      aws-sdk: 2.818.0
+      aws-sdk: 2.820.0
       fs-extra: 9.0.1
       jest: 26.6.3
       prettier: 2.2.1
@@ -3334,18 +3332,18 @@ packages:
       '@xtuc/long': 4.2.2
     resolution:
       integrity: sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==
-  /@webpack-cli/info/1.2.0_webpack-cli@4.3.0:
+  /@webpack-cli/info/1.2.1_webpack-cli@4.3.1:
     dependencies:
       envinfo: 7.7.3
-      webpack-cli: 4.3.0_webpack@4.44.2
+      webpack-cli: 4.3.1_webpack@4.44.2
     dev: true
     peerDependencies:
       webpack-cli: 4.x.x
     resolution:
-      integrity: sha512-+wA8lBKopgKmN76BSGJVJby5ZXDlsrO6p/nm7fUBsHznRNWB/ozotJP7Yfcz8JPfqeG2LxwYlTH2u6D9a/0XAw==
-  /@webpack-cli/serve/1.2.0_webpack-cli@4.3.0:
+      integrity: sha512-fLnDML5HZ5AEKzHul8xLAksoKN2cibu6MgonkUj8R9V7bbeVRkd1XbGEGWrAUNYHbX1jcqCsDEpBviE5StPMzQ==
+  /@webpack-cli/serve/1.2.1_webpack-cli@4.3.1:
     dependencies:
-      webpack-cli: 4.3.0_webpack@4.44.2
+      webpack-cli: 4.3.1_webpack@4.44.2
     dev: true
     peerDependencies:
       webpack-cli: 4.x.x
@@ -3354,7 +3352,7 @@ packages:
       webpack-dev-server:
         optional: true
     resolution:
-      integrity: sha512-jI3P7jMp/AXDSPkM+ClwRcJZbxnlvNC8bVZBmyRr4scMMZ4p5WQcXkw3Q+Hc7RQekomJlBMN+UQGliT4hhG8Vw==
+      integrity: sha512-Zj1z6AyS+vqV6Hfi7ngCjFGdHV5EwZNIHo6QfFTNe9PyW+zBU1zJ9BiOW1pmUEq950RC4+Dym6flyA/61/vhyw==
   /@xtuc/ieee754/1.2.0:
     resolution:
       integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==
@@ -3962,7 +3960,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-yvsRHIaY51EYDml6MGlbqyJGfl4n7zezGYf+R7gvM8c5LNpRGc4SISkvgAswSS8SWxk/OrGCylKV9mJyVstz7w==
-  /aws-sdk/2.818.0:
+  /aws-sdk/2.820.0:
     dependencies:
       buffer: 4.9.2
       events: 1.1.1
@@ -3977,7 +3975,7 @@ packages:
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha512-xxIEdaKXtrEZNVUvKiW8MRj1Ux2tH/ubDLl8+tnrfhNOJbq5u5FfD56Kui4Ca+CG4xamQ5LaBktVYWAEyaMtUw==
+      integrity: sha512-OwGHxprG4KX5QC+vc77Xl7RCkJdwwKYPB7Gw3odNlMfdljedw7ICBylsMSBEwi/YjwaPryKPevHdOJAHbTKvQg==
   /aws-sign2/0.7.0:
     resolution:
       integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
@@ -6581,6 +6579,22 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
+  /execa/5.0.0:
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.0
+      human-signals: 2.1.0
+      is-stream: 2.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.3
+      strip-final-newline: 2.0.0
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
   /exit/0.1.2:
     dev: true
     engines:
@@ -7304,6 +7318,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
+  /get-stream/6.0.0:
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
   /get-uri/2.0.4:
     dependencies:
       data-uri-to-buffer: 1.2.0
@@ -7974,6 +7994,12 @@ packages:
       node: '>=8.12.0'
     resolution:
       integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+  /human-signals/2.1.0:
+    dev: true
+    engines:
+      node: '>=10.17.0'
+    resolution:
+      integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
   /humanize-ms/1.2.1:
     dependencies:
       ms: 2.1.2
@@ -11509,137 +11535,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
-  /npm/6.14.10:
-    bundledDependencies:
-      - abbrev
-      - ansicolors
-      - ansistyles
-      - aproba
-      - archy
-      - bin-links
-      - bluebird
-      - byte-size
-      - cacache
-      - call-limit
-      - chownr
-      - ci-info
-      - cli-columns
-      - cli-table3
-      - cmd-shim
-      - columnify
-      - config-chain
-      - debuglog
-      - detect-indent
-      - detect-newline
-      - dezalgo
-      - editor
-      - figgy-pudding
-      - find-npm-prefix
-      - fs-vacuum
-      - fs-write-stream-atomic
-      - gentle-fs
-      - glob
-      - graceful-fs
-      - has-unicode
-      - hosted-git-info
-      - iferr
-      - imurmurhash
-      - infer-owner
-      - inflight
-      - inherits
-      - ini
-      - init-package-json
-      - is-cidr
-      - json-parse-better-errors
-      - JSONStream
-      - lazy-property
-      - libcipm
-      - libnpm
-      - libnpmaccess
-      - libnpmhook
-      - libnpmorg
-      - libnpmsearch
-      - libnpmteam
-      - libnpx
-      - lock-verify
-      - lockfile
-      - lodash._baseindexof
-      - lodash._baseuniq
-      - lodash._bindcallback
-      - lodash._cacheindexof
-      - lodash._createcache
-      - lodash._getnative
-      - lodash.clonedeep
-      - lodash.restparam
-      - lodash.union
-      - lodash.uniq
-      - lodash.without
-      - lru-cache
-      - meant
-      - mississippi
-      - mkdirp
-      - move-concurrently
-      - node-gyp
-      - nopt
-      - normalize-package-data
-      - npm-audit-report
-      - npm-cache-filename
-      - npm-install-checks
-      - npm-lifecycle
-      - npm-package-arg
-      - npm-packlist
-      - npm-pick-manifest
-      - npm-profile
-      - npm-registry-fetch
-      - npm-user-validate
-      - npmlog
-      - once
-      - opener
-      - osenv
-      - pacote
-      - path-is-inside
-      - promise-inflight
-      - qrcode-terminal
-      - query-string
-      - qw
-      - read-cmd-shim
-      - read-installed
-      - read-package-json
-      - read-package-tree
-      - read
-      - readable-stream
-      - readdir-scoped-modules
-      - request
-      - retry
-      - rimraf
-      - safe-buffer
-      - semver
-      - sha
-      - slide
-      - sorted-object
-      - sorted-union-stream
-      - ssri
-      - stringify-package
-      - tar
-      - text-table
-      - tiny-relative-date
-      - uid-number
-      - umask
-      - unique-filename
-      - unpipe
-      - update-notifier
-      - uuid
-      - validate-npm-package-license
-      - validate-npm-package-name
-      - which
-      - worker-farm
-      - write-file-atomic
-    dev: false
-    engines:
-      node: 6 >=6.2.0 || 8 || >=9.3.0
-    hasBin: true
-    resolution:
-      integrity: sha512-FT23Qy/JMA+qxEYReMOr1MY7642fKn8Onn+72LASPi872Owvmw0svm+/DXTHOC3yO9CheEO+EslyXEpdBdRtIA==
   /npmlog/4.1.2:
     dependencies:
       are-we-there-yet: 1.1.5
@@ -15534,7 +15429,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.44.2_webpack-cli@4.3.0
+      webpack: 4.44.2_webpack-cli@4.3.1
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: true
@@ -15873,7 +15768,7 @@ packages:
       typescript: '>=3.8 <5.0'
     resolution:
       integrity: sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
-  /ts-loader/8.0.12_typescript@4.1.3+webpack@4.44.2:
+  /ts-loader/8.0.13_typescript@4.1.3+webpack@4.44.2:
     dependencies:
       chalk: 2.4.2
       enhanced-resolve: 4.3.0
@@ -15881,7 +15776,7 @@ packages:
       micromatch: 4.0.2
       semver: 6.3.0
       typescript: 4.1.3
-      webpack: 4.44.2_webpack-cli@4.3.0
+      webpack: 4.44.2_webpack-cli@4.3.1
     dev: true
     engines:
       node: '>=10.0.0'
@@ -15889,7 +15784,7 @@ packages:
       typescript: '*'
       webpack: '*'
     resolution:
-      integrity: sha512-UIivVfGVJDdwwjgSrbtcL9Nf10c1BWnL1mxAQUVcnhNIn/P9W3nP5v60Z0aBMtc7ZrE11lMmU6+5jSgAXmGaYw==
+      integrity: sha512-1o1nO6aqouA23d2nlcMSEyPMAWRhnYUU0EQUJSc60E0TUyBNX792RHFYUN1ZM29vhMUNayrsbj2UVdZwKhXCDA==
   /ts-node/9.1.0_typescript@4.1.3:
     dependencies:
       arg: 4.1.3
@@ -16032,7 +15927,7 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-0hHBxwmfxE0rkIslOiO39fJyYwaScQEhUIxcpqx3uS1BL3zhFW5oQfUaPx2cv2XLL/GXhYFxhdFLoVmNptbxEQ==
-  /typedoc/0.20.2_typescript@4.1.3:
+  /typedoc/0.20.10_typescript@4.1.3:
     dependencies:
       colors: 1.4.0
       fs-extra: 9.0.1
@@ -16053,7 +15948,7 @@ packages:
     peerDependencies:
       typescript: 3.9.x || 4.0.x || 4.1.x
     resolution:
-      integrity: sha512-edJOcp9T4ObjZleYWSWHAgaA1J4VzKd8PnnWWSN4UtB9owg45Xmsc642Hi6zDrPufyE7Z8JqB5IoYtd0wIjAng==
+      integrity: sha512-1Bqbmf/1pwRiUkd1j1tvL7GIlBOFANFcjC+W5cZ02R0CKgUN+fIIl2Z2OhuaM7MVytKq6snF1KYVIwBvplO37g==
   /typescript/4.1.2:
     dev: true
     engines:
@@ -16530,38 +16425,35 @@ packages:
       node: '>=10.4'
     resolution:
       integrity: sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
-  /webpack-cli/4.3.0_webpack@4.44.2:
+  /webpack-cli/4.3.1_webpack@4.44.2:
     dependencies:
       '@discoveryjs/json-ext': 0.5.2
-      '@webpack-cli/info': 1.2.0_webpack-cli@4.3.0
-      '@webpack-cli/serve': 1.2.0_webpack-cli@4.3.0
+      '@webpack-cli/info': 1.2.1_webpack-cli@4.3.1
+      '@webpack-cli/serve': 1.2.1_webpack-cli@4.3.1
       colorette: 1.2.1
       commander: 6.2.1
       enquirer: 2.3.6
-      execa: 4.1.0
+      execa: 5.0.0
       fastest-levenshtein: 1.0.12
       import-local: 3.0.2
       interpret: 2.2.0
       rechoir: 0.7.0
       v8-compile-cache: 2.2.0
-      webpack: 4.44.2_webpack-cli@4.3.0
+      webpack: 4.44.2_webpack-cli@4.3.1
       webpack-merge: 4.2.2
     dev: true
     engines:
       node: '>=10.13.0'
     hasBin: true
     peerDependencies:
-      '@webpack-cli/generate-loader': '*'
-      '@webpack-cli/generate-plugin': '*'
+      '@webpack-cli/generators': '*'
       '@webpack-cli/init': '*'
       '@webpack-cli/migrate': '*'
       webpack: 4.x.x || 5.x.x
       webpack-bundle-analyzer: '*'
       webpack-dev-server: '*'
     peerDependenciesMeta:
-      '@webpack-cli/generate-loader':
-        optional: true
-      '@webpack-cli/generate-plugin':
+      '@webpack-cli/generators':
         optional: true
       '@webpack-cli/init':
         optional: true
@@ -16572,7 +16464,7 @@ packages:
       webpack-dev-server:
         optional: true
     resolution:
-      integrity: sha512-gve+BBKrzMPTOYDjupzV8JchUznhVWMKtWM1hFIQWi6XoeLvGNoQwkrtMWVb+aJ437GgCKdta7sIn10v621pKA==
+      integrity: sha512-/F4+9QNZM/qKzzL9/06Am8NXIkGV+/NqQ62Dx7DSqudxxpAgBqYn6V7+zp+0Y7JuWksKUbczRY3wMTd+7Uj6OA==
   /webpack-merge/4.2.2:
     dependencies:
       lodash: 4.17.20
@@ -16624,7 +16516,7 @@ packages:
         optional: true
     resolution:
       integrity: sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==
-  /webpack/4.44.2_webpack-cli@4.3.0:
+  /webpack/4.44.2_webpack-cli@4.3.1:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -16648,7 +16540,7 @@ packages:
       tapable: 1.1.3
       terser-webpack-plugin: 1.4.5_webpack@4.44.2
       watchpack: 1.7.4
-      webpack-cli: 4.3.0_webpack@4.44.2
+      webpack-cli: 4.3.1_webpack@4.44.2
       webpack-sources: 1.4.3
     dev: true
     engines:


### PR DESCRIPTION
The Grouparoo CLI now runs NPM as a binary via a sub-process.   This fixes a class of errors in which the Grouparoo CLI could not install node modules which had a binary (GYP) install step.

Closes T-894