### PR TITLE
`/object` page works by looking up IDs in the database

### DIFF
--- a/core/__tests__/actions/object.ts
+++ b/core/__tests__/actions/object.ts
@@ -1,0 +1,89 @@
+import { helper } from "@grouparoo/spec-helper";
+import { specHelper, Connection } from "actionhero";
+
+describe("actions/object", () => {
+  helper.grouparooTestServer({
+    truncate: true,
+    resetSettings: true,
+    enableTestPlugin: true,
+  });
+
+  let connection: Connection;
+  let csrfToken: string;
+  let teamId: string;
+  let appId: string;
+
+  beforeAll(async () => {
+    await specHelper.runAction("team:initialize", {
+      firstName: "Mario",
+      lastName: "Mario",
+      password: "P@ssw0rd!",
+      email: "mario@example.com",
+    });
+  });
+
+  beforeAll(async () => {
+    connection = await specHelper.buildConnection();
+    connection.params = { email: "mario@example.com", password: "P@ssw0rd!" };
+    const sessionResponse = await specHelper.runAction(
+      "session:create",
+      connection
+    );
+    csrfToken = sessionResponse.csrfToken;
+  });
+
+  test("an administrator can create a new team", async () => {
+    connection.params = {
+      csrfToken,
+      name: "new team",
+    };
+    const { team } = await specHelper.runAction("team:create", connection);
+    teamId = team.id;
+  });
+
+  test("an administrator can create a new app", async () => {
+    connection.params = {
+      csrfToken,
+      name: "test app",
+      type: "test-plugin-app",
+      options: { fileId: "abc123" },
+    };
+    const { app, error } = await specHelper.runAction("app:create", connection);
+    console.log(error);
+    appId = app.id;
+  });
+
+  describe("we can search for objects across many tables", () => {
+    test("can find apps", async () => {
+      connection.params = { csrfToken, id: appId };
+      const { records, error } = await specHelper.runAction(
+        "object:find",
+        connection
+      );
+      expect(error).toBeUndefined();
+      expect(records.length).toBe(1);
+      expect(records[0].tableName).toBe("apps");
+    });
+
+    test("can find teams", async () => {
+      connection.params = { csrfToken, id: teamId };
+      const { records, error } = await specHelper.runAction(
+        "object:find",
+        connection
+      );
+      expect(error).toBeUndefined();
+      expect(records.length).toBe(1);
+      expect(records[0].tableName).toBe("teams");
+    });
+
+    test("will return empty array if object cannot be found", async () => {
+      connection.params = { csrfToken, id: "foo" };
+      const { records, error } = await specHelper.runAction(
+        "object:find",
+        connection
+      );
+      expect(error).toBeUndefined();
+      expect(records.length).toBe(0);
+    });
+  });
+});

