### PR TITLE
Grouparoo Run Schedule options

### DIFF
--- a/core/__tests__/tasks/schedule/updateSchedules.ts
+++ b/core/__tests__/tasks/schedule/updateSchedules.ts
@@ -84,16 +84,12 @@ describe("tasks/schedule:updateSchedules", () => {
         recurringFrequency: 60 * 1000,
       });
 
-      const run = await Run.create(
-        {
-          creatorGuid: schedule.guid,
-          creatorType: "schedule",
-          state: "complete",
-          createdAt: new Date(0),
-          updatedAt: new Date(0),
-        },
-        { silent: true }
-      );
+      const run = await Run.create({
+        creatorGuid: schedule.guid,
+        creatorType: "schedule",
+        state: "complete",
+        completedAt: new Date(0),
+      });
 
       await specHelper.runTask("schedule:updateSchedules", {});
 
@@ -113,6 +109,7 @@ describe("tasks/schedule:updateSchedules", () => {
         creatorGuid: schedule.guid,
         creatorType: "schedule",
         state: "complete",
+        completedAt: new Date(),
       });
 
       await specHelper.runTask("schedule:updateSchedules", {});

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -102,7 +102,7 @@ export class RunCLI extends CLI {
     }
 
     const tasks = {
-      "schedule:updateSchedules": {},
+      "schedule:updateSchedules": { checkDeltas },
       "run:recurringInternalRun": {},
       "group:updateCalculatedGroups": {},
     };
@@ -110,8 +110,8 @@ export class RunCLI extends CLI {
     for (const name in tasks) {
       const args = tasks[name];
       const task: Task = api.tasks.tasks[name];
-      log(`Running task: ${task.name}`);
-      await task.run(args, { checkDeltas });
+      log(`Running task: ${task.name}, ${JSON.stringify(args)}`);
+      await task.run(args, {});
     }
   }
 

--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -70,11 +70,15 @@ export namespace GrouparooCLI {
       const runs = await Run.findAll({
         where: {
           creatorGuid: schedules[i].guid,
-          state: { [Op.ne]: "running" },
           highWaterMark: { [Op.ne]: null },
         },
       });
-      for (const j in runs) await runs[j].destroy();
+
+      for (const j in runs) {
+        const run = runs[j];
+        if (run.state === "running") await run.stop();
+        await run.update({ highWaterMark: {} });
+      }
     }
   }
 

--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -64,7 +64,6 @@ export namespace GrouparooCLI {
   }
 
   export async function resetHighWatermarks() {
-    log("Resetting Schedule high water marks...", "warning");
     const schedules = await Schedule.findAll();
     for (const i in schedules) {
       const runs = await Run.findAll({

--- a/core/src/tasks/run/recurringInternalRun.ts
+++ b/core/src/tasks/run/recurringInternalRun.ts
@@ -19,9 +19,7 @@ export class RunRecurringInternalRun extends CLSTask {
       where: { key: "runs-recurring-internal-run-frequency-hours" },
     });
     const frequencyInMs = parseInt(setting.value) * 60 * 60 * 1000;
-    if (frequencyInMs <= 0) {
-      return;
-    }
+    if (frequencyInMs <= 0) return;
 
     const lastRun = await Run.findOne({
       where: { creatorType: "task" },

--- a/core/src/tasks/schedule/updateSchedules.ts
+++ b/core/src/tasks/schedule/updateSchedules.ts
@@ -18,7 +18,8 @@ export class UpdateSchedules extends CLSTask {
   }
 
   async runWithinTransaction(params) {
-    const checkDeltas = params.checkDeltas || true;
+    const checkDeltas =
+      params.checkDeltas === undefined ? true : params.checkDeltas;
     const schedules = await Schedule.findAll({
       where: { recurring: true, state: "ready" },
     });

--- a/core/src/tasks/schedule/updateSchedules.ts
+++ b/core/src/tasks/schedule/updateSchedules.ts
@@ -18,7 +18,7 @@ export class UpdateSchedules extends CLSTask {
   }
 
   async runWithinTransaction(params) {
-    const { checkDeltas } = params;
+    const checkDeltas = params.checkDeltas || true;
     const schedules = await Schedule.findAll({
       where: { recurring: true, state: "ready" },
     });


### PR DESCRIPTION
* Adds `--run-all-schedules` flag which will run all Schedules, even those that are not recurring (Closes T-985) 
* Updates the behavior of `--reset-high-watermarks` to not delete old runs, but ensure that all of them are moved to the `stopped` state before a new run is started (Closes T-924).

```bash
$ grouparoo run --help
Usage: grouparoo run [options]

Run all Schedules, Runs, Imports and Exports pending in this cluster.  Use GROUPAROO_LOG_LEVEL env to set log level.

Options:
  --destroy [destroy]                              [DANGER] Empty the cluster of all Profile data before starting the run? (default: "false")
  --reset-high-watermarks [reset-high-watermarks]  Should we run all Schedules from the beginning? (default: "false")
  --run-all-schedules [run-all-schedules]          Should we run all Schedules, event those that do not have a recurring time set? (default: "false")
  --web [web]                                      Enable the web server during this run? (default: "false")
  --timestamps [timestamps]                        Should timestamps be prepended to each log line? (default: "false")
  -h, --help                                       display help for command
```