### PR TITLE
Remove SetupStep to create a Team

### DIFF
--- a/core/__tests__/actions/setupSteps.ts
+++ b/core/__tests__/actions/setupSteps.ts
@@ -54,11 +54,13 @@ describe("actions/setupSteps", () => {
 
       expect(setupSteps.length).toBe(8);
       expect(setupSteps[0].position).toBe(1);
-      expect(setupSteps[0].key).toBe("create_a_team");
-      expect(setupSteps[0].title).toBe("Create a Team");
-      expect(setupSteps[0].description).toMatch(/Create .* team/);
-      expect(setupSteps[0].href).toBe("/teams");
-      expect(setupSteps[0].cta).toBe("Create a Team");
+      expect(setupSteps[0].key).toBe("name_your_grouparoo_instance");
+      expect(setupSteps[0].title).toBe("Name your Grouparoo Instance");
+      expect(setupSteps[0].description).toMatch(
+        "Give your Grouparoo cluster a name"
+      );
+      expect(setupSteps[0].href).toBe("/setting");
+      expect(setupSteps[0].cta).toBe("Change your Grouparoo Cluster Name");
       expect(setupSteps[0].outcome).toBe(null);
       expect(setupSteps[0].skipped).toBe(false);
       expect(setupSteps[0].complete).toBe(false);

--- a/core/__tests__/actions/setupSteps.ts
+++ b/core/__tests__/actions/setupSteps.ts
@@ -1,9 +1,9 @@
 import { helper } from "@grouparoo/spec-helper";
 import { specHelper } from "actionhero";
-import { SetupStep, Team, Setting } from "../../src";
+import { plugin, SetupStep, Setting } from "../../src";
 
 describe("actions/setupSteps", () => {
-  helper.grouparooTestServer({ truncate: true });
+  helper.grouparooTestServer({ truncate: true, resetSettings: true });
 
   beforeAll(async () => {
     await specHelper.runAction("team:initialize", {
@@ -52,14 +52,14 @@ describe("actions/setupSteps", () => {
 
       expect(error).toBeFalsy();
 
-      expect(setupSteps.length).toBe(8);
+      expect(setupSteps.length).toBe(7);
       expect(setupSteps[0].position).toBe(1);
       expect(setupSteps[0].key).toBe("name_your_grouparoo_instance");
       expect(setupSteps[0].title).toBe("Name your Grouparoo Instance");
       expect(setupSteps[0].description).toMatch(
         "Give your Grouparoo cluster a name"
       );
-      expect(setupSteps[0].href).toBe("/setting");
+      expect(setupSteps[0].href).toBe("/settings/core");
       expect(setupSteps[0].cta).toBe("Change your Grouparoo Cluster Name");
       expect(setupSteps[0].outcome).toBe(null);
       expect(setupSteps[0].skipped).toBe(false);
@@ -87,15 +87,16 @@ describe("actions/setupSteps", () => {
     });
 
     test("setupSteps can be completed outside of the action and re-calculated when viewed", async () => {
-      await Team.create({ name: "new team" });
+      const setting = await plugin.readSetting("core", "cluster-name");
+      await setting.update({ value: "Test Cluster" });
 
       connection.params = { csrfToken };
       const { setupSteps } = await specHelper.runAction(
         "setupSteps:list",
         connection
       );
-      expect(setupSteps.length).toBe(8);
-      expect(setupSteps[0].key).toBe("create_a_team");
+      expect(setupSteps.length).toBe(7);
+      expect(setupSteps[0].key).toBe("name_your_grouparoo_instance");
       expect(setupSteps[0].complete).toBe(true);
     });
 

--- a/core/__tests__/models/setupStep.ts
+++ b/core/__tests__/models/setupStep.ts
@@ -72,9 +72,9 @@ describe("models/setupStep", () => {
 
   test("setupSteps can getCta", async () => {
     const step = await SetupStep.findOne({
-      where: { key: "create_a_team" },
+      where: { key: "name_your_grouparoo_instance" },
     });
 
-    expect(step.getCta()).toBe("Create a Team");
+    expect(step.getCta()).toBe("Name your Grouparoo Instance");
   });
 });

--- a/core/__tests__/models/setupStep.ts
+++ b/core/__tests__/models/setupStep.ts
@@ -1,18 +1,22 @@
 import { helper } from "@grouparoo/spec-helper";
-import { SetupStep, Team } from "../../src";
+import { SetupStep, plugin } from "../../src";
 import { SetupStepOps } from "../../src/modules/ops/setupSteps";
 
 describe("models/setupStep", () => {
-  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  helper.grouparooTestServer({
+    truncate: true,
+    enableTestPlugin: true,
+    resetSettings: true,
+  });
 
   test("setupSteps will be created when the server boots", async () => {
     const setupSteps = await SetupStep.findAll({
       order: [["position", "asc"]],
     });
 
-    expect(setupSteps.length).toBe(8);
+    expect(setupSteps.length).toBe(7);
     expect(setupSteps[0].position).toBe(1);
-    expect(setupSteps[0].key).toBe("create_a_team");
+    expect(setupSteps[0].key).toBe("name_your_grouparoo_instance");
   });
 
   test("setupSteps can return the related title and description", async () => {
@@ -29,16 +33,16 @@ describe("models/setupStep", () => {
 
   test("setup steps have unique keys", async () => {
     await expect(
-      SetupStep.create({ position: 1, key: "create_a_team" })
+      SetupStep.create({ position: 1, key: "name_your_grouparoo_instance" })
     ).rejects.toThrow();
   });
 
   test("setupSteps can performCheck", async () => {
-    await Team.create({ name: "test team" });
-    await Team.create({ name: "other test team" });
+    const setting = await plugin.readSetting("core", "cluster-name");
+    await setting.update({ value: "Test Cluster" });
 
     const teamStep = await SetupStep.findOne({
-      where: { key: "create_a_team" },
+      where: { key: "name_your_grouparoo_instance" },
     });
     const groupStep = await SetupStep.findOne({
       where: { key: "create_a_group" },
@@ -49,24 +53,25 @@ describe("models/setupStep", () => {
   });
 
   test("complete checks will remain complete and not check again", async () => {
-    await Team.truncate();
+    const setting = await plugin.readSetting("core", "cluster-name");
+    await setting.update({ value: setting.defaultValue });
 
     const teamStep = await SetupStep.findOne({
-      where: { key: "create_a_team" },
+      where: { key: "name_your_grouparoo_instance" },
     });
 
     expect(await teamStep.performCheck()).toBe(true);
   });
 
   test("setupSteps can getOutcome", async () => {
-    const teamStep = await SetupStep.findOne({
-      where: { key: "create_a_team" },
+    const nameStep = await SetupStep.findOne({
+      where: { key: "name_your_grouparoo_instance" },
     });
     const groupStep = await SetupStep.findOne({
       where: { key: "create_a_group" },
     });
 
-    expect(await teamStep.getOutcome()).toBe(null);
+    expect(await nameStep.getOutcome()).toBe(null);
     expect(await groupStep.getOutcome()).toBe("0 Group Memberships created");
   });
 
@@ -75,6 +80,6 @@ describe("models/setupStep", () => {
       where: { key: "name_your_grouparoo_instance" },
     });
 
-    expect(step.getCta()).toBe("Name your Grouparoo Instance");
+    expect(step.getCta()).toBe("Change your Grouparoo Cluster Name");
   });
 });

--- a/core/src/modules/ops/setupSteps.ts
+++ b/core/src/modules/ops/setupSteps.ts
@@ -26,19 +26,6 @@ export namespace SetupStepOps {
   export const setupStepDescriptions: Array<setupStepDescription> = [
     {
       position: 1,
-      key: "create_a_team",
-      title: "Create a Team",
-      description:
-        "Create another team so that your colleagues can use Grouparoo.",
-      href: "/teams",
-      cta: "Create a Team",
-      check: async () => {
-        const count = await Team.count();
-        return count > 1;
-      },
-    },
-    {
-      position: 2,
       key: "name_your_grouparoo_instance",
       title: "Name your Grouparoo Instance",
       description: "Give your Grouparoo cluster a name.",
@@ -50,7 +37,7 @@ export namespace SetupStepOps {
       },
     },
     {
-      position: 3,
+      position: 2,
       key: "add_an_app",
       title: "Add an App",
       description:
@@ -63,7 +50,7 @@ export namespace SetupStepOps {
       },
     },
     {
-      position: 4,
+      position: 3,
       key: "create_a_source",
       title: "Create a Source",
       description:
@@ -76,7 +63,7 @@ export namespace SetupStepOps {
       },
     },
     {
-      position: 5,
+      position: 4,
       key: "create_a_unique_profile_property",
       title: "Create a Unique Profile Property",
       description:
@@ -95,7 +82,7 @@ export namespace SetupStepOps {
       },
     },
     {
-      position: 6,
+      position: 5,
       key: "create_a_schedule",
       title: "Create a Schedule",
       description:
@@ -112,7 +99,7 @@ export namespace SetupStepOps {
       },
     },
     {
-      position: 7,
+      position: 6,
       key: "create_a_group",
       title: "Create a Group",
       description:
@@ -129,7 +116,7 @@ export namespace SetupStepOps {
       },
     },
     {
-      position: 8,
+      position: 7,
       key: "create_a_destination",
       title: "Create a Destination",
       description:


### PR DESCRIPTION
Creating a new team is not a required part of setting up Grouparoo