### PR TITLE
CLI Install & Uninstall + fixes

### DIFF
--- a/cli/__tests__/test.sh
+++ b/cli/__tests__/test.sh
@@ -3,10 +3,13 @@
 set -e
 
 TIME=`date +%s`
+cd "$(dirname "$0")/../../"
+CORE_VERSION=`cat lerna.json | jq '.version'`
+cd "./cli/__tests__"
 WORKDIR="/tmp/grouparoo-$TIME"
 export INIT_CWD=$WORKDIR
 
-echo " >>> testing with WORKDIR=$WORKDIR <<< "
+echo " >>> testing with WORKDIR=$WORKDIR against CORE_VERSION=$CORE_VERSION <<< "
 
 ## to get around premission issues on CI
 ## https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally
@@ -14,8 +17,8 @@ mkdir -p ~/.npm-global
 export NPM_CONFIG_PREFIX=~/.npm-global
 export PATH="$HOME/.npm-global/bin:$PATH"
 
-## use /this/ version of the "grouparoo" package with NPX
-npm link
+## use /this/ version of the "grouparoo" package with
+npm link ../
 
 echo ""
 echo "--- npm linked ---"
@@ -23,21 +26,21 @@ echo "--- npm linked ---"
 ## try the version command
 echo ""
 echo "--- test: version ---"
-npx grouparoo --version
+grouparoo --version
 
 ## the help command should be the default
 # echo "--- test: (empty) ---"
-# npx grouparoo (we can't test this because the output is actually stderr)
+# grouparoo (we can't test this because the output is actually stderr)
 
 ## the help command should work too
 echo ""
 echo "--- test: help ---"
-npx grouparoo --help
+grouparoo --help
 
 ## try the init command
 echo ""
 echo "--- test: init ---"
-npx grouparoo init $WORKDIR
+grouparoo init $WORKDIR
 
 if [ -f "$WORKDIR/package.json" ]; then
     echo "✅ package.json exists."
@@ -63,20 +66,30 @@ fi
 ## try the update command
 echo ""
 echo "--- test: update ---"
-cd $WORKDIR && npx grouparoo update
+cd $WORKDIR && grouparoo update
 
 ## try the install command
 echo ""
 echo "--- test: install ---"
-cd $WORKDIR && npx grouparoo install @grouparoo/logger@next
+cd $WORKDIR && grouparoo install @grouparoo/logger
 echo ""
 echo ""
 cd $WORKDIR && cat package.json
 echo ""
 echo ""
 
-## reset the NPM/NPX link
-npm unlink
+## try the uninstall command
+echo ""
+echo "--- test: uninstall ---"
+cd $WORKDIR && grouparoo uninstall @grouparoo/logger
+echo ""
+echo ""
+cd $WORKDIR && cat package.json
+echo ""
+echo ""
+
+## reset the NPM link
+npm unlink ../
 echo "--- npm unlinked ---"
 
 echo ""

--- a/cli/package.json
+++ b/cli/package.json
@@ -35,6 +35,7 @@
     "commander": "7.0.0",
     "fs-extra": "9.1.0",
     "glob": "7.1.6",
+    "isomorphic-fetch": "3.0.0",
     "npm-check-updates": "11.1.1",
     "ora": "5.3.0",
     "semver": "7.3.4"

--- a/cli/src/grouparoo.ts
+++ b/cli/src/grouparoo.ts
@@ -8,6 +8,7 @@ import { checkNodeVersion } from "./utils/checkNodeVersion";
 import Initialize from "./lib/initialize";
 import Update from "./lib/update";
 import Install from "./lib/install";
+import Uninstall from "./lib/uninstall";
 
 const Package = require("../package.json");
 
@@ -43,6 +44,13 @@ async function main() {
       "Install a grouparoo plugin (via npm install) and enable it.  Use package@version for a specific version or tag"
     )
     .action(Install);
