### PR TITLE
UI enterprise bugs (React 17 compatibility)

### DIFF
--- a/apps/staging-community/package.json
+++ b/apps/staging-community/package.json
@@ -34,8 +34,7 @@
   },
   "scripts": {
     "start": "cd node_modules/@grouparoo/core && ./bin/start",
-    "dev": "cd node_modules/@grouparoo/core && ./bin/dev",
-    "actionhero": "cd node_modules/@grouparoo/core && node_modules/.bin/actionhero"
+    "dev": "cd node_modules/@grouparoo/core && ./bin/dev"
   },
   "grouparoo": {
     "grouparoo_monorepo_app": "staging-community",

--- a/apps/staging-enterprise/package.json
+++ b/apps/staging-enterprise/package.json
@@ -34,8 +34,7 @@
   },
   "scripts": {
     "start": "cd node_modules/@grouparoo/core && ./bin/start",
-    "dev": "cd node_modules/@grouparoo/core && ./bin/dev",
-    "actionhero": "cd node_modules/@grouparoo/core && node_modules/.bin/actionhero"
+    "dev": "cd node_modules/@grouparoo/core && ./bin/dev"
   },
   "grouparoo": {
     "grouparoo_monorepo_app": "staging-enterprise",

--- a/cli/templates/package.json
+++ b/cli/templates/package.json
@@ -24,9 +24,7 @@
     "@grouparoo/zendesk": "~~VERSION~~"
   },
   "scripts": {
-    "start": "cd node_modules/@grouparoo/core && ./bin/start",
-    "dev": "cd node_modules/@grouparoo/core && ./bin/dev",
-    "actionhero": "cd node_modules/@grouparoo/core && ../../../.bin/actionhero"
+    "start": "cd node_modules/@grouparoo/core && ./bin/start"
   },
   "grouparoo": {
     "plugins": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1067,7 +1067,6 @@ importers:
       react-bootstrap: 1.4.3_react-dom@17.0.1+react@17.0.1
       react-bootstrap-typeahead: 5.1.4_react-dom@17.0.1+react@17.0.1
       react-date-range: 1.1.3_date-fns@2.16.1+react@17.0.1
-      react-datepicker: 3.4.1_react-dom@17.0.1+react@17.0.1
       react-dom: 17.0.1_react@17.0.1
       react-hook-form: 6.14.2_react@17.0.1
       react-markdown: 5.0.3_@types+react@17.0.0+react@17.0.1
@@ -1108,7 +1107,6 @@ importers:
       react-bootstrap: 1.4.3
       react-bootstrap-typeahead: 5.1.4
       react-date-range: 1.1.3
-      react-datepicker: 3.4.1
       react-dom: 17.0.1
       react-hook-form: 6.14.2
       react-markdown: 5.0.3
@@ -1138,7 +1136,6 @@ importers:
       react-bootstrap: 1.4.3_react-dom@17.0.1+react@17.0.1
       react-bootstrap-typeahead: 5.1.4_react-dom@17.0.1+react@17.0.1
       react-date-range: 1.1.3_date-fns@2.16.1+react@17.0.1
-      react-datepicker: 3.4.1_react-dom@17.0.1+react@17.0.1
       react-dom: 17.0.1_react@17.0.1
       react-hook-form: 6.14.2_react@17.0.1
       react-markdown: 5.0.3_@types+react@17.0.0+react@17.0.1
@@ -1192,7 +1189,6 @@ importers:
       react-bootstrap: 1.4.3
       react-bootstrap-typeahead: 5.1.4
       react-date-range: 1.1.3
-      react-datepicker: 3.4.1
       react-dom: 17.0.1
       react-hook-form: 6.14.2
       react-markdown: 5.0.3
@@ -12724,20 +12720,6 @@ packages:
       react: ^0.14 || ^15.0.0-rc || >=15.0
     resolution:
       integrity: sha512-Q0+80JaEw3O2J50Lf1dcwWfqkzu3SaCZUTgtVEG9kIHy1h1x8XTNrumX08hKz+M//wg7NOymaTzP1RPBYoLpmw==
-  /react-datepicker/3.4.1_react-dom@17.0.1+react@17.0.1:
-    dependencies:
-      classnames: 2.2.6
-      date-fns: 2.16.1
-      prop-types: 15.7.2
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-      react-onclickoutside: 6.10.0_react-dom@17.0.1+react@17.0.1
-      react-popper: 1.3.7_react@17.0.1
-    peerDependencies:
-      react: ^16.9.0
-      react-dom: ^16.9.0
-    resolution:
-      integrity: sha512-ASyVb7UmVx1vzeITidD7Cr/EXRXhKyjjbSkBndPc1MipYq4rqQ3eMFgvRQzpsXc3JmIMFgICm7nmN6Otc1GE/Q==
   /react-dom/17.0.1_react@17.0.1:
     dependencies:
       loose-envify: 1.4.0
@@ -12820,15 +12802,6 @@ packages:
       react: ^0.14.9 || ^15.3.0 || ^16.0.0
     resolution:
       integrity: sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==
-  /react-onclickoutside/6.10.0_react-dom@17.0.1+react@17.0.1:
-    dependencies:
-      react: 17.0.1
-      react-dom: 17.0.1_react@17.0.1
-    peerDependencies:
-      react: ^15.5.x || ^16.x || ^17.x
-      react-dom: ^15.5.x || ^16.x || ^17.x
-    resolution:
-      integrity: sha512-7i2L3ef+0ILXpL6P+Hg304eCQswh4jl3ynwR71BSlMU49PE2uk31k8B2GkP6yE9s2D4jTGKnzuSpzWxu4YxfQQ==
   /react-overlays/4.1.1_react-dom@17.0.1+react@17.0.1:
     dependencies:
       '@babel/runtime': 7.12.5

--- a/ui/ui-community/next.config.js
+++ b/ui/ui-community/next.config.js
@@ -4,11 +4,12 @@ const withSourceMaps = require("@zeit/next-source-maps");
 const { getParentPath } = require("@grouparoo/core/dist/utils/pluginDetails");
 
 function getPluginPath(pluginName) {
-  return path.join(
+  const p = path.join(
     path.dirname(require.resolve(`${pluginName}/package.json`)),
     "..",
     pluginName
   );
+  return p;
 }
 
 const envFile = path.resolve(path.join(getParentPath(), ".env"));

--- a/ui/ui-components/components/datePicker.tsx
+++ b/ui/ui-components/components/datePicker.tsx
@@ -1,35 +1,22 @@
-import { Component } from "react";
-import DatePicker from "react-datepicker";
+import { Form } from "react-bootstrap";
 
-class DatePickerInput extends Component<{
-  onClick: (e) => {};
-  value: string;
-}> {
-  render() {
-    const { onClick, value } = this.props;
+export default function GrouparooDatePicker({
+  selected = new Date(),
+  onChange,
+}: {
+  selected: Date;
+  onChange: Function;
+}) {
+  const selectedString = selected ? selected.toISOString().split("T")[0] : "";
 
-    return (
-      <input
-        type="text"
-        className="form-control"
-        style={{ width: 275 }}
-        onClick={onClick}
-        value={value}
-        onChange={() => {}} // will be overwritten, but needed to suppress warnings
-      />
-    );
-  }
-}
-
-export default function GrouparooDatePicker({ selected, onChange }) {
   return (
-    <DatePicker
-      showTimeSelect
-      dateFormat="MMMM d, yyyy h:mm aa"
-      selected={selected}
-      onChange={onChange}
-      // @ts-ignore
-      customInput={<DatePickerInput />}
+    <Form.Control
+      type="date"
+      value={selectedString}
+      placeholder="yyyy-mm-dd"
+      onChange={(event) => {
+        onChange(new Date(event.target.value));
+      }}
     />
   );
 }

--- a/ui/ui-components/package.json
+++ b/ui/ui-components/package.json
@@ -56,7 +56,6 @@
     "react-bootstrap": "1.4.3",
     "react-bootstrap-typeahead": "5.1.4",
     "react-date-range": "1.1.3",
-    "react-datepicker": "3.4.1",
     "react-dom": "17.0.1",
     "react-hook-form": "6.14.2",
     "react-markdown": "5.0.3",

--- a/ui/ui-components/scss/grouparoo.scss
+++ b/ui/ui-components/scss/grouparoo.scss
@@ -148,7 +148,6 @@ hr {
 @import "~swagger-ui-dist/swagger-ui.css";
 @import "~react-date-range/dist/styles.css";
 @import "~react-date-range/dist/theme/default.css";
-@import "~react-datepicker/dist/react-datepicker.css";
 
 // -- Theme Overrides
 

--- a/ui/ui-enterprise/next.config.js
+++ b/ui/ui-enterprise/next.config.js
@@ -4,11 +4,12 @@ const withSourceMaps = require("@zeit/next-source-maps");
 const { getParentPath } = require("@grouparoo/core/dist/utils/pluginDetails");
 
 function getPluginPath(pluginName) {
-  return path.join(
+  const p = path.join(
     path.dirname(require.resolve(`${pluginName}/package.json`)),
     "..",
     pluginName
   );
+  return p;
 }
 
 const envFile = path.resolve(path.join(getParentPath(), ".env"));

--- a/ui/ui-enterprise/package.json
+++ b/ui/ui-enterprise/package.json
@@ -47,7 +47,6 @@
     "react-bootstrap": "1.4.3",
     "react-bootstrap-typeahead": "5.1.4",
     "react-date-range": "1.1.3",
-    "react-datepicker": "3.4.1",
     "react-dom": "17.0.1",
     "react-hook-form": "6.14.2",
     "react-markdown": "5.0.3",


### PR DESCRIPTION
This PR removes UI packages which do not work with react v17.

1. `react-datepicker` has been replaced with native `<input type='date'>` forms
    * There is a known bug with Safari that date inputs do not render properly. See https://stackoverflow.com/questions/35682138/html5-date-picker-doesnt-show-on-safari

<img width="1138" alt="Screen Shot 2021-02-10 at 3 23 09 PM" src="https://user-images.githubusercontent.com/303226/107586435-be8b0800-6bb4-11eb-937f-8b50eef9edaa.png">


Also:
* Remove dev and actionhero commands from project template