### PR TITLE
Update helper text for cli generate command

### DIFF
--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -1,4 +1,5 @@
 import { GrouparooCLI } from "../modules/cli";
+import Colors from "colors/safe";
 import {
   ConfigTemplate,
   ConfigTemplateRunResponse,
@@ -83,11 +84,17 @@ export class Generate extends CLI {
 
     const template = await this.getTemplate(params.template);
 
+    const preparedParams = template.prepareParams({ ...params });
+
+    if (preparedParams.id !== params.id) {
+      console.log(
+        `${Colors.yellow("notice")}: ID was changed to ${preparedParams.id}`
+      );
+    }
+
     let fileData: ConfigTemplateRunResponse = {};
     try {
-      fileData = await template.run({
-        params: template.prepareParams(params),
-      });
+      fileData = await template.run({ params: preparedParams });
     } catch (error) {
       this.fatalError(error.message);
     }

--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -12,7 +12,8 @@ export class Generate extends CLI {
   constructor() {
     super();
     this.name = "generate [template] [id]"; // I will include the template ARG vs OPT
-    this.description = "Generate new code config files from templates";
+    this.description =
+      "Generate new code config files from templates. Each template requires an ID, a unique identifier that is used to linked templates to each other.";
     this.inputs = {
       list: {
         required: false,
@@ -70,13 +71,14 @@ export class Generate extends CLI {
   }
 
   async generate(params) {
+    const learnMoreText =
+      "Learn more with `grouparoo generate --help` and `grouparoo generate --list`";
+
     if (!params.template) {
-      this.fatalError(
-        `template is required.  Learn more with \`grouparoo generate --help\` and \`grouparoo generate --list\``
-      );
+      this.fatalError(`template is required. ${learnMoreText}`);
     }
     if (!params.id) {
-      this.fatalError(`id is required`);
+      this.fatalError(`id is required. ${learnMoreText}`);
     }
 
     const template = await this.getTemplate(params.template);

--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -143,7 +143,7 @@ Commands:
     if (!params.template) {
       console.log("");
       console.log(
-        "You can filter this list by providing a (partial) template to match template names against"
+        "You can filter this list by providing a (partial) template to match template names against. (e.g. `grouparoo generate postgres --list`)"
       );
     }
   }

--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -13,8 +13,14 @@ export class Generate extends CLI {
   constructor() {
     super();
     this.name = "generate [template] [id]"; // I will include the template ARG vs OPT
-    this.description =
-      "Generate new code config files from templates. Each template requires an ID, a unique identifier that is used to linked templates to each other.";
+    this.description = `Generate new code config files from templates.
+
+Commands:
+  [options]   See "Options" section below.
+  [template]  Name of the template. This is a starting point for building your configuration.
+              Use --list for a list of available templates.
+  [id]        A unique ID used to link items created from templates.
+              The value must be unique, using lower case letters and underscores only.`;
     this.inputs = {
       list: {
         required: false,

--- a/plugins/@grouparoo/app-templates/public/templates/query-property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/query-property/{{{id}}}.js.template
@@ -4,13 +4,13 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "property",
-      sourceId: "purchases_table", // The ID of the Source that this Property belongs to.
+      sourceId: "...", // The ID of the Source that this Property belongs to - e.g. `sourceId: "purchases_table"`
       type: "float", // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: false, // Will Profiles have unique records for this Property?
       identifying: false, // Should we consider this property Identifying in the UI? Only one Property can be identifying.
       isArray: false, // Is this an Array Property?
       options: {
-        query: "SELECT SUM(price) from purchases where user_id = \{\{userId\}\}", // The query to extract the property.  You can use mustache variables to represent the keys of other properties in the system.
+        query: "SELECT SUM(price) from purchases where user_id = \{\{userId\}\}", // The query to extract the property.  You can use mustache variables (https://github.com/janl/mustache.js#variables) to represent the keys of other properties in the system.
       },
     },
   ];

--- a/plugins/@grouparoo/app-templates/public/templates/query-schedule/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/query-schedule/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "schedule",
-      sourceId: "queries_source", // The id of the Source this Schedule uses
+      sourceId: "...", // The ID of the Source this Schedule uses - e.g. `sourceId: "query_source"`
       recurring: true, // should this Schedule regularly run?
       recurringFrequency: 1000 * 60 * 15, // 15 minutes, in ms
       options: {

--- a/plugins/@grouparoo/app-templates/public/templates/query-source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/query-source/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-query-import",
-      appId: "dataWarehouse", // The id of the App this Source uses
+      appId: "...", // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
     },
   ];
 };

--- a/plugins/@grouparoo/app-templates/public/templates/table-property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/table-property/{{{id}}}.js.template
@@ -4,13 +4,13 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "property",
-      sourceId: "users_table", // The ID of the Source that this Property belongs to.
+      sourceId: "...", // The ID of the Source that this Property belongs to - e.g. `sourceId: "users_table"`
       type: "string", // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: true, // Will Profiles have unique records for this Property?
       identifying: true, // Should we consider this property Identifying in the UI? Only one Property can be identifying.
       isArray: false, // Is this an Array Property?
       options: {
-        column: "first_name", // The column to use for this Property
+        column: "...", // The column to use for this Property - e.g. `column: "first_name"`
         aggregationMethod: "exact", // The aggregation method.  Options are: {{{__aggregationMethodOptions}}}
         sort: null, // You can sort the results by another column in this table
       },

--- a/plugins/@grouparoo/app-templates/public/templates/table-schedule/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/table-schedule/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "schedule",
-      sourceId: "users_table", // The id of the Source this Schedule uses
+      sourceId: "...", // The ID of the Source this Schedule uses - e.g. `sourceId: "users_table"`
       recurring: true, // should this Schedule regularly run?
       recurringFrequency: 1000 * 60 * 15, // 15 minutes, in ms
       options: {

--- a/plugins/@grouparoo/app-templates/public/templates/table-source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/table-source/{{{id}}}.js.template
@@ -1,55 +1,46 @@
 exports.default = async function buildConfig() {
-  // Option 1: This is the first source and you need to bootstrap the first property as well
   return [
     {
       class: "source",
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-table-import",
-      appId: "dataWarehouse", // The id of the App this Source uses
+      appId: "...", // Set this value to the ID of the App this Source uses.
       options: {
-        table: "users", // the table in your DB
+        table: "users", // Name of the table in your DB.
       },
 
-      /*
-       * For example, if you want to say your users table has an ID and it maps to the Property `user_id` in grouparoo (defined below in bootstrappedProperty):
-       *   mapping: {id: 'user_id'}
+      /**
+       * A list of mappings for this source as:
+       *
+       *     "remote_column": "grouparoo_property_id"
+       *
+       * For example, if your users table has an `id` column, and you want to map that to the
+       * `user_id` property in this Grouparoo source, your mapping would look like:
+       *
+       *     mapping: { id: "user_id" }
+       *
+       * If this is the first Source for this App, you'll want to create a property in the
+       * bootstrappedProperty section below. Otherwise, you can create properties with the Grouparoo
+       * CLI.
        */
       mapping: {
         id: "user_id", // Looks like `remote column`:`grouparoo property id`
       },
 
-      // If this is the first source, you will also need to make the first property.  This is a special first-time bootstrapping process/
-      bootstrappedProperty: {
-        id: "user_id",
-        name: "User Id",
-        type: "integer",
-        options: {
-          column: "id",
-        },
-      },
+      /**
+       * If this is the first Source for this App, you must bootstrap it with an initial property.
+       * To do so, uncomment the lines below and fill in the appropriate values. Otherwise, you can
+       * create properties with the Grouparoo CLI.
+       */
+      // bootstrappedProperty: {
+      //   id: "user_id",
+      //   name: "User Id",
+      //   type: "integer",
+      //   options: {
+      //     column: "id",
+      //   },
+      // },
     },
   ];
-
-  // Option 2: This is not the first source, and you can reference other properties which already exist
-  // return [
-  //   {
-  //     class: "source",
-  //     id: {{{id}}},
-  //     name: {{{id}}},
-  //     type: {{{__pluginName}}}-table-import,
-  //     appId: "dataWarehouse", // The id of the app this source uses
-  //     options: {
-  //       table: "purchases", // the table in your DB
-  //     },
-  //
-  //     /*
-  //      * For example, if you want to say your purchases table has a column user_id that maps to the Property `user_id` in Grouparoo:
-  //      *   mapping: {user_id: 'user_id'}
-  //      */
-  //     mapping: {
-  //       user_id: "user_id", // Looks like `remote column`:`grouparoo property id`
-  //     },
-  //   },
-  // ];
 };

--- a/plugins/@grouparoo/app-templates/public/templates/table-source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/table-source/{{{id}}}.js.template
@@ -5,9 +5,9 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-table-import",
-      appId: "...", // Set this value to the ID of the App this Source uses.
+      appId: "...", // Set this value to the ID of the App this Source uses - e.g. `appId: "data_warehouse"`
       options: {
-        table: "users", // Name of the table in your DB.
+        table: "...", // Name of the table in your DB - e.g. `table: "users"`
       },
 
       /**
@@ -25,7 +25,7 @@ exports.default = async function buildConfig() {
        * CLI.
        */
       mapping: {
-        id: "user_id", // Looks like `remote column`:`grouparoo property id`
+        id: "user_id",
       },
 
       /**

--- a/plugins/@grouparoo/bigquery/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/bigquery/public/templates/app/{{{id}}}.js.template
@@ -6,10 +6,10 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       type: "{{{__pluginName}}}",
       options: {
-        project_id: "data-warehouse", // Project id from Google
-        dataset: "dataset", // Default dataset id to use for sources
-        client_email: "grouparoo-access@grouparoo-sources.iam.gserviceaccount.com", // Client Email Address
-        private_key: "-----BEGIN PRIVATE KEY-----\nABC123", // Private key of service account
+        project_id: "...", // Project ID from Google - e.g. `project_id: "data_warehouse"`
+        dataset: "...", // Default dataset ID to use for sources - e.g. `dataset: "dataset"`
+        client_email: "xxx@xxx.iam.gserviceaccount.com", // Client Email Address
+        private_key: "-----BEGIN PRIVATE KEY-----\n...", // Private key of service account
       }
     },
   ];

--- a/plugins/@grouparoo/csv/public/templates/property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/csv/public/templates/property/{{{id}}}.js.template
@@ -4,13 +4,13 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "property",
-      sourceId: "csvSource", // The ID of the Source that this Property belongs to.
+      sourceId: "...", // The ID of the Source that this Property belongs to - e.g. `sourceId: "csv_app"`
       type: "string", // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: false, // Will Profiles have unique records for this Property?
       identifying: false, // Should we consider this property Identifying in the UI? Only one Property can be identifying.
       isArray: false, // Is this an Array Property?
       options: {
-        column: "first_name", // The column to use for this Property from the CSV.
+        column: "...", // The column to use for this Property from the CSV - e.g. `column: "first_name"`
       },
     },
   ];

--- a/plugins/@grouparoo/csv/public/templates/schedule/{{{id}}}.js.template
+++ b/plugins/@grouparoo/csv/public/templates/schedule/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "schedule",
-      sourceId: "csvSchedule", // The id of the Source this Schedule uses
+      sourceId: "...", // The id of the Source this Schedule uses - e.g. `sourceId: "csv_schedule"`
       recurring: true, // should this Schedule regularly run?
       recurringFrequency: 1000 * 60 * 15, // 15 minutes, in ms
     },

--- a/plugins/@grouparoo/csv/public/templates/source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/csv/public/templates/source/{{{id}}}.js.template
@@ -5,9 +5,9 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-import",
-      appId: "...", // Set this value to the ID of the App this Source uses.
+      appId: "...", // Set this value to the ID of the App this Source uses - e.g. `appId: "csv_app"`
       options: {
-        fileGuid: "fil_abc123" // The guid of a File already uploaded to Grouparoo
+        fileGuid: "..." // The guid of a File already uploaded to Grouparoo - e.g. `fileGuid: "fil_abc123"`
       },
 
       /**

--- a/plugins/@grouparoo/csv/public/templates/source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/csv/public/templates/source/{{{id}}}.js.template
@@ -1,53 +1,46 @@
 exports.default = async function buildConfig() {
-  // Option 1: This is the first source and you need to bootstrap the first property as well
   return [
     {
       class: "source",
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-import",
-      appId: "csvApp", // The id of the App this Source uses
+      appId: "...", // Set this value to the ID of the App this Source uses.
       options: {
         fileGuid: "fil_abc123" // The guid of a File already uploaded to Grouparoo
       },
 
-      /*
-       * For example, if you want to say the column form the CSV "id" maps the Grouparoo Property "userId".
+      /**
+       * A list of mappings for this source as:
+       *
+       *     "csv_column": "grouparoo_property_id"
+       *
+       * For example, if your CSV files has an `id` column, and you want to map that to the
+       * `user_id` property in this Grouparoo source, your mapping would look like:
+       *
+       *     mapping: { id: "user_id" }
+       *
+       * If this is the first Source for this App, you'll want to create a property in the
+       * bootstrappedProperty section below. Otherwise, you can create properties with the Grouparoo
+       * CLI.
        */
       mapping: {
         "id": "userId",
       },
 
-      // If this is the first source, you will also need to make the first property.  This is a special first-time bootstrapping process/
-      bootstrappedProperty: {
-        id: "user_id",
-        name: "User Id",
-        type: "integer",
-        options: {
-          column: "id",
-        },
-      },
+      /**
+       * If this is the first Source for this App, you must bootstrap it with an initial property.
+       * To do so, uncomment the lines below and fill in the appropriate values. Otherwise, you can
+       * create properties with the Grouparoo CLI.
+       */
+      // bootstrappedProperty: {
+      //   id: "user_id",
+      //   name: "User Id",
+      //   type: "integer",
+      //   options: {
+      //     column: "id",
+      //   },
+      // },
     },
   ];
-
-  // Option 2: This is not the first source, and you can reference other properties which already exist
-  // return [
-  //   {
-  //     class: "source",
-  //     id: {{{id}}},
-  //     name: {{{id}}},
-  //     type: {{{__pluginName}}}-import,
-  //     appId: "csvApp", // The id of the app this source uses
-  //     options: {
-  //       fileGuid: "fil_abc123" // The guid of a File already uploaded to Grouparoo
-  //     },
-  //
-  //     /*
-  //      * For example, if you want to say the column form the CSV "id" maps the Grouparoo Property "userId".
-  //      */
-  //     mapping: {
-  //       "id": "userId",
-  //     },
-  //   },
-  // ];
 };

--- a/plugins/@grouparoo/facebook/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/facebook/public/templates/app/{{{id}}}.js.template
@@ -6,8 +6,8 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       type: "{{{__pluginName}}}",
       options: {
-        adAccountId: "562677826929881", // Number from your settings and in the URL
-        accessToken: "abc123", // The Access Token needs the ads_management permission
+        adAccountId: "...", // Number from your settings and in the URL - e.g. `adAccountId: "562677826929881"`
+        accessToken: "...", // The Access Token needs the ads_management permission
       }
     },
   ];

--- a/plugins/@grouparoo/facebook/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/facebook/public/templates/destination/{{{id}}}.js.template
@@ -5,8 +5,8 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "facebookApp", // The id of the App this Source uses
-      groupId: "high_value_customers", // The id of the group whose members you want to export
+      appId: "...", // The ID of the App this Source uses - e.g. `appId: "facebookApp"`
+      groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {
         primaryKey: 'userId', // Which field should uniquely identify Facebook users?

--- a/plugins/@grouparoo/google-sheets/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/google-sheets/public/templates/app/{{{id}}}.js.template
@@ -6,8 +6,8 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       type: "{{{__pluginName}}}",
       options: {
-        client_email: "grouparoo-access@grouparoo-sources.iam.gserviceaccount.com", // Email of service account
-        private_key: "-----BEGIN PRIVATE KEY-----\nABC123", // Private key of service account
+        client_email: "xxx@xxx.iam.gserviceaccount.com", // Email of service account
+        private_key: "-----BEGIN PRIVATE KEY-----\n...", // Private key of service account
       }
     },
   ];

--- a/plugins/@grouparoo/google-sheets/public/templates/property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/google-sheets/public/templates/property/{{{id}}}.js.template
@@ -4,13 +4,13 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "property",
-      sourceId: "googleSheetsSource", // The ID of the Source that this Property belongs to.
+      sourceId: "...", // The ID of the Source that this Property belongs to - e.g. `sourceId: "google_sheets_source"`
       type: "string", // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: false, // Will Profiles have unique records for this Property?
       identifying: false, // Should we consider this property Identifying in the UI? Only one Property can be identifying.
       isArray: false, // Is this an Array Property?
       options: {
-        column: "first_name", // The column to use for this Property
+        column: "...", // The column to use for this Property - e.g. `column: "first_name"`
       },
     },
   ];

