### PR TITLE
`parseInt` should always be passed a radix

### DIFF
--- a/core/__tests__/modules/groupExport.ts
+++ b/core/__tests__/modules/groupExport.ts
@@ -94,44 +94,44 @@ describe("modules/groupExport", () => {
       // mario
       let properties = await mario.properties();
       expect(rows[0].guid).toBe(mario.guid);
-      expect(parseInt(rows[0].createdAt)).toBeGreaterThan(0);
+      expect(parseInt(rows[0].createdAt, 10)).toBeGreaterThan(0);
       expect(rows[0]["email"]).toBe(properties.email.values[0]);
       expect(parseFloat(rows[0]["ltv"])).toBe(properties.ltv.values[0]);
       lastLoginAt = properties.lastLoginAt.values[0] as Date;
-      expect(parseInt(rows[0]["lastLoginAt"])).toBe(
+      expect(parseInt(rows[0]["lastLoginAt"], 10)).toBe(
         Math.round(lastLoginAt.getTime() / 1000)
       );
 
       // luigi
       properties = await luigi.properties();
       expect(rows[1].guid).toBe(luigi.guid);
-      expect(parseInt(rows[1].createdAt)).toBeGreaterThan(0);
+      expect(parseInt(rows[1].createdAt, 10)).toBeGreaterThan(0);
       expect(rows[1]["email"]).toBe(properties.email.values[0]);
       expect(parseFloat(rows[1]["ltv"])).toBe(properties.ltv.values[0]);
       lastLoginAt = properties.lastLoginAt.values[0] as Date;
-      expect(parseInt(rows[1]["lastLoginAt"])).toBe(
+      expect(parseInt(rows[1]["lastLoginAt"], 10)).toBe(
         Math.round(lastLoginAt.getTime() / 1000)
       );
 
       // peach
       properties = await peach.properties();
       expect(rows[2].guid).toBe(peach.guid);
-      expect(parseInt(rows[2].createdAt)).toBeGreaterThan(0);
+      expect(parseInt(rows[2].createdAt, 10)).toBeGreaterThan(0);
       expect(rows[2]["email"]).toBe(properties.email.values[0]);
       expect(parseFloat(rows[2]["ltv"])).toBe(properties.ltv.values[0]);
       lastLoginAt = properties.lastLoginAt.values[0] as Date;
-      expect(parseInt(rows[2]["lastLoginAt"])).toBe(
+      expect(parseInt(rows[2]["lastLoginAt"], 10)).toBe(
         Math.round(lastLoginAt.getTime() / 1000)
       );
 
       // toad
       properties = await toad.properties();
       expect(rows[3].guid).toBe(toad.guid);
-      expect(parseInt(rows[3].createdAt)).toBeGreaterThan(0);
+      expect(parseInt(rows[3].createdAt, 10)).toBeGreaterThan(0);
       expect(rows[3]["email"]).toBe(properties.email.values[0]);
       expect(parseFloat(rows[3]["ltv"])).toBe(properties.ltv.values[0]);
       lastLoginAt = properties.lastLoginAt.values[0] as Date;
-      expect(parseInt(rows[3]["lastLoginAt"])).toBe(
+      expect(parseInt(rows[3]["lastLoginAt"], 10)).toBe(
         Math.round(lastLoginAt.getTime() / 1000)
       );
     });

--- a/core/__tests__/modules/notifiers.ts
+++ b/core/__tests__/modules/notifiers.ts
@@ -62,8 +62,8 @@ describe("modules/notifiers", () => {
 
       expect(notifications.length).toBe(2);
       expect(notifications.map((n) => n.guid)).not.toContain(firstMessage.guid);
-      expect(parseInt(notifications[0].body)).toBeGreaterThan(
-        parseInt(notifications[1].body)
+      expect(parseInt(notifications[0].body, 10)).toBeGreaterThan(
+        parseInt(notifications[1].body, 10)
       );
     });
 

--- a/core/src/actions/apiKeys.ts
+++ b/core/src/actions/apiKeys.ts
@@ -9,8 +9,12 @@ export class ApiKeysList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "apiKey", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
     };
   }
 

--- a/core/src/actions/apps.ts
+++ b/core/src/actions/apps.ts
@@ -12,8 +12,12 @@ export class AppsList extends AuthenticatedAction {
     this.permission = { topic: "app", mode: "read" };
     this.outputExample = {};
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
       state: { required: false },
       order: {
         required: false,

--- a/core/src/actions/destinations.ts
+++ b/core/src/actions/destinations.ts
@@ -19,8 +19,12 @@ export class DestinationsList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "destination", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
       state: { required: false },
       order: {
         required: false,

--- a/core/src/actions/events.ts
+++ b/core/src/actions/events.ts
@@ -18,8 +18,12 @@ export class EventsList extends AuthenticatedAction {
       type: { required: false },
       associated: { required: false },
       data: { required: false },
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
       order: {
         required: false,
         default: [["occurredAt", "desc"]],

--- a/core/src/actions/files.ts
+++ b/core/src/actions/files.ts
@@ -11,8 +11,12 @@ export class FilesList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "file", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
       order: {
         required: false,
         default: [

--- a/core/src/actions/groups.ts
+++ b/core/src/actions/groups.ts
@@ -14,8 +14,12 @@ export class GroupsList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "group", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
       state: { required: false },
       order: {
         required: false,
@@ -56,7 +60,7 @@ export class GroupsListByNewestMember extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "group", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 5, formatter: parseInt },
+      limit: { required: true, default: 5, formatter: (p) => parseInt(p, 10) },
     };
   }
 

--- a/core/src/actions/imports.ts
+++ b/core/src/actions/imports.ts
@@ -12,8 +12,12 @@ export class ImportsList extends AuthenticatedAction {
     this.inputs = {
       creatorGuid: { required: false },
       profileGuid: { required: false },
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
       order: {
         required: false,
         default: [["createdAt", "desc"]],

--- a/core/src/actions/logs.ts
+++ b/core/src/actions/logs.ts
@@ -14,8 +14,12 @@ export class LogsList extends AuthenticatedAction {
       topic: { required: false },
       verb: { required: false },
       ownerGuid: { required: false },
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
       order: {
         required: false,
         default: [

--- a/core/src/actions/notifications.ts
+++ b/core/src/actions/notifications.ts
@@ -10,8 +10,12 @@ export class NotificationsList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "notification", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
       order: {
         required: false,
         default: [["createdAt", "desc"]],

--- a/core/src/actions/properties.ts
+++ b/core/src/actions/properties.ts
@@ -15,8 +15,12 @@ export class PropertiesList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "property", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
       unique: { required: false },
       state: { required: false },
       sourceGuid: { required: false },

--- a/core/src/actions/resque.ts
+++ b/core/src/actions/resque.ts
@@ -109,12 +109,12 @@ export class ResqueQueued extends ResqueActionRead {
       },
       offset: {
         required: true,
-        formatter: parseInt,
+        formatter: (p) => parseInt(p, 10),
         default: 0,
       },
       limit: {
         required: true,
-        formatter: parseInt,
+        formatter: (p) => parseInt(p, 10),
         default: 100,
       },
     };
@@ -155,12 +155,12 @@ export class ResqueResqueFailed extends ResqueActionRead {
     this.inputs = {
       offset: {
         required: true,
-        formatter: parseInt,
+        formatter: (p) => parseInt(p, 10),
         default: 0,
       },
       limit: {
         required: true,
-        formatter: parseInt,
+        formatter: (p) => parseInt(p, 10),
         default: 100,
       },
     };
@@ -186,7 +186,7 @@ export class ResqueRemoveFailed extends ResqueActionWrite {
     this.inputs = {
       id: {
         required: true,
-        formatter: parseInt,
+        formatter: (p) => parseInt(p, 10),
       },
     };
   }
@@ -224,7 +224,7 @@ export class ResqueRetryAndRemoveFailed extends ResqueActionWrite {
     this.inputs = {
       id: {
         required: true,
-        formatter: parseInt,
+        formatter: (p) => parseInt(p, 10),
       },
     };
   }
@@ -290,12 +290,12 @@ export class ResqueDelayedJobs extends ResqueActionRead {
     this.inputs = {
       offset: {
         required: true,
-        formatter: parseInt,
+        formatter: (p) => parseInt(p, 10),
         default: 0,
       },
       limit: {
         required: true,
-        formatter: parseInt,
+        formatter: (p) => parseInt(p, 10),
         default: 100,
       },
     };
@@ -333,11 +333,11 @@ export class ResqueDelDelayed extends ResqueActionWrite {
     this.inputs = {
       timestamp: {
         required: true,
-        formatter: parseInt,
+        formatter: (p) => parseInt(p, 10),
       },
       count: {
         required: true,
-        formatter: parseInt,
+        formatter: (p) => parseInt(p, 10),
       },
     };
   }
@@ -363,11 +363,11 @@ export class ResqueRunDelayed extends ResqueActionWrite {
     this.inputs = {
       timestamp: {
         required: true,
-        formatter: parseInt,
+        formatter: (p) => parseInt(p, 10),
       },
       count: {
         required: true,
-        formatter: parseInt,
+        formatter: (p) => parseInt(p, 10),
       },
     };
   }

--- a/core/src/actions/runs.ts
+++ b/core/src/actions/runs.ts
@@ -15,8 +15,12 @@ export class RunsList extends AuthenticatedAction {
       guid: { required: false },
       state: { required: false },
       hasError: { required: false },
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
       order: {
         required: false,
         default: [["createdAt", "desc"]],

--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -9,8 +9,12 @@ export class SchedulesList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "source", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
       state: { required: false },
       order: {
         required: false,

--- a/core/src/actions/sources.ts
+++ b/core/src/actions/sources.ts
@@ -16,8 +16,12 @@ export class SourcesList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "source", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: {
+        required: true,
+        default: 100,
+        formatter: (p) => parseInt(p, 10),
+      },
+      offset: { required: true, default: 0, formatter: (p) => parseInt(p, 10) },
       state: { required: false },
       order: {
         required: false,

--- a/core/src/actions/status.ts
+++ b/core/src/actions/status.ts
@@ -51,7 +51,8 @@ export class PrivateStatus extends CLSAction {
 
     const maxResqueQueueLength: number =
       parseInt(
-        (await plugin.readSetting("core", "runs-profile-batch-size")).value
+        (await plugin.readSetting("core", "runs-profile-batch-size")).value,
+        10
       ) * 10;
 
     if (length > maxResqueQueueLength) {

--- a/core/src/config/redis.ts
+++ b/core/src/config/redis.ts
@@ -28,7 +28,7 @@ function RealRedisConfig() {
     port,
     host,
     password,
-    db: parseInt(db),
+    db: parseInt(db, 10),
     // you can learn more about retryStrategy @ https://github.com/luin/ioredis#auto-reconnect
     retryStrategy: (times) => {
       if (times === 1) {

--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -88,7 +88,7 @@ export const DEFAULT = {
       autoMigrate: true,
       logging: false,
       dialect: dialect,
-      port: parseInt(port),
+      port: parseInt(port, 10),
       database: database,
       host: host,
       username: username,
@@ -101,7 +101,7 @@ export const DEFAULT = {
           dialect === "sqlite"
             ? 1
             : process.env.SEQUELIZE_POOL_SIZE
-            ? parseInt(process.env.SEQUELIZE_POOL_SIZE)
+            ? parseInt(process.env.SEQUELIZE_POOL_SIZE, 10)
             : 5,
         min: 0,
         acquire: 30000,

--- a/core/src/config/servers/web.ts
+++ b/core/src/config/servers/web.ts
@@ -122,7 +122,7 @@ export const test = {
         secure: false,
         port: process.env.PORT
           ? process.env.PORT
-          : 18080 + parseInt(process.env.JEST_WORKER_ID || "0"),
+          : 18080 + parseInt(process.env.JEST_WORKER_ID || "0", 10),
         matchExtensionMime: true,
         metadataOptions: {
           serverInformation: true,

--- a/core/src/config/tasks.ts
+++ b/core/src/config/tasks.ts
@@ -45,11 +45,11 @@ export const DEFAULT = {
       // at minimum, how many parallel taskProcessors should this node spawn?
       // (have number > 0 to enable, and < 1 to disable)
       minTaskProcessors: process.env.WORKERS
-        ? parseInt(process.env.WORKERS)
+        ? parseInt(process.env.WORKERS, 10)
         : 0,
       // at maximum, how many parallel taskProcessors should this node spawn?
       maxTaskProcessors: process.env.WORKERS
-        ? parseInt(process.env.WORKERS)
+        ? parseInt(process.env.WORKERS, 10)
         : 0,
       // how often should we check the event loop to spawn more taskProcessors?
       checkTimeout: 500,

--- a/core/src/models/Event.ts
+++ b/core/src/models/Event.ts
@@ -219,7 +219,7 @@ export class Event extends LoggedModel<Event> {
         eventDataWhere["value"] = localWhere;
         eventDataWhere["key"] = key;
       } else if (key === "occurredAt") {
-        localWhere[opSymbol] = new Date(parseInt(match.toString()));
+        localWhere[opSymbol] = new Date(parseInt(match.toString(), 10));
         eventWhere[key] = localWhere;
       } else {
         localWhere[opSymbol] = match;

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -234,7 +234,8 @@ export class Export extends Model {
   static async sweep(limit: number) {
     const days = parseInt(
       (await plugin.readSetting("core", "sweeper-delete-old-exports-days"))
-        .value
+        .value,
+      10
     );
 
     const _exports = await Export.findAll({

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -240,7 +240,7 @@ export class Group extends LoggedModel<Group> {
       }
 
       await GroupRule.create({
-        position: parseInt(i) + 1,
+        position: parseInt(i, 10) + 1,
         groupGuid: this.guid,
         propertyGuid: property ? property.guid : null,
         profileColumn: property ? null : key,
@@ -344,7 +344,7 @@ export class Group extends LoggedModel<Group> {
     const setting = await Setting.findOne({
       where: { pluginName: "core", key: "groups-calculation-delay-minutes" },
     });
-    const delayMinutes = parseInt(setting.value);
+    const delayMinutes = parseInt(setting.value, 10);
     return Moment(this.calculatedAt).add(delayMinutes, "minutes").toDate();
   }
 
@@ -518,7 +518,7 @@ export class Group extends LoggedModel<Group> {
 
         if (rawValueMatch[Op[operation.op]] && type === "date") {
           rawValueMatch[Op[operation.op]] = new Date(
-            parseInt(rawValueMatch[Op[operation.op]])
+            parseInt(rawValueMatch[Op[operation.op]], 10)
           ).getTime();
         }
 

--- a/core/src/models/Import.ts
+++ b/core/src/models/Import.ts
@@ -245,7 +245,8 @@ export class Import extends Model {
   static async sweep(limit: number) {
     const days = parseInt(
       (await plugin.readSetting("core", "sweeper-delete-old-imports-days"))
-        .value
+        .value,
+      10
     );
 
     const imports = await Import.findAll({

--- a/core/src/models/Log.ts
+++ b/core/src/models/Log.ts
@@ -120,7 +120,7 @@ export class Log extends Model {
     const setting = await Setting.findOne({
       where: { pluginName: "core", key: "sweeper-delete-old-logs-days" },
     });
-    const days = parseInt(setting.value);
+    const days = parseInt(setting.value, 10);
 
     const count = await Log.destroy({
       where: {

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -306,7 +306,7 @@ export class Property extends LoggedModel<Property> {
       const filter = filters[i];
 
       await PropertyFilter.create({
-        position: parseInt(i) + 1,
+        position: parseInt(i, 10) + 1,
         propertyGuid: this.guid,
         key: filter.key,
         op: filter.op,

--- a/core/src/models/Run.ts
+++ b/core/src/models/Run.ts
@@ -378,7 +378,8 @@ export class Run extends Model {
 
   static async sweep(limit: number) {
     const days = parseInt(
-      (await plugin.readSetting("core", "sweeper-delete-old-runs-days")).value
+      (await plugin.readSetting("core", "sweeper-delete-old-runs-days")).value,
+      10
     );
 
     const runs = await Run.findAll({

--- a/core/src/modules/ops/profileProperty.ts
+++ b/core/src/modules/ops/profileProperty.ts
@@ -52,9 +52,9 @@ export namespace ProfilePropertyOps {
       case "float":
         return parseFloat(rawValue);
       case "integer":
-        return parseInt(rawValue);
+        return parseInt(rawValue, 10);
       case "date":
-        return new Date(parseInt(rawValue));
+        return new Date(parseInt(rawValue, 10));
       case "string":
         return rawValue;
       case "email":

--- a/core/src/modules/ops/schedule.ts
+++ b/core/src/modules/ops/schedule.ts
@@ -27,7 +27,8 @@ export namespace ScheduleOps {
     await source.validateOptions(sourceOptions);
 
     const limit: number = parseInt(
-      (await plugin.readSetting("core", "runs-profile-batch-size")).value
+      (await plugin.readSetting("core", "runs-profile-batch-size")).value,
+      10
     );
 
     let highWaterMark = {};

--- a/core/src/tasks/event/associateProfiles.ts
+++ b/core/src/tasks/event/associateProfiles.ts
@@ -17,7 +17,8 @@ export class EventsAssociateProfiles extends CLSTask {
 
   async runWithinTransaction() {
     const limit = parseInt(
-      (await plugin.readSetting("core", "runs-profile-batch-size")).value
+      (await plugin.readSetting("core", "runs-profile-batch-size")).value,
+      10
     );
 
     const events = await Event.findAll({

--- a/core/src/tasks/export/enqueue.ts
+++ b/core/src/tasks/export/enqueue.ts
@@ -21,7 +21,8 @@ export class EnqueueExports extends RetryableTask {
   async runWithinTransaction(params) {
     const count = params.count || 0;
     const limit = parseInt(
-      (await plugin.readSetting("core", "exports-profile-batch-size")).value
+      (await plugin.readSetting("core", "exports-profile-batch-size")).value,
+      10
     );
 
     let totalEnqueued = 0;

--- a/core/src/tasks/group/destroy.ts
+++ b/core/src/tasks/group/destroy.ts
@@ -26,7 +26,8 @@ export class GroupDestroy extends CLSTask {
     const limit: number =
       params.limit ||
       parseInt(
-        (await plugin.readSetting("core", "runs-profile-batch-size")).value
+        (await plugin.readSetting("core", "runs-profile-batch-size")).value,
+        10
       );
 
     const group = await Group.scope(null).findOne({

--- a/core/src/tasks/group/exportToCSV.ts
+++ b/core/src/tasks/group/exportToCSV.ts
@@ -22,7 +22,8 @@ export class GroupExportToCSV extends CLSTask {
     const limit: number =
       params.limit ||
       parseInt(
-        (await plugin.readSetting("core", "runs-profile-batch-size")).value
+        (await plugin.readSetting("core", "runs-profile-batch-size")).value,
+        10
       );
 
     const group = await Group.findByGuid(params.groupGuid);

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -42,7 +42,8 @@ export class RunGroup extends CLSTask {
     const limit: number =
       params.limit ||
       parseInt(
-        (await plugin.readSetting("core", "runs-profile-batch-size")).value
+        (await plugin.readSetting("core", "runs-profile-batch-size")).value,
+        10
       );
 
     const group = await Group.findByGuid(params.groupGuid);

--- a/core/src/tasks/group/updateCalculatedGroups.ts
+++ b/core/src/tasks/group/updateCalculatedGroups.ts
@@ -20,7 +20,7 @@ export class GroupsUpdateCalculatedGroups extends CLSTask {
       "core",
       "groups-calculation-delay-minutes"
     );
-    const delayMinutes = parseInt(setting.value);
+    const delayMinutes = parseInt(setting.value, 10);
     const lastCheckTime = Moment().subtract(delayMinutes, "minutes");
 
     const calculatedGroups = await Group.scope(null).findAll({

--- a/core/src/tasks/profile/checkReady.ts
+++ b/core/src/tasks/profile/checkReady.ts
@@ -15,7 +15,8 @@ export class ProfilesCheckReady extends CLSTask {
 
   async runWithinTransaction() {
     const limit = parseInt(
-      (await plugin.readSetting("core", "runs-profile-batch-size")).value
+      (await plugin.readSetting("core", "runs-profile-batch-size")).value,
+      10
     );
 
     const toExport = process.env.GROUPAROO_DISABLE_EXPORTS

--- a/core/src/tasks/profileProperty/enqueue.ts
+++ b/core/src/tasks/profileProperty/enqueue.ts
@@ -23,7 +23,8 @@ export class ProfilePropertiesEnqueue extends CLSTask {
           "core",
           "imports-profile-properties-batch-size"
         )
-      ).value
+      ).value,
+      10
     );
 
     const properties = await Property.findAll({

--- a/core/src/tasks/profileProperty/sweep.ts
+++ b/core/src/tasks/profileProperty/sweep.ts
@@ -24,7 +24,8 @@ export class ProfilePropertySweep extends CLSTask {
           "core",
           "imports-profile-properties-batch-size"
         )
-      ).value
+      ).value,
+      10
     );
 
     // delete those profile properties who have no profile

--- a/core/src/tasks/run/internalRun.ts
+++ b/core/src/tasks/run/internalRun.ts
@@ -66,7 +66,8 @@ export class RunInternalRun extends CLSTask {
     const limit: number =
       params.limit ||
       parseInt(
-        (await plugin.readSetting("core", "runs-profile-batch-size")).value
+        (await plugin.readSetting("core", "runs-profile-batch-size")).value,
+        10
       );
 
     const run = await Run.scope(null).findOne({

--- a/core/src/tasks/run/recurringInternalRun.ts
+++ b/core/src/tasks/run/recurringInternalRun.ts
@@ -18,7 +18,7 @@ export class RunRecurringInternalRun extends CLSTask {
     const setting = await Setting.findOne({
       where: { key: "runs-recurring-internal-run-frequency-hours" },
     });
-    const frequencyInMs = parseInt(setting.value) * 60 * 60 * 1000;
+    const frequencyInMs = parseInt(setting.value, 10) * 60 * 60 * 1000;
     if (frequencyInMs <= 0) return;
 
     const lastRun = await Run.findOne({

--- a/plugins/@grouparoo/app-templates/src/source/query/profiles.ts
+++ b/plugins/@grouparoo/app-templates/src/source/query/profiles.ts
@@ -28,12 +28,13 @@ export const getProfilesMethod = (getChangedRows: GetChangedRowsMethod) => {
     properties,
   }) => {
     let offset = highWaterMark.offset
-      ? parseInt(highWaterMark.offset.toString())
+      ? parseInt(highWaterMark.offset.toString(), 10)
       : 0;
     const limit = highWaterMark.limit
-      ? parseInt(highWaterMark.limit.toString())
+      ? parseInt(highWaterMark.limit.toString(), 10)
       : parseInt(
-          (await plugin.readSetting("core", "runs-profile-batch-size")).value
+          (await plugin.readSetting("core", "runs-profile-batch-size")).value,
+          10
         );
 
     const rows = await getChangedRows({

--- a/plugins/@grouparoo/app-templates/src/source/table/profiles.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/profiles.ts
@@ -36,7 +36,7 @@ export const getProfiles: GetProfilesMethod = ({ getChangedRows }) => {
       source,
       highWaterMark,
     });
-    sourceOffset = parseInt(sourceOffset.toString()); // we use integers
+    sourceOffset = parseInt(sourceOffset.toString(), 10); // we use integers
     const highWaterMarkAndSortColumnASC = scheduleOptions[columnNameKey];
     const secondarySortColumnASC = Object.keys(sourceMapping)[0];
 

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/getChangedRowCount.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/getChangedRowCount.ts
@@ -22,6 +22,6 @@ export const getChangedRowCount: GetChangedRowCountMethod = async ({
 
   const options = { query, params, types };
   const [rows] = await connection.query(options);
-  const total = parseInt(rows[0]["__count"]);
+  const total = parseInt(rows[0]["__count"], 10);
   return total;
 };

--- a/plugins/@grouparoo/csv/src/lib/file-import/profiles.ts
+++ b/plugins/@grouparoo/csv/src/lib/file-import/profiles.ts
@@ -36,7 +36,7 @@ export const profiles: ProfilesPluginMethod = async ({
   //       Scanning the whole file each time seems silly.
   let importsCount = 0;
   let rowId = -1;
-  const offset = sourceOffset ? parseInt(sourceOffset.toString()) : 0;
+  const offset = sourceOffset ? parseInt(sourceOffset.toString(), 10) : 0;
 
   await new Promise((resolve, reject) => {
     parser.once("readable", async () => {

--- a/plugins/@grouparoo/demo/src/util/MockSession.ts
+++ b/plugins/@grouparoo/demo/src/util/MockSession.ts
@@ -223,7 +223,8 @@ export class MockSession {
     } else {
       // some time after created
       const userId =
-        parseInt((this.currentUserId || "").toString()) || this.randomUserId();
+        parseInt((this.currentUserId || "").toString(), 10) ||
+        this.randomUserId();
       let generatedCreateAt = await userCreatedAt(userId);
       let creationAgo = now - generatedCreateAt.getTime();
       creationAgo = Math.random() * creationAgo;

--- a/plugins/@grouparoo/demo/src/util/postgres.ts
+++ b/plugins/@grouparoo/demo/src/util/postgres.ts
@@ -153,11 +153,11 @@ export default class Postgres {
       const insertQuery = `INSERT INTO ${sqlTable} (${columnNames}) VALUES (${variables})`;
       for (const fileRow of rows) {
         const row = Object.assign({}, fileRow);
-        row.id = parseInt(row.id);
+        row.id = parseInt(row.id, 10);
         if (row.id <= 0) {
           throw new Error(`no id column on ${tableName}`);
         }
-        row[userId] = parseInt(row[userId]);
+        row[userId] = parseInt(row[userId], 10);
         if (row[userId] <= 0) {
           throw new Error(`no ${userId} column on ${tableName}`);
         }

--- a/plugins/@grouparoo/demo/src/util/shared.ts
+++ b/plugins/@grouparoo/demo/src/util/shared.ts
@@ -44,7 +44,7 @@ export function userCreatedAt(userId: any) {
   // 1000 people in last 3 months, spaced out
   const secondsBack = 60 * 60 * 24 * 30 * 3;
   const secondsEach = secondsBack / 1000; // for each user
-  const ageNumber = numberOfUsers - parseInt(userId);
+  const ageNumber = numberOfUsers - parseInt(userId, 10);
   const creationAgo = secondsEach * ageNumber * 1000;
 
   // use that from something specific.

--- a/plugins/@grouparoo/facebook/src/lib/export/utils.ts
+++ b/plugins/@grouparoo/facebook/src/lib/export/utils.ts
@@ -248,7 +248,7 @@ export default class ServerSideUtils {
       dobd = "0" + dobd;
     }
 
-    const dobd_int = parseInt(dobd);
+    const dobd_int = parseInt(dobd, 10);
     if (dobd_int < 1 || dobd_int > 31) {
       throw new Error(
         "Invalid format for dobd:'" +
@@ -270,7 +270,7 @@ export default class ServerSideUtils {
       dobm = "0" + dobm;
     }
 
-    const dobm_int = parseInt(dobm);
+    const dobm_int = parseInt(dobm, 10);
     if (dobm_int < 1 || dobm_int > 12) {
       throw new Error(
         "Invalid format for dobm:'" +

--- a/plugins/@grouparoo/google-sheets/src/lib/sheet-import/profiles.ts
+++ b/plugins/@grouparoo/google-sheets/src/lib/sheet-import/profiles.ts
@@ -21,7 +21,7 @@ export const profiles: ProfilesPluginMethod = async ({
     }
   }
 
-  const offset = sourceOffset ? parseInt(sourceOffset.toString()) : 0;
+  const offset = sourceOffset ? parseInt(sourceOffset.toString(), 10) : 0;
   let importsCount = 0;
   const sheet = new Spreadsheet(appOptions, sourceOptions.sheet_url);
   const rows = await sheet.read({ limit, offset });

--- a/plugins/@grouparoo/intercom/src/lib/export-contacts/exportProfile.ts
+++ b/plugins/@grouparoo/intercom/src/lib/export-contacts/exportProfile.ts
@@ -575,7 +575,7 @@ async function getValueLock(
   if (!set || checkValue !== expireAt) {
     // didn't get the lock
     const now = new Date().getTime();
-    const doneAtMs = parseInt(checkValue) || now;
+    const doneAtMs = parseInt(checkValue, 10) || now;
     if (doneAtMs < now) {
       await client.del(lockKey); // didn't expire! clean up.
       return 0; // it was in the past

--- a/plugins/@grouparoo/mailchimp/src/lib/import/profiles.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/import/profiles.ts
@@ -22,7 +22,7 @@ export const profiles: ProfilesPluginMethod = async ({
     }
   }
 
-  const offset = sourceOffset ? parseInt(sourceOffset.toString()) : 0;
+  const offset = sourceOffset ? parseInt(sourceOffset.toString(), 10) : 0;
   // TODO: how to handle this? what's the parent doing?
   if (limit > 1000) {
     // max per documentation: https://mailchimp.com/developer/api/marketing/list-members/list-members-info/

--- a/plugins/@grouparoo/mysql/src/lib/connect.ts
+++ b/plugins/@grouparoo/mysql/src/lib/connect.ts
@@ -10,7 +10,7 @@ export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
 
   const config = {
     host,
-    port: port ? parseInt(port) : null,
+    port: port ? parseInt(port, 10) : null,
     database,
     user,
     password,

--- a/plugins/@grouparoo/mysql/src/lib/table-import/getChangedRowCount.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/getChangedRowCount.ts
@@ -15,6 +15,6 @@ export const getChangedRowCount: GetChangedRowCountMethod = async ({
   validateQuery(query);
 
   const rows = await connection.asyncQuery(query, params);
-  const total = parseInt(rows[0]["__count"]);
+  const total = parseInt(rows[0]["__count"], 10);
   return total;
 };

--- a/plugins/@grouparoo/postgres/src/lib/table-import/getChangedRowCount.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/getChangedRowCount.ts
@@ -16,6 +16,6 @@ export const getChangedRowCount: GetChangedRowCountMethod = async ({
   validateQuery(query);
 
   const { rows } = await connection.query(format(query, ...params));
-  const total = parseInt(rows[0]["__count"]);
+  const total = parseInt(rows[0]["__count"], 10);
   return total;
 };

--- a/plugins/@grouparoo/snowflake/src/lib/table-import/getChangedRowCount.ts
+++ b/plugins/@grouparoo/snowflake/src/lib/table-import/getChangedRowCount.ts
@@ -13,6 +13,6 @@ export const getChangedRowCount: GetChangedRowCountMethod = async ({
   validateQuery(query);
 
   const rows = await connection.execute(query, params);
-  const total = parseInt(rows[0]["__COUNT"]);
+  const total = parseInt(rows[0]["__COUNT"], 10);
   return total;
 };

--- a/ui/components/visualizations/eventsTotals.tsx
+++ b/ui/components/visualizations/eventsTotals.tsx
@@ -25,12 +25,12 @@ export default function EventsTotals(props) {
   );
   const [startDate, setStartDate] = useState<Date>(
     router.query.startTime
-      ? new Date(parseInt(router.query.startTime.toString()))
+      ? new Date(parseInt(router.query.startTime.toString(), 10))
       : NodeMoment().subtract(1, "month").toDate()
   );
   const [endDate, setEndDate] = useState<Date>(
     router.query.endTime
-      ? new Date(parseInt(router.query.endTime.toString()))
+      ? new Date(parseInt(router.query.endTime.toString(), 10))
       : NodeMoment().add(1, "day").toDate()
   );
 

--- a/ui/hooks/URLParams.ts
+++ b/ui/hooks/URLParams.ts
@@ -27,7 +27,7 @@ export function updateURLParams(
 export function useOffset(defaultValue = 0) {
   const router = useRouter();
   const [offset, setOffset] = useState(
-    parseInt(router.query.offset?.toString() || defaultValue.toString())
+    parseInt(router.query.offset?.toString() || defaultValue.toString(), 10)
   );
 
   return { offset, setOffset };

--- a/ui/pages/group/[guid]/rules.tsx
+++ b/ui/pages/group/[guid]/rules.tsx
@@ -306,7 +306,7 @@ export default function Page(props) {
                             <DatePicker
                               selected={
                                 rule.match && rule.match !== "null"
-                                  ? new Date(parseInt(rule.match))
+                                  ? new Date(parseInt(rule.match, 10))
                                   : null
                               }
                               onChange={(d: Date) => {

--- a/ui/pages/properties.tsx
+++ b/ui/pages/properties.tsx
@@ -182,7 +182,7 @@ export default function Page(props) {
                       ? examples[rule.guid].slice(0, 3).map((ex, idx) => (
                           <Fragment key={`${rule.guid}-${idx}`}>
                             {rule.type === "date"
-                              ? new Date(parseInt(ex)).toLocaleString()
+                              ? new Date(parseInt(ex, 10)).toLocaleString()
                               : ex}
                             <br />
                           </Fragment>

--- a/ui/pages/property/[guid]/edit.tsx
+++ b/ui/pages/property/[guid]/edit.tsx
@@ -552,7 +552,9 @@ export default function Page(props) {
                                   selected={
                                     localFilter.match &&
                                     localFilter.match !== "null"
-                                      ? new Date(parseInt(localFilter.match))
+                                      ? new Date(
+                                          parseInt(localFilter.match, 10)
+                                        )
                                       : new Date()
                                   }
                                   onChange={(d: Date) => {

--- a/ui/pages/resque/delayed.tsx
+++ b/ui/pages/resque/delayed.tsx
@@ -45,7 +45,7 @@ export default function ResqueDelayedList(props) {
     if (response.delayedjobs) {
       Object.keys(response.delayedjobs).forEach(function (t) {
         _timestamps.push({
-          date: new Date(parseInt(t)),
+          date: new Date(parseInt(t, 10)),
           key: t,
         });
       });

--- a/ui/pages/resque/locks.tsx
+++ b/ui/pages/resque/locks.tsx
@@ -32,7 +32,7 @@ export default function ResqueLocksList(props) {
     Object.keys(response.locks).forEach(function (l) {
       _locks.push({
         lock: l,
-        at: new Date(parseInt(response.locks[l]) * 1000),
+        at: new Date(parseInt(response.locks[l], 10) * 1000),
       });
     });
     setLoading(false);

--- a/ui/pages/source/[guid]/schedule.tsx
+++ b/ui/pages/source/[guid]/schedule.tsx
@@ -145,7 +145,9 @@ export default function Page(props) {
                         disabled={loading}
                         value={recurringFrequencyMinutes.toString()}
                         onChange={(e) =>
-                          setRecurringFrequencyMinutes(parseInt(e.target.value))
+                          setRecurringFrequencyMinutes(
+                            parseInt(e.target.value, 10)
+                          )
                         }
                       />
                     </Form.Group>


### PR DESCRIPTION
It's generally safer to pass a radix (ie: the base of the number system you are using) to `parseInt`.  See https://stackoverflow.com/questions/6611824/why-do-we-need-to-use-radix-parameter-when-calling-parseint for all sorts of ways the default guess of the radix can go bad.

Closes T-902