### PR TITLE
`Grouparoo Run` CLI command

### DIFF
--- a/core/__tests__/bin/run.ts
+++ b/core/__tests__/bin/run.ts
@@ -1,0 +1,95 @@
+import { RunCLI } from "../../src/bin/run";
+import { helper } from "@grouparoo/spec-helper";
+import { Run } from "../../src/models/Run";
+let actionhero;
+
+describe("bin/run", () => {
+  beforeAll(async () => {
+    const env = await helper.prepareForAPITest();
+    actionhero = env.actionhero;
+    await helper.factories.properties();
+  }, helper.setupTime);
+
+  afterAll(async () => {
+    await helper.shutdown(actionhero);
+  });
+
+  let messages = [];
+  let spy;
+
+  beforeEach(() => {
+    messages = [];
+    spy = jest
+      .spyOn(console, "log")
+      .mockImplementation((message) => messages.push(message));
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  test("workers and scheduler are required", async () => {
+    process.env.WORKERS = "0";
+    process.env.SCHEDULER = "false";
+
+    const command = new RunCLI();
+    await expect(command.run()).rejects.toThrow();
+  });
+
+  describe("with instance", () => {
+    // NOTE: The command cannot be run in full as the config/env is already set at boot
+    // We can test each method individually
+
+    let instance: RunCLI;
+    beforeAll(() => {
+      instance = new RunCLI();
+    });
+
+    test("we can tell if the app has booted", async () => {
+      await instance.waitForReady(); // does not time out
+    });
+
+    test("paused tasks can be run", async () => {
+      await instance.runPausedTasks(); // does not throw
+    });
+
+    test("will be complete with no pending items", async () => {
+      await Run.truncate(); // there will be pending runs from `factories.properties()`
+
+      const complete = await instance.checkForComplete();
+      expect(complete).toBe(true);
+    });
+
+    test("will not be complete with a pending profile", async () => {
+      const profile = await helper.factories.profile();
+      await profile.update({ state: "pending" });
+      expect(await instance.checkForComplete()).toBe(false);
+      await profile.destroy();
+    });
+
+    test("will not be complete with a pending import", async () => {
+      const profile = await helper.factories.profile();
+      await profile.update({ state: "ready" });
+      await helper.factories.import(null, { profileGuid: profile.guid });
+
+      expect(await instance.checkForComplete()).toBe(false);
+      await profile.destroy();
+    });
+
+    test("will not be complete with a pending export", async () => {
+      const profile = await helper.factories.profile();
+      await profile.update({ state: "ready" });
+      await helper.factories.export(profile);
+
+      expect(await instance.checkForComplete()).toBe(false);
+      await profile.destroy();
+    });
+
+    test("will not be complete with a pending export", async () => {
+      const run = await helper.factories.run(null, { state: "running" });
+
+      expect(await instance.checkForComplete()).toBe(false);
+      await run.destroy();
+    });
+  });
+});

--- a/core/__tests__/bin/statuts.ts
+++ b/core/__tests__/bin/statuts.ts
@@ -35,7 +35,8 @@ describe("bin/status", () => {
 
       const output = messages.join(" ");
       expect(spy).toHaveBeenCalled();
-      expect(output).toContain("Status for My Grouparoo Cluster (test)");
+      expect(output).toContain("Cluster Status @");
+      expect(output).toContain("Cluster Name: My Grouparoo Cluster / test");
       expect(output).toContain("Groups: 0");
       expect(output).toContain("Pending Exports: 0");
     });
@@ -48,9 +49,7 @@ describe("bin/status", () => {
 
       const output = messages.join(" ");
       expect(output).toContain("Groups: 1");
-      expect(output).toContain(
-        `${group.name}: 0 members (most recent addition - Never)`
-      );
+      expect(output).toContain(`0 members / newest member: Never`);
     });
   });
 });

--- a/core/__tests__/bin/statuts.ts
+++ b/core/__tests__/bin/statuts.ts
@@ -13,43 +13,41 @@ describe("bin/status", () => {
     await helper.shutdown(actionhero);
   });
 