--- a/plugins/@grouparoo/google-sheets/public/templates/schedule/{{{id}}}.js.template
+++ b/plugins/@grouparoo/google-sheets/public/templates/schedule/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "schedule",
-      sourceId: "googleSheetsSource", // The id of the Source this Schedule uses
+      sourceId: "...", // The ID of the Source this Schedule uses - e.g. `sourceId: "google_sheet_source"`
       recurring: true, // should this Schedule regularly run?
       recurringFrequency: 1000 * 60 * 15, // 15 minutes, in ms
     },

--- a/plugins/@grouparoo/google-sheets/public/templates/source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/google-sheets/public/templates/source/{{{id}}}.js.template
@@ -1,55 +1,46 @@
 exports.default = async function buildConfig() {
-  // Option 1: This is the first source and you need to bootstrap the first property as well
   return [
     {
       class: "source",
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-table-import",
-      appId: "googleSheetsApp", // The id of the App this Source uses
+      appId: "...", // Set this value to the ID of the App this Source uses.
       options: {
         sheet_url: "https://sheets.google.com/....", // The URL of your sheet
       },
 
-      /*
-       * For example, if you want to say your users table has an ID and it maps to the Property `user_id` in grouparoo (defined below in bootstrappedProperty):
-       *   mapping: {id: 'user_id'}
+      /**
+       * A list of mappings for this source as:
+       *
+       *     "sheet_column": "grouparoo_property_id"
+       *
+       * For example, if your Google Sheet has an `id` column, and you want to map that to the
+       * `user_id` property in this Grouparoo source, your mapping would look like:
+       *
+       *     mapping: { id: "user_id" }
+       *
+       * If this is the first Source for this App, you'll want to create a property in the
+       * bootstrappedProperty section below. Otherwise, you can create properties with the Grouparoo
+       * CLI.
        */
       mapping: {
-        id: "user_id", // Looks like `remote column`:`grouparoo property id`
+        id: "user_id",
       },
 
-      // If this is the first source, you will also need to make the first property.  This is a special first-time bootstrapping process/
-      bootstrappedProperty: {
-        id: "user_id",
-        name: "User Id",
-        type: "integer",
-        options: {
-          column: "id",
-        },
-      },
+      /**
+       * If this is the first Source for this App, you must bootstrap it with an initial property.
+       * To do so, uncomment the lines below and fill in the appropriate values. Otherwise, you can
+       * create properties with the Grouparoo CLI.
+       */
+      // bootstrappedProperty: {
+      //   id: "user_id",
+      //   name: "User Id",
+      //   type: "integer",
+      //   options: {
+      //     column: "id",
+      //   },
+      // },
     },
   ];
-
-  // Option 2: This is not the first source, and you can reference other properties which already exist
-  // return [
-  //   {
-  //     class: "source",
-  //     id: {{{id}}},
-  //     name: {{{id}}},
-  //     type: {{{__pluginName}}}-table-import,
-  //     appId: "googleSheetsApp", // The id of the app this source uses
-  //     options: {
-  //       sheet_url: "https://sheets.google.com/....", // The URL of your sheet
-  //     },
-  //
-  //     /*
-  //      * For example, if you want to say your purchases table has a column user_id that maps to the Property `user_id` in Grouparoo:
-  //      *   mapping: {user_id: 'user_id'}
-  //      */
-  //     mapping: {
-  //       user_id: "user_id", // Looks like `remote column`:`grouparoo property id`
-  //     },
-  //   },
-  // ];
 };

