### PR TITLE
Externally validate config by default

### DIFF
--- a/core/__tests__/modules/cls.ts
+++ b/core/__tests__/modules/cls.ts
@@ -17,8 +17,27 @@ describe("modules/cls", () => {
       result = CLS.get("test");
     };
 
-    await CLS.wrap(() => runner());
+    await CLS.wrap(runner);
     expect(result).toEqual({ k: 123 });
+  });
+
+  describe("#wrap", () => {
+    test("throw errors by default", async () => {
+      const runner = async () => {
+        throw new Error("oh no");
+      };
+
+      await expect(CLS.wrap(runner)).rejects.toThrow(/oh no/);
+    });
+
+    test("return errors if specified", async () => {
+      const runner = async () => {
+        throw new Error("oh no");
+      };
+
+      const error = await CLS.wrap(runner, true); // Does not throw error
+      expect(error.message).toMatch(/oh no/);
+    });
   });
 
   describe("#afterCommit", () => {
@@ -30,7 +49,7 @@ describe("modules/cls", () => {
         results.push("in-line");
       };
 
-      await CLS.wrap(() => runner());
+      await CLS.wrap(runner);
       expect(results).toEqual(["in-line", "side-effect-1", "side-effect-2"]);
     });
 
@@ -57,7 +76,7 @@ describe("modules/cls", () => {
         await CLS.afterCommit(async () => CLS.enqueueTask("sweeper", { a: 1 }));
       };
 
-      await CLS.wrap(() => runner());
+      await CLS.wrap(runner);
       const foundTasks = await specHelper.findEnqueuedTasks("sweeper");
       expect(foundTasks.length).toBe(1);
       expect(foundTasks[0].args[0]).toEqual({ a: 1 });
@@ -87,7 +106,7 @@ describe("modules/cls", () => {
         );
       };
 
-      await CLS.wrap(() => runner());
+      await CLS.wrap(runner);
       const foundTasks = await specHelper.findEnqueuedTasks("sweeper");
       expect(foundTasks.length).toBe(1);
       expect(foundTasks[0].args[0]).toEqual({ a: 1 });

--- a/core/src/bin/apply.ts
+++ b/core/src/bin/apply.ts
@@ -14,10 +14,9 @@ export class Validate extends CLI {
     this.name = "apply";
     this.description = "Apply changes from code config";
     this.inputs = {
-      "externally-validate": {
+      local: {
         required: false,
-        description:
-          "Should we validate the config by connecting to sources and destinations?",
+        description: "Disable external validation",
       },
     };
 
@@ -34,13 +33,18 @@ export class Validate extends CLI {
 
     log(`applying ${configObjects.length} objects...`);
 
-    await CLS.wrap(async () =>
-      processConfigObjects(configObjects, !!params.externallyValidate)
-    );
+    await CLS.wrap(async () => {
+      const { errors } = await processConfigObjects(
+        configObjects,
+        !params.local
+      );
 
-    log(
-      `✅ Config applied - ${configObjects.length} config objects up-to-date!`
-    );
+      if (errors.length > 0) throw errors;
+
+      log(
+        `✅ Config applied - ${configObjects.length} config objects up-to-date!`
+      );
+    }, true);
 
     return true;
   }

--- a/core/src/bin/validate.ts
+++ b/core/src/bin/validate.ts
@@ -17,10 +17,9 @@ export class Validate extends CLI {
     this.name = "validate";
     this.description = "Validate your code config";
     this.inputs = {
-      "externally-validate": {
+      local: {
         required: false,
-        description:
-          "Should we validate the config by connecting to sources and destinations?",
+        description: "Disable external validation",
       },
     };
 
@@ -50,7 +49,7 @@ export class Validate extends CLI {
       await api.sequelize.transaction(async () => {
         const { errors } = await processConfigObjects(
           configObjects,
-          !!params.externallyValidate,
+          !params.local,
           true
         );
         if (errors.length > 0) {


### PR DESCRIPTION
This reverses the default behavior of the `grouparoo validate` command. Previously, it would only run external validations (e.g. test a connection) if `--externally-validate` was passed an option. Now that is the default behavior and `--local` must be passed to override it.

Note that if `--local` exists in any way, it is treated as true. IOW `grouparoo validate --local false` will still skip external validation.

---

This also adds a second parameter to `CLS.wrap` which catches _and returns_ errors. This enabled us to keep the output from `grouparoo validate` all nice and pretty.

---

Closes T-981