-  describe("mock console.log", () => {
-    let messages = [];
-    let spy;
+  let messages = [];
+  let spy;
 
-    beforeEach(() => {
-      messages = [];
-      spy = jest
-        .spyOn(console, "log")
-        .mockImplementation((message) => messages.push(message));
-    });
+  beforeEach(() => {
+    messages = [];
+    spy = jest
+      .spyOn(console, "log")
+      .mockImplementation((message) => messages.push(message));
+  });
 
-    afterEach(() => {
-      spy.mockRestore();
-    });
+  afterEach(() => {
+    spy.mockRestore();
+  });
 
-    test("the status command can be run", async () => {
-      const command = new Status();
-      const toStop = await command.run();
-      expect(toStop).toBe(true);
+  test("the status command can be run", async () => {
+    const command = new Status();
+    const toStop = await command.run();
+    expect(toStop).toBe(true);
 
-      const output = messages.join(" ");
-      expect(spy).toHaveBeenCalled();
-      expect(output).toContain("Cluster Status @");
-      expect(output).toContain("Cluster Name: My Grouparoo Cluster / test");
-      expect(output).toContain("Groups: 0");
-      expect(output).toContain("Pending Exports: 0");
-    });
+    const output = messages.join(" ");
+    expect(spy).toHaveBeenCalled();
+    expect(output).toContain("Cluster Status @");
+    expect(output).toContain("Cluster Name: My Grouparoo Cluster / test");
+    expect(output).toContain("Groups: 0");
+    expect(output).toContain("Pending Exports: 0");
+  });
 
-    test("with a group", async () => {
-      const group = await helper.factories.group();
+  test("with a group", async () => {
+    const group = await helper.factories.group();
 
-      const command = new Status();
-      await command.run();
+    const command = new Status();
+    await command.run();
 
-      const output = messages.join(" ");
-      expect(output).toContain("Groups: 1");
-      expect(output).toContain(`0 members / newest member: Never`);
-    });
+    const output = messages.join(" ");
+    expect(output).toContain("Groups: 1");
+    expect(output).toContain(`0 members / newest member: Never`);
   });
 });

--- a/core/__tests__/bin/validate.ts
+++ b/core/__tests__/bin/validate.ts
@@ -41,6 +41,20 @@ describe("bin/validate", () => {
     await actionhero.stop();
   });
 
