### PR TITLE
Reset previously set ProfileId when changing tracked Group in Destination Preview

### DIFF
--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -348,10 +348,10 @@ export class Destination extends LoggedModel<Destination> {
   }
 
   async checkProfileWillBeExported(profile: Profile) {
-    const profilegroupIds = (
+    const profileGroupIds = (
       await profile.$get("groups", { attributes: ["id"] })
     ).map((group) => group.id);
-    if (!profilegroupIds.includes(this.groupId)) {
+    if (!profileGroupIds.includes(this.groupId)) {
       throw new Error(
         `profile ${profile.id} will not be exported by this destination`
       );

--- a/ui/ui-components/components/destination/profilePreview.tsx
+++ b/ui/ui-components/components/destination/profilePreview.tsx
@@ -59,7 +59,7 @@ export default function ProfilePreview(props) {
     setToHide(false);
     storeProfilePropertyId(_profileId);
 
-    if (!destination.destinationGroup?.id && trackedGroupId === "_none") {
+    if (trackedGroupId === "_none") {
       setToHide(true);
       return;
     }

--- a/ui/ui-components/components/destination/profilePreview.tsx
+++ b/ui/ui-components/components/destination/profilePreview.tsx
@@ -6,13 +6,7 @@ import { useRouter } from "next/router";
 import { Actions } from "../../utils/apiData";
 
 export default function ProfilePreview(props) {
-  const {
-    errorHandler,
-    destination,
-    groups,
-    trackedGroupId,
-    mappingOptions,
-  } = props;
+  const { errorHandler, destination, trackedGroupId, mappingOptions } = props;
   const router = useRouter();
   const [profileId, setProfileId] = useState(
     router.query.profileId?.toString()
@@ -47,23 +41,26 @@ export default function ProfilePreview(props) {
     JSON.stringify(destination.destinationGroupMemberships),
   ]);
 
-  function storeProfilePropertyId(profileId: string) {
+  function storeProfilePropertyId(profileId: string = "") {
     setProfileId(profileId);
     let url = `${window.location.pathname}?`;
-    url += `profileId=${profileId}&`;
+
+    if (profileId !== "") {
+      url += `profileId=${profileId}&`;
+    }
 
     const routerMethod =
       url === `${window.location.pathname}?` ? "replace" : "push";
     router[routerMethod](router.route, url, { shallow: true });
   }
 
-  async function load(
-    _profileId = profileId === "" ? undefined : profileId,
-    _sleep = sleep
-  ) {
+  async function load(_profileId = "", _sleep = sleep) {
     setSleeping(true);
+    setToHide(false);
+    storeProfilePropertyId(_profileId);
 
     if (!destination.destinationGroup?.id && trackedGroupId === "_none") {
+      setToHide(true);
       return;
     }
 
@@ -85,17 +82,19 @@ export default function ProfilePreview(props) {
           groupId,
           mapping: destination.mapping,
           destinationGroupMemberships: destinationGroupMembershipsObject,
-          profileId: _profileId,
+          profileId: _profileId !== "" ? _profileId : undefined,
         }
       );
+
+      setSleeping(false);
 
       if (profile) {
         setToHide(false);
         setProfile(profile);
         storeProfilePropertyId(profile.id);
+      } else {
+        setToHide(true);
       }
-
-      setSleeping(false);
     }, _sleep);
   }
 


### PR DESCRIPTION
This PR fixes 2 bugs:
* When changing the tracked Group, the Destination Preview does not use the previously previewed Profile, it will try to find a new Profile in the newly tracked Group
* If there are no Profiles in the tracked Group, the Preview doesn't crash

![screenshot](https://user-images.githubusercontent.com/303226/107827172-19e70280-6d3b-11eb-8ab7-d6865a415c7b.gif)
