### PR TITLE
Do not trhow an error when the schedule:run task cannot find the schedule

### DIFF
--- a/core/__tests__/tasks/schedule/run.ts
+++ b/core/__tests__/tasks/schedule/run.ts
@@ -44,12 +44,36 @@ describe("tasks/schedule:run", () => {
       expect(found[0].timestamp).toBeNull();
     });
 
-    test("throws without a runGuid", async () => {
+    test("throws without a scheduleGuid", async () => {
       await expect(
         task.enqueue("schedule:run", {
           runGuid: "abc123",
         })
       ).rejects.toThrow(/scheduleGuid is a required input/);
+    });
+
+    test("throws without a runGuid", async () => {
+      await expect(
+        task.enqueue("schedule:run", {
+          scheduleGuid: "abc123",
+        })
+      ).rejects.toThrow(/runGuid is a required input/);
+    });
+
+    test("doesn't throw when scheduleGuid is **found** in DB", async () => {
+      const run = await helper.factories.run(schedule);
+
+      specHelper.runTask("schedule:run", {
+        scheduleGuid: schedule.guid,
+        runGuid: run.guid,
+      }); // doesn't throw
+    });
+
+    test("doesn't throw when scheduleGuid is **not found** in DB", async () => {
+      specHelper.runTask("schedule:run", {
+        scheduleGuid: "abc123",
+        runGuid: "abc123",
+      }); // doesn't throw
     });
   });
 });

--- a/core/src/modules/cls.ts
+++ b/core/src/modules/cls.ts
@@ -5,7 +5,7 @@ import cls from "cls-hooked";
  * This module is so you can delay the execution of side-effects within a transaction.
  * Say your new Model() creates a task... you don't want to enqueue it until after the transaction settles.
  * Use: `CLS.enqueueTaskIn(1000, taskName, args)`
- *   If you are in a CLS transaction, it will be un afterwords by CLSTask or CLSAction
+ *   If you are in a CLS transaction, it will be run afterwards by CLSTask or CLSAction
  *   If you aren't in a CLS transaction, it will be run now.
  *
  * The more generic usage is `CLS.afterCommit(() => {})` where you can supply any async function

--- a/core/src/tasks/schedule/run.ts
+++ b/core/src/tasks/schedule/run.ts
@@ -18,7 +18,11 @@ export class ScheduleRun extends RetryableTask {
   }
 
   async runWithinTransaction(params) {
-    const schedule = await Schedule.findByGuid(params.scheduleGuid);
+    const schedule = await Schedule.findOne({
+      where: { guid: params.scheduleGuid },
+    });
+    if (!schedule) return;
+
     if (schedule.state !== "ready") {
       throw new Error(`schedule ${params.scheduleGuid} is not ready`);
     }


### PR DESCRIPTION
Prevents an error from being thrown from a Task if a user deletes a Schedule.  Also, fixed some Typos!

Closes T-914


Work done with @vishal-sood! 