### PR TITLE
peerDependencies match core version

### DIFF
--- a/plugins/@grouparoo/app-templates/package.json
+++ b/plugins/@grouparoo/app-templates/package.json
@@ -28,7 +28,7 @@
     "watch": "tsc --watch"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/bigquery/package.json
+++ b/plugins/@grouparoo/bigquery/package.json
@@ -32,7 +32,7 @@
     "@grouparoo/app-templates": "^0.2.0-alpha.17"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/csv/package.json
+++ b/plugins/@grouparoo/csv/package.json
@@ -32,7 +32,7 @@
     "fs-extra": "9.1.0"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/demo/package.json
+++ b/plugins/@grouparoo/demo/package.json
@@ -36,7 +36,7 @@
     "uuid": "8.3.2"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/files-local/package.json
+++ b/plugins/@grouparoo/files-local/package.json
@@ -31,7 +31,7 @@
     "fs-extra": "9.1.0"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/files-s3/package.json
+++ b/plugins/@grouparoo/files-s3/package.json
@@ -32,7 +32,7 @@
     "fs-extra": "9.1.0"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/google-sheets/package.json
+++ b/plugins/@grouparoo/google-sheets/package.json
@@ -31,7 +31,7 @@
     "google-spreadsheet": "3.1.15"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/hubspot/package.json
+++ b/plugins/@grouparoo/hubspot/package.json
@@ -33,7 +33,7 @@
     "hubspot-api": "2.15.3"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/intercom/package.json
+++ b/plugins/@grouparoo/intercom/package.json
@@ -32,7 +32,7 @@
     "intercom-client": "2.11.0"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/iterable/package.json
+++ b/plugins/@grouparoo/iterable/package.json
@@ -32,7 +32,7 @@
     "node-iterable-api": "^1.0.2"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/logger/package.json
+++ b/plugins/@grouparoo/logger/package.json
@@ -28,7 +28,7 @@
     "watch": "tsc --watch"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/mailchimp/package.json
+++ b/plugins/@grouparoo/mailchimp/package.json
@@ -31,7 +31,7 @@
     "mailchimp-api-v3": "1.14.0"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/marketo/package.json
+++ b/plugins/@grouparoo/marketo/package.json
@@ -32,7 +32,7 @@
     "node-marketo-rest": "grouparoo/node-marketo#restler_upgrade"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/mysql/package.json
+++ b/plugins/@grouparoo/mysql/package.json
@@ -32,7 +32,7 @@
     "mysql": "2.18.1"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/newrelic/package.json
+++ b/plugins/@grouparoo/newrelic/package.json
@@ -31,7 +31,7 @@
     "newrelic": "7.1.0"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/postgres/package.json
+++ b/plugins/@grouparoo/postgres/package.json
@@ -35,7 +35,7 @@
     "postgres-date": "2.0.0"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/redshift/package.json
+++ b/plugins/@grouparoo/redshift/package.json
@@ -32,7 +32,7 @@
     "@grouparoo/postgres": "^0.2.0-alpha.17"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/sailthru/package.json
+++ b/plugins/@grouparoo/sailthru/package.json
@@ -32,7 +32,7 @@
     "sailthru-client": "3.0.5"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/salesforce/package.json
+++ b/plugins/@grouparoo/salesforce/package.json
@@ -32,7 +32,7 @@
     "jsforce": "^1.9.3"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/snowflake/package.json
+++ b/plugins/@grouparoo/snowflake/package.json
@@ -33,7 +33,7 @@
     "snowflake-sdk": "1.5.3"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/spec-helper/package.json
+++ b/plugins/@grouparoo/spec-helper/package.json
@@ -36,7 +36,7 @@
     "uuid": "8.3.2"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/zendesk/package.json
+++ b/plugins/@grouparoo/zendesk/package.json
@@ -32,7 +32,7 @@
     "node-zendesk": "2.0.3"
   },
   "peerDependencies": {
-    "@grouparoo/core": "^0.2.0",
+    "@grouparoo/core": "^0.2.0-alpha.17",
     "actionhero": "25.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
With the release of NPM v7, Peer Dependencies are matched more strictly.  This PR updates the peerDependencies of the `@grouparoo/core` package to match what PNPM/Lerna produce.

The error produced:

```
Error: npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: @grouparoo/app-example@0.0.1
npm ERR! Found: @grouparoo/core@0.2.0-alpha.17
npm ERR! node_modules/@grouparoo/core
npm ERR!   @grouparoo/core@"0.2.0-alpha.17" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer @grouparoo/core@"^0.2.0" from @grouparoo/bigquery@0.2.0-alpha.17
npm ERR! node_modules/@grouparoo/bigquery
npm ERR!   @grouparoo/bigquery@"0.2.0-alpha.17" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/evan/.npm/eresolve-report.txt for a full report.
```

Clients currently need to ` npm install --legacy-peer-deps`