### PR TITLE
Validate config objects for duplicate ID values

### DIFF
--- a/core/__tests__/modules/codeConfig/errors.ts
+++ b/core/__tests__/modules/codeConfig/errors.ts
@@ -3,7 +3,10 @@ import { Setting, Team } from "../../../src";
 import path from "path";
 import { api } from "actionhero";
 import { loadConfigDirectory } from "../../../src/modules/configLoaders";
-import { validateConfigObjectKeys } from "../../../src/classes/codeConfig";
+import {
+  validateConfigObjectKeys,
+  validateConfigObjects,
+} from "../../../src/classes/codeConfig";
 
 describe("modules/codeConfig", () => {
   helper.grouparooTestServer({
@@ -24,6 +27,24 @@ describe("modules/codeConfig", () => {
       expect(() => validateConfigObjectKeys(Team, configObject)).toThrow(
         /id is required for a Team/
       );
+    });
+
+    test("catches duplicate ID values", async () => {
+      const objs = [
+        {
+          id: "marketing_team",
+          name: "Marketing Team",
+          class: "team",
+        },
+        {
+          id: "marketing_team",
+          name: "Marketing Team",
+          class: "team",
+        },
+      ];
+
+      const { errors } = validateConfigObjects(objs);
+      expect(errors).toContain("Duplicate ID values found: marketing_team");
     });
 
     test("extraneous keys throw an error", async () => {

--- a/core/__tests__/modules/validators/extractDuplicates.ts
+++ b/core/__tests__/modules/validators/extractDuplicates.ts
@@ -1,0 +1,34 @@
+import extractDuplicates from "../../../src/modules/validators/extractDuplicates";
+
+describe("extractDuplicates()", () => {
+  test("Returns an empty array when no duplicates", () => {
+    const input = [1, 2, 3];
+    const res = extractDuplicates(input);
+    expect(res).toEqual([]);
+  });
+  test("Returns duplicate strings", () => {
+    const input = ["hello", "world", "hello"];
+    const res = extractDuplicates(input);
+    expect(res).toEqual(["hello"]);
+  });
+  test("Returns duplicate numbers", () => {
+    const input = [1, 2, 3, 2];
+    const res = extractDuplicates(input);
+    expect(res).toEqual([2]);
+  });
+  test("Returns the duplicate only once", () => {
+    const input = [1, 2, 3, 2, 2];
+    const res = extractDuplicates(input);
+    expect(res).toEqual([2]);
+  });
+  test("Won't find duplicates of objects without a valid key", () => {
+    const input = [{ name: "hello" }, { name: "world" }, { name: "hello" }];
+    const res = extractDuplicates(input);
+    expect(res).toEqual([]);
+  });
+  test("Returns duplicate objects by ID", () => {
+    const input = [{ name: "hello" }, { name: "world" }, { name: "hello" }];
+    const res = extractDuplicates(input, "name");
+    expect(res).toEqual(["hello"]);
+  });
+});

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -1,6 +1,7 @@
 import { log } from "actionhero";
 import { PropertyFiltersWithKey } from "../models/Property";
 import { GroupRuleWithKey } from "../models/Group";
+import extractDuplicates from "../modules/validators/extractDuplicates";
 
 export interface IdsByClass {
   app?: string[];
@@ -183,6 +184,22 @@ export function sortConfigurationObjects(
     configObjectsWithIds
   );
   return sortedConfigObjectsWithIds.map((o) => o.configObject);
+}
+
+/**
+ * Check a set of config objects for duplicate IDs.
+ *
+ * @param configObjects ConfigurationObject[]
+ */
+export function validateConfigObjects(
+  configObjects: ConfigurationObject[]
+): { configObjects: ConfigurationObject[]; errors: string[] } {
+  let errors = [];
+  const duplicates = extractDuplicates(configObjects, "id");
+  if (duplicates.length > 0) {
+    errors.push(`Duplicate ID values found: ${duplicates.join(",")}`);
+  }
+  return { configObjects, errors };
 }
 
 export function getParentIds(configObject: ConfigurationObject) {

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -5,6 +5,7 @@ import glob from "glob";
 import {
   ConfigurationObject,
   sortConfigurationObjects,
+  validateConfigObjects,
   IdsByClass,
 } from "../../classes/codeConfig";
 import { loadApp, deleteApps } from "./app";
@@ -110,6 +111,12 @@ export async function processConfigObjects(
   const errors: string[] = [];
 
   configObjects = sortConfigurationObjects(configObjects);
+
+  const { errors: validationErrors } = validateConfigObjects(configObjects);
+  validationErrors.map((err) =>
+    log(`[ config ] ${err}`, env === "test" ? "info" : "error")
+  );
+  errors.push(...validationErrors);
 
   for (const i in configObjects) {
     const configObject = configObjects[i];

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -118,6 +118,8 @@ export async function processConfigObjects(
   );
   errors.push(...validationErrors);
 
+  if (errors.length > 0) return { seenIds, errors };
+
   for (const i in configObjects) {
     const configObject = configObjects[i];
     if (Object.keys(configObject).length === 0) continue;

--- a/core/src/modules/validators/extractDuplicates.ts
+++ b/core/src/modules/validators/extractDuplicates.ts
@@ -1,0 +1,18 @@
+/**
+ * Extracts duplicate items from an array and returns unique duplicate values
+ * (i.e. only one version of each duplicate).
+ *
+ * @param objects An array of strings or objects to test for validation.
+ * @param key (optional) If the array is an array of objects, use this property
+ * to locate duplicates.
+ */
+export default function extractDuplicates(
+  objects: any[],
+  key?: string
+): string[] {
+  const values: string[] = key ? objects.map((obj) => obj[key]) : objects;
+  const onlyUnique = (value, index, self) => self.indexOf(value) === index;
+  const onlyDuplicates = (value, index, self) => self.indexOf(value) !== index;
+  const duplicates = values.filter(onlyDuplicates).filter(onlyUnique);
+  return duplicates;
+}


### PR DESCRIPTION
This will validate for duplicate ID values. This uniqueness validation is type-agnostic. While not strictly necessary, it has some benefits:

- Simpler logic.
- Potentially faster for users to debug.
- Seems like a good practices anyways — even though you _can_ have duplicate ID values across types, you probably _shouldn't_.
- One less thing for the object checker in the UI to do.

![Screen Shot 2021-02-15 at 9 07 48 AM](https://user-images.githubusercontent.com/5245089/107956539-47b38d80-6f6d-11eb-8e4e-d7d28e2edca6.png)


This also moves existing core test util to a `__utils__` directory. It was being ignored. I wanted to use `utils` for a test because it matches the structure of `src`. I don't feel strongly about `__utils__` being the name or this being the ideal solution. I mostly just wanted it to get out of the way.