### PR TITLE
Task Resilience

### DIFF
--- a/core/__tests__/integration/happyPath.ts
+++ b/core/__tests__/integration/happyPath.ts
@@ -1,4 +1,4 @@
-import { helper } from "@grouparoo/spec-helper";
+import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
 import { specHelper } from "actionhero";
 
 let actionhero;
@@ -320,12 +320,7 @@ describe("integration/happyPath", () => {
       expect(tasks.length).toBe(1);
       await specHelper.runTask("group:run", tasks[0].args[0]);
 
-      // profiles
-      await specHelper.runTask("profiles:checkReady", {});
-      tasks = await specHelper.findEnqueuedTasks("profile:completeImport");
-      expect(tasks.length).toBe(1);
-      expect(tasks[0].args[0].profileGuid).toBe(profileGuid);
-      await specHelper.runTask("profile:completeImport", tasks[0].args[0]);
+      await ImportWorkflow();
     });
 
     test("the profile will be in the calculated group", async () => {

--- a/core/__tests__/tasks/export/send.ts
+++ b/core/__tests__/tasks/export/send.ts
@@ -1,4 +1,4 @@
-import { helper } from "@grouparoo/spec-helper";
+import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
 import { api, task, specHelper } from "actionhero";
 import { Profile } from "../../../src/models/Profile";
 import { Group } from "../../../src/models/Group";
@@ -70,11 +70,7 @@ describe("tasks/export:send", () => {
     });
 
     test("the profile can be imported and exported", async () => {
-      await profile.import();
-      await profile.updateGroupMembership();
-      await specHelper.runTask("profile:completeImport", {
-        profileGuid: profile.guid,
-      });
+      await ImportWorkflow();
     });
 
     test("export:send will be enqueued into a custom queue with the app type", async () => {

--- a/core/__tests__/tasks/export/sendBatch.ts
+++ b/core/__tests__/tasks/export/sendBatch.ts
@@ -1,4 +1,4 @@
-import { helper } from "@grouparoo/spec-helper";
+import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
 import { api, task, specHelper } from "actionhero";
 import { Profile } from "../../../src/models/Profile";
 import { Group } from "../../../src/models/Group";
@@ -72,11 +72,7 @@ describe("tasks/export:sendBatch", () => {
     });
 
     test("the profile can be imported and exported", async () => {
-      await profile.import();
-      await profile.updateGroupMembership();
-      await specHelper.runTask("profile:completeImport", {
-        profileGuid: profile.guid,
-      });
+      await ImportWorkflow();
     });
 
     test("export:sendBatch will be enqueued after a batch from the run", async () => {

--- a/core/__tests__/tasks/profile/completeImport.ts
+++ b/core/__tests__/tasks/profile/completeImport.ts
@@ -1,4 +1,4 @@
-import { helper } from "@grouparoo/spec-helper";
+import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
 import { api, task, specHelper } from "actionhero";
 import { Group, Profile } from "../../../src";
 
@@ -43,7 +43,7 @@ describe("tasks/profile:completeImport", () => {
       expect(found.length).toEqual(1);
     });
 
-    test("it updates the profile state to ready", async () => {
+    test("it re-enqueues the task if the profile is not ready", async () => {
       const profile = await helper.factories.profile();
       await profile.import();
       await profile.update({ state: "pending" });
@@ -53,7 +53,15 @@ describe("tasks/profile:completeImport", () => {
       });
 
       await profile.reload();
-      expect(profile.state).toBe("ready");
+      expect(profile.state).toBe("pending");
+
+      const foundTasks = await specHelper.findEnqueuedTasks(
+        "profile:completeImport"
+      );
+      expect(foundTasks.length).toBe(1);
+      expect(foundTasks[0].args[0]).toEqual({
+        profileGuid: profile.guid,
+      });
 
       await profile.destroy();
     });
@@ -62,6 +70,7 @@ describe("tasks/profile:completeImport", () => {
       const profile = await helper.factories.profile();
       await profile.addOrUpdateProperties({ lastName: ["Mario"] });
       await profile.import();
+      await profile.update({ state: "ready" });
 
       let groups = await profile.$get("groups");
       expect(groups.length).toBe(0);
@@ -91,6 +100,7 @@ describe("tasks/profile:completeImport", () => {
 
       const profile = await Profile.findOne();
       await profile.import();
+      await profile.update({ state: "ready" });
 
       expect(_import.newGroupGuids).toEqual([]);
       expect(_import.newProfileProperties).toEqual({});
@@ -117,13 +127,18 @@ describe("tasks/profile:completeImport", () => {
     test("it will enqueue a profile:export task", async () => {
       const profile = await helper.factories.profile();
       await profile.import();
+      await profile.update({ state: "ready" });
 
       await specHelper.runTask("profile:completeImport", {
         profileGuid: profile.guid,
       });
 
-      const found = await specHelper.findEnqueuedTasks("profile:export");
-      expect(found.length).toEqual(1);
+      const foundTasks = await specHelper.findEnqueuedTasks("profile:export");
+      expect(foundTasks.length).toEqual(1);
+      expect(foundTasks[0].args[0]).toEqual({
+        force: false,
+        profileGuid: profile.guid,
+      });
     });
   });
 });

--- a/core/__tests__/tasks/profile/export.ts
+++ b/core/__tests__/tasks/profile/export.ts
@@ -1,4 +1,4 @@
-import { helper } from "@grouparoo/spec-helper";
+import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
 import { api, task, specHelper } from "actionhero";
 import { Profile } from "./../../../src/models/Profile";
 import { Import } from "./../../../src/models/Import";
@@ -180,12 +180,7 @@ describe("tasks/profile:export", () => {
         profiles = await Profile.findAll();
         expect(profiles.length).toBe(1);
 
-        // mock the import pipeline
-        await profiles[0].import();
-        await profiles[0].updateGroupMembership();
-        await specHelper.runTask("profile:completeImport", {
-          profileGuid: profiles[0].guid,
-        });
+        await ImportWorkflow();
 
         const foundExportTasks = await specHelper.findEnqueuedTasks(
           "profile:export"
@@ -247,12 +242,7 @@ describe("tasks/profile:export", () => {
         const profiles = await Profile.findAll();
         expect(profiles.length).toBe(2);
 
-        // mock the import pipeline
-        await profiles[1].import();
-        await profiles[1].updateGroupMembership();
-        await specHelper.runTask("profile:completeImport", {
-          profileGuid: profiles[1].guid,
-        });
+        await ImportWorkflow();
 
         const foundExportTasks = await specHelper.findEnqueuedTasks(
           "profile:export"

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -35,7 +35,7 @@ export namespace ProfileOps {
   export async function properties(profile: Profile) {
     const profileProperties =
       profile.profileProperties ||
-      (await ProfileProperty.findAll({
+      (await ProfileProperty.scope(null).findAll({
         where: { profileGuid: profile.guid },
         order: [["position", "ASC"]],
       }));
@@ -539,6 +539,7 @@ export namespace ProfileOps {
       }
 
       // re-import and update groups
+      delete profile.profileProperties;
       await profile.buildNullProperties();
       await profile.markPending();
 

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -5,6 +5,7 @@ import { Source } from "../../models/Source";
 import { Group } from "../../models/Group";
 import { Destination } from "../../models/Destination";
 import { Event } from "../../models/Event";
+import { Log } from "../../models/Log";
 import { api } from "actionhero";
 import { Op } from "sequelize";
 import { waitForLock } from "../locks";
@@ -537,6 +538,15 @@ export namespace ProfileOps {
       if (!profile.anonymousId && otherProfile.anonymousId) {
         await profile.update({ anonymousId: otherProfile.anonymousId });
       }
+
+      // log the merge
+      await Log.create({
+        topic: "profile",
+        verb: "merge",
+        message: `merged with profile ${otherProfile.guid}`,
+        ownerGuid: profile.guid,
+        data: { previousProperties: properties, otherProperties },
+      });
 
       // re-import and update groups
       delete profile.profileProperties;

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -539,9 +539,7 @@ export namespace ProfileOps {
       }
 
       // re-import and update groups
-      delete profile.profileProperties; // remove any cached values from the instance
-      await profile.import(true, false);
-      await profile.updateGroupMembership();
+      await profile.markPending();
 
       return profile;
     } finally {

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -539,6 +539,7 @@ export namespace ProfileOps {
       }
 
       // re-import and update groups
+      await profile.buildNullProperties();
       await profile.markPending();
 
       return profile;

--- a/core/src/tasks/event/associateProfile.ts
+++ b/core/src/tasks/event/associateProfile.ts
@@ -20,7 +20,7 @@ export class EventAssociateProfile extends Task {
         retryLimit: 3,
         backoffStrategy: [
           1000, // 1 second
-          1000 * 1, // 5 seconds
+          1000 * 5, // 5 seconds
           1000 * 10, // 10 seconds
         ],
       },

--- a/core/src/tasks/profile/completeImport.ts
+++ b/core/src/tasks/profile/completeImport.ts
@@ -1,4 +1,5 @@
 import { CLS } from "../../modules/cls";
+import { config } from "actionhero";
 import { Profile } from "../../models/Profile";
 import { Property } from "../../models/Property";
 import { ProfilePropertyType } from "../../modules/ops/profile";
@@ -32,21 +33,8 @@ export class ProfileCompleteImport extends RetryableTask {
     });
 
     if (!profile) return; // the profile may have been deleted or merged by the time this task ran
-
-    // calling this task implies we expect the profile to be in the ready state
     if (profile.state !== "ready") {
-      try {
-        await profile.update({ state: "ready" });
-      } catch (error) {
-        if (
-          error.toString().match(/cannot transition profile .* to ready state/)
-        ) {
-          // it's OK.  The next run of profile:checkReady will check this profile again
-          return;
-        } else {
-          throw error;
-        }
-      }
+      return CLS.enqueueTaskIn(config.tasks.timeout + 1, this.name, params);
     }
 
     const mergedValues = {};

--- a/core/src/tasks/profile/completeImport.ts
+++ b/core/src/tasks/profile/completeImport.ts
@@ -33,7 +33,13 @@ export class ProfileCompleteImport extends RetryableTask {
     });
 
     if (!profile) return; // the profile may have been deleted or merged by the time this task ran
-    if (profile.state !== "ready") {
+    const profileProperties = await profile.properties();
+    const pendingProfileProperty = Object.keys(profileProperties).find(
+      // a property may have gone back into the pending state
+      (k) => profileProperties[k].state !== "ready"
+    );
+
+    if (profile.state !== "ready" || pendingProfileProperty) {
       return CLS.enqueueTaskIn(config.tasks.timeout + 1, this.name, params);
     }
 

--- a/core/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/src/tasks/profileProperty/importProfileProperties.ts
@@ -90,9 +90,5 @@ export class ImportProfileProperties extends RetryableTask {
         },
       }
     );
-
-    log(
-      `imported ${property.key} (${property.guid}) for ${profilesWithDependenciesMet.length} profiles`
-    );
   }
 }

--- a/core/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/src/tasks/profileProperty/importProfileProperty.ts
@@ -72,7 +72,5 @@ export class ImportProfileProperty extends RetryableTask {
         }
       );
     }
-
-    log(`imported ${property.key} (${property.guid}) for 1 profile`);
   }
 }


### PR DESCRIPTION
Investigations into why running `grouparoo demo-data-purchases` to completion always leaves ~5 profiles that aren't in the `All Email` group which should be.

Ideas Tested in this PR:
* ❌ Are we not properly setting the profile/properties to pending if/when group membership changes?
* ❌ Are we removing profiles from groups who have been added or removed in the middle of a group run? Or, are we skipping over profiles because a head/trailing profile changed the offset?
* ❌ Are the Profiles who were merged (due to event data) the ones which aren't in the group?
* ✅ Are we importing/completing the import of profiles if/when a property has gone pending again?

Notes

```sql
-- query to find profiles which have a non-null email property who aren't in the `All Emails` group

select distinct(profiles.guid) from profiles 
join "profileProperties" on "profileProperties"."profileGuid" = profiles.guid 
where "profileProperties"."propertyGuid" = (select guid from properties where key = 'email')
and "profileProperties"."rawValue" != ''
and profiles.guid NOT IN (
  select profiles.guid from profiles
  join "groupMembers" on "groupMembers"."profileGuid" = profiles.guid
  where "groupMembers"."groupGuid" = (select guid from groups where name = 'All Emails')
);
```

Closes T-921