### PR TITLE
Copy Code Config README templates into the work directory.

### DIFF
--- a/cli/__tests__/test.sh
+++ b/cli/__tests__/test.sh
@@ -60,6 +60,13 @@ else
     exit 1
 fi
 
+if [ -f "$WORKDIR/config/README.md" ]; then
+    echo "✅ config/README exists."
+else
+    echo "🚫 config/README does not exist."
+    exit 1
+fi
+
 ## try the update command
 echo ""
 echo "--- test: update ---"

--- a/cli/src/lib/initialize.ts
+++ b/cli/src/lib/initialize.ts
@@ -24,13 +24,23 @@ export default async function Initialize(
     logger.succeed(`Created ${workDir}`);
   }
 
-  const configDir = path.join(workDir, "config");
-  if (!fs.existsSync(configDir) || opts.force) {
-    fs.mkdirpSync(configDir);
-    logger.succeed("Created config directory");
-  } else {
-    logger.warn("config directory already exists, not modifying");
-  }
+  /**
+   * Copy Code Config README templates into the work directory. This also
+   * results in a skeleton structure representing the directories in which Code
+   * Config files will be generated.
+   */
+  const templates = Templates.getConfigTemplates();
+  templates.map(({ absoluteFilePath, relativeFilePath }) => {
+    const destDir = path.dirname(relativeFilePath);
+    if (!fs.existsSync(destDir)) {
+      fs.mkdirSync(destDir, { recursive: true });
+    }
+    const destFilePath = path.join(workDir, relativeFilePath);
+    if (!fs.existsSync(destFilePath)) {
+      fs.copyFileSync(absoluteFilePath, destFilePath);
+    }
+  });
+  logger.succeed("Created directories for config objects.");
 
   const packageJson = path.join(workDir, "package.json");
   if (!fs.existsSync(packageJson) || opts.force) {

--- a/cli/src/lib/initialize.ts
+++ b/cli/src/lib/initialize.ts
@@ -31,10 +31,10 @@ export default async function Initialize(
    */
   const templates = Templates.getConfigTemplates();
   templates.map(({ absoluteFilePath, relativeFilePath }) => {
-    const destDir = path.dirname(relativeFilePath);
-    if (!fs.existsSync(destDir)) {
-      fs.mkdirSync(destDir, { recursive: true });
-    }
+    // Create directory for file if it doesn't exist.
+    const destDir = path.join(workDir, path.dirname(relativeFilePath));
+    if (!fs.existsSync(destDir)) fs.mkdirpSync(destDir);
+    // Copy the file into the working project's config directory.
     const destFilePath = path.join(workDir, relativeFilePath);
     if (!fs.existsSync(destFilePath)) {
       fs.copyFileSync(absoluteFilePath, destFilePath);

--- a/cli/src/utils/templates.ts
+++ b/cli/src/utils/templates.ts
@@ -1,9 +1,25 @@
 import fs from "fs-extra";
 import path from "path";
+import glob from "glob";
 
 export namespace Templates {
-  export function getTemplatePath(filename: string) {
-    return path.join(__dirname, "..", "..", "templates", filename);
+  export function getTemplatePath(...filename: string[]) {
+    const rootDir = path.join(__dirname, "..", "..", "templates");
+    if (!filename || filename.length === 0) return rootDir;
+    return path.join(rootDir, ...filename);
+  }
+
+  export function getConfigTemplates(): {
+    absoluteFilePath: string;
+    relativeFilePath: string;
+  }[] {
+    const templateDir = getTemplatePath();
+    return glob
+      .sync(`${templateDir}/config/**/*`, { nodir: true })
+      .map((filePath) => ({
+        absoluteFilePath: filePath,
+        relativeFilePath: path.relative(templateDir, filePath),
+      }));
   }
 
   export function replacePlaceholders(

--- a/cli/templates/config/README.md
+++ b/cli/templates/config/README.md
@@ -1,0 +1,11 @@
+# Code Configuration
+
+Welcome to your very own Grouparoo project! You are awesome for supporting open-source software!
+
+This directory will contain all your application's configuration files. You can generate them automatically using [the `generate` command](https://www.grouparoo.com/docs/cli/config#generate) from the Grouparoo CLI.
+
+Here are some other resources that may be helpful:
+
+- If you are not familiar with Code Config, [start here](https://www.grouparoo.com/docs/config/code-config).
+- New to Grouparoo? You may also want to check out our [Product Concepts overview](https://www.grouparoo.com/docs/getting-started/product-concepts).
+- And if you run into an issue, see your options for getting help on [our Support page](https://www.grouparoo.com/docs/support).

--- a/cli/templates/config/README.md
+++ b/cli/templates/config/README.md
@@ -1,6 +1,6 @@
 # Code Configuration
 
-Welcome to your very own Grouparoo project! You are awesome for supporting open-source software!
+Welcome to your very own Grouparoo project!
 
 This directory will contain all your application's configuration files. You can generate them automatically using [the `generate` command](https://www.grouparoo.com/docs/cli/config#generate) from the Grouparoo CLI.
 

--- a/cli/templates/config/apps/README.md
+++ b/cli/templates/config/apps/README.md
@@ -1,0 +1,12 @@
+# Apps Code Configuration
+
+This directory is where you will put configuration files for the Apps you add to your Grouparoo application. If you use [the `generate` command](https://www.grouparoo.com/docs/cli/config#generate) to build these files, they will be placed here automatically.
+
+See our [Apps Code Config Guide](https://www.grouparoo.com/docs/config/apps/community) for more information on generating App config files.
+
+These docs may also be helpful:
+
+- [Code Config Overview](https://www.grouparoo.com/docs/config/code-config)
+- [Product Concepts](https://www.grouparoo.com/docs/getting-started/product-concepts)
+
+If you run into an issue, see your options for getting help on [our Support page](https://www.grouparoo.com/docs/support).

--- a/cli/templates/config/destinations/README.md
+++ b/cli/templates/config/destinations/README.md
@@ -1,0 +1,12 @@
+# Destinations Code Configuration
+
+This directory is where you will put configuration files for the Destinations you add to your Grouparoo application. If you use [the `generate` command](https://www.grouparoo.com/docs/cli/config#generate) to build these files, they will be placed here automatically.
+
+See our [Destinations Code Config Guide](https://www.grouparoo.com/docs/config/destinations/community) for more information on generating Destination config files.
+
+These docs may also be helpful:
+
+- [Code Config Overview](https://www.grouparoo.com/docs/config/code-config)
+- [Product Concepts](https://www.grouparoo.com/docs/getting-started/product-concepts)
+
+If you run into an issue, see your options for getting help on [our Support page](https://www.grouparoo.com/docs/support).

--- a/cli/templates/config/groups/README.md
+++ b/cli/templates/config/groups/README.md
@@ -1,0 +1,12 @@
+# Groups Code Configuration
+
+This directory is where you will put configuration files for the Groups you add to your Grouparoo application. If you use [the `generate` command](https://www.grouparoo.com/docs/cli/config#generate) to build these files, they will be placed here automatically.
+
+See our [Groups Code Config Guide](https://www.grouparoo.com/docs/config/groups/community) for more information on generating Group config files.
+
+These docs may also be helpful:
+
+- [Code Config Overview](https://www.grouparoo.com/docs/config/code-config)
+- [Product Concepts](https://www.grouparoo.com/docs/getting-started/product-concepts)
+
+If you run into an issue, see your options for getting help on [our Support page](https://www.grouparoo.com/docs/support).

--- a/cli/templates/config/properties/README.md
+++ b/cli/templates/config/properties/README.md
@@ -1,0 +1,12 @@
+# Properties Code Configuration
+
+This directory is where you will put configuration files for the Properties you add to your Grouparoo application. If you use [the `generate` command](https://www.grouparoo.com/docs/cli/config#generate) to build these files, they will be placed here automatically.
+
+See our [Properties Code Config Guide](https://www.grouparoo.com/docs/config/properties/community) for more information on generating Property config files.
+
+These docs may also be helpful:
+
+- [Code Config Overview](https://www.grouparoo.com/docs/config/code-config)
+- [Product Concepts](https://www.grouparoo.com/docs/getting-started/product-concepts)
+
+If you run into an issue, see your options for getting help on [our Support page](https://www.grouparoo.com/docs/support).

--- a/cli/templates/config/sources/README.md
+++ b/cli/templates/config/sources/README.md
@@ -1,0 +1,12 @@
+# Sources Code Configuration
+
+This directory is where you will put configuration files for the Sources you add to your Grouparoo application. If you use [the `generate` command](https://www.grouparoo.com/docs/cli/config#generate) to build these files, they will be placed here automatically.
+
+See our [Sources Code Config Guide](https://www.grouparoo.com/docs/config/sources/community) for more information on generating Source config files.
+
+These docs may also be helpful:
+
+- [Code Config Overview](https://www.grouparoo.com/docs/config/code-config)
+- [Product Concepts](https://www.grouparoo.com/docs/getting-started/product-concepts)
+
+If you run into an issue, see your options for getting help on [our Support page](https://www.grouparoo.com/docs/support).


### PR DESCRIPTION
This also results in a skeleton structure representing the directories in which Code Config files will be generated.

I added README files for:

- `/config`
- `/config/apps`
- `/config/destinations`
- `/config/groups`
- `/config/properties`
- `/config/sources`

After running `init` and then generating one object of each type, this is what the structure looks like:

![Screen Shot 2021-02-12 at 4 00 41 PM](https://user-images.githubusercontent.com/5245089/107822137-9e418180-6d4b-11eb-88d9-becaf9f122d3.png)

---

I didn't add any tests. There aren't many CLI tests. Would you like some here?
