### PR TITLE
Client test updates

### DIFF
--- a/apps/staging-public/__tests__/test.js
+++ b/apps/staging-public/__tests__/test.js
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment node
+ */
+
+// Should we load configuration from a .env file? Use to set DATABASE_URL, etc
+// Set before requiring @grouparoo/spec-helper
+// Otherwise, set DATABASE_URL, etc in jest.config.js or in CI
+process.env.GROUPAROO_ENV_CONFIG_FILE = `${__dirname}/../.env`;
+
+const { helper, relaxedSnapshot } = require("@grouparoo/spec-helper");
+
+describe("snapshot", () => {
+  // utility to start and stop the server within the test suite
+  helper.grouparooTestServer();
+
+  test("a profile snapshot can be tested", async () => {
+    const { profile, snapshot } = await helper.getProfile({
+      email: "person@example.com",
+    });
+
+    // You can do snapshot testing
+    // `relaxedSnapshot` lets you skip time and UUID generated properties, but ensure everything else matches exactly
+    expect(snapshot).toMatchSnapshot(relaxedSnapshot(snapshot));
+
+    // Or you can test the properties of the snapshot directly
+    expect(snapshot.properties.userId.values).toEqual([100]);
+    expect(snapshot.groups.length).toBe(1);
+    expect(snapshot.groups[0].name).toBe("People with Email Addresses");
+    expect(profile.state).toBe("ready");
+  });
+});
+
+/**
+ * Note:
+ *
+ * This file is included as an example.  It will not run without installing `pnpm install jest @grouparoo/spec-helper@next`
+ * You will also need to test with a Profile that really exists in your configured dataset
+ */

--- a/core/__tests__/modules/codeConfig/snapshotTest.ts
+++ b/core/__tests__/modules/codeConfig/snapshotTest.ts
@@ -42,7 +42,7 @@ describe("modules/codeConfig", () => {
 
     test("a profile snapshot can be tested", async () => {
       const { profile, snapshot } = await helper.getProfile({
-        email: ["test-person@example.com"],
+        email: "test-person@example.com",
       });
 
       // You can do snapshot testing

--- a/core/src/utils/pluginDetails.js
+++ b/core/src/utils/pluginDetails.js
@@ -6,6 +6,10 @@ if (process.env.INIT_CWD) {
   initialPackageJSON = readPackageJson(
     path.join(process.env.INIT_CWD, "package.json")
   );
+} else if (process.env.JEST_WORKER_ID && process.env.PWD) {
+  initialPackageJSON = readPackageJson(
+    path.join(process.env.PWD, "package.json")
+  );
 }
 const grouparooMonorepoApp = initialPackageJSON.grouparoo
   ? initialPackageJSON.grouparoo.grouparoo_monorepo_app

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -449,11 +449,16 @@ export namespace helper {
    * Calls Profile.findOrCreateByUniqueProfileProperties() under the hood, as well as Profile.sync()
    */
   export async function getProfile(
-    args: { [key: string]: any },
+    args: { [key: string]: string | number },
     opts: { saveExports?: boolean } = { saveExports: false }
   ) {
+    const arrayedArgs = {};
+    for (const k in args) {
+      arrayedArgs[k] = [args[k]];
+    }
+
     const { profile } = await Profile.findOrCreateByUniqueProfileProperties(
-      args
+      arrayedArgs
     );
     const snapshot = await profile.snapshot(opts.saveExports);
     await profile.reload();

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -19,8 +19,8 @@ if (fs.existsSync(envFile)) {
 module.exports = withSourceMaps({
   webpack: (config, options) => {
     // There may be different version of these core packages in our dependency tree.  We need to pick only one version (our version).
-    ["react", "react-dom"].forEach((package) => {
-      config.resolve.alias[package] = getPluginPath(package);
+    ["react", "react-dom"].forEach((_package) => {
+      config.resolve.alias[_package] = getPluginPath(_package);
     });
 
     config.module.rules.push({


### PR DESCRIPTION
## Testing

In order to help fit Grouparoo into the CI/CD tools you use today, we've adding testing utilities to Grouparoo which you can use to build up a test suite that ensures that the application is producing the Profiles and Groups you expect.   Grouparoo relies on [Jest](https://jestjs.io) to provide expectations and snapshot testing.   To enable Grouparoo testing:

1. `npm install --save @grouparoo/spec-helper jest`
2. Create a new test in `__tests__` within your project
3. Write you test
4. Run your test with `./node_modules/.bin/jest [path/to/test]`

```ts
/**
 * @jest-environment node
 */

// Should we load configuration from a .env file? Use to set DATABASE_URL, etc
// Set before requiring @grouparoo/spec-helper
// Otherwise, set DATABASE_URL, etc in jest.config.js or in CI
process.env.GROUPAROO_ENV_CONFIG_FILE = `${__dirname}/../.env`;

const { helper, relaxedSnapshot } = require("@grouparoo/spec-helper");

describe("snapshot", () => {
  // utility to start and stop the server within the test suite
  helper.grouparooTestServer();

  test("a profile snapshot can be tested", async () => {
    const { profile, snapshot } = await helper.getProfile({ email: "person@example" });

    // You can do snapshot testing
    // `relaxedSnapshot` lets you skip time and UUID generated properties, but ensure everything else matches exactly
    expect(snapshot).toMatchSnapshot(relaxedSnapshot(snapshot));

    // Or you can test the properties of the snapshot directly
    expect(snapshot.properties.userId.values).toEqual([100]);
    expect(snapshot.groups.length).toBe(1);
    expect(snapshot.groups[0].name).toBe("People with Email Addresses");
    expect(profile.state).toBe("ready");
  });
});
```

A few items of note:
* Unless you specify in your `package.json` or `jest.config.js`, You'll need to use magic comments to let Jest know that we are running a node.js app (`@jest-environment node`)
* You need to specify to grouparoo which database to use, server_token to use, etc. You can either define these directly in your test, as environment variable on your CI tool, or tell Grouparoo to load a `.env` file directly by setting `process.env.GROUPAROO_ENV_CONFIG_FILE`.  With either of these methods, this needs to be done before requiring `@grouparoo/spec-helper`


Closes T-882