### PR TITLE
Ensure that posgres SSL option is always treated as boolean

### DIFF
--- a/plugins/@grouparoo/postgres/src/lib/connect.ts
+++ b/plugins/@grouparoo/postgres/src/lib/connect.ts
@@ -6,6 +6,12 @@ import { ConnectPluginAppMethod } from "@grouparoo/core";
 export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
   const formattedOptions: any = Object.assign({}, appOptions);
 
+  // ensure that the "ssl" option by itself, if present, is a boolean
+  if (formattedOptions["ssl"]) {
+    formattedOptions["ssl"] =
+      formattedOptions["ssl"].toString().toLowerCase() === "true";
+  }
+
   // handle SSL options
   const sslOptions = ["ssl_cert", "ssl_key", "ssl_ca"];
   sslOptions.forEach((opt) => {


### PR DESCRIPTION
Fixes a bug in which `ssl=false` in code config would sometimes be considered `ssl=true`

Closes T-976