### PR TITLE
Require `parent` when generating code-config objects

### DIFF
--- a/core/__tests__/bin/generate.ts
+++ b/core/__tests__/bin/generate.ts
@@ -136,6 +136,33 @@ describe("bin/generate", () => {
     });
 
     const output = messages.join(" ");
-    expect(output).not.toContain(`ID was changed to \"new-group\"`);
+    expect(output).not.toContain(`ID was changed`);
+  });
+
+  test("if a parent is required and not provided an error will be shown", async () => {
+    const command = new Generate();
+    await command.run({
+      params: {
+        path: tmpDir,
+        template: "team:member",
+        id: "new-team-member",
+      },
+    });
+    const output = messages.join(" ");
+    expect(output).toMatch("teamId is needed for a team:member");
+  });
+
+  test("if a parent is required and provided it will be used", async () => {
+    const command = new Generate();
+    await command.run({
+      params: {
+        path: tmpDir,
+        template: "team:member",
+        id: "new-team-member",
+        parent: "admin_team",
+      },
+    });
+    const output = messages.join(" ");
+    expect(output).toMatch("/config/teamMembers/new-team-member.js"); // success
   });
 });

--- a/core/public/templates/events/app/{{{id}}}.js.template
+++ b/core/public/templates/events/app/{{{id}}}.js.template
@@ -6,7 +6,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       type: "events",
       options: {
-        identifyingPropertyId: "user_id", // The id of a Grouparoo property to be used to identify data in the 'identify' event to link those events to profiles.
+        identifyingPropertyId: "...", // The id of a Grouparoo property to be used to identify data in the 'identify' event to link those events to profiles. Often "user_id" or similar.
       },
     },
   ];

--- a/core/public/templates/events/property/{{{id}}}.js.template
+++ b/core/public/templates/events/property/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "property",
-      sourceId: "eventSource", // The ID of the Source that this Property belongs to.
+      sourceId: {{{sourceId}}}, // The ID of the Source that this Property belongs to.
       type: "string", // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: false, // Will Profiles have unique records for this Property?
       identifying: false, // Should we consider this property Identifying in the UI? Only one Property can be identifying.

--- a/core/public/templates/events/source/{{{id}}}.js.template
+++ b/core/public/templates/events/source/{{{id}}}.js.template
@@ -5,9 +5,9 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       type: "events-table-import",
-      appId: "eventsApp", // The id of the app this source uses
+      appId: {{{appId}}}, // The id of the app this source uses
       options: {
-        type: "pageview", // The type of event to use
+        type: "...", // The type of event to use
       }
     }
   ];

--- a/core/public/templates/manual/property/{{{id}}}.js.template
+++ b/core/public/templates/manual/property/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "property",
-      sourceId: "manualSource", // The ID of the Source that this Property belongs to.
+      sourceId: {{{sourceId}}}, // The ID of the Source that this Property belongs to.
       type: "string", // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: false, // Will Profiles have unique records for this Property?
       identifying: false, // Should we consider this property Identifying in the UI? Only one Property can be identifying.

--- a/core/public/templates/manual/source/{{{id}}}.js.template
+++ b/core/public/templates/manual/source/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       type: "manual",
-      appId: "manualApp", // The id of the app this source uses
+      appId: {{{appId}}}, // The id of the app this source uses
     }
   ];
 };

--- a/core/public/templates/teamMembers/{{{id}}}.js.template
+++ b/core/public/templates/teamMembers/{{{id}}}.js.template
@@ -3,12 +3,12 @@ exports.default = async function buildConfig() {
     {
       class: "teamMember",
       id: {{{id}}},
-      email: "person@example.com",
-      teamId: "admin_team", // The ID of the Team that this Team Member belongs to
+      email: "...", // The Email address of your Team Member
+      teamId: {{{teamId}}}, // The ID of the Team that this Team Member belongs to
       options: {
         firstName: {{{id}}},
-        lastName: "Team Member",
-        password: "P@ssword!",
+        lastName: "...",
+        password: "...",
       },
     },
   ];

