### PR TITLE
`grouparoo init` does not include any plugins

### DIFF
--- a/cli/src/grouparoo.ts
+++ b/cli/src/grouparoo.ts
@@ -44,6 +44,12 @@ async function main() {
     )
     .action(Install);
 
+  program.addHelpText(
+    "after",
+    `
+You can add plugins to to this project to connect to new Sources and Destinations and add additional commands with the \`grouparoo install\` command.  Learn more at www.grouparoo.com/docs`
+  );
+
   program.parse(process.argv);
 }
 

--- a/cli/src/lib/initialize.ts
+++ b/cli/src/lib/initialize.ts
@@ -73,6 +73,9 @@ export default async function Initialize(
     "    - Now that your Grouparoo project is ready, run `grouparoo --help` to see new available commands"
   );
   console.info(
-    `    - Visit www.grouparoo.com/docs to learn about configuring your Grouparoo application`
+    "    - You can add plugins to to this project to connect to new Sources and Destinations and add additional commands with the `grouparoo install` command."
+  );
+  console.info(
+    "    - Visit www.grouparoo.com/docs to learn about configuring your Grouparoo application."
   );
 }

--- a/cli/templates/package.json
+++ b/cli/templates/package.json
@@ -9,40 +9,15 @@
     "node": ">=12.0.0 <16.0.0"
   },
   "dependencies": {
-    "@grouparoo/bigquery": "~~VERSION~~",
     "@grouparoo/core": "~~VERSION~~",
-    "@grouparoo/csv": "~~VERSION~~",
-    "@grouparoo/google-sheets": "~~VERSION~~",
-    "@grouparoo/hubspot": "~~VERSION~~",
-    "@grouparoo/mailchimp": "~~VERSION~~",
-    "@grouparoo/mysql": "~~VERSION~~",
-    "@grouparoo/postgres": "~~VERSION~~",
-    "@grouparoo/redshift": "~~VERSION~~",
-    "@grouparoo/salesforce": "~~VERSION~~",
-    "@grouparoo/snowflake": "~~VERSION~~",
-    "@grouparoo/ui-community": "~~VERSION~~",
-    "@grouparoo/zendesk": "~~VERSION~~"
+    "@grouparoo/ui-community": "~~VERSION~~"
   },
   "scripts": {
     "start": "cd node_modules/@grouparoo/core && ./bin/start"
   },
   "grouparoo": {
     "plugins": [
-      "@grouparoo/bigquery",
-      "@grouparoo/csv",
-      "@grouparoo/google-sheets",
-      "@grouparoo/hubspot",
-      "@grouparoo/mailchimp",
-      "@grouparoo/mysql",
-      "@grouparoo/postgres",
-      "@grouparoo/redshift",
-      "@grouparoo/salesforce",
-      "@grouparoo/snowflake",
-      "@grouparoo/ui-community",
-      "@grouparoo/zendesk"
-    ],
-    "includedFiles": [
-      "assets"
+      "@grouparoo/ui-community"
     ]
   }
 }

--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -155,6 +155,9 @@ Commands:
         "You can filter this list by providing a (partial) template to match template names against. (e.g. `grouparoo generate postgres --list`)"
       );
     }
+    console.log(
+      "You can add plugins to to this project to connect to new Sources and Destinations and add additional commands with the `grouparoo install` command."
+    );
   }
 
   async getTemplate(templateName: string) {


### PR DESCRIPTION
This PR removes plugins from new Grouparoo projects generated with `grouparoo init`, other than `ui-community`.  

This PR also adds messaging to the end of the `grouparoo init` and `grouparoo generate --list` commands to remind users they can add plugins to add additional functionality

> You can add plugins to to this project to connect to new Sources and Destinations and add additional commands with the `grouparoo install` command.