+
+  program
+    .command("uninstall <package>")
+    .description(
+      "Uninstall a grouparoo plugin (via npm uninstall) and disable it."
+    )
+    .action(Uninstall);
 
   program.addHelpText(
     "after",

--- a/cli/src/lib/install.ts
+++ b/cli/src/lib/install.ts
@@ -6,13 +6,15 @@ import { ensurePath } from "../utils/ensurePath";
 import { ensurePackageJSON } from "../utils/ensurePackageJSON";
 import { readPackageJSON } from "../utils/readPackageJSON";
 import { isGrouparooPlugin } from "../utils/isGrouparooPlugin";
+import { getCoreVersion } from "../utils/getCoreVersion";
 
 const JSON_SPACER = 2;
 
 export default async function Update(pkg: string) {
   const workDir: string = process.env.INIT_CWD;
 
-  if (pkg && !pkg.match(/^.+@/)) pkg = `${pkg}@latest`;
+  const coreVersion = getCoreVersion(workDir);
+  if (pkg && !pkg.match(/^.+@/)) pkg = `${pkg}@${coreVersion}`;
   const logger = buildLogger(`Installing${pkg ? ` ${pkg}` : ""}`);
 
   ensurePath(workDir, logger);

--- a/cli/src/lib/install.ts
+++ b/cli/src/lib/install.ts
@@ -5,6 +5,7 @@ import { buildLogger } from "../utils/logger";
 import { ensurePath } from "../utils/ensurePath";
 import { ensurePackageJSON } from "../utils/ensurePackageJSON";
 import { readPackageJSON } from "../utils/readPackageJSON";
+import { isGrouparooPlugin } from "../utils/isGrouparooPlugin";
 
 const JSON_SPACER = 2;
 
@@ -22,7 +23,7 @@ export default async function Update(pkg: string) {
   let plugins: string[] = pkgJSONContents?.grouparoo?.plugins;
 
   if (!plugins) {
-    logger.fail("There is no `grouparoo` section in this package.json");
+    logger.fail("There is no `grouparoo` section in this package.json.");
     process.exit(1);
   }
 
@@ -34,6 +35,11 @@ export default async function Update(pkg: string) {
       );
       process.exit(1);
     }
+  }
+
+  if (!(await isGrouparooPlugin(pkg))) {
+    logger.fail(`Package \`${pkg}\` is not a Grouparoo plugin.`);
+    process.exit(1);
   }
 
   await NPM.install(logger, workDir, pkg);

--- a/cli/src/lib/install.ts
+++ b/cli/src/lib/install.ts
@@ -22,8 +22,18 @@ export default async function Update(pkg: string) {
   let plugins: string[] = pkgJSONContents?.grouparoo?.plugins;
 
   if (!plugins) {
-    logger.fail("there is no grouparoo section in this package.json");
-    process.exit();
+    logger.fail("There is no `grouparoo` section in this package.json");
+    process.exit(1);
+  }
+
+  if (pkg?.match("@grouparoo/ui-")) {
+    const existingUIPackage = plugins.find((p) => p.match(/@grouparoo\/ui.*/));
+    if (existingUIPackage) {
+      logger.fail(
+        "There is already a ui package in this project. Uninstall the existing ui package before adding another."
+      );
+      process.exit(1);
+    }
   }
 
   await NPM.install(logger, workDir, pkg);
@@ -33,7 +43,8 @@ export default async function Update(pkg: string) {
   plugins = pkgJSONContents?.grouparoo?.plugins;
 
   if (pkg) {
-    let cleanedPackageName = "@" + pkg.split("@")[1];
+    let cleanedPackageName =
+      pkg.split("@").length === 3 ? "@" + pkg.split("@")[1] : pkg.split("@")[0];
     if (!plugins.includes(cleanedPackageName)) {
       plugins.push(cleanedPackageName);
       plugins.sort();

--- a/cli/src/lib/uninstall.ts
+++ b/cli/src/lib/uninstall.ts
@@ -1,0 +1,45 @@
+import path from "path";
+import fs from "fs-extra";
+import { NPM } from "../utils/npm";
+import { buildLogger } from "../utils/logger";
+import { ensurePath } from "../utils/ensurePath";
+import { ensurePackageJSON } from "../utils/ensurePackageJSON";
+import { readPackageJSON } from "../utils/readPackageJSON";
+
+const JSON_SPACER = 2;
+
+export default async function Update(pkg: string) {
+  const workDir: string = process.env.INIT_CWD;
+
+  const logger = buildLogger(`Uninstalling${pkg ? ` ${pkg}` : ""}`);
+
+  ensurePath(workDir, logger);
+  ensurePackageJSON(workDir, logger);
+
+  const packageFile = path.join(workDir, "package.json");
+  let pkgJSONContents = readPackageJSON(packageFile);
+  const dependencies: { [key: string]: string } = pkgJSONContents.dependencies;
+  if (!Object.keys(dependencies).includes(pkg)) {
+    logger.fail(
+      `package \'${pkg}\' is not present within dependencies of ${packageFile}`
+    );
+    process.exit();
+  }
+
+  await NPM.uninstall(logger, workDir, pkg);
+
+  // reload after npm uninstall
+  pkgJSONContents = readPackageJSON(packageFile);
+  const plugins = pkgJSONContents?.grouparoo?.plugins;
+
+  if (plugins.includes(pkg)) {
+    plugins.splice(plugins.indexOf(pkg), 1);
+    plugins.sort();
+    fs.writeFileSync(
+      packageFile,
+      JSON.stringify(pkgJSONContents, null, JSON_SPACER)
+    );
+  }
+
+  logger.succeed(`Uninstalled${pkg ? ` ${pkg}` : ""}!`);
+}

--- a/cli/src/lib/uninstall.ts
+++ b/cli/src/lib/uninstall.ts
@@ -23,7 +23,7 @@ export default async function Update(pkg: string) {
     logger.fail(
       `package \'${pkg}\' is not present within dependencies of ${packageFile}`
     );
-    process.exit();
+    process.exit(1);
   }
 
   await NPM.uninstall(logger, workDir, pkg);

--- a/cli/src/utils/getCoreVersion.ts
+++ b/cli/src/utils/getCoreVersion.ts
@@ -1,0 +1,16 @@
+import path from "path";
+import fs from "fs";
+import { readPackageJSON } from "./readPackageJSON";
+
+export function getCoreVersion(workDir: string) {
+  let coreVersion = "latest";
+  const packageFile = path.join(workDir, "package.json");
+  if (fs.existsSync(packageFile)) {
+    let pkgJSONContents = readPackageJSON(packageFile);
+    if (pkgJSONContents.dependencies["@grouparoo/core"]) {
+      coreVersion = pkgJSONContents.dependencies["@grouparoo/core"].trim();
+    }
+  }
+
+  return coreVersion;
+}

--- a/cli/src/utils/isGrouparooPlugin.ts
+++ b/cli/src/utils/isGrouparooPlugin.ts
@@ -1,0 +1,31 @@
+import "isomorphic-fetch";
+
+/**
+ *
+ * @param pkg already has the version appended with @ or `latest`
+ */
+export async function isGrouparooPlugin(pkg: string) {
+  let pkgUrl = `https://registry.npmjs.com`;
+  const parts = pkg.split("@");
+
+  if (parts.length === 3) {
+    pkgUrl += `/@${parts[1]}/${parts[2]}`;
+  } else {
+    pkgUrl += `/${parts[0]}/${parts[1]}`;
+  }
+
+  const response = await fetch(pkgUrl);
+  const packageJson = await response.json();
+
+  // if we can't find this package, the install step will tell us more info (doesn't exist? needs auth?)
+  if (packageJson === "Unauthorized" || packageJson.error) return true;
+
+  const deps = [].concat(
+    Object.keys(packageJson.dependencies ?? []),
+    Object.keys(packageJson.devDependencies ?? []),
+    Object.keys(packageJson.peerDependencies ?? [])
+  );
+
+  if (deps.includes(`@grouparoo/core`)) return true;
+  return false;
+}

--- a/cli/src/utils/npm.ts
+++ b/cli/src/utils/npm.ts
@@ -1,3 +1,4 @@
+import os from "os";
 import { spawnPromise } from "./spawnPromise";
 import Chalk from "chalk";
 
@@ -35,7 +36,8 @@ export namespace NPM {
       console.log(Chalk.gray(stdout));
       console.log("------\r\n");
     } else {
-      throw new Error(stderr);
+      logger.fail("Could not install:");
+      return exitWithError(logger, stdout, stderr);
     }
   }
 
@@ -62,7 +64,26 @@ export namespace NPM {
       console.log(Chalk.gray(stdout));
       console.log("------\r\n");
     } else {
-      throw new Error(stderr);
+      logger.fail("Could not uninstall:");
+      return exitWithError(logger, stdout, stderr);
     }
+  }
+
+  function exitWithError(logger, stdout: string, stderr: string) {
+    const lines = [];
+    function logUniqueLines(s: string, level: "warn" | "fail") {
+      s.split(os.EOL).map((line) => {
+        if (!lines.includes(line)) {
+          line = line.trim();
+          console.info(Chalk.gray(line));
+          lines.push(line.trim());
+        }
+      });
+    }
+
+    logUniqueLines(stderr, "warn");
+    logUniqueLines(stdout, "fail");
+
+    process.exit(1);
   }
 }

--- a/cli/src/utils/npm.ts
+++ b/cli/src/utils/npm.ts
@@ -38,4 +38,31 @@ export namespace NPM {
       throw new Error(stderr);
     }
   }
+
+  export async function uninstall(
+    logger: any,
+    workDir: string,
+    pkg: string,
+    npm_config_loglevel = "error"
+  ) {
+    const args = ["uninstall", pkg];
+    logger.start("Uninstalling...");
+
+    const { exitCode, stdout, stderr } = await spawnPromise(
+      "npm",
+      args,
+      workDir,
+      { npm_config_loglevel },
+      logger
+    );
+
+    if (exitCode === 0) {
+      logger.succeed("Uninstall Complete!");
+      console.log("\r\n------\r\n");
+      console.log(Chalk.gray(stdout));
+      console.log("------\r\n");
+    } else {
+      throw new Error(stderr);
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,7 @@ importers:
       commander: 7.0.0
       fs-extra: 9.1.0
       glob: 7.1.6
+      isomorphic-fetch: 3.0.0
       npm-check-updates: 11.1.1
       ora: 5.3.0
       semver: 7.3.4
@@ -130,6 +131,7 @@ importers:
       commander: 7.0.0
       fs-extra: 9.1.0
       glob: 7.1.6
+      isomorphic-fetch: 3.0.0
       npm-check-updates: 11.1.1
       ora: 5.3.0
       prettier: 2.2.1
@@ -205,11 +207,11 @@ importers:
       '@types/faker': 5.1.6
       '@types/jest': 26.0.20
       csv-parse: 4.15.1
-      jest: 26.6.3_ts-node@9.1.1
+      jest: 26.6.3
       jest-fetch-mock: 3.0.3
       nock: 13.0.7
       ts-jest: 26.5.1_jest@26.6.3+typescript@4.1.5
-      type-fest: 0.20.2
+      type-fest: 0.21.0
       typedoc: 0.20.24_typescript@4.1.5
       typescript: 4.1.5
     specifiers:
@@ -257,7 +259,7 @@ importers:
       sqlite3: 5.0.1
       ts-jest: 26.5.1
       ts-node: 9.1.1
-      type-fest: 0.20.2
+      type-fest: 0.21.0
       typedoc: 0.20.24
       typescript: 4.1.5
       umzug: 2.3.0
@@ -1074,7 +1076,7 @@ importers:
       stacktrace-js: 2.0.2
       swagger-ui-dist: 3.43.0
       ts-jest: 26.5.1_jest@26.6.3+typescript@4.1.5
-      type-fest: 0.20.2
+      type-fest: 0.21.0
       typescript: 4.1.5
     specifiers:
       '@fortawesome/fontawesome-svg-core': 1.2.34
@@ -1114,7 +1116,7 @@ importers:
       stacktrace-js: 2.0.2
       swagger-ui-dist: 3.43.0
       ts-jest: 26.5.1
-      type-fest: 0.20.2
+      type-fest: 0.21.0
       typescript: 4.1.5
   ui/ui-enterprise:
     dependencies:
@@ -1817,43 +1819,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
-  /@jest/core/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/reporters': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 14.14.27
-      ansi-escapes: 4.3.1
-      chalk: 4.1.0
-      exit: 0.1.2
-      graceful-fs: 4.2.6
-      jest-changed-files: 26.6.2
-      jest-config: 26.6.3_ts-node@9.1.1
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-resolve-dependencies: 26.6.3
-      jest-runner: 26.6.3_ts-node@9.1.1
-      jest-runtime: 26.6.3_ts-node@9.1.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      jest-watcher: 26.6.2
-      micromatch: 4.0.2
-      p-each-series: 2.2.0
-      rimraf: 3.0.2
-      slash: 3.0.0
-      strip-ansi: 6.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   /@jest/environment/26.6.2:
     dependencies:
       '@jest/fake-timers': 26.6.2
@@ -1952,20 +1917,6 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
-  /@jest/test-sequencer/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@jest/test-result': 26.6.2
-      graceful-fs: 4.2.6
-      jest-haste-map: 26.6.2
-      jest-runner: 26.6.3_ts-node@9.1.1
-      jest-runtime: 26.6.3_ts-node@9.1.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
     resolution:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/transform/26.6.2:
@@ -8992,29 +8943,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
-  /jest-cli/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@jest/core': 26.6.3_ts-node@9.1.1
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      chalk: 4.1.0
-      exit: 0.1.2
-      graceful-fs: 4.2.6
-      import-local: 3.0.2
-      is-ci: 2.0.0
-      jest-config: 26.6.3_ts-node@9.1.1
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      prompts: 2.4.0
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-config/26.6.3:
     dependencies:
       '@babel/core': 7.12.16
@@ -9035,37 +8963,6 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.2
       pretty-format: 26.6.2
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    resolution:
-      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
-  /jest-config/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@babel/core': 7.12.16
-      '@jest/test-sequencer': 26.6.3_ts-node@9.1.1
-      '@jest/types': 26.6.2
-      babel-jest: 26.6.3_@babel+core@7.12.16
-      chalk: 4.1.0
-      deepmerge: 4.2.2
-      glob: 7.1.6
-      graceful-fs: 4.2.6
-      jest-environment-jsdom: 26.6.2
-      jest-environment-node: 26.6.2
-      jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3_ts-node@9.1.1
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      micromatch: 4.0.2
-      pretty-format: 26.6.2
-      ts-node: 9.1.1_typescript@4.1.5
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -9213,33 +9110,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
-  /jest-jasmine2/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@babel/traverse': 7.12.13
-      '@jest/environment': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 14.14.27
-      chalk: 4.1.0
-      co: 4.6.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runtime: 26.6.3_ts-node@9.1.1
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      pretty-format: 26.6.2
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
   /jest-leak-detector/26.6.2:
     dependencies:
       jest-get-type: 26.3.0
@@ -9376,35 +9246,6 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
-  /jest-runner/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 14.14.27
-      chalk: 4.1.0
-      emittery: 0.7.2
-      exit: 0.1.2
-      graceful-fs: 4.2.6
-      jest-config: 26.6.3_ts-node@9.1.1
-      jest-docblock: 26.0.0
-      jest-haste-map: 26.6.2
-      jest-leak-detector: 26.6.2
-      jest-message-util: 26.6.2
-      jest-resolve: 26.6.2
-      jest-runtime: 26.6.3_ts-node@9.1.1
-      jest-util: 26.6.2
-      jest-worker: 26.6.2
-      source-map-support: 0.5.19
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      ts-node: '*'
-    resolution:
-      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   /jest-runtime/26.6.3:
     dependencies:
       '@jest/console': 26.6.2
@@ -9438,43 +9279,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
-  /jest-runtime/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@jest/console': 26.6.2
-      '@jest/environment': 26.6.2
-      '@jest/fake-timers': 26.6.2
-      '@jest/globals': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/transform': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/yargs': 15.0.13
-      chalk: 4.1.0
-      cjs-module-lexer: 0.6.0
-      collect-v8-coverage: 1.0.1
-      exit: 0.1.2
-      glob: 7.1.6
-      graceful-fs: 4.2.6
-      jest-config: 26.6.3_ts-node@9.1.1
-      jest-haste-map: 26.6.2
-      jest-message-util: 26.6.2
-      jest-mock: 26.6.2
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.6.2
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      jest-validate: 26.6.2
-      slash: 3.0.0
-      strip-bom: 4.0.0
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
     resolution:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-serializer/26.6.2:
@@ -9588,19 +9392,6 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
-    resolution:
-      integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
-  /jest/26.6.3_ts-node@9.1.1:
-    dependencies:
-      '@jest/core': 26.6.3_ts-node@9.1.1
-      import-local: 3.0.2
-      jest-cli: 26.6.3_ts-node@9.1.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
     resolution:
       integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
   /jju/1.4.0:
@@ -15431,6 +15222,12 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+  /type-fest/0.21.0:
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-1l9DXlbflV880ZijiK9qx4jdD0VOqogKx5i33t3hDN+ZiaqMOr7aSwH/jzmnBXPQon+SNvr+cH6wltATEzGJEg==
   /type-fest/0.3.1:
     dev: true
     engines:


### PR DESCRIPTION
* Add the `grouparoo uninstall` command
* Only allow one `@grouparoo/ui-*` package to be installed at a time
* Only `grouparoo install [package]` plugins which depend on `@grouparoo/core` as a dependency, peerDependency, or devDependency
* Default to matching the locally-installed version of `@grouparoo/core` when installing plugins
* Better @ parsing when adding packages to `package.json/grouparoo/plugins`
* Better NPM error logging when something goes wrong