--- a/core/src/actions/object.ts
+++ b/core/src/actions/object.ts
@@ -24,7 +24,6 @@ export class ObjectFind extends AuthenticatedAction {
       "files",
       "groups",
       "imports",
-      "logs",
       "notifications",
       "profiles",
       "properties",

--- a/core/src/actions/object.ts
+++ b/core/src/actions/object.ts
@@ -1,0 +1,58 @@
+import { QueryTypes } from "sequelize";
+import { api } from "actionhero";
+import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
+
+export class ObjectFind extends AuthenticatedAction {
+  constructor() {
+    super();
+    this.name = "object:find";
+    this.description = "find an object by id";
+    this.outputExample = {};
+    this.permission = { topic: "*", mode: "read" };
+    this.inputs = {
+      id: { required: true },
+    };
+  }
+
+  async runWithinTransaction({ params }) {
+    const tables = [
+      "apiKeys",
+      "apps",
+      "destinations",
+      "events",
+      "exports",
+      "files",
+      "groups",
+      "imports",
+      "logs",
+      "notifications",
+      "profiles",
+      "properties",
+      "runs",
+      "schedules",
+      "settings",
+      "sources",
+      "teams",
+      "teamMembers",
+    ];
+
+    let { id }: { id: string } = params;
+    id = id.replace(/[^a-zA-Z0-9-_\/.]/g, "");
+
+    const query =
+      `SELECT id, "tableName" FROM (` +
+      tables
+        .map((t) => `SELECT id, '${t}' AS "tableName" FROM "${t}"`)
+        .join(" UNION ALL ") +
+      `) AS UNIONS WHERE id = '${id}'`;
+
+    const records: {
+      id: string;
+      tableName: string;
+    }[] = await api.sequelize.query(query, {
+      type: QueryTypes.SELECT,
+    });
+
+    return { id, records };
+  }
+}

--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -76,7 +76,8 @@ export const DEFAULT = {
         { path: "/v:apiVersion/file/:id/details", action: "file:details" },
         { path: "/v:apiVersion/file/:id", action: "file:view" },
         { path: "/v:apiVersion/notifications", action: "notifications:list" },
-        { path: "/v:apiVersion/notification/:id", action: "notification:view" }
+        { path: "/v:apiVersion/notification/:id", action: "notification:view" },
+        { path: "/v:apiVersion/object/:id", action: "object:find" }
       ],
 
       post: [

--- a/ui/ui-components/pages/object/[id].tsx
+++ b/ui/ui-components/pages/object/[id].tsx
@@ -7,6 +7,11 @@ import { Actions } from "../../utils/apiData";
 import { Card } from "react-bootstrap";
 import { singular } from "pluralize";
 
+const detailPages = {
+  groups: "members",
+  sources: "overview",
+};
+
 export default function FindObject(props) {
   const router = useRouter();
   const { errorHandler } = props;
@@ -28,9 +33,9 @@ export default function FindObject(props) {
       response.records.length === 1 &&
       process.env.GROUPAROO_UI_EDITION === "enterprise"
     ) {
-      router.push(
-        `/${singular(response.records[0].tableName.toLowerCase())}/${id}/edit`
-      );
+      const table = response.records[0].tableName.toLowerCase();
+      const detailPage = detailPages[table] || "edit";
+      router.push(`/${singular(table)}/${id}/${detailPage}`);
     } else if (
       response.records.length === 1 &&
       process.env.GROUPAROO_UI_EDITION === "community"
@@ -47,22 +52,25 @@ export default function FindObject(props) {
         <h2>Multiple objects found:</h2>
         <table>
           <tbody>
-            {records.map((r) => (
-              <tr>
-                <td>{id} in </td>
-                <td>
-                  <Link
-                    href={
-                      process.env.GROUPAROO_UI_EDITION === "enterprise"
-                        ? `/${singular(r)}/${id}/edit`
-                        : `/${r}`
-                    }
-                  >
-                    <a>{r}</a>
-                  </Link>
-                </td>
-              </tr>
-            ))}
+            {records.map((r) => {
+              const detailPage = detailPages[r] || "edit";
+              return (
+                <tr>
+                  <td>{id} in </td>
+                  <td>
+                    <Link
+                      href={
+                        process.env.GROUPAROO_UI_EDITION === "enterprise"
+                          ? `/${singular(r)}/${id}/${detailPage}`
+                          : `/${r}`
+                      }
+                    >
+                      <a>{r}</a>
+                    </Link>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </>

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -249,6 +249,7 @@ import {
   TeamsList,
 } from "@grouparoo/core/src/actions/teams";
 import { TotalsAction } from "@grouparoo/core/src/actions/totals";
+import { ObjectFind } from "@grouparoo/core/src/actions/object";
 
 export namespace Actions {
   export type ApiKeyCreate = AsyncReturnType<
@@ -706,5 +707,9 @@ export namespace Actions {
 
   export type TotalsAction = AsyncReturnType<
     typeof TotalsAction.prototype.runWithinTransaction
+  >;
+
+  export type ObjectFind = AsyncReturnType<
+    typeof ObjectFind.prototype.runWithinTransaction
   >;
 }


### PR DESCRIPTION
Now that we do not prefix our objects (https://github.com/grouparoo/grouparoo/pull/1255), the `/object` page needs to ask all of our major database tables if the object exists to see what type of Model it is.  