### PR TITLE
Use mapping values as prereq for determining code config order

### DIFF
--- a/core/__tests__/classes/codeConfig.ts
+++ b/core/__tests__/classes/codeConfig.ts
@@ -1,0 +1,35 @@
+import path from "path";
+import { loadConfigObjects } from "../../src/modules/configLoaders";
+import { getParentIds } from "../../src/classes/codeConfig";
+
+describe("classes/codeConfig", () => {
+  describe("#getParentIds", () => {
+    let configObjects;
+
+    beforeAll(async () => {
+      const dir = path.join(
+        __dirname,
+        "..",
+        "fixtures",
+        "codeConfig",
+        "initial"
+      );
+
+      const res = await loadConfigObjects(dir);
+      configObjects = res.configObjects;
+    });
+
+    test("includes its id as a provided id", async () => {
+      const parent = configObjects.find(({ id }) => id === "test_destination");
+      const { providedIds } = getParentIds(parent);
+      expect(providedIds).toEqual(["test_destination"]);
+    });
+
+    test("includes the values of mappings", async () => {
+      const parent = configObjects.find(({ id }) => id === "test_destination");
+      const { prerequisiteIds } = getParentIds(parent);
+      expect(prerequisiteIds).toContain("user_id");
+      expect(prerequisiteIds).toContain("email");
+    });
+  });
+});

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -163,7 +163,7 @@ export function sortConfigurationObject(configObjects: ConfigurationObject[]) {
   return sortedConfigObjectsWithIds.map((o) => o.configObject);
 }
 
-function getParentIds(configObject: ConfigurationObject) {
+export function getParentIds(configObject: ConfigurationObject) {
   const keys = Object.keys(configObject);
   const prerequisiteIds: string[] = [];
   const providedIds: string[] = [];

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -213,7 +213,7 @@ function getParentIds(configObject: ConfigurationObject) {
   });
 
   if (configObject["mapping"]) {
-    const mappingValues = Object.keys(configObject["mapping"]);
+    const mappingValues = Object.values(configObject["mapping"]);
     mappingValues.forEach((v) => {
       prerequisiteIds.push(v);
     });
@@ -269,6 +269,9 @@ function sortConfigObjectsWithIds(configObjectsWithIds: orderedConfigObject[]) {
       }
     }
   });
+
+  console.log(sortedConfigObjectsWithIds.map((obj) => obj.configObject.id));
+  // console.log(sortedConfigObjectsWithIds);
 
   return sortedConfigObjectsWithIds;
 }

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -270,8 +270,5 @@ function sortConfigObjectsWithIds(configObjectsWithIds: orderedConfigObject[]) {
     }
   });
 
-  console.log(sortedConfigObjectsWithIds.map((obj) => obj.configObject.id));
-  // console.log(sortedConfigObjectsWithIds);
-
   return sortedConfigObjectsWithIds;
 }


### PR DESCRIPTION
This closes T-984 by using values (instead of keys) as the prerequisite ID value when building the config dependency tree thing.

I looked through all the templates and it appears that we are consistently using the mapping values as the internal ID, so this is a change we want and can safely make.

That said, I don't see any tests for the file I adjusted, except when used through the code config module. But I also don't see tests for any of the files in `core/src/classes`. Do we want specs to cover this file? If so, I can add to this this PR.