### PR TITLE
After change Destination Options, the tracked Group is re-run

### DIFF
--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -219,6 +219,7 @@ describe("models/destination", () => {
         await destination.setOptions({ table: newTable });
         const foundTasks = await specHelper.findEnqueuedTasks("group:run");
         expect(foundTasks.length).toBe(1);
+        expect(foundTasks[0].args[0].force).toBe(true);
       });
 
       test("re-setting options with the same value will not trigger a group run ", async () => {

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -167,6 +167,10 @@ export class Destination extends LoggedModel<Destination> {
     return OptionHelper.setOptions(this, options);
   }
 
+  async afterSetOptions(hasChanges: boolean) {
+    if (hasChanges) return this.exportGroupMembers();
+  }
+
   async getExportArrayProperties() {
     return DestinationOps.getExportArrayProperties(this);
   }

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -168,7 +168,7 @@ export class Destination extends LoggedModel<Destination> {
   }
 
   async afterSetOptions(hasChanges: boolean) {
-    if (hasChanges) return this.exportGroupMembers();
+    if (hasChanges) return this.exportGroupMembers(true);
   }
 
   async getExportArrayProperties() {


### PR DESCRIPTION
If a Destination has options, and those options are changed, we should re-run any group being tracked. 

Closes T-991