--- a/plugins/@grouparoo/google-sheets/public/templates/source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/google-sheets/public/templates/source/{{{id}}}.js.template
@@ -5,9 +5,9 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-table-import",
-      appId: "...", // Set this value to the ID of the App this Source uses.
+      appId: "...", // Set this value to the ID of the App this Source uses - e.g. `appId: "google_sheet_app"`
       options: {
-        sheet_url: "https://sheets.google.com/....", // The URL of your sheet
+        sheet_url: "https://sheets.google.com/...", // The URL of your sheet.
       },
 
       /**

--- a/plugins/@grouparoo/hubspot/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/hubspot/public/templates/app/{{{id}}}.js.template
@@ -6,7 +6,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       type: "{{{__pluginName}}}",
       options: {
-        hapikey: "abc123", // Hubspot hapikey (api) key
+        hapikey: "...", // Hubspot hapikey (API) key
       }
     },
   ];

--- a/plugins/@grouparoo/hubspot/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/hubspot/public/templates/destination/{{{id}}}.js.template
@@ -5,8 +5,8 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "hubspotApp", // The id of the App this Source uses
-      groupId: "high_value_customers", // The id of the group whose members you want to export
+      appId: "...", // The ID of the App this Source uses - e.g. `appId: "hubspot_app"`
+      groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {},
 

--- a/plugins/@grouparoo/intercom/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/intercom/public/templates/app/{{{id}}}.js.template
@@ -6,7 +6,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       type: "{{{__pluginName}}}",
       options: {
-        token: "abc123", // Access token from your private app in the developer hub
+        token: "...", // Access token from your private app in the developer hub
       }
     },
   ];

--- a/plugins/@grouparoo/intercom/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/intercom/public/templates/destination/{{{id}}}.js.template
@@ -5,8 +5,8 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "intercomApp", // The id of the App this Source uses
-      groupId: "high_value_customers", // The id of the group whose members you want to export
+      appId: "...", // The ID of the App this Source uses - e.g. `appId: "intercom_app"`
+      groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {
         creationMode: "User", // How should Grouparoo create Intercom contacts?  Options: "User", "Lead", "Enrich", "Lifecycle"

--- a/plugins/@grouparoo/mailchimp/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/app/{{{id}}}.js.template
@@ -6,7 +6,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       type: "{{{__pluginName}}}",
       options: {
-        apiKey: "abc123", // Mailchimp API key
+        apiKey: "...", // Mailchimp API key
       }
     },
   ];

--- a/plugins/@grouparoo/mailchimp/public/templates/destination/email/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/destination/email/{{{id}}}.js.template
@@ -5,11 +5,11 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "mailchimpApp", // The id of the App this Source uses
-      groupId: "high_value_customers", // The id of the group whose members you want to export
+      appId: "...", // The ID of the App this Source uses - e.g. `appId: "mailchimp_app"`
+      groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {
-        listId: "abc123" // The Mailchimp List ID
+        listId: "..." // The Mailchimp List ID (https://mailchimp.com/help/find-audience-id/)
       },
 
       // Mappings are how you choose which properties to export to this destination.

--- a/plugins/@grouparoo/mailchimp/public/templates/destination/id/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/destination/id/{{{id}}}.js.template
@@ -5,11 +5,11 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "mailchimpApp", // The id of the App this Source uses
-      groupId: "high_value_customers", // The id of the group whose members you want to export
+      appId: "...", // The ID of the App this Source uses - e.g. `appId: "mailchimp_app"`
+      groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {
-        listId: "abc123" // The Mailchimp List ID
+        listId: "..." // The Mailchimp List ID (https://mailchimp.com/help/find-audience-id/)
       },
 
       // Mappings are how you choose which properties to export to this destination.

--- a/plugins/@grouparoo/mailchimp/public/templates/property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/property/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "property",
-      sourceId: "mailchimpSource", // The ID of the Source that this Property belongs to.
+      sourceId: "...", // The ID of the Source that this Property belongs to - e.g. `sourceId: "mailchimp_source"`
       type: "string", // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: false, // Will Profiles have unique records for this Property?
       identifying: false, // Should we consider this property Identifying in the UI? Only one Property can be identifying.

--- a/plugins/@grouparoo/mailchimp/public/templates/schedule/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/schedule/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "schedule",
-      sourceId: "mailchimpSource", // The id of the Source this Schedule uses
+      sourceId: "...", // The id of the Source this Schedule uses - e.g. `sourceId: "mailchimp_source"`
       recurring: true, // should this Schedule regularly run?
       recurringFrequency: 1000 * 60 * 15, // 15 minutes, in ms
     },

--- a/plugins/@grouparoo/mailchimp/public/templates/source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/source/{{{id}}}.js.template
@@ -1,53 +1,50 @@
 exports.default = async function buildConfig() {
-  // Option 1: This is the first source and you need to bootstrap the first property as well
   return [
     {
       class: "source",
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-import",
-      appId: "mailchimpApp", // The id of the App this Source uses
+      appId: "...", // Set this value to the ID of the App this Source uses.
       options: {
-        listId: "abc123" // The Mailchimp List ID
+        listId: "..." // The Mailchimp List ID
       },
 
-      /*
-       * For example, if you want to say your MERGE_VAR "id" maps the Grouparoo Property "userId".
+      /**
+       * A list of mappings for this source as:
+       *
+       *     "merge_var": "grouparoo_property_id"
+       *
+       * For example, if you want your MERGE_VAR `USER_ID` to map to the `user_id` property in this
+       * Grouparoo source, your mapping would look like:
+       *
+       *     mapping: { "merge_fields.USER_ID": "user_id" }
+       *
+       * Note that MERGE_VARS use a prefix `merge_fields`, while other properties like
+       * `email_address` can be used directly.
+       *
+       * If this is the first Source for this App, you'll want to create a property in the
+       * bootstrappedProperty section below. Otherwise, you can create properties with the Grouparoo
+       * CLI.
        */
       mapping: {
-        "merge_fields.USER_ID": "userId", // Merge vars look like "merge_fields.FNAME" while you can access "email_address" directly.
+        "email_address": "email",
+        "merge_fields.FNAME": "first_name",
       },
 