--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -90,7 +90,7 @@ Commands:
   }
 
   async describe(params) {
-    if (!params.template) this.fatalError(`no template provided`);
+    if (!params.template) return this.fatalError(`no template provided`);
 
     const template = await this.getTemplate(params.template);
     this.logTemplateAndOptions(template);
@@ -101,10 +101,10 @@ Commands:
       "Learn more with `grouparoo generate --help` and `grouparoo generate --list`";
 
     if (!params.template) {
-      this.fatalError(`template is required. ${learnMoreText}`);
+      return this.fatalError(`template is required. ${learnMoreText}`);
     }
     if (!params.id) {
-      this.fatalError(`id is required. ${learnMoreText}`);
+      return this.fatalError(`id is required. ${learnMoreText}`);
     }
 
     const template = await this.getTemplate(params.template);
@@ -113,7 +113,7 @@ Commands:
     try {
       preparedParams = template.prepareParams({ ...params });
     } catch (error) {
-      this.fatalError(error);
+      return this.fatalError(error);
     }
 
     if (preparedParams.id.toString().replace(/['"]+/g, "") !== params.id) {
@@ -126,7 +126,7 @@ Commands:
     try {
       fileData = await template.run({ params: preparedParams });
     } catch (error) {
-      this.fatalError(error.message);
+      return this.fatalError(error.message);
     }
 
     Object.keys(fileData).forEach((filename) => {

--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -2,6 +2,7 @@ import { GrouparooCLI } from "../modules/cli";
 import Colors from "colors/safe";
 import {
   ConfigTemplate,
+  ConfigTemplateParams,
   ConfigTemplateRunResponse,
 } from "../classes/configTemplate";
 import { CLI, api } from "actionhero";
@@ -40,6 +41,12 @@ Commands:
         letter: "d",
         flag: true,
         description: "Display the options for the template in detail",
+      },
+      parent: {
+        required: false,
+        letter: "a",
+        description:
+          "The id of the object that is the direct parent of this new object.  ie: the appId if you are creating a new Source, the sourceId if you are creating a new Property, etc.",
       },
       overwrite: {
         required: true,
@@ -102,7 +109,12 @@ Commands:
 
     const template = await this.getTemplate(params.template);
 
-    const preparedParams = template.prepareParams({ ...params });
+    let preparedParams: ConfigTemplateParams;
+    try {
+      preparedParams = template.prepareParams({ ...params });
+    } catch (error) {
+      this.fatalError(error);
+    }
 
     if (preparedParams.id.toString().replace(/['"]+/g, "") !== params.id) {
       console.log(

--- a/core/src/classes/configTemplate.ts
+++ b/core/src/classes/configTemplate.ts
@@ -77,7 +77,7 @@ export abstract class ConfigTemplate {
       params[this.parentId] = params["parent"];
       if (!params[this.parentId])
         throw new Error(
-          `option parent (-i, --parent) is required - ${this.parentId} is needed for a ${this.name}`
+          `option parent (-a, --parent) is required - ${this.parentId} is needed for a ${this.name}`
         );
     }
 

--- a/core/src/classes/configTemplate.ts
+++ b/core/src/classes/configTemplate.ts
@@ -28,6 +28,7 @@ export abstract class ConfigTemplate {
   };
   files: string[]; // a list of files or a glob of files
   destinationDir: string;
+  parentId?: string;
 
   constructor() {
     this.inputs = {
@@ -70,6 +71,15 @@ export abstract class ConfigTemplate {
         params[k] = "null";
       }
     });
+
+    // parentId
+    if (this.parentId) {
+      params[this.parentId] = params["parent"];
+      if (!params[this.parentId])
+        throw new Error(
+          `option parent (-i, --parent) is required - ${this.parentId} is needed for a ${this.name}`
+        );
+    }
 
     // format inputs
     Object.keys(this.inputs).forEach((k) => {

--- a/core/src/templates/events.ts
+++ b/core/src/templates/events.ts
@@ -32,6 +32,7 @@ export class EventsSourceTemplate extends ConfigTemplate {
     this.description = "Config for a Grouparoo Source based on an Events App";
     this.files = [path.join(templateRoot, "source", "*.template")];
     this.destinationDir = "sources";
+    this.parentId = "appId";
   }
 
   async run({ params }) {
@@ -47,6 +48,7 @@ export class EventsPropertyTemplate extends ConfigTemplate {
       "Config for a Grouparoo Property based on an Events Source";
     this.files = [path.join(templateRoot, "property", "*.template")];
     this.destinationDir = "properties";
+    this.parentId = "sourceId";
   }
 
   async run({ params }) {

--- a/core/src/templates/manual.ts
+++ b/core/src/templates/manual.ts
@@ -32,6 +32,7 @@ export class ManualSourceTemplate extends ConfigTemplate {
     this.description = "Config for a Grouparoo Source based on a Manual App";
     this.files = [path.join(templateRoot, "source", "*.template")];
     this.destinationDir = "sources";
+    this.parentId = "appId";
   }
 
   async run({ params }) {
@@ -47,6 +48,7 @@ export class ManualPropertyTemplate extends ConfigTemplate {
       "Config for a Grouparoo Property based on a Manual Source";
     this.files = [path.join(templateRoot, "property", "*.template")];
     this.destinationDir = "properties";
+    this.parentId = "sourceId";
   }
 
   async run({ params }) {

--- a/core/src/templates/teamMember.ts
+++ b/core/src/templates/teamMember.ts
@@ -18,6 +18,7 @@ export class TeamMemberTemplate extends ConfigTemplate {
       ),
     ];
     this.destinationDir = "teamMembers";
+    this.parentId = "teamId";
   }
 
   async run({ params }) {

--- a/plugins/@grouparoo/app-templates/public/templates/query-property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/query-property/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "property",
-      sourceId: "...", // The ID of the Source that this Property belongs to - e.g. `sourceId: "purchases_table"`
+      sourceId: {{{sourceId}}}, // The ID of the Source that this Property belongs to - e.g. `sourceId: "purchases_table"`
       type: "float", // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: false, // Will Profiles have unique records for this Property?
       identifying: false, // Should we consider this property Identifying in the UI? Only one Property can be identifying.

--- a/plugins/@grouparoo/app-templates/public/templates/query-schedule/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/query-schedule/{{{id}}}.js.template
@@ -4,12 +4,12 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "schedule",
-      sourceId: "...", // The ID of the Source this Schedule uses - e.g. `sourceId: "query_source"`
+      sourceId: {{{sourceId}}}, // The ID of the Source this Schedule uses - e.g. `sourceId: "query_source"`
       recurring: true, // should this Schedule regularly run?
-      recurringFrequency: 1000 * 60 * 15, // 15 minutes, in ms
+      recurringFrequency: 1000 * 60 * 60, // 60 minutes, in ms
       options: {
-        query: "SELECT id FROM users WHERE updated_at >= (NOW() - INTERVAL '2 day')", // A SQL query to return that includes only the IDs of properties to check.
-        propertyId: "userId" // The ID of the Grouparoo Property whose data is returned by options.query
+        query: "...", // A SQL query to return that includes only the IDs of properties to check, e.g. "SELECT id FROM users WHERE updated_at >= (NOW() - INTERVAL '2 day')"
+        propertyId: "..." // The ID of the Grouparoo Property whose data is returned by options.query, e.g. "user_id"
       },
     },
   ];

--- a/plugins/@grouparoo/app-templates/public/templates/query-source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/query-source/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-query-import",
-      appId: "...", // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
+      appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
     },
   ];
 };

--- a/plugins/@grouparoo/app-templates/public/templates/table-property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/table-property/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "property",
-      sourceId: "...", // The ID of the Source that this Property belongs to - e.g. `sourceId: "users_table"`
+      sourceId: {{{sourceId}}}, // The ID of the Source that this Property belongs to - e.g. `sourceId: "users_table"`
       type: "string", // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: true, // Will Profiles have unique records for this Property?
       identifying: true, // Should we consider this property Identifying in the UI? Only one Property can be identifying.

--- a/plugins/@grouparoo/app-templates/public/templates/table-schedule/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/table-schedule/{{{id}}}.js.template
@@ -4,11 +4,11 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "schedule",
-      sourceId: "...", // The ID of the Source this Schedule uses - e.g. `sourceId: "users_table"`
+      sourceId: {{{sourceId}}}, // The ID of the Source this Schedule uses - e.g. `sourceId: "users_table"`
       recurring: true, // should this Schedule regularly run?
-      recurringFrequency: 1000 * 60 * 15, // 15 minutes, in ms
+      recurringFrequency: 1000 * 60 * 60, // 60 minutes, in ms
       options: {
-        column: "updated_at", // the column to check for new records in table which this Schedule's Source is using
+        column: "...", // the column to check for new records in table which this Schedule's Source is using, e.g. "updated_at"
       },
     },
   ];

--- a/plugins/@grouparoo/app-templates/public/templates/table-source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/table-source/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-table-import",
-      appId: "...", // Set this value to the ID of the App this Source uses - e.g. `appId: "data_warehouse"`
+      appId: {{{appId}}}, // Set this value to the ID of the App this Source uses - e.g. `appId: "data_warehouse"`
       options: {
         table: "...", // Name of the table in your DB - e.g. `table: "users"`
       },

--- a/plugins/@grouparoo/app-templates/src/destination/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/destination/templates.ts
@@ -7,6 +7,7 @@ export class DestinationTemplate extends ConfigTemplate {
     this.description = `Config for a ${name} Destination`;
     this.files = files;
     this.destinationDir = "destinations";
+    this.parentId = "appId";
   }
 
   async run({ params }) {

--- a/plugins/@grouparoo/app-templates/src/source/query/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/query/templates.ts
@@ -20,6 +20,7 @@ export class QuerySourceTemplate extends ConfigTemplate {
     this.description = `Config for a ${name} Query Source. Work with multiple tables and build custom queries for its properties.`;
     this.files = files;
     this.destinationDir = "sources";
+    this.parentId = "appId";
   }
 
   async run({ params }) {
@@ -38,6 +39,7 @@ export class QueryScheduleTemplate extends ConfigTemplate {
     this.description = `Config for a ${name} Query Schedule`;
     this.files = files;
     this.destinationDir = "schedules";
+    this.parentId = "sourceId";
   }
 
   async run({ params }) {
@@ -56,6 +58,7 @@ export class QueryPropertyTemplate extends ConfigTemplate {
     this.description = `Config for a ${name} Query Property`;
     this.files = files;
     this.destinationDir = "properties";
+    this.parentId = "sourceId";
   }
 
   async run({ params }) {

--- a/plugins/@grouparoo/app-templates/src/source/table/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/templates.ts
@@ -21,6 +21,7 @@ export class TableSourceTemplate extends ConfigTemplate {
     this.description = `Config for a ${name} Table Source. Construct properties from the data in the table without writing SQL.`;
     this.files = files;
     this.destinationDir = "sources";
+    this.parentId = "appId";
   }
 
   async run({ params }) {
@@ -39,6 +40,7 @@ export class TableScheduleTemplate extends ConfigTemplate {
     this.description = `Config for a ${name} Table Schedule`;
     this.files = files;
     this.destinationDir = "schedules";
+    this.parentId = "sourceId";
   }
 
   async run({ params }) {
@@ -57,6 +59,7 @@ export class TablePropertyTemplate extends ConfigTemplate {
     this.description = `Config for a ${name} Table Property`;
     this.files = files;
     this.destinationDir = "properties";
+    this.parentId = "sourceId";
   }
 
   async run({ params }) {

--- a/plugins/@grouparoo/csv/public/templates/property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/csv/public/templates/property/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "property",
-      sourceId: "...", // The ID of the Source that this Property belongs to - e.g. `sourceId: "csv_app"`
+      sourceId: {{{sourceId}}}, // The ID of the Source that this Property belongs to - e.g. `sourceId: "csv_app"`
       type: "string", // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: false, // Will Profiles have unique records for this Property?
       identifying: false, // Should we consider this property Identifying in the UI? Only one Property can be identifying.

--- a/plugins/@grouparoo/csv/public/templates/schedule/{{{id}}}.js.template
+++ b/plugins/@grouparoo/csv/public/templates/schedule/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "schedule",
-      sourceId: "...", // The id of the Source this Schedule uses - e.g. `sourceId: "csv_schedule"`
+      sourceId: {{{sourceId}}}, // The id of the Source this Schedule uses - e.g. `sourceId: "csv_schedule"`
       recurring: true, // should this Schedule regularly run?
       recurringFrequency: 1000 * 60 * 15, // 15 minutes, in ms
     },

--- a/plugins/@grouparoo/csv/public/templates/source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/csv/public/templates/source/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-import",
-      appId: "...", // Set this value to the ID of the App this Source uses - e.g. `appId: "csv_app"`
+      appId: {{{appId}}}, // Set this value to the ID of the App this Source uses - e.g. `appId: "csv_app"`
       options: {
         fileId: "..." // The id of a File already uploaded to Grouparoo - e.g. `fileId: "fil_abc123"`
       },

--- a/plugins/@grouparoo/csv/src/lib/templates.ts
+++ b/plugins/@grouparoo/csv/src/lib/templates.ts
@@ -25,6 +25,7 @@ export class CSVSourceTemplate extends ConfigTemplate {
     this.description = `Config for a CSV Source`;
     this.files = [path.join(templateRoot, "source", "*.template")];
     this.destinationDir = "sources";
+    this.parentId = "appId";
   }
 
   async run({ params }) {
@@ -40,6 +41,7 @@ export class CSVScheduleTemplate extends ConfigTemplate {
     this.description = `Config for a CSV Schedule`;
     this.files = [path.join(templateRoot, "schedule", "*.template")];
     this.destinationDir = "schedules";
+    this.parentId = "sourceId";
   }
 
   async run({ params }) {
@@ -55,6 +57,7 @@ export class CSVPropertyTemplate extends ConfigTemplate {
     this.description = `Config for a CSV Property`;
     this.files = [path.join(templateRoot, "property", "*.template")];
     this.destinationDir = "properties";
+    this.parentId = "sourceId";
   }
 
   async run({ params }) {

--- a/plugins/@grouparoo/facebook/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/facebook/public/templates/destination/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "...", // The ID of the App this Source uses - e.g. `appId: "facebookApp"`
+      appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "facebookApp"`
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {

--- a/plugins/@grouparoo/google-sheets/public/templates/property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/google-sheets/public/templates/property/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "property",
-      sourceId: "...", // The ID of the Source that this Property belongs to - e.g. `sourceId: "google_sheets_source"`
+      sourceId: {{{sourceId}}}, // The ID of the Source that this Property belongs to - e.g. `sourceId: "google_sheets_source"`
       type: "string", // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: false, // Will Profiles have unique records for this Property?
       identifying: false, // Should we consider this property Identifying in the UI? Only one Property can be identifying.

--- a/plugins/@grouparoo/google-sheets/public/templates/schedule/{{{id}}}.js.template
+++ b/plugins/@grouparoo/google-sheets/public/templates/schedule/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "schedule",
-      sourceId: "...", // The ID of the Source this Schedule uses - e.g. `sourceId: "google_sheet_source"`
+      sourceId: {{{sourceId}}}, // The ID of the Source this Schedule uses - e.g. `sourceId: "google_sheet_source"`
       recurring: true, // should this Schedule regularly run?
       recurringFrequency: 1000 * 60 * 15, // 15 minutes, in ms
     },

--- a/plugins/@grouparoo/google-sheets/public/templates/source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/google-sheets/public/templates/source/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-table-import",
-      appId: "...", // Set this value to the ID of the App this Source uses - e.g. `appId: "google_sheet_app"`
+      appId: {{{appId}}}, // Set this value to the ID of the App this Source uses - e.g. `appId: "google_sheet_app"`
       options: {
         sheet_url: "https://sheets.google.com/...", // The URL of your sheet.
       },

--- a/plugins/@grouparoo/google-sheets/src/lib/sheet-import/templates.ts
+++ b/plugins/@grouparoo/google-sheets/src/lib/sheet-import/templates.ts
@@ -32,6 +32,7 @@ export class GoogleSheetSourceTemplate extends ConfigTemplate {
     this.description = `Config for a Google Sheets Source`;
     this.files = [path.join(templateRoot, "source", "*.template")];
     this.destinationDir = "sources";
+    this.parentId = "appId";
   }
 
   async run({ params }) {
@@ -47,6 +48,7 @@ export class GoogleSheetScheduleTemplate extends ConfigTemplate {
     this.description = `Config for a Google Sheets Schedule`;
     this.files = [path.join(templateRoot, "schedule", "*.template")];
     this.destinationDir = "schedules";
+    this.parentId = "sourceId";
   }
 
   async run({ params }) {
@@ -62,6 +64,7 @@ export class GoogleSheetPropertyTemplate extends ConfigTemplate {
     this.description = `Config for a Google Sheets Property`;
     this.files = [path.join(templateRoot, "property", "*.template")];
     this.destinationDir = "properties";
+    this.parentId = "sourceId";
   }
 
   async run({ params }) {

--- a/plugins/@grouparoo/hubspot/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/hubspot/public/templates/destination/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "...", // The ID of the App this Source uses - e.g. `appId: "hubspot_app"`
+      appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "hubspot_app"`
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {},

--- a/plugins/@grouparoo/intercom/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/intercom/public/templates/destination/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "...", // The ID of the App this Source uses - e.g. `appId: "intercom_app"`
+      appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "intercom_app"`
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {

--- a/plugins/@grouparoo/mailchimp/public/templates/destination/email/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/destination/email/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "...", // The ID of the App this Source uses - e.g. `appId: "mailchimp_app"`
+      appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "mailchimp_app"`
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {

--- a/plugins/@grouparoo/mailchimp/public/templates/destination/id/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/destination/id/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "...", // The ID of the App this Source uses - e.g. `appId: "mailchimp_app"`
+      appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "mailchimp_app"`
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {

--- a/plugins/@grouparoo/mailchimp/public/templates/property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/property/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "property",
-      sourceId: "...", // The ID of the Source that this Property belongs to - e.g. `sourceId: "mailchimp_source"`
+      sourceId: {{{sourceId}}}, // The ID of the Source that this Property belongs to - e.g. `sourceId: "mailchimp_source"`
       type: "string", // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: false, // Will Profiles have unique records for this Property?
       identifying: false, // Should we consider this property Identifying in the UI? Only one Property can be identifying.

--- a/plugins/@grouparoo/mailchimp/public/templates/schedule/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/schedule/{{{id}}}.js.template
@@ -4,7 +4,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       class: "schedule",
-      sourceId: "...", // The id of the Source this Schedule uses - e.g. `sourceId: "mailchimp_source"`
+      sourceId: {{{sourceId}}}, // The id of the Source this Schedule uses - e.g. `sourceId: "mailchimp_source"`
       recurring: true, // should this Schedule regularly run?
       recurringFrequency: 1000 * 60 * 15, // 15 minutes, in ms
     },

--- a/plugins/@grouparoo/mailchimp/public/templates/source/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/source/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       id: {{{id}}},
       name: {{{id}}},
       type: "{{{__pluginName}}}-import",
-      appId: "...", // Set this value to the ID of the App this Source uses - e.g. `appId: "mailchimp_app"`
+      appId: {{{appId}}}, // Set this value to the ID of the App this Source uses - e.g. `appId: "mailchimp_app"`
       options: {
         listId: "..." // The Mailchimp List ID (https://mailchimp.com/help/find-audience-id/)
       },

--- a/plugins/@grouparoo/mailchimp/src/lib/templates.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/templates.ts
@@ -25,6 +25,7 @@ export class MailchimpSourceTemplate extends ConfigTemplate {
     this.description = `Config for a Mailchimp Source`;
     this.files = [path.join(templateRoot, "source", "*.template")];
     this.destinationDir = "sources";
+    this.parentId = "appId";
   }
 
   async run({ params }) {
@@ -40,6 +41,7 @@ export class MailchimpScheduleTemplate extends ConfigTemplate {
     this.description = `Config for a Mailchimp Schedule`;
     this.files = [path.join(templateRoot, "schedule", "*.template")];
     this.destinationDir = "schedules";
+    this.parentId = "sourceId";
   }
 
   async run({ params }) {
@@ -55,6 +57,7 @@ export class MailchimpPropertyTemplate extends ConfigTemplate {
     this.description = `Config for a Mailchimp Property`;
     this.files = [path.join(templateRoot, "property", "*.template")];
     this.destinationDir = "properties";
+    this.parentId = "sourceId";
   }
 
   async run({ params }) {
@@ -71,6 +74,7 @@ export class MailchimpIdDestinationTemplate extends ConfigTemplate {
     this.description = `Config for a Mailchimp ID Destination. Note: Use the email destination unless you know you need this.`;
     this.files = [path.join(templateRoot, "destination", "id", "*.template")];
     this.destinationDir = "destinations";
+    this.parentId = "appId";
   }
 
   async run({ params }) {
@@ -88,6 +92,7 @@ export class MailchimpEmailDestinationTemplate extends ConfigTemplate {
       path.join(templateRoot, "destination", "email", "*.template"),
     ];
     this.destinationDir = "destinations";
+    this.parentId = "appId";
   }
 
   async run({ params }) {

--- a/plugins/@grouparoo/marketo/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/marketo/public/templates/destination/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "...", // The ID of the App this Source uses - e.g. `appId: "marketo_app"`
+      appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "marketo_app"`
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {},

--- a/plugins/@grouparoo/mysql/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mysql/public/templates/destination/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "...", // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
+      appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {

--- a/plugins/@grouparoo/postgres/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/postgres/public/templates/destination/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "...", // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
+      appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {

--- a/plugins/@grouparoo/redshift/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/redshift/public/templates/destination/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "...", // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
+      appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
       groupId: "...", // The ID of the group whose members you want to export - e.g. `appId: "high_value_customers"`
 
       options: {

--- a/plugins/@grouparoo/salesforce/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/salesforce/public/templates/destination/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-objects-export",
-      appId: "...", // The ID of the App this Source uses - e.g. `appId: "salesforce_app"`
+      appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "salesforce_app"`
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       // Note that depending on your Salesforce configuration, not all options are required

--- a/plugins/@grouparoo/zendesk/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/zendesk/public/templates/destination/{{{id}}}.js.template
@@ -5,7 +5,7 @@ exports.default = async function buildConfig() {
       name: {{{id}}},
       class: "destination",
       type: "{{{__pluginName}}}-export",
-      appId: "...", // The ID of the App this Source uses - e.g. `appId: "zendesk_app"`
+      appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "zendesk_app"`
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
       options: {},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,7 +167,7 @@ importers:
       '@types/validator': 13.1.3
       actionhero: 25.0.6
       ah-next-plugin: 0.5.0_actionhero@25.0.6
-      ah-sequelize-plugin: 3.0.1_7f390017760487b9a6ab263f6def5edc
+      ah-sequelize-plugin: 3.0.1_96190f3d4c64c35bb4d86bd12f189f29
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
       colors: 1.4.0
@@ -194,7 +194,7 @@ importers:
       prettier: 2.2.1
       reflect-metadata: 0.1.13
       sequelize: 6.5.0_8222121c541e29ff6dc977ab76aac44f
-      sequelize-typescript: 2.0.0_ae0c0f080b5f5ab07bde2879c1e21bc5
+      sequelize-typescript: 2.1.0_ae0c0f080b5f5ab07bde2879c1e21bc5
       sqlite3: 5.0.1
       ts-node: 9.1.1_typescript@4.1.5
       umzug: 2.3.0
@@ -255,7 +255,7 @@ importers:
       prettier: 2.2.1
       reflect-metadata: 0.1.13
       sequelize: 6.5.0
-      sequelize-typescript: 2.0.0
+      sequelize-typescript: 2.1.0
       sqlite3: 5.0.1
       ts-jest: 26.5.1
       ts-node: 9.1.1
@@ -444,7 +444,7 @@ importers:
       typescript: 4.1.5
   plugins/@grouparoo/files-s3:
     dependencies:
-      aws-sdk: 2.842.0
+      aws-sdk: 2.843.0
       fs-extra: 9.1.0
     devDependencies:
       '@grouparoo/core': link:../../../core
@@ -460,7 +460,7 @@ importers:
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 25.0.6
-      aws-sdk: 2.842.0
+      aws-sdk: 2.843.0
       fs-extra: 9.1.0
       jest: 26.6.3
       prettier: 2.2.1
@@ -3837,11 +3837,11 @@ packages:
       react-dom: ^16.6.0 || ^17
     resolution:
       integrity: sha512-Xkyag+yQpnpr/QRoRX3S3FhvrW0oxLCKQ9fz+NGA+BO2HdZVZJANnXw6MVefWZRIkphDZSyqKVVo6uc8TOwJKg==
-  /ah-sequelize-plugin/3.0.1_7f390017760487b9a6ab263f6def5edc:
+  /ah-sequelize-plugin/3.0.1_96190f3d4c64c35bb4d86bd12f189f29:
     dependencies:
       actionhero: 25.0.6
       sequelize: 6.5.0_8222121c541e29ff6dc977ab76aac44f
-      sequelize-typescript: 2.0.0_ae0c0f080b5f5ab07bde2879c1e21bc5
+      sequelize-typescript: 2.1.0_ae0c0f080b5f5ab07bde2879c1e21bc5
       umzug: 3.0.0-beta.5
     dev: false
     engines:
@@ -4252,7 +4252,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
-  /aws-sdk/2.842.0:
+  /aws-sdk/2.843.0:
     dependencies:
       buffer: 4.9.2
       events: 1.1.1
@@ -4267,7 +4267,7 @@ packages:
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha512-9vjVDxsLzNI79JChUgEHDUpv2obkTe35F3oGFGViKsf4C7xlOexzKOCfTRNcgzh0MON6rVDFpYBtF2LlEyDGKg==
+      integrity: sha512-wTHKHDzblaNjWsdCuKTnfAr2zSLgN+Nc2yGpqPxnr7emEQG4V3B0gYEfV9rvv9dVq5Jw8Y1q6VNWS6k8oclnSw==
   /aws-sign2/0.7.0:
     resolution:
       integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
@@ -4678,7 +4678,7 @@ packages:
   /buffer/4.9.2:
     dependencies:
       base64-js: 1.5.1
-      ieee754: 1.1.13
+      ieee754: 1.2.1
       isarray: 1.0.0
     resolution:
       integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
@@ -7536,17 +7536,6 @@ packages:
     optional: true
     resolution:
       integrity: sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
-  /glob/7.1.2:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.0.4
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: false
-    resolution:
-      integrity: sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
   /glob/7.1.6:
     dependencies:
       fs.realpath: 1.0.0
@@ -8106,6 +8095,7 @@ packages:
     resolution:
       integrity: sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
   /ieee754/1.1.13:
+    dev: false
     resolution:
       integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
   /ieee754/1.2.1:
@@ -13657,24 +13647,23 @@ packages:
       node: '>= 10.0.0'
     resolution:
       integrity: sha512-4YwEw3ZgK/tY/so+GfnSgXkdwIJJ1I32uZJztIEgZeAO6HMgj64OzySbWLgxj+tXhZCJnzRfkY9gINw8Ft8ZMg==
-  /sequelize-typescript/2.0.0_ae0c0f080b5f5ab07bde2879c1e21bc5:
+  /sequelize-typescript/2.1.0_ae0c0f080b5f5ab07bde2879c1e21bc5:
     dependencies:
       '@types/node': 14.14.27
       '@types/validator': 13.1.3
-      glob: 7.1.2
+      glob: 7.1.6
       reflect-metadata: 0.1.13
       sequelize: 6.5.0_8222121c541e29ff6dc977ab76aac44f
     dev: false
     engines:
       node: '>=10.0.0'
     peerDependencies:
-      '@types/bluebird': '*'
       '@types/node': '*'
       '@types/validator': '*'
       reflect-metadata: '*'
-      sequelize: ^6.0.0
+      sequelize: '>=6.2.0'
     resolution:
-      integrity: sha512-4nCX18iNAkuRCgxsFOOH9FsUyeqsqLuj7VIZPOWgdRT8ZeQkQl3SgU5MXlji5o2NVekaV9QQzSE0D/6xtUKCmQ==
+      integrity: sha512-wwPxydBQ/wIZ92pFxDQEAhW8uRHqwFZGm6JkPmpsCjrODWrH8TANZiOCjwGouygFMgBwCNK91RNwLe5TYoy5pg==
   /sequelize/6.5.0:
     dependencies:
       debug: 4.3.1
@@ -16091,7 +16080,7 @@ packages:
       integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
   /xml2js/0.4.19:
     dependencies:
-      sax: 1.2.1
+      sax: 1.2.4
       xmlbuilder: 9.0.7
     dev: false
     resolution:


### PR DESCRIPTION
This PR now requires a parent id when creating Sources, Properties, Destinations, and Team Members with the `grouparoo generate` command.

```bash
grouparoo generate postgres:app data_warehouse # no change
grouparoo generate postgres:table:source users_table --parent data_warehouse # data_warehouse required
```

This PR does not check that the supplied parent IDs exist.  Otherwise, we would require everyone to `grouparoo apply` constantly... the `grouparoo validate` and `grouparoo apply` commands will check.

- [x] what do we do about destinations? - Only `appId` is the 'parent', groups are left as `...` 
- [x] tests
