### PR TITLE
@grouparoo/core is not a plugin

### DIFF
--- a/core/src/utils/pluginDetails.js
+++ b/core/src/utils/pluginDetails.js
@@ -51,6 +51,8 @@ function getPluginManifest() {
     for (const i in manifest.parent.grouparoo.plugins) {
       const pluginName = manifest.parent.grouparoo.plugins[i];
 
+      if (pluginName === "@grouparoo/core") continue;
+
       let pluginPath = "";
       try {
         pluginPath = require.resolve(pluginName);

--- a/core/src/utils/pluginDetails.js
+++ b/core/src/utils/pluginDetails.js
@@ -75,21 +75,23 @@ function getPluginManifest() {
       }
 
       pluginPath = fs.realpathSync(pluginPath);
-
       const pluginPkg = readPackageJson(path.join(pluginPath, "package.json"));
-      manifest.plugins.push({
-        name: pluginPkg.name,
-        version: pluginPkg.version,
-        license: pluginPkg.license,
-        url:
-          pluginPkg.url ||
-          (pluginPkg.repository && pluginPkg.repository.url
-            ? pluginPkg.repository.url
-            : null) ||
-          pluginPkg.homepage,
-        path: pluginPath,
-        grouparoo: pluginPkg.grouparoo || null,
-      });
+
+      if (pluginPkg.name) {
+        manifest.plugins.push({
+          name: pluginPkg.name,
+          version: pluginPkg.version,
+          license: pluginPkg.license,
+          url:
+            pluginPkg.url ||
+            (pluginPkg.repository && pluginPkg.repository.url
+              ? pluginPkg.repository.url
+              : null) ||
+            pluginPkg.homepage,
+          path: pluginPath,
+          grouparoo: pluginPkg.grouparoo || null,
+        });
+      }
     }
 
     manifest.plugins.sort((a, b) => {


### PR DESCRIPTION
`@grouparoo/core` should always be excluded from the list of plugins. 

Also,  `getPluginManifest()` will use `require.resolve()` to find each plugin's path, but may resolve `@grouparoo/plugin/dist/index.js` rather than `@grouparoo/plugin` if there is an explicit export.  This PR fixes that.

Closes https://github.com/grouparoo/grouparoo/issues/1141
Closes T-912