-      // If this is the first source, you will also need to make the first property.  This is a special first-time bootstrapping process/
-      bootstrappedProperty: {
-        id: "user_id",
-        name: "User Id",
-        type: "integer",
-        options: {
-          column: "id",
-        },
-      },
+      /**
+       * If this is the first Source for this App, you must bootstrap it with an initial property.
+       * To do so, uncomment the lines below and fill in the appropriate values. Otherwise, you can
+       * create properties with the Grouparoo CLI.
+       */
+      // bootstrappedProperty: {
+      //   id: "user_id",
+      //   name: "User Id",
+      //   type: "integer",
+      //   options: {
+      //     column: "id",
+      //   },
+      // },
     },
   ];
-
-  // Option 2: This is not the first source, and you can reference other properties which already exist
-  // return [
-  //   {
-  //     class: "source",
-  //     id: {{{id}}},
-  //     name: {{{id}}},
-  //     type: {{{__pluginName}}}-import,
-  //     appId: "mailchimpApp", // The id of the app this source uses
-  //     options: {
-  //       listId: "abc123" // The Mailchimp List ID
-  //     },
-  //
-  //     /*
-  //      * For example, if you want to say your MERGE_VAR "id" maps the Grouparoo Property "userId"
-  //      */
-  //     mapping: {
-  //       "merge_fields.USER_ID": "userId", // Merge vars look like "merge_fields.FNAME" while you can access "email_address" directly.
-  //     },
-  //   },
-  // ];
 };

