### PR TITLE
Property Lifecycle Fixes

### DIFF
--- a/core/__tests__/models/profile.ts
+++ b/core/__tests__/models/profile.ts
@@ -223,7 +223,7 @@ describe("models/profile", () => {
       await profile.save();
       await expect(
         profile.addOrUpdateProperty({ email: ["luigi@example.com"] })
-      ).rejects.toThrow(/cannot find a property for key email/);
+      ).rejects.toThrow("cannot find a property for guid or key `email`");
       await profile.destroy();
     });
 

--- a/core/__tests__/models/profile.ts
+++ b/core/__tests__/models/profile.ts
@@ -549,6 +549,28 @@ describe("models/profile", () => {
         });
       });
 
+      test("profile properties can be addded by key", async () => {
+        await profile.addOrUpdateProperty({ email: ["luigi@example.com"] });
+        const properties = await profile.properties();
+        expect(simpleProfileValues(properties).email).toEqual([
+          "luigi@example.com",
+        ]);
+      });
+
+      test("profile properties can be addded by guid", async () => {
+        const emailProperty = await Property.findOne({
+          where: { key: "email" },
+        });
+        await profile.addOrUpdateProperty({
+          [emailProperty.guid]: ["luigi@example.com"],
+        });
+
+        const properties = await profile.properties();
+        expect(simpleProfileValues(properties).email).toEqual([
+          "luigi@example.com",
+        ]);
+      });
+
       test("adding a profile property touches the profile", async () => {
         await profile.removeProperty("email");
 

--- a/core/__tests__/models/source.ts
+++ b/core/__tests__/models/source.ts
@@ -485,7 +485,7 @@ describe("models/source", () => {
       await profile.addOrUpdateProperties({ userId: [1000] });
 
       lnameProperty = await Property.create({
-        key: "__fname",
+        key: "__lname",
         sourceGuid: source.guid,
         type: "string",
       });
@@ -548,9 +548,9 @@ describe("models/source", () => {
       await source.importProfileProperty(profile, lnameProperty, null, []); // does not throw
     });
 
-    test("it can import all profile properties for this source, mapped to the keys properly", async () => {
+    test("it can import all profile properties for this source, mapped to the property guids properly", async () => {
       const properties = await source.import(profile);
-      expect(properties).toEqual({ __fname: "...mario" });
+      expect(properties).toEqual({ [lnameProperty.guid]: "...mario" });
     });
 
     test("if importing returned null, it will not be included in the response hash to set profile properties", async () => {

--- a/core/src/modules/ops/event.ts
+++ b/core/src/modules/ops/event.ts
@@ -95,7 +95,7 @@ export namespace EventOps {
     }
 
     const profileProperties = {};
-    profileProperties[property.key] = event.userId;
+    profileProperties[property.guid] = event.userId;
 
     try {
       await profile.addOrUpdateProperties(profileProperties);

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -263,16 +263,16 @@ export namespace SourceOps {
       rules.map((rule) =>
         source
           .importProfileProperty(profile, rule, null, null, preloadedArgs)
-          .then((response) => (hash[rule.key] = response))
+          .then((response) => (hash[rule.guid] = response))
       )
     );
 
     // remove null and undefined as we cannot set that value
     const hashKeys = Object.keys(hash);
     for (const i in hashKeys) {
-      const key = hashKeys[i];
-      if (hash[key] === null || hash[key] === undefined) {
-        delete hash[key];
+      const guid = hashKeys[i];
+      if (hash[guid] === null || hash[guid] === undefined) {
+        delete hash[guid];
       }
     }
 

--- a/core/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/src/tasks/profileProperty/importProfileProperties.ts
@@ -72,7 +72,7 @@ export class ImportProfileProperties extends RetryableTask {
         (p) => p.guid === profileGuid
       );
       const hash = {};
-      hash[property.key] = propertyValuesBatch[profileGuid];
+      hash[property.guid] = propertyValuesBatch[profileGuid];
       await profile.addOrUpdateProperties(hash);
     }
 

--- a/core/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/src/tasks/profileProperty/importProfileProperty.ts
@@ -56,7 +56,7 @@ export class ImportProfileProperty extends RetryableTask {
 
     if (propertyValues) {
       const hash = {};
-      hash[property.key] = Array.isArray(propertyValues)
+      hash[property.guid] = Array.isArray(propertyValues)
         ? propertyValues
         : [propertyValues];
       await profile.addOrUpdateProperty(hash);


### PR DESCRIPTION
The PR Includes a number of improvements to aid in the creation/editing/deletion of Properties and the reduction of Resque errors.

1. Use GUIDs whenever possible to set Profile Properties so that `key` changes matter less 
  * `profile.addOrUpdateProperty` can have property keys or guids as hash keys - Closes T-901

Also closes T-746 (indirectly) 