### PR TITLE
`grouparoo destroy` command

### DIFF
--- a/core/src/bin/destroy.ts
+++ b/core/src/bin/destroy.ts
@@ -1,0 +1,22 @@
+import { GrouparooCLI } from "../modules/cli";
+import { CLI, log } from "actionhero";
+
+export class Destroy extends CLI {
+  constructor() {
+    super();
+    this.name = "destroy";
+    this.description =
+      "Remove imported Profiles, Groups, Imports, and Exports from your cluster.  Properties, Groups and other configuration will remain.";
+
+    GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.timestampOption(this);
+  }
+
+  async run() {
+    GrouparooCLI.logCLI(this, false);
+    await GrouparooCLI.destroyProfiles();
+    log(`✅ Success!`);
+
+    return true;
+  }
+}

--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -47,7 +47,7 @@ export namespace GrouparooCLI {
   }
 
   export async function destroyProfiles() {
-    log("Destroying all Profile and Related data", "warning");
+    log("Destroying all Profiles and related data...", "warning");
     await Profile.truncate();
     await ProfileProperty.truncate();
     await GroupMember.truncate();


### PR DESCRIPTION
```
➜  grouparoo destroy --help
Usage: grouparoo destroy [options]

Remove imported Profiles, Groups, Imports, and Exports from your cluster.  Properties, Groups and other configuration will remain.

Options:
  --timestamps [timestamps]  Should timestamps be prepended to each log line? (default: "false")
  -h, --help                 display help for command
```

Closes T-923