### PR TITLE
`grouparoo run` can skip exports

### DIFF
--- a/core/__tests__/tasks/profile/completeImport.ts
+++ b/core/__tests__/tasks/profile/completeImport.ts
@@ -24,7 +24,10 @@ describe("tasks/profile:completeImport", () => {
 
   describe("profile:completeImport", () => {
     test("can be enqueued", async () => {
-      await task.enqueue("profile:completeImport", { profileGuid: "abc123" });
+      await task.enqueue("profile:completeImport", {
+        profileGuid: "abc123",
+        toExport: true,
+      });
       const found = await specHelper.findEnqueuedTasks(
         "profile:completeImport"
       );
@@ -38,6 +41,7 @@ describe("tasks/profile:completeImport", () => {
 
       await specHelper.runTask("profile:completeImport", {
         profileGuid: profile.guid,
+        toExport: true,
       });
 
       await profile.reload();
@@ -49,6 +53,7 @@ describe("tasks/profile:completeImport", () => {
       expect(foundTasks.length).toBe(1);
       expect(foundTasks[0].args[0]).toEqual({
         profileGuid: profile.guid,
+        toExport: true,
       });
 
       await profile.destroy();
@@ -67,6 +72,7 @@ describe("tasks/profile:completeImport", () => {
 
       await specHelper.runTask("profile:completeImport", {
         profileGuid: profile.guid,
+        toExport: true,
       });
 
       const foundTasks = await specHelper.findEnqueuedTasks(
@@ -75,6 +81,7 @@ describe("tasks/profile:completeImport", () => {
       expect(foundTasks.length).toBe(1);
       expect(foundTasks[0].args[0]).toEqual({
         profileGuid: profile.guid,
+        toExport: true,
       });
 
       await profile.destroy();
@@ -91,6 +98,7 @@ describe("tasks/profile:completeImport", () => {
 
       await specHelper.runTask("profile:completeImport", {
         profileGuid: profile.guid,
+        toExport: true,
       });
 
       groups = await profile.$get("groups");
@@ -124,6 +132,7 @@ describe("tasks/profile:completeImport", () => {
 
       await specHelper.runTask("profile:completeImport", {
         profileGuid: profile.guid,
+        toExport: true,
       });
 
       await _import.reload();
@@ -145,6 +154,7 @@ describe("tasks/profile:completeImport", () => {
 
       await specHelper.runTask("profile:completeImport", {
         profileGuid: profile.guid,
+        toExport: true,
       });
 
       const foundTasks = await specHelper.findEnqueuedTasks("profile:export");
@@ -153,6 +163,20 @@ describe("tasks/profile:completeImport", () => {
         force: false,
         profileGuid: profile.guid,
       });
+    });
+
+    test("optionally enqueuing a profile:export task can be skipped", async () => {
+      const profile = await helper.factories.profile();
+      await profile.import();
+      await profile.update({ state: "ready" });
+
+      await specHelper.runTask("profile:completeImport", {
+        profileGuid: profile.guid,
+        toExport: false,
+      });
+
+      const foundTasks = await specHelper.findEnqueuedTasks("profile:export");
+      expect(foundTasks.length).toEqual(0);
     });
   });
 });

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -32,6 +32,12 @@ export class RunCLI extends CLI {
         letter: "s",
         flag: true,
       },
+      "no-export": {
+        default: false,
+        description: "Skip exporting the profiles",
+        letter: "n",
+        flag: true,
+      },
       web: {
         default: false,
         description: "Enable the web server during this run?",
@@ -51,6 +57,9 @@ export class RunCLI extends CLI {
     if (!params.web) GrouparooCLI.disableWebServer();
     if (params.destroy) await GrouparooCLI.destroyProfiles();
     if (params.resetHighWatermarks) await GrouparooCLI.resetHighWatermarks();
+    process.env.GROUPAROO_DISABLE_EXPORTS = String(
+      params.export.toString().toLowerCase() !== "true"
+    );
 
     await import("../grouparoo"); // run the server
 

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -582,7 +582,7 @@ export namespace ProfileOps {
    * Find profiles that are not ready but whose properties are and make them ready.
    * Task `profile:completeImport` will be enqueued for each Profile.
    */
-  export async function makeReady(limit = 100) {
+  export async function makeReady(limit = 100, toExport = true) {
     let profiles: Profile[];
 
     const notInQuery = api.sequelize.dialect.queryGenerator
@@ -623,6 +623,7 @@ export namespace ProfileOps {
       profiles.map((profile) =>
         CLS.enqueueTask("profile:completeImport", {
           profileGuid: profile.guid,
+          toExport,
         })
       )
     );

--- a/core/src/tasks/profile/checkReady.ts
+++ b/core/src/tasks/profile/checkReady.ts
@@ -18,6 +18,10 @@ export class ProfilesCheckReady extends CLSTask {
       (await plugin.readSetting("core", "runs-profile-batch-size")).value
     );
 
-    await ProfileOps.makeReady(limit);
+    const toExport = process.env.GROUPAROO_DISABLE_EXPORTS
+      ? process.env.GROUPAROO_DISABLE_EXPORTS !== "true"
+      : true;
+
+    await ProfileOps.makeReady(limit, toExport);
   }
 }

--- a/core/src/tasks/profile/completeImport.ts
+++ b/core/src/tasks/profile/completeImport.ts
@@ -68,6 +68,7 @@ export class ProfileCompleteImport extends RetryableTask {
         _import.profileUpdatedAt = now;
         _import.newGroupGuids = newGroupGuids;
         _import.groupsUpdatedAt = now;
+        if (!params.toExport) _import.exportedAt = now; // we want to indicate that the import's lifecycle is complete
         await _import.save();
       }
 

--- a/core/src/tasks/profile/completeImport.ts
+++ b/core/src/tasks/profile/completeImport.ts
@@ -2,7 +2,6 @@ import { CLS } from "../../modules/cls";
 import { config } from "actionhero";
 import { Profile } from "../../models/Profile";
 import { Property } from "../../models/Property";
-import { ProfilePropertyType } from "../../modules/ops/profile";
 import { RetryableTask } from "../../classes/tasks/retryableTask";
 
 export class ProfileCompleteImport extends RetryableTask {
@@ -15,6 +14,7 @@ export class ProfileCompleteImport extends RetryableTask {
     this.queue = "profiles";
     this.inputs = {
       profileGuid: { required: true },
+      toExport: { required: true },
     };
   }
 
@@ -71,12 +71,12 @@ export class ProfileCompleteImport extends RetryableTask {
         await _import.save();
       }
 
-      let force = false;
-
-      await CLS.enqueueTask("profile:export", {
-        profileGuid: profile.guid,
-        force,
-      });
+      if (params.toExport) {
+        await CLS.enqueueTask("profile:export", {
+          profileGuid: profile.guid,
+          force: false,
+        });
+      }
     } catch (error) {
       await Promise.all(imports.map((e) => e.setError(error, this.name)));
       throw error;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,14 +5,14 @@ importers:
       lerna: 3.22.1
       lerna-changelog: 1.0.1
       license-checker: github.com/grouparoo/license-checker/1054593024d6f7e50ad47feb3b61d52c9506c274
-      npm-check-updates: 10.2.5
+      npm-check-updates: 11.1.1
       prettier: 2.2.1
     specifiers:
       glob: 7.1.6
       lerna: 3.22.1
       lerna-changelog: 1.0.1
       license-checker: github:grouparoo/license-checker
-      npm-check-updates: 10.2.5
+      npm-check-updates: 11.1.1
       prettier: 2.2.1
   apps/staging-public:
     dependencies:
@@ -72,8 +72,8 @@ importers:
       commander: 7.0.0
       fs-extra: 9.1.0
       glob: 7.1.6
-      npm-check-updates: 10.2.5
-      ora: 5.1.0
+      npm-check-updates: 11.1.1
+      ora: 5.3.0
       semver: 7.3.4
     devDependencies:
       '@types/fs-extra': 9.0.2
@@ -88,8 +88,8 @@ importers:
       commander: 7.0.0
       fs-extra: 9.1.0
       glob: 7.1.6
-      npm-check-updates: 10.2.5
-      ora: 5.1.0
+      npm-check-updates: 11.1.1
+      ora: 5.3.0
       prettier: 2.2.1
       semver: 7.3.4
       ts-node: 9.1.1
@@ -164,7 +164,7 @@ importers:
       csv-parse: 4.15.0
       jest: 26.6.3
       jest-fetch-mock: 3.0.3
-      nock: 13.0.5
+      nock: 13.0.6
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       type-fest: 0.20.2
       typedoc: 0.20.19_typescript@4.1.3
@@ -200,7 +200,7 @@ importers:
       mime: 2.5.0
       moment: 2.29.1
       mustache: 4.1.0
-      nock: 13.0.5
+      nock: 13.0.6
       node-resque: 8.2.0
       nodemon: 2.0.7
       pacote: 11.2.3
@@ -229,7 +229,7 @@ importers:
       '@types/node': 14.14.7
       actionhero: 25.0.4
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -240,7 +240,7 @@ importers:
       '@types/node': '*'
       actionhero: 25.0.4
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4
       typescript: 4.1.3
@@ -257,7 +257,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -272,7 +272,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4
       typescript: 4.1.3
@@ -352,7 +352,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -370,7 +370,7 @@ importers:
       iso-3166-1-alpha-2: 1.0.0
       jest: 26.6.3
       js-sha256: 0.9.0
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4
       typescript: 4.1.3
@@ -432,7 +432,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -446,7 +446,7 @@ importers:
       fs-extra: 9.1.0
       google-spreadsheet: 3.1.15
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4
       typescript: 4.1.3
@@ -464,7 +464,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -480,7 +480,7 @@ importers:
       fs-extra: 9.1.0
       hubspot-api: 2.15.3
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4
       typescript: 4.1.3
@@ -497,7 +497,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -512,7 +512,7 @@ importers:
       fs-extra: 9.1.0
       intercom-client: 2.11.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4
       typescript: 4.1.3
@@ -548,7 +548,7 @@ importers:
       actionhero: 25.0.4
       dotenv: 8.2.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -561,7 +561,7 @@ importers:
       dotenv: 8.2.0
       jest: 26.6.3
       mailchimp-api-v3: 1.14.0
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4
       typescript: 4.1.3
@@ -578,7 +578,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -592,7 +592,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       node-marketo-rest: grouparoo/node-marketo#restler_upgrade
       prettier: 2.2.1
       ts-jest: 26.4.4
@@ -728,7 +728,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -742,7 +742,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       sailthru-client: 3.0.5
       ts-jest: 26.4.4
@@ -760,7 +760,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -775,7 +775,7 @@ importers:
       fs-extra: 9.1.0
       jest: 26.6.3
       jsforce: ^1.9.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4
       typescript: 4.1.3
@@ -793,7 +793,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -807,7 +807,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       snowflake-promise: 4.2.0
       snowflake-sdk: 1.5.3
@@ -816,7 +816,7 @@ importers:
   plugins/@grouparoo/spec-helper:
     dependencies:
       faker: 5.1.0
-      nock: 13.0.5
+      nock: 13.0.6
       sequelize: 5.22.3
       uuid: 8.3.2
     devDependencies:
@@ -837,7 +837,7 @@ importers:
       actionhero: 25.0.4
       faker: 5.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       sequelize: 5.22.3
       ts-jest: 26.4.4
@@ -856,7 +856,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       prettier: 2.2.1
       ts-jest: 26.4.4_jest@26.6.3+typescript@4.1.3
       typescript: 4.1.3
@@ -870,7 +870,7 @@ importers:
       dotenv: 8.2.0
       fs-extra: 9.1.0
       jest: 26.6.3
-      nock: 13.0.5
+      nock: 13.0.6
       node-zendesk: 2.0.3
       prettier: 2.2.1
       ts-jest: 26.4.4
@@ -2740,12 +2740,33 @@ packages:
       react-dom: '*'
     resolution:
       integrity: sha512-+Q+zTjp4LsjmUNMA3tFe13UdjANsE1NLTKajrwEBvQEx87GWYUJP2G+tNBrb2WfkBUmH0XTkkH7upLy4Gx//HA==
+  /@nodelib/fs.scandir/2.1.4:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.4
+      run-parallel: 1.1.10
+    engines:
+      node: '>= 8'
+    resolution:
+      integrity: sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
   /@nodelib/fs.stat/1.1.3:
     dev: true
     engines:
       node: '>= 6'
     resolution:
       integrity: sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+  /@nodelib/fs.stat/2.0.4:
+    engines:
+      node: '>= 8'
+    resolution:
+      integrity: sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==
+  /@nodelib/fs.walk/1.2.6:
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.4
+      fastq: 1.10.0
+    engines:
+      node: '>= 8'
+    resolution:
+      integrity: sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
   /@npmcli/ci-detect/1.3.0:
     resolution:
       integrity: sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==
@@ -3727,6 +3748,9 @@ packages:
       sprintf-js: 1.0.3
     resolution:
       integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  /argparse/2.0.1:
+    resolution:
+      integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
   /arity-n/1.0.4:
     dev: false
     resolution:
@@ -3801,6 +3825,11 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
+  /array-union/2.1.0:
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
   /array-uniq/1.0.3:
     dev: true
     engines:
@@ -4213,7 +4242,6 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.0
     dev: false
-    optional: true
     resolution:
       integrity: sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
   /block-stream/0.0.9:
@@ -5091,13 +5119,7 @@ packages:
   /commander/2.20.3:
     resolution:
       integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-  /commander/6.2.0:
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
   /commander/6.2.1:
-    dev: true
     engines:
       node: '>= 6'
     resolution:
@@ -6000,6 +6022,13 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
+  /dir-glob/3.0.1:
+    dependencies:
+      path-type: 4.0.0
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   /discontinuous-range/1.0.0:
     dev: true
     resolution:
@@ -6795,6 +6824,18 @@ packages:
       node: '>=4.0.0'
     resolution:
       integrity: sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==
+  /fast-glob/3.2.5:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.4
+      '@nodelib/fs.walk': 1.2.6
+      glob-parent: 5.1.1
+      merge2: 1.4.1
+      micromatch: 4.0.2
+      picomatch: 2.2.2
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
   /fast-json-patch/3.0.0-1:
     dev: false
     resolution:
@@ -6816,6 +6857,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
+  /fastq/1.10.0:
+    dependencies:
+      reusify: 1.0.4
+    resolution:
+      integrity: sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==
   /fault/1.0.4:
     dependencies:
       format: 0.2.2
@@ -7565,6 +7611,18 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+  /globby/11.0.2:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.2.5
+      ignore: 5.1.8
+      merge2: 1.4.1
+      slash: 3.0.0
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
   /globby/9.2.0:
     dependencies:
       '@types/glob': 7.1.3
@@ -8144,6 +8202,11 @@ packages:
       node: '>= 4'
     resolution:
       integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+  /ignore/5.1.8:
+    engines:
+      node: '>= 4'
+    resolution:
+      integrity: sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
   /immediate/3.0.6:
     dev: true
     resolution:
@@ -9477,6 +9540,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+  /js-yaml/4.0.0:
+    dependencies:
+      argparse: 2.0.1
+    hasBin: true
+    resolution:
+      integrity: sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
   /jsbn/0.1.1:
     resolution:
       integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
@@ -10197,6 +10266,13 @@ packages:
     dev: true
     resolution:
       integrity: sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=
+  /map-age-cleaner/0.1.3:
+    dependencies:
+      p-defer: 1.0.0
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
   /map-cache/0.2.2:
     engines:
       node: '>=0.10.0'
@@ -10276,6 +10352,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
+  /mem/8.0.0:
+    dependencies:
+      map-age-cleaner: 0.1.3
+      mimic-fn: 3.1.0
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-qrcJOe6uD+EW8Wrci1Vdiua/15Xw3n/QnaNXE7varnB6InxSk7nu3/i5jfy3S6kWxr8WYJ6R1o0afMUtvorTsA==
   /memoizee/0.4.15:
     dependencies:
       d: 1.0.1
@@ -10357,7 +10441,6 @@ packages:
     resolution:
       integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
   /merge2/1.4.1:
-    dev: true
     engines:
       node: '>= 8'
     resolution:
@@ -10431,7 +10514,6 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.2.2
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -10482,6 +10564,11 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+  /mimic-fn/3.1.0:
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
   /mimic-response/1.0.1:
     engines:
       node: '>=4'
@@ -10739,6 +10826,7 @@ packages:
     resolution:
       integrity: sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
   /mute-stream/0.0.8:
+    dev: true
     resolution:
       integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
   /mv/2.1.1:
@@ -10967,7 +11055,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-  /nock/13.0.5:
+  /nock/13.0.6:
     dependencies:
       debug: 4.2.0
       json-stringify-safe: 5.0.1
@@ -10976,7 +11064,7 @@ packages:
     engines:
       node: '>= 10.13'
     resolution:
-      integrity: sha512-1ILZl0zfFm2G4TIeJFW0iHknxr2NyA+aGCMTjDVUsBY4CkMRispF1pfIYkTRdAR/3Bg+UzdEuK0B6HczMQZcCg==
+      integrity: sha512-W81UZ1Tv21SWDZcA8Lu9LXYVl2gO9ADY5GadC6gFV9690h4TXz0oCkEoMckN/sPMHkDA79Ka9dXga9Mt1+j+Sg==
   /node-abi/2.19.1:
     dependencies:
       semver: 5.7.1
@@ -11295,26 +11383,28 @@ packages:
       npm-normalize-package-bin: 1.0.1
     resolution:
       integrity: sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  /npm-check-updates/10.2.5:
+  /npm-check-updates/11.1.1:
     dependencies:
       chalk: 4.1.0
       cint: 8.2.1
       cli-table: 0.3.4
-      commander: 6.2.0
+      commander: 6.2.1
       find-up: 5.0.0
       fp-and-or: 0.1.3
       get-stdin: 8.0.0
+      globby: 11.0.2
       hosted-git-info: 3.0.7
       json-parse-helpfulerror: 1.0.3
       jsonlines: 0.1.1
       libnpmconfig: 1.2.1
       lodash: 4.17.20
+      mem: 8.0.0
       p-map: 4.0.0
-      pacote: 11.1.13
+      pacote: 11.2.3
       parse-github-url: 1.0.2
       progress: 2.0.3
       prompts: 2.4.0
-      rc-config-loader: 3.0.0
+      rc-config-loader: 4.0.0
       remote-git-tags: 3.0.0
       rimraf: 3.0.2
       semver: 7.3.4
@@ -11325,7 +11415,7 @@ packages:
       node: '>=10.17'
     hasBin: true
     resolution:
-      integrity: sha512-R0BN+MqE6T12k0iGivF0WKfn3tuaeQuCai0haVvmsr7GcoPXU+yrlHxl9aFlO2XZ6z4m+pCd107YnbJDcRAf8Q==
+      integrity: sha512-0K2csepXxqXd3sh05qxU9BcW/pvFBatlM6E4UKKVFe6XlGjQXo4TfI5vRT4uZLG0v2Zj/bWUouQiZvEg5iAFHA==
   /npm-install-checks/4.0.0:
     dependencies:
       semver: 7.3.4
@@ -11677,21 +11767,21 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
-  /ora/5.1.0:
+  /ora/5.3.0:
     dependencies:
+      bl: 4.0.3
       chalk: 4.1.0
       cli-cursor: 3.1.0
       cli-spinners: 2.5.0
       is-interactive: 1.0.0
       log-symbols: 4.0.0
-      mute-stream: 0.0.8
       strip-ansi: 6.0.0
       wcwidth: 1.0.1
     dev: false
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-9tXIMPvjZ7hPTbk8DFq1f7Kow/HU/pQYB60JbNq+QnGwcyhWVZaQ4hM9zQDEsPxw/muLpgiHSaumUZxCAmod/w==
+      integrity: sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==
   /os-browserify/0.3.0:
     resolution:
       integrity: sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
@@ -11733,6 +11823,11 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
+  /p-defer/1.0.0:
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
   /p-each-series/2.1.0:
     engines:
       node: '>=8'
@@ -11766,17 +11861,9 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
-  /p-limit/3.0.2:
-    dependencies:
-      p-try: 2.2.0
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
   /p-limit/3.1.0:
     dependencies:
       yocto-queue: 0.1.0
-    dev: false
     engines:
       node: '>=10'
     resolution:
@@ -11805,7 +11892,7 @@ packages:
       integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   /p-locate/5.0.0:
     dependencies:
-      p-limit: 3.0.2
+      p-limit: 3.1.0
     engines:
       node: '>=10'
     resolution:
@@ -11922,32 +12009,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
-  /pacote/11.1.13:
-    dependencies:
-      '@npmcli/git': 2.0.4
-      '@npmcli/installed-package-contents': 1.0.5
-      '@npmcli/promise-spawn': 1.2.0
-      '@npmcli/run-script': 1.7.2
-      cacache: 15.0.5
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      infer-owner: 1.0.4
-      minipass: 3.1.3
-      mkdirp: 1.0.4
-      npm-package-arg: 8.1.0
-      npm-packlist: 2.1.4
-      npm-pick-manifest: 6.1.0
-      npm-registry-fetch: 9.0.0
-      promise-retry: 1.1.1
-      read-package-json-fast: 1.2.1
-      rimraf: 3.0.2
-      ssri: 8.0.0
-      tar: 6.0.5
-    engines:
-      node: '>=10'
-    hasBin: true
-    resolution:
-      integrity: sha512-oJ7Bg7p3izrIMhZPHCCHmMHQl+xb+pKBXL5ZYeM2oCZrw6sBRSx7f8l7F+95V2qA0BP3c1cNaaBmUNkbo6Hn9w==
   /pacote/11.2.3:
     dependencies:
       '@npmcli/git': 2.0.4
@@ -11969,7 +12030,6 @@ packages:
       rimraf: 3.0.2
       ssri: 8.0.0
       tar: 6.1.0
-    dev: false
     engines:
       node: '>=10'
     hasBin: true
@@ -12183,6 +12243,11 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  /path-type/4.0.0:
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
   /pbkdf2/3.1.1:
     dependencies:
       create-hash: 1.2.0
@@ -12883,14 +12948,14 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     resolution:
       integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==
-  /rc-config-loader/3.0.0:
+  /rc-config-loader/4.0.0:
     dependencies:
       debug: 4.2.0
-      js-yaml: 3.14.0
+      js-yaml: 4.0.0
       json5: 2.1.3
       require-from-string: 2.0.2
     resolution:
-      integrity: sha512-bwfUSB37TWkHfP+PPjb/x8BUjChFmmBK44JMfVnU7paisWqZl/o5k7ttCH+EQLnrbn2Aq8Fo1LAsyUiz+WF4CQ==
+      integrity: sha512-//LRTblJEcqbmmro1GCmZ39qZXD+JqzuD8Y5/IZU3Dhp3A1Yr0Xn68ks8MQ6qKfKvYCWDveUmRDKDA40c+sCXw==
   /rc/1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -13882,6 +13947,12 @@ packages:
   /retry/0.10.1:
     resolution:
       integrity: sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
+  /reusify/1.0.4:
+    engines:
+      iojs: '>=1.0.0'
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
   /rework-visit/1.0.0:
     dev: false
     resolution:
@@ -13938,6 +14009,9 @@ packages:
       node: '>=0.12.0'
     resolution:
       integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+  /run-parallel/1.1.10:
+    resolution:
+      integrity: sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
   /run-queue/1.0.3:
     dependencies:
       aproba: 1.2.0
@@ -14459,7 +14533,6 @@ packages:
     resolution:
       integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
   /slash/3.0.0:
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -15306,6 +15379,7 @@ packages:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+    dev: true
     engines:
       node: '>= 10'
     resolution:
@@ -16915,7 +16989,6 @@ packages:
     resolution:
       integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
   /yocto-queue/0.1.0:
-    dev: false
     engines:
       node: '>=10'
     resolution:


### PR DESCRIPTION
```
$ grouparoo run --help

Usage: grouparoo run [options]

Run all Schedules, Runs, Imports and Exports pending in this cluster.  Use GROUPAROO_LOG_LEVEL env to set log level.

Options:
  -d, --destroy                 [DANGER] Empty the cluster of all Profile data before starting the run? (default: false)
  -m, --reset-high-watermarks   Should we run all Schedules from the beginning? (default: false)
  -s, --run-all-schedules       Should we run all Schedules, event those that do not have a recurring time set? (default: false)
  -n, --no-export               Skip exporting the profiles
  -w, --web                     Enable the web server during this run? (default: false)
  -t, --timestamps              Should timestamps be prepended to each log line? (default: false)
  -h, --help                    display help for command
```

Closes T-986