### PR TITLE
Update CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,10 @@ references:
     branches:
       ignore:
         - gh-pages
-  node-module-cache-options: &node-module-cache-options
-    key: node-module-package-cache-{{ .Branch }}-{{ .Revision }}
+  plugin-modules-cache-options: &plugin-modules-cache-options
+    key: plugin-module-package-cache-{{ .Branch }}-{{ .Revision }}
+  other-modules-cache-options: &other-modules-cache-options
+    key: other-module-package-cache-{{ .Branch }}-{{ .Revision }}
   dist-cache-options: &dist-cache-options
     key: dist-package-cache-{{ .Branch }}-{{ .Revision }}
   core-cache-options: &core-cache-options
@@ -33,14 +35,8 @@ jobs:
           name: pnpm-install
           command: pnpm install --prefer-frozen-lockfile
       - save_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
           paths:
-            - apps/staging-community/node_modules
-            - apps/staging-enterprise/node_modules
-            - cli/node_modules
-            - clients/@grouparoo/web/node_modules
-            - core/node_modules
-            - node_modules
             - plugins/@grouparoo/app-templates/node_modules
             - plugins/@grouparoo/bigquery/node_modules
             - plugins/@grouparoo/csv/node_modules
@@ -63,6 +59,15 @@ jobs:
             - plugins/@grouparoo/snowflake/node_modules
             - plugins/@grouparoo/spec-helper/node_modules
             - plugins/@grouparoo/zendesk/node_modules
+      - save_cache:
+          <<: *other-modules-cache-options
+          paths:
+            - apps/staging-community/node_modules
+            - apps/staging-enterprise/node_modules
+            - cli/node_modules
+            - clients/@grouparoo/web/node_modules
+            - core/node_modules
+            - node_modules
             - tools/merger/node_modules
             - ui/ui-community/node_modules
             - ui/ui-components/node_modules
@@ -109,7 +114,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -129,7 +136,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -149,7 +158,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -179,7 +190,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -215,7 +228,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -251,7 +266,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -287,7 +304,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -323,7 +342,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -359,7 +380,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -395,7 +418,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -431,7 +456,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -467,7 +494,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -497,7 +526,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -530,7 +561,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -572,7 +605,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -614,7 +649,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -652,7 +689,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -694,7 +733,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -736,7 +777,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -772,7 +815,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -808,7 +853,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -844,7 +891,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -880,7 +929,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -916,7 +967,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -952,7 +1005,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -988,7 +1043,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1024,7 +1081,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1060,7 +1119,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1096,7 +1157,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1132,7 +1195,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1168,7 +1233,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1208,7 +1275,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1250,7 +1319,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1286,7 +1357,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1322,7 +1395,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1358,7 +1433,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1394,7 +1471,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1430,7 +1509,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1466,7 +1547,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1502,7 +1585,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1538,7 +1623,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1564,7 +1651,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:
@@ -1594,7 +1683,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:

--- a/tools/merger/data/ci/apps/job.yml.template
+++ b/tools/merger/data/ci/apps/job.yml.template
@@ -18,7 +18,9 @@
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:

--- a/tools/merger/data/ci/base.yml.template
+++ b/tools/merger/data/ci/base.yml.template
@@ -11,8 +11,10 @@ references:
       ignore:
         - gh-pages
 
-  node-module-cache-options: &node-module-cache-options
-    key: node-module-package-cache-{{ .Branch }}-{{ .Revision }}
+  plugin-modules-cache-options: &plugin-modules-cache-options
+    key: plugin-module-package-cache-{{ .Branch }}-{{ .Revision }}
+  other-modules-cache-options: &other-modules-cache-options
+    key: other-module-package-cache-{{ .Branch }}-{{ .Revision }}
   dist-cache-options: &dist-cache-options
     key: dist-package-cache-{{ .Branch }}-{{ .Revision }}
   core-cache-options: &core-cache-options
@@ -35,9 +37,13 @@ jobs:
           name: pnpm-install
           command: pnpm install --prefer-frozen-lockfile
       - save_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
           paths:
-{{{node_module_list}}}
+{{{plugin_node_module_list}}}
+      - save_cache:
+          <<: *other-modules-cache-options
+          paths:
+{{{other_node_module_list}}}
       - save_cache:
           <<: *dist-cache-options
           paths:

--- a/tools/merger/data/ci/cli/job.yml.template
+++ b/tools/merger/data/ci/cli/job.yml.template
@@ -8,7 +8,9 @@
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:

--- a/tools/merger/data/ci/client/job.yml.template
+++ b/tools/merger/data/ci/client/job.yml.template
@@ -18,7 +18,9 @@
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:

--- a/tools/merger/data/ci/command/job.yml.template
+++ b/tools/merger/data/ci/command/job.yml.template
@@ -8,7 +8,9 @@
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:

--- a/tools/merger/data/ci/core-local/job.yml.template
+++ b/tools/merger/data/ci/core-local/job.yml.template
@@ -12,7 +12,9 @@
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:

--- a/tools/merger/data/ci/core/job.yml.template
+++ b/tools/merger/data/ci/core/job.yml.template
@@ -18,7 +18,9 @@
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:

--- a/tools/merger/data/ci/plugin/job.yml.template
+++ b/tools/merger/data/ci/plugin/job.yml.template
@@ -18,7 +18,9 @@
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:

--- a/tools/merger/data/ci/publish/core.yml.template
+++ b/tools/merger/data/ci/publish/core.yml.template
@@ -7,7 +7,9 @@
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:

--- a/tools/merger/data/ci/ui/job.yml.template
+++ b/tools/merger/data/ci/ui/job.yml.template
@@ -22,7 +22,9 @@
     steps:
       - checkout
       - restore_cache:
-          <<: *node-module-cache-options
+          <<: *plugin-modules-cache-options
+      - restore_cache:
+          <<: *other-modules-cache-options
       - restore_cache:
           <<: *dist-cache-options
       - restore_cache:

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -201,7 +201,7 @@ class Generator {
     }
   }
 
-  node_module_list() {
+  full_node_module_list() {
     const packagePaths = allPackagePaths(glob);
     const relativePaths = [];
     for (const packagePath of packagePaths) {
@@ -218,9 +218,18 @@ class Generator {
     }
 
     const prefix = " ".repeat(12) + "- ";
-    return relativePaths
-      .map((p) => `${prefix}${p}`)
-      .sort()
+    return relativePaths.map((p) => `${prefix}${p}`).sort();
+  }
+
+  plugin_node_module_list() {
+    return this.full_node_module_list()
+      .filter((path) => path.includes("plugins/@grouparoo"))
+      .join("\n");
+  }
+
+  other_node_module_list() {
+    return this.full_node_module_list()
+      .filter((path) => !path.includes("plugins/@grouparoo"))
       .join("\n");
   }
 
@@ -300,7 +309,8 @@ class Generator {
     view[".Revision"] = "{{ .Revision }}";
 
     const methods = [
-      "node_module_list",
+      "plugin_node_module_list",
+      "other_node_module_list",
       "dist_list",
       "jobs",
       "workflows",


### PR DESCRIPTION
It seems there is a limit to the number of paths you can cache in circle CI and we are starting to hit it.
https://support.circleci.com/hc/en-us/articles/360037695934-save-cache-step-fails-with-Error-uploading-archive-MetadataTooLarge-Your-metadata-headers-exceed-the-maximum-allowed-metadata-size-

<img width="1629" alt="Screen Shot 2021-02-02 at 9 56 32 PM" src="https://user-images.githubusercontent.com/36106/106706904-36e63d80-65a5-11eb-8a24-23c349d41520.png">

This PR splits up the caches