--- a/plugins/@grouparoo/mailchimp/public/templates/source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/source/{{{id}}}.js.template
@@ -5,9 +5,9 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-import",
-      appId: "...", // Set this value to the ID of the App this Source uses.
+      appId: "...", // Set this value to the ID of the App this Source uses - e.g. `appId: "mailchimp_app"`
       options: {
-        listId: "..." // The Mailchimp List ID
+        listId: "..." // The Mailchimp List ID (https://mailchimp.com/help/find-audience-id/)
       },
 
       /**

--- a/plugins/@grouparoo/mailchimp/src/lib/templates.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/templates.ts
@@ -68,7 +68,7 @@ export class MailchimpIdDestinationTemplate extends ConfigTemplate {
   constructor() {
     super();
     this.name = `mailchimp:id:destination`;
-    this.description = `Config for a Mailchimp ID Destination`;
+    this.description = `Config for a Mailchimp ID Destination. Note: Use the email destination unless you know you need this.`;
     this.files = [path.join(templateRoot, "destination", "id", "*.template")];
     this.destinationDir = "destinations";
   }

--- a/plugins/@grouparoo/marketo/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/marketo/public/templates/app/{{{id}}}.js.template
@@ -6,10 +6,10 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       type: "{{{__pluginName}}}",
       options: {
-        endpoint: "https://123-ABC-456.mktorest.com/rest", // Found in Marketo Web Services
-        identity: "https://123-ABC-456.mktorest.com/identity", // Found in Marketo Web Services
-        clientId: "xxx", // Found in LaunchPoint for an API user
-        clientSecret: "xxx", // Found in LaunchPoint for an API user
+        endpoint: "https://xxx.mktorest.com/rest", // Found in Marketo Web Services
+        identity: "https://xxx.mktorest.com/identity", // Found in Marketo Web Services
+        clientId: "...", // Found in LaunchPoint for an API user
+        clientSecret: "...", // Found in LaunchPoint for an API user
       }
     },
   ];

--- a/plugins/@grouparoo/marketo/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/marketo/public/templates/destination/{{{id}}}.js.template
@@ -5,8 +5,8 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "marketoApp", // The id of the App this Source uses
-      groupId: "high_value_customers", // The id of the group whose members you want to export
+      appId: "...", // The ID of the App this Source uses - e.g. `appId: "marketo_app"`
+      groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {},
 

--- a/plugins/@grouparoo/mysql/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mysql/public/templates/app/{{{id}}}.js.template
@@ -8,9 +8,9 @@ exports.default = async function buildConfig() {
       options: {
         host: "localhost",
         port: 3306,
-        database: "data_warehouse",
-        user: "grouparoo_user", // the user to connect to the database.  If you are connecting to localhost, leave as `undefined`
-        password: "P@ssword", // the database password.  If you don't have a password, leave as `undefined`
+        database: "...", // The database name - e.g. `database: "data_warehouse"`
+        user: "...", // The user to connect to the database - e.g. `user: "grouparoo_user"`.  If you are connecting to localhost, leave as `undefined`.
+        password: "...", // The database password - e.g. `password: "P@assword"`.  If you don't have a password, leave as `undefined`.
       }
     },
   ];

--- a/plugins/@grouparoo/mysql/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mysql/public/templates/destination/{{{id}}}.js.template
@@ -5,8 +5,8 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "data_warehouse", // The id of the App this Source uses
-      groupId: "high_value_customers", // The id of the group whose members you want to export
+      appId: "...", // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
+      groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {
         table: 'users_export', // The table to write profiles to

--- a/plugins/@grouparoo/postgres/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/postgres/public/templates/app/{{{id}}}.js.template
@@ -8,10 +8,10 @@ exports.default = async function buildConfig() {
       options: {
         host: "localhost",
         port: 5432,
-        database: "data_warehouse",
+        database: "...", // The database name - e.g. `database: "data_warehouse"`
         schema: "public",
-        user: "grouparoo_user", // the user to connect to the database.  If you are connecting to localhost, leave as `undefined`
-        password: "P@ssword", // the database password.  If you don't have a password, leave as `undefined`
+        user: "...", // The user to connect to the database - e.g. `user: "grouparoo_user"`.  If you are connecting to localhost, leave as `undefined`.
+        password: "...", // The database password - e.g. `password: "P@assword"`.  If you don't have a password, leave as `undefined`.
 
         // you can also optionally set SSL options
         ssl: false, // enforce SSL connections only.  Default "false" will use ssl optionally if supported by the server.

--- a/plugins/@grouparoo/postgres/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/postgres/public/templates/destination/{{{id}}}.js.template
@@ -5,8 +5,8 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "data_warehouse", // The id of the App this Source uses
-      groupId: "high_value_customers", // The id of the group whose members you want to export
+      appId: "...", // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
+      groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {
         table: 'users_export', // The table to write profiles to

--- a/plugins/@grouparoo/redshift/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/redshift/public/templates/app/{{{id}}}.js.template
@@ -8,10 +8,10 @@ exports.default = async function buildConfig() {
       options: {
         host: "redshift.company.us-west-1.redshift.amazonaws.com",
         port: 5432,
-        database: "data_warehouse",
+        database: "...", // The name of the database - e.g. `database: "data_warehouse"`
         schema: "public",
-        user: "grouparoo_user", // the user to connect to the database.  If you are connecting to localhost, leave as `undefined`
-        password: "P@ssword", // the database password.  If you don't have a password, leave as `undefined`
+        user: "...", // The user to connect to the database - e.g. `user: "grouparoo_user"`.  If you are connecting to localhost, leave as `undefined`
+        password: "...", // The database password - e.g. `password: "P@ssword"`.  If you don't have a password, leave as `undefined`
       }
     },
   ];

--- a/plugins/@grouparoo/redshift/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/redshift/public/templates/destination/{{{id}}}.js.template
@@ -5,8 +5,8 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "data_warehouse", // The id of the App this Source uses
-      groupId: "high_value_customers", // The id of the group whose members you want to export
+      appId: "...", // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
+      groupId: "...", // The ID of the group whose members you want to export - e.g. `appId: "high_value_customers"`
 
       options: {
         table: 'users_export', // The table to write profiles to

--- a/plugins/@grouparoo/salesforce/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/salesforce/public/templates/app/{{{id}}}.js.template
@@ -6,9 +6,9 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       type: "{{{__pluginName}}}",
       options: {
-        username: "person@example.com", // Email address for logging into Salesforce
-        password: "P@ssw0rd!", // Password for logging into Salesforce
-        securityToken: "abc123", // To get a new security token, click on 'Reset My Security Token' in `personal settings`
+        username: "...@example.com", // Email address for logging into Salesforce
+        password: "...", // Password for logging into Salesforce
+        securityToken: "...", // To get a new security token, click on 'Reset My Security Token' in `personal settings`
       }
     },
   ];

--- a/plugins/@grouparoo/salesforce/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/salesforce/public/templates/destination/{{{id}}}.js.template
@@ -5,8 +5,8 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-objects-export",
-      appId: "salesforceApp", // The id of the App this Source uses
-      groupId: "high_value_customers", // The id of the group whose members you want to export
+      appId: "...", // The ID of the App this Source uses - e.g. `appId: "salesforce_app"`
+      groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       // Note that depending on your Salesforce configuration, not all options are required
       // Learn more @ https://www.grouparoo.com/blog/salesforce-destination

--- a/plugins/@grouparoo/snowflake/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/snowflake/public/templates/app/{{{id}}}.js.template
@@ -6,11 +6,11 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       type: "{{{__pluginName}}}",
       options: {
-        account: "xyz12345.us-east-1 or xy12345.us-east-2.aws", // The full name of the account (provided by Snowflake). It is the subdomain you use to access Snowflake
-        username: "JOHN_DOE", // Snowflake user login name to connect with
-        password: "password", // Password for the given username
-        warehouse: "COMPUTE_WH", // The Snowflake warehouse to use
-        database: "database", // The Snowflake database to use
+        account: "xxx.us-east-1 or xxx.us-east-2.aws", // The full name of the account (provided by Snowflake). It is the subdomain you use to access Snowflake
+        username: "...", // Snowflake user login name to connect with
+        password: "...", // Password for the given username
+        warehouse: "...", // The Snowflake warehouse to use - e.g. `warehouse: "COMPUTE_WH"`
+        database: "...", // The Snowflake database to use
         schema: "PUBLIC", // The Snowflake schema (default: PUBLIC)
       }
     },

--- a/plugins/@grouparoo/zendesk/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/zendesk/public/templates/app/{{{id}}}.js.template
@@ -6,9 +6,9 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       type: "{{{__pluginName}}}",
       options: {
-        subdomain: "companyname", // The `companyname` in companyname.zendesk.com
-        username: "user", // Zendesk username, often the email address of an admin user
-        token: "abc123", // Zendesk api token for the admin user
+        subdomain: "...", // The `companyname` in companyname.zendesk.com
+        username: "...", // Zendesk username, often the email address of an admin user
+        token: "...", // Zendesk API token for the admin user
       }
     },
   ];

--- a/plugins/@grouparoo/zendesk/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/zendesk/public/templates/destination/{{{id}}}.js.template
@@ -5,8 +5,8 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "zendeskApp", // The id of the App this Source uses
-      groupId: "high_value_customers", // The id of the group whose members you want to export
+      appId: "...", // The ID of the App this Source uses - e.g. `appId: "zendesk_app"`
+      groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {},
 


### PR DESCRIPTION
Changes here:

- T-972: Give the user a notice when the `generate` command changes the `id`. I used `Colors` directly in the `generate.ts` file to give it some emphasis.
- T-997: Add example to partial match on `grouparoo generate --list`. I created this one on the fly as I was working. Seemed like it would help.
- T-971 / T-974: The description for the `generate` command is ... _lengthy_ now. I don't love the way I did this, but it does shove the info right in the dev's face. I played around with using a library like [columnify](https://www.npmjs.com/package/columnify), but it seemed a little heavy-handed. I figured we could keep it a little uglier like this and come back to it as we think more about workflows in the CLI.
- T-980: Real simple note on the mailchimp `id` destination based on our conversation from yesterday. As a dev coming in blind, I feel like that note would be enough to tell me what to do.
- T-975: Reworked the four source templates with bootstrapped properties. This was the biggest change I made. The way I formatted it would have helped me work through it yesterday. But it's a decent-sized change to how you had those files setup, so I won't be offended if you want to keep playing with it.