+  let messages = [];
+  let spy;
+
+  beforeEach(() => {
+    messages = [];
+    spy = jest
+      .spyOn(console, "log")
+      .mockImplementation((message) => messages.push(message));
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
   test("the validate command can be run", async () => {
     process.env.GROUPAROO_CONFIG_DIR = join(
       __dirname,

--- a/core/package.json
+++ b/core/package.json
@@ -43,6 +43,7 @@
     "ah-next-plugin": "0.4.0",
     "ah-sequelize-plugin": "2.2.4",
     "bcryptjs": "2.4.3",
+    "colors": "1.4.0",
     "compare-versions": "3.6.0",
     "csv-stringify": "5.6.0",
     "date-fns": "2.16.1",

--- a/core/src/bin/console.ts
+++ b/core/src/bin/console.ts
@@ -1,3 +1,4 @@
+import { GrouparooCLI } from "../modules/cli";
 import * as REPL from "repl";
 import { api, env, CLI } from "actionhero";
 
@@ -7,9 +8,14 @@ export class Console extends CLI {
     this.name = "console";
     this.description =
       "Start an interactive REPL session with the api object in-scope";
+
+    GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.timestampOption(this);
   }
 
   async run() {
+    GrouparooCLI.logCLI(this);
+
     await new Promise((resolve, reject) => {
       const repl = REPL.start({
         prompt: "[🦘::" + env + " ] >> ",

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -41,9 +41,11 @@ export class RunCLI extends CLI {
 
     await import("../grouparoo"); // run the server
 
-    const status = await GrouparooCLI.getPendingStatus();
+    const pendingStatus = await GrouparooCLI.getPendingStatus();
+    const runStatus = await GrouparooCLI.getRunsStatus();
     GrouparooCLI.logStatus("Initial Status", [
-      { header: "Pending Items", status },
+      { header: "Pending Items", status: pendingStatus },
+      { header: "Active Runs", status: runStatus },
     ]);
 
     await this.waitForReady();
@@ -98,13 +100,17 @@ export class RunCLI extends CLI {
   }
 
   async checkForComplete() {
-    const status = await GrouparooCLI.getPendingStatus();
-    GrouparooCLI.logStatus("Cluster Status", [
-      { header: "Pending Items", status },
+    const pendingStatus = await GrouparooCLI.getPendingStatus();
+    const runStatus = await GrouparooCLI.getRunsStatus();
+    GrouparooCLI.logStatus("Initial Status", [
+      { header: "Pending Items", status: pendingStatus },
+      { header: "Active Runs", status: runStatus },
     ]);
 
     let pendingItems = 0;
-    for (const key in status) pendingItems += status[key][0] as number;
+    for (const key in pendingStatus) {
+      pendingItems += pendingStatus[key][0] as number;
+    }
 
     if (pendingItems > 0) return false;
     return true;

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -1,7 +1,7 @@
 import { GrouparooCLI } from "../modules/cli";
 import { CLI, Task, log, api, config } from "actionhero";
 
-const CHECK_TIMEOUT = 1000 * 5;
+const CHECK_TIMEOUT = 1000 * 10;
 
 export class RunCLI extends CLI {
   constructor() {

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -1,0 +1,104 @@
+import { GrouparooCLI } from "../modules/cli";
+import { CLI, Task, api, log } from "actionhero";
+import { Op } from "sequelize";
+
+import { Run, Profile, Import, Export } from "..";
+
+const CHECK_TIMEOUT = 1000 * 5;
+
+export class RunCLI extends CLI {
+  constructor() {
+    super();
+    this.name = "run";
+    this.description =
+      "Run all Schedules, Runs, Imports and Exports pending in this cluster.";
+
+    GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.timestampOption(this);
+  }
+
+  async run() {
+    GrouparooCLI.logCLI(this, false);
+
+    await import("../grouparoo"); // run the server
+    await this.waitForReady();
+    await this.runPausedTasks();
+
+    this.tick();
+
+    return false;
+  }
+
+  async waitForReady() {
+    return new Promise((resolve) => {
+      function check() {
+        if (api.process.running) return resolve(null);
+        setTimeout(() => check(), CHECK_TIMEOUT);
+      }
+
+      check();
+    });
+  }
+
+  async runPausedTasks() {
+    const tasks = [
+      "schedule:updateSchedules",
+      "run:recurringInternalRun",
+      "group:updateCalculatedGroups",
+    ];
+
+    for (const i in tasks) {
+      const task: Task = api.tasks.tasks[tasks[i]];
+      log(`Running task: ${task.name}`);
+      await task.run({}, {});
+    }
+  }
+
+  async tick() {
+    setTimeout(async () => {
+      const done = await this.checkForComplete();
+      if (done) {
+        await this.stopServer();
+      } else {
+        this.tick();
+      }
+    }, CHECK_TIMEOUT);
+  }
+
+  async checkForComplete() {
+    const pendingProfiles = await Profile.count({
+      where: { [Op.ne]: "ready" },
+    });
+    const pendingImports = await Import.count({
+      where: { exportedAt: null },
+    });
+    const pendingExports = await Export.count({
+      where: {
+        completedAt: null,
+        errorMessage: null,
+      },
+    });
+    const pendingRuns = await Run.count({ where: { state: "running" } });
+
+    console.log("---");
+    console.log({
+      pendingProfiles,
+      pendingImports,
+      pendingExports,
+      pendingRuns,
+    });
+    console.log("---");
+
+    const pendingItems =
+      pendingProfiles + pendingImports + pendingExports + pendingRuns;
+    if (pendingItems > 0) return false;
+
+    return true;
+  }
+
+  async stopServer() {
+    log("All good!", "notice");
+    await api.process.stop();
+    process.exit(0);
+  }
+}

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -10,6 +10,12 @@ export class RunCLI extends CLI {
     this.description =
       "Run all Schedules, Runs, Imports and Exports pending in this cluster.  Use GROUPAROO_LOG_LEVEL env to set log level.";
     this.inputs = {
+      destroy: {
+        required: true,
+        default: "false",
+        description:
+          "[DANGER] Empty the cluster of all Profile data before starting the run?",
+      },
       web: {
         required: true,
         default: "false",
@@ -28,6 +34,10 @@ export class RunCLI extends CLI {
   async run() {
     GrouparooCLI.logCLI(this, false);
     this.checkWorkers();
+
+    if (process.argv.slice(2).includes("--destroy")) {
+      await GrouparooCLI.destroyProfiles();
+    }
 
     await import("../grouparoo"); // run the server
 

--- a/core/src/bin/start.ts
+++ b/core/src/bin/start.ts
@@ -5,7 +5,8 @@ export class Start extends CLI {
   constructor() {
     super();
     this.name = "start";
-    this.description = "Run the Grouparoo server";
+    this.description =
+      "Run the Grouparoo server.  Use GROUPAROO_LOG_LEVEL env to set log level.";
 
     GrouparooCLI.setGrouparooRunMode(this);
     GrouparooCLI.timestampOption(this);

--- a/core/src/bin/start.ts
+++ b/core/src/bin/start.ts
@@ -1,3 +1,4 @@
+import { GrouparooCLI } from "../modules/cli";
 import { CLI } from "actionhero";
 
 export class Start extends CLI {
@@ -5,9 +6,14 @@ export class Start extends CLI {
     super();
     this.name = "start";
     this.description = "Run the Grouparoo server";
+
+    GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.timestampOption(this);
   }
 
   async run() {
+    GrouparooCLI.logCLI(this, false);
+
     await import("../grouparoo"); // run the server
     return false;
   }

--- a/core/src/bin/status.ts
+++ b/core/src/bin/status.ts
@@ -1,3 +1,4 @@
+import { GrouparooCLI } from "../modules/cli";
 import { plugin } from "../modules/plugin";
 import { Profile } from "../models/Profile";
 import { Group } from "../models/Group";
@@ -12,16 +13,20 @@ export class Status extends CLI {
     super();
     this.name = "status";
     this.description = "Display the status of your Grouparoo cluster";
+
+    GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.timestampOption(this);
   }
 
   async run() {
+    GrouparooCLI.logCLI(this);
+
     const { value: clusterName } = await plugin.readSetting(
       "core",
       "cluster-name"
     );
 
     // Intro
-    console.log("");
     console.log(`Status for ${clusterName} (${env}):`);
     console.log("");
 

--- a/core/src/bin/status.ts
+++ b/core/src/bin/status.ts
@@ -3,9 +3,6 @@ import { plugin } from "../modules/plugin";
 import { Profile } from "../models/Profile";
 import { Group } from "../models/Group";
 import { GroupOps } from "../modules/ops/group";
-import { Run } from "../models/Run";
-import { Import } from "../models/Import";
-import { Export } from "../models/Export";
 import { env, CLI } from "actionhero";
 
 export class Status extends CLI {
@@ -26,64 +23,37 @@ export class Status extends CLI {
       "cluster-name"
     );
 
-    // Intro
-    console.log(`Status for ${clusterName} (${env}):`);
-    console.log("");
-
-    // Profiles
-    const profilesCount = await Profile.count();
-    const pendingProfilesCount = await Profile.count({
-      where: { state: "pending" },
-    });
-    console.log(`Profiles: ${profilesCount} (${pendingProfilesCount} pending)`);
-
-    // Groups
-    const groupsCount = await Group.count();
+    const totalProfiles = await Profile.count();
+    const totalGroups = await Group.count();
     const { groups, newestMembersAdded } = await GroupOps.newestGroupMembers(
       100
     );
-    console.log(`Groups: ${groupsCount}`);
+    const groupsStatus = {};
     for (const i in groups) {
       const group = groups[i];
       const additionTime = newestMembersAdded[group.guid]
         ? new Date(newestMembersAdded[group.guid]).toISOString()
         : "Never";
-      console.log(
-        `  ${group.name}: ${await group.$count(
-          "groupMembers"
-        )} members (most recent addition - ${additionTime})`
-      );
+      const groupMembersCount = await group.$count("groupMembers");
+      groupsStatus[group.name] = [
+        `${groupMembersCount} members`,
+        "newest member: " + additionTime,
+      ];
     }
 
-    // Runs
-    const runningRuns = await Run.findAll({ where: { state: "running" } });
-    console.log("Active Runs:");
-    if (runningRuns.length === 0) {
-      console.log("  None");
-    } else {
-      for (const i in runningRuns) {
-        const run = runningRuns[i];
-        console.log(
-          `  ${await run.getCreatorName()} - ${run.percentComplete}% ${
-            Object.keys(run.highWaterMark).length > 0
-              ? `(${Object.keys(run.highWaterMark)[0]})`
-              : ""
-          }`
-        );
-      }
-    }
+    const overview = {
+      ClusterName: [clusterName, env ? `${env}` : undefined],
+      TotalProfiles: [totalProfiles],
+      TotalGroups: [totalGroups],
+    };
 
-    // Imports
-    const pendingImportsCount = await Import.count({
-      where: { groupsUpdatedAt: null },
-    });
-    console.log(`Pending Imports: ${pendingImportsCount}`);
+    const pendingStatus = await GrouparooCLI.getPendingStatus();
 
-    // Exports
-    const pendingExportsCount = await Export.count({
-      where: { completedAt: null, errorMessage: null },
-    });
-    console.log(`Pending Exports: ${pendingExportsCount}`);
+    GrouparooCLI.logStatus("Cluster Status", [
+      { header: "Overview", status: overview },
+      { header: "Groups", status: groupsStatus },
+      { header: "Pending Items", status: pendingStatus },
+    ]);
 
     return true;
   }

--- a/core/src/bin/status.ts
+++ b/core/src/bin/status.ts
@@ -48,10 +48,12 @@ export class Status extends CLI {
     };
 
     const pendingStatus = await GrouparooCLI.getPendingStatus();
+    const runStatus = await GrouparooCLI.getRunsStatus();
 
     GrouparooCLI.logStatus("Cluster Status", [
       { header: "Overview", status: overview },
       { header: "Groups", status: groupsStatus },
+      { header: "Active Runs", status: runStatus },
       { header: "Pending Items", status: pendingStatus },
     ]);
 

--- a/core/src/bin/validate.ts
+++ b/core/src/bin/validate.ts
@@ -1,3 +1,4 @@
+import { GrouparooCLI } from "../modules/cli";
 import { CLI, api, log } from "actionhero";
 import {
   ConfigurationObject,
@@ -23,10 +24,13 @@ export class Validate extends CLI {
           "Should we validate the config by connecting to sources and destinations?",
       },
     };
+
+    GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.timestampOption(this);
   }
 
   async run({ params }) {
-    api.plugins.announcePlugins();
+    GrouparooCLI.logCLI(this);
 
     const configDir = getConfigDir();
     let configObjects: ConfigurationObject[];

--- a/core/src/config/logger.ts
+++ b/core/src/config/logger.ts
@@ -40,21 +40,15 @@ export const test = {
 
 function buildConsoleLogger(level = "info") {
   const formats = [];
-  if (
-    process.env.GROUPAROO_LOGS_STDOUT_DISABLE_COLOR?.toLowerCase() !== "true"
-  ) {
-    formats.push(winston.format.colorize());
-  }
-  if (
-    process.env.GROUPAROO_LOGS_STDOUT_DISABLE_TIMESTAMP?.toLowerCase() !==
-    "true"
-  ) {
-    formats.push(winston.format.timestamp());
-  }
+
+  if (!disableColor()) formats.push(winston.format.colorize());
+  if (!disableTimestamps()) formats.push(winston.format.timestamp());
 
   formats.push(
     winston.format.printf((info) => {
-      return `${info.timestamp ? `${info.timestamp} - ` : ""}${info.level}: ${
+      return `${
+        info.timestamp && !disableTimestamps() ? `${info.timestamp} - ` : ""
+      }${info.level}: ${
         info.message
       } ${stringifyExtraMessagePropertiesForConsole(info)}`;
     })
@@ -107,3 +101,8 @@ function buildFileLogger(path, level = "info", maxFiles = undefined) {
     });
   };
 }
+
+const disableColor = () =>
+  process.env.GROUPAROO_LOGS_STDOUT_DISABLE_COLOR?.toLowerCase() === "true";
+const disableTimestamps = () =>
+  process.env.GROUPAROO_LOGS_STDOUT_DISABLE_TIMESTAMP?.toLowerCase() === "true";

--- a/core/src/config/logger.ts
+++ b/core/src/config/logger.ts
@@ -7,7 +7,7 @@ import * as winston from "winston";
 export const DEFAULT = {
   logger: (config) => {
     const loggers = [];
-    loggers.push(buildConsoleLogger());
+    loggers.push(buildConsoleLogger(process.env.GROUPAROO_LOG_LEVEL));
     config.general.paths.log.forEach((p) => {
       loggers.push(buildFileLogger(p));
     });

--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -80,6 +80,27 @@ export namespace GrouparooCLI {
     };
   }
 
+  export async function getRunsStatus(): Promise<LogStatus> {
+    const activeRuns = await Run.findAll({ where: { state: "running" } });
+
+    const status = {};
+    for (const i in activeRuns) {
+      const run = activeRuns[i];
+      const creatorName = await run.getCreatorName();
+      const percentComplete = run.percentComplete;
+      const highWaterMark = run.highWaterMark
+        ? Object.values(run.highWaterMark)[0]
+        : run.groupHighWaterMark;
+      status[creatorName] = [`${percentComplete}%`, highWaterMark];
+    }
+
+    if (activeRuns.length === 0) {
+      status["None"] = [null];
+    }
+
+    return status;
+  }
+
   /** Logging */
 
   export function logStatus(title: string, statusArray: LogStatusArray) {
@@ -95,8 +116,8 @@ export namespace GrouparooCLI {
       for (const key in status) {
         const [v1, v2] = status[key];
         console.log(
-          `${blueBold("|")} * ${deCamel(key)}: ${
-            v1.toString() + (v2 ? ` / ${v2.toString()}` : "")
+          `${blueBold("|")} * ${deCamel(key)}${
+            (v1 ? ": " + v1.toString() : "") + (v2 ? ` / ${v2.toString()}` : "")
           }`
         );
       }

--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -1,7 +1,18 @@
 import { CLI, api } from "actionhero";
 import Colors from "colors/safe";
+import { Op } from "sequelize";
+import { Run, Profile, Import, Export } from "..";
 
 export namespace GrouparooCLI {
+  /** Types */
+  export interface LogStatus {
+    [key: string]: number[] | string[];
+  }
+
+  export type LogStatusArray = Array<{ header: string; status: LogStatus }>;
+
+  /** Settings and Boot Options */
+
   export function timestampOption(cli: CLI) {
     if (!cli.inputs) cli.inputs = {};
     cli.inputs.timestamps = {
@@ -10,7 +21,7 @@ export namespace GrouparooCLI {
       description: "Should timestamps be prepended to each log line?",
     };
 
-    if (!process.argv.includes("--timestamps")) {
+    if (!process.argv.slice(2).includes("--timestamps")) {
       process.env.GROUPAROO_LOGS_STDOUT_DISABLE_TIMESTAMP = "true";
     }
   }
@@ -25,5 +36,66 @@ export namespace GrouparooCLI {
     console.log("");
     console.log(Colors.underline(Colors.bold(`🦘 Grouparoo: ${cli.name}`)));
     console.log("");
+  }
+
+  /** Status */
+
+  export async function getPendingStatus(): Promise<LogStatus> {
+    const activeRuns = await Run.count({ where: { state: "running" } });
+    const pendingProfiles = await Profile.count({
+      where: { state: { [Op.ne]: "ready" } },
+    });
+    const totalProfiles = await Profile.count();
+    const pendingImports = await Import.count({
+      where: { exportedAt: null },
+    });
+    const pendingExports = await Export.count({
+      where: { completedAt: null, errorMessage: null },
+    });
+
+    return {
+      ActiveRuns: [activeRuns],
+      PendingProfiles: [pendingProfiles, totalProfiles],
+      PendingImports: [pendingImports],
+      PendingExports: [pendingExports],
+    };
+  }
+
+  /** Logging */
+
+  export function logStatus(title: string, statusArray: LogStatusArray) {
+    const formattedTitle = `┌-- ${title} @ ${new Date().toISOString()} ---`;
+
+    console.log("");
+    console.log(blueBold(formattedTitle));
+
+    statusArray.forEach(({ header, status }, idx) => {
+      if (idx > 0) console.log(blueBold(`|`));
+
+      console.log(blueBold(`|`) + " " + underlineBold(header));
+      for (const key in status) {
+        const [v1, v2] = status[key];
+        console.log(
+          `${blueBold("|")} * ${deCamel(key)}: ${
+            v1.toString() + (v2 ? ` / ${v2.toString()}` : "")
+          }`
+        );
+      }
+    });
+
+    console.log(blueBold("└" + "-".repeat(formattedTitle.length - 1)));
+    console.log("");
+  }
+
+  function blueBold(s: string) {
+    return Colors.blue(Colors.bold(s));
+  }
+
+  function underlineBold(s: string) {
+    return Colors.underline(Colors.bold(s));
+  }
+
+  function deCamel(s: string) {
+    return s.replace(/([a-z])([A-Z])/g, "$1 $2");
   }
 }

--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -1,0 +1,29 @@
+import { CLI, api } from "actionhero";
+import Colors from "colors/safe";
+
+export namespace GrouparooCLI {
+  export function timestampOption(cli: CLI) {
+    if (!cli.inputs) cli.inputs = {};
+    cli.inputs.timestamps = {
+      required: true,
+      default: "false",
+      description: "Should timestamps be prepended to each log line?",
+    };
+
+    if (!process.argv.includes("--timestamps")) {
+      process.env.GROUPAROO_LOGS_STDOUT_DISABLE_TIMESTAMP = "true";
+    }
+  }
+
+  export function setGrouparooRunMode(cli: CLI) {
+    process.env.GROUPAROO_RUN_MODE = `cli:${cli.name}`;
+  }
+
+  export function logCLI(cli: CLI, announcePlugins = true) {
+    if (announcePlugins) api.plugins.announcePlugins();
+
+    console.log("");
+    console.log(Colors.underline(Colors.bold(`🦘 Grouparoo: ${cli.name}`)));
+    console.log("");
+  }
+}

--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -1,7 +1,15 @@
-import { CLI, api } from "actionhero";
+import { CLI, api, log } from "actionhero";
 import Colors from "colors/safe";
 import { Op } from "sequelize";
-import { Run, Profile, Import, Export } from "..";
+import {
+  Run,
+  Profile,
+  ProfileProperty,
+  GroupMember,
+  Import,
+  Export,
+  Log,
+} from "..";
 
 export namespace GrouparooCLI {
   /** Types */
@@ -36,6 +44,17 @@ export namespace GrouparooCLI {
     console.log("");
     console.log(Colors.underline(Colors.bold(`🦘 Grouparoo: ${cli.name}`)));
     console.log("");
+  }
+
+  export async function destroyProfiles() {
+    log("Destroying all Profile and Related data", "warning");
+    await Profile.truncate();
+    await ProfileProperty.truncate();
+    await GroupMember.truncate();
+    await Import.truncate();
+    await Export.truncate();
+    await Run.truncate();
+    await Log.truncate();
   }
 
   /** Status */

--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -117,7 +117,8 @@ export namespace GrouparooCLI {
         const [v1, v2] = status[key];
         console.log(
           `${blueBold("|")} * ${deCamel(key)}${
-            (v1 ? ": " + v1.toString() : "") + (v2 ? ` / ${v2.toString()}` : "")
+            (v1 !== null && v1 !== undefined ? ": " + v1.toString() : "") +
+            (v2 !== null && v2 !== undefined ? ` / ${v2.toString()}` : "")
           }`
         );
       }

--- a/core/src/tasks/group/updateCalculatedGroups.ts
+++ b/core/src/tasks/group/updateCalculatedGroups.ts
@@ -10,7 +10,8 @@ export class GroupsUpdateCalculatedGroups extends Task {
     this.name = "group:updateCalculatedGroups";
     this.description =
       "enqueue an update of calculated groups that to be updated";
-    this.frequency = 1000 * 60 * 5; // Run every 5 minutes
+    this.frequency =
+      process.env.GROUPAROO_RUN_MODE === "cli:run" ? 0 : 1000 * 60 * 5; // Run every 5 minutes
     this.queue = "groups";
   }
 

--- a/core/src/tasks/run/recurringInternalRun.ts
+++ b/core/src/tasks/run/recurringInternalRun.ts
@@ -9,7 +9,8 @@ export class RunRecurringInternalRun extends Task {
     this.name = "run:recurringInternalRun";
     this.description =
       "check if we should run an internal import on a frequency";
-    this.frequency = 1000 * 60 * 10; // 10 minutes
+    this.frequency =
+      process.env.GROUPAROO_RUN_MODE === "cli:run" ? 0 : 1000 * 60 * 10; // 10 minutes
     this.queue = "runs";
   }
 

--- a/core/src/tasks/schedule/updateSchedules.ts
+++ b/core/src/tasks/schedule/updateSchedules.ts
@@ -7,7 +7,8 @@ export class UpdateSchedules extends Task {
     super();
     this.name = "schedule:updateSchedules";
     this.description = "check all schedules and run them if it is time";
-    this.frequency = 1000 * 60 * 5; // Run every 5 minutes
+    this.frequency =
+      process.env.GROUPAROO_RUN_MODE === "cli:run" ? 0 : 1000 * 60 * 5; // Run every 5 minutes
     this.queue = "schedules";
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,7 @@ importers:
       ah-next-plugin: 0.4.0_actionhero@25.0.2
       ah-sequelize-plugin: 2.2.4_d942fb36d97b052d8fff18743f3446f5
       bcryptjs: 2.4.3
+      colors: 1.4.0
       compare-versions: 3.6.0
       csv-stringify: 5.6.0
       date-fns: 2.16.1
@@ -179,6 +180,7 @@ importers:
       ah-next-plugin: 0.4.0
       ah-sequelize-plugin: 2.2.4
       bcryptjs: 2.4.3
+      colors: 1.4.0
       compare-versions: 3.6.0
       csv-parse: 4.14.2
       csv-stringify: 5.6.0
@@ -15750,7 +15752,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3
+      jest: 26.6.3_ts-node@9.1.0
       jest-util: 26.6.1
       json5: 2.1.3
       lodash.memoize: 4.1.2


### PR DESCRIPTION
**`grouparoo run` command**:

This command will keep this process up and running until there are no more pending Runs, Imports, Exports, and Profiles.  

```
➜  grouparoo run --help
Usage: grouparoo run [options]

Run all Schedules, Runs, Imports and Exports pending in this cluster.  Use GROUPAROO_LOG_LEVEL env to set log level.

Options:
  --destroy [destroy]        [DANGER] Empty the cluster of all Profile data before starting the run? (default: "false")
  --web [web]                Enable the web server during this run? (default: "false")
  --timestamps [timestamps]  Should timestamps be prepended to each log line? (default: "false")
  -h, --help                 display help for command
```

<img width="1249" alt="Screen Shot 2021-01-05 at 11 57 11 AM" src="https://user-images.githubusercontent.com/303226/103692994-76415000-4f4d-11eb-95ec-707d3402e5d2.png">

At the start of the `run` command we disable some tasks which would normally keep processing things, but run them once at the beginning of the process explicitly: 
* `schedule:updateSchedules`
* `run:recurringInternalRun`
* `group:updateCalculatedGroups` 

In the console, we periodically show an `InfoBox` to share cluster status with the user.

```
┌-- Initial Status @ 2021-01-05T21:57:17.264Z ---
| Pending Items
| * Active Runs: 1
| * Pending Profiles: 740 / 892
| * Pending Imports: 846
| * Pending Exports: 0
|
| Active Runs
| * Users Table: 80% / 2020-12-15 14:49:03.338
└------------------------------------------------
```

The web server can be enabled with the `--web` flag (default disabled).

Closes T-845

---

Also in this PR:
* Environment Variable `GROUPAROO_LOG_LEVEL` can be used to configure logging.  Options are like `info`, `alert`, etc (see Actionhero and Winston)
* Update Status command to use `InfoBox`

<img width="1263" alt="Screen Shot 2021-01-05 at 11 53 43 AM" src="https://user-images.githubusercontent.com/303226/103692525-b94ef380-4f4c-11eb-8cd0-742baafce36b.png">

* All CLI commands included within `@groupoaroo/core` gain the `--timestamps` flag (default `false`) to opt-into displaying the timestamps in the console.  Default for CLI commands is now to NOT have timestamps. Closes T-891

<img width="1170" alt="Screen Shot 2021-01-04 at 5 45 27 PM" src="https://user-images.githubusercontent.com/303226/103597246-a4bf1c80-4eb4-11eb-8e2b-cb9370c3db3e.png">

