### PR TITLE
Remove stale settings on init

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -83,4 +83,20 @@ cd apps/staging-public
 (npx) grouparoo demo-event-stream
 ```
 
+## Running Tests
+
+Grouparoo uses [Jest](https://jestjs.io/) as our testing framework. To run tests, first make sure you've installed all dependencies in the root of the project.
+
+    cd ../
+    pnpm install
+
+Next, create the test databases:
+
+    cd core
+    ./bin/create_test_database
+
+Then you can run the tests. We recommend you run only the test files you're working on. Let our CI server do the bulk of the work:
+
+    npm run test path/to/test/file
+
 🦘

--- a/core/src/initializers/settings.ts
+++ b/core/src/initializers/settings.ts
@@ -171,6 +171,14 @@ export class Plugins extends Initializer {
       },
     ];
 
+    const settingKeys: string[] = [
+      ...coreSettings,
+      ...interfaceSettings,
+      ...telemetrySettings,
+    ].map(({ key }) => key);
+
+    await plugin.cleanSettings(settingKeys);
+
     await this.registerSettingsArray(coreSettings, "core");
     await this.registerSettingsArray(interfaceSettings, "interface");
     await this.registerSettingsArray(telemetrySettings, "telemetry");

--- a/core/src/modules/plugin.ts
+++ b/core/src/modules/plugin.ts
@@ -76,10 +76,10 @@ export namespace plugin {
     });
   }
 
-  export async function cleanSettings(staleKeys: string[]) {
+  export async function cleanSettings(inUseKeys: string[]) {
     return await Setting.destroy({
       where: {
-        key: { [Op.notIn]: staleKeys },
+        key: { [Op.notIn]: inUseKeys },
       },
     });
   }

--- a/core/src/modules/plugin.ts
+++ b/core/src/modules/plugin.ts
@@ -1,4 +1,5 @@
 import { api } from "actionhero";
+import { Op } from "sequelize";
 import { GrouparooPlugin } from "../classes/plugin";
 import { MustacheUtils } from "./mustacheUtils";
 
@@ -72,6 +73,14 @@ export namespace plugin {
   export function mountModels() {
     models.map((model) => {
       if (!model.isInitialized) api.sequelize.addModels([model]);
+    });
+  }
+
+  export async function cleanSettings(staleKeys: string[]) {
+    return await Setting.destroy({
+      where: {
+        key: { [Op.notIn]: staleKeys },
+      },
     });
   }
 


### PR DESCRIPTION
Before the settings are registered, remove any lingering settings that don't match the expected set. This uses the `key` attribute to determine if a setting is stale or not.

---

Closes T-832