### PR TITLE
Fetch up to 1000 mail chimp lists

### DIFF
--- a/plugins/@grouparoo/mailchimp/__tests__/fixtures/mailchimp-export-id.js
+++ b/plugins/@grouparoo/mailchimp/__tests__/fixtures/mailchimp-export-id.js
@@ -643,6 +643,7 @@ nock("https://us3.api.mailchimp.com:443", { encodedQueryParams: true })
   );
 nock("https://us3.api.mailchimp.com:443", { encodedQueryParams: true })
   .get("/3.0/lists", {})
+  .query({ count: "1000" })
   .once()
   .reply(
     200,
@@ -1665,6 +1666,7 @@ nock("https://us3.api.mailchimp.com:443", { encodedQueryParams: true })
   );
 nock("https://us3.api.mailchimp.com:443", { encodedQueryParams: true })
   .get("/3.0/lists", {})
+  .query({ count: "1000" })
   .once()
   .reply(
     200,

--- a/plugins/@grouparoo/mailchimp/__tests__/fixtures/mailchimp-export.js
+++ b/plugins/@grouparoo/mailchimp/__tests__/fixtures/mailchimp-export.js
@@ -464,6 +464,7 @@ nock("https://us3.api.mailchimp.com:443", { encodedQueryParams: true })
   );
 nock("https://us3.api.mailchimp.com:443", { encodedQueryParams: true })
   .get("/3.0/lists", {})
+  .query({ count: "1000" })
   .once()
   .reply(
     200,
@@ -1486,6 +1487,7 @@ nock("https://us3.api.mailchimp.com:443", { encodedQueryParams: true })
   );
 nock("https://us3.api.mailchimp.com:443", { encodedQueryParams: true })
   .get("/3.0/lists", {})
+  .query({ count: "1000" })
   .once()
   .reply(
     200,

--- a/plugins/@grouparoo/mailchimp/__tests__/fixtures/mailchimp-import.js
+++ b/plugins/@grouparoo/mailchimp/__tests__/fixtures/mailchimp-import.js
@@ -2,6 +2,7 @@ const nock = require("nock");
 
 nock("https://us3.api.mailchimp.com:443", { encodedQueryParams: true })
   .get("/3.0/lists", {})
+  .query({ count: "1000" })
   .once()
   .reply(
     200,

--- a/plugins/@grouparoo/mailchimp/src/lib/shared/connectionOptions.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/shared/connectionOptions.ts
@@ -8,7 +8,6 @@ import {
   App,
 } from "@grouparoo/core";
 import { connect } from "../connect";
-import { getMergeVars } from "./getMergeVars";
 
 export type MailchimpOptionKey = "listId";
 export interface ConnectionOptionsMethod {
@@ -59,7 +58,7 @@ export const getConnectionOptions: GetConnectionOptionsMethod = (
 
     if (optionKeys.includes("listId")) {
       response.listId = { type: "list", options: [], descriptions: [] };
-      const { lists } = await client.get(`/lists`);
+      const { lists } = await client.get("/lists?count=1000");
       lists.map((list) => {
         response.listId.options.push(list.id);
         response.listId.descriptions.push(list.name);

--- a/plugins/@grouparoo/mailchimp/src/lib/test.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/test.ts
@@ -3,7 +3,7 @@ import { connect } from "./connect";
 
 export const test: TestPluginMethod = async ({ appOptions }) => {
   const client = await connect(appOptions);
-  const { lists } = await client.get("/lists");
+  const { lists } = await client.get("/lists?count=1000");
   const success = lists ? true : false;
   const message = success ? `${lists.length} Mailchimp lists available` : null;
 


### PR DESCRIPTION
The previous (default) number was 10. Some users have more than that.
1000 seems reasonable and better than paging logic.