### PR TITLE
Task updates after CLSTask introduction

### DIFF
--- a/core/__tests__/tasks/export/enqueue.ts
+++ b/core/__tests__/tasks/export/enqueue.ts
@@ -124,7 +124,9 @@ describe("tasks/export:enqueue", () => {
 
     test("batch size is variable", async () => {
       await plugin.updateSetting("core", "exports-profile-batch-size", 1);
-      await specHelper.runTask("export:enqueue", {});
+      await specHelper.runTask("export:enqueue", {}); // first batch
+      await specHelper.runTask("export:enqueue", {}); // second batch
+      await specHelper.runTask("export:enqueue", {}); // no one
 
       const foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
       expect(foundTasks.length).toBe(2);

--- a/core/__tests__/tasks/export/enqueue.ts
+++ b/core/__tests__/tasks/export/enqueue.ts
@@ -125,10 +125,16 @@ describe("tasks/export:enqueue", () => {
     test("batch size is variable", async () => {
       await plugin.updateSetting("core", "exports-profile-batch-size", 1);
       await specHelper.runTask("export:enqueue", {}); // first batch
+
+      // another instance of the task should have been enqueued
+      let foundTasks = await specHelper.findEnqueuedTasks("export:enqueue");
+      expect(foundTasks.length).toBe(1);
+      expect(foundTasks[0].args[0]).toEqual({ count: 1 });
+
       await specHelper.runTask("export:enqueue", {}); // second batch
       await specHelper.runTask("export:enqueue", {}); // no one
 
-      const foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
+      foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
       expect(foundTasks.length).toBe(2);
     });
   });

--- a/core/src/tasks/export/enqueue.ts
+++ b/core/src/tasks/export/enqueue.ts
@@ -20,24 +20,19 @@ export class EnqueueExports extends RetryableTask {
       (await plugin.readSetting("core", "exports-profile-batch-size")).value
     );
 
+    let totalEnqueued = 0;
     const destinations = await Destination.scope(null).findAll();
 
-    let totalEnqueued = 0;
-
     for (const i in destinations) {
-      let enqueuedExportsCount = 1;
-
-      while (enqueuedExportsCount > 0) {
-        enqueuedExportsCount = await ExportOps.processPendingExportsForDestination(
-          destinations[i],
-          limit
+      const enqueuedExportsCount = await ExportOps.processPendingExportsForDestination(
+        destinations[i],
+        limit
+      );
+      totalEnqueued += enqueuedExportsCount;
+      if (enqueuedExportsCount > 0) {
+        log(
+          `enqueued ${enqueuedExportsCount} exports to send to ${destinations[i].name} (${destinations[i].guid})`
         );
-        totalEnqueued += enqueuedExportsCount;
-        if (enqueuedExportsCount > 0) {
-          log(
-            `enqueued ${enqueuedExportsCount} exports to send to ${destinations[i].name} (${destinations[i].guid})`
-          );
-        }
       }
     }
 

--- a/core/src/tasks/import/associateProfile.ts
+++ b/core/src/tasks/import/associateProfile.ts
@@ -1,9 +1,10 @@
-import { log, env } from "actionhero";
-import { CLSTask } from "../../classes/tasks/clsTask";
+import { log, env, Task } from "actionhero";
 import { Import } from "../../models/Import";
 import { ProfilePropertyType } from "../../modules/ops/profile";
 
-export class ImportAssociateProfile extends CLSTask {
+export class ImportAssociateProfile extends Task {
+  // This Task extends Task rather than CLSTask as we want to be able to view newly created profiles happening in parallel to this task/transaction
+  // This Task has no side effects
   constructor() {
     super();
     this.name = "import:associateProfile";
@@ -24,7 +25,7 @@ export class ImportAssociateProfile extends CLSTask {
     return simpleProperties;
   }
 
-  async runWithinTransaction(params) {
+  async run(params) {
     const { importGuid } = params;
     const _import = await Import.findByGuid(importGuid);
 

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -35,7 +35,7 @@ import ExportFactory from "./factories/export";
 import RunFactory from "./factories/run";
 import ApiKeyFactory from "./factories/apiKey";
 
-export { ImportWorkflow } from "./workflows/import";
+export * from "./workflows/import";
 
 import {
   // modules


### PR DESCRIPTION
After https://github.com/grouparoo/grouparoo/pull/1156:
*  `export:enqueue` task should only one once and then commit.  Then the Task should be enqueued again.
* `import:associateProfile`  should not be un in a transaction