### PR TITLE
Set the Sequelize pool size via  WORKERS or SEQUELIZE_POOL_SIZE, whichever is larger

### DIFF
--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -97,12 +97,11 @@ export const DEFAULT = {
       migrations: [join(__dirname, "..", "migrations")],
       storage, // only used for sqlite
       pool: {
-        max:
-          dialect === "sqlite"
-            ? 1
-            : process.env.SEQUELIZE_POOL_SIZE
-            ? parseInt(process.env.SEQUELIZE_POOL_SIZE)
-            : 5,
+        max: Math.max(
+          parseInt(process.env.SEQUELIZE_POOL_SIZE || "0"),
+          parseInt(process.env.WORKERS || "0") + 1,
+          1
+        ),
         min: 0,
         acquire: 30000,
         idle: 10000,

--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -97,11 +97,14 @@ export const DEFAULT = {
       migrations: [join(__dirname, "..", "migrations")],
       storage, // only used for sqlite
       pool: {
-        max: Math.max(
-          parseInt(process.env.SEQUELIZE_POOL_SIZE || "0"),
-          parseInt(process.env.WORKERS || "0") + 1,
-          1
-        ),
+        max:
+          dialect === "sqlite"
+            ? 1
+            : Math.max(
+                parseInt(process.env.SEQUELIZE_POOL_SIZE || "0"),
+                parseInt(process.env.WORKERS || "0") + 1,
+                1
+              ),
         min: 0,
         acquire: 30000,
         idle: 10000,


### PR DESCRIPTION
This PR will ensure that Grouparoo created N+1 connections between your application and the Grouparoo postgres database, where N is the number of workers running within this process.  This should help reduce the class of bugs related to Seqeulize connections, timeouts, etc