### PR TITLE
Remove ability to disable SCHEDULER

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -716,7 +716,6 @@ jobs:
             PORT: 3000
             GROUPAROO_TELEMETRY_ENABLED: "false"
             WEB_SERVER: "true"
-            SCHEDULER: "true"
             WORKERS: 1
   test-staging-enterprise:
     docker:
@@ -760,7 +759,6 @@ jobs:
             PORT: 3000
             GROUPAROO_TELEMETRY_ENABLED: "false"
             WEB_SERVER: "true"
-            SCHEDULER: "true"
             WORKERS: 1
   test-plugin-app-templates:
     docker:

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web:    cd apps/$GROUPAROO_MONOREPO_APP && WEB_SERVER=true  SCHEDULER=false WORKERS=0 npm start
-worker: cd apps/$GROUPAROO_MONOREPO_APP && WEB_SERVER=false SCHEDULER=true  WORKERS=5 npm start
+web:    cd apps/$GROUPAROO_MONOREPO_APP && WEB_SERVER=true WORKERS=0 npm start
+worker: cd apps/$GROUPAROO_MONOREPO_APP && WEB_SERVER=false WORKERS=5 npm start

--- a/apps/staging-community/.env.example
+++ b/apps/staging-community/.env.example
@@ -6,7 +6,6 @@ PORT=3000
 WEB_URL=http://localhost:3000
 
 WEB_SERVER=true
-SCHEDULER=true
 WORKERS=1
 SERVER_TOKEN=change_me
 

--- a/apps/staging-enterprise/.env.example
+++ b/apps/staging-enterprise/.env.example
@@ -6,7 +6,6 @@ PORT=3000
 WEB_URL=http://localhost:3000
 
 WEB_SERVER=true
-SCHEDULER=true
 WORKERS=1
 SERVER_TOKEN=change_me
 

--- a/cli/templates/.env
+++ b/cli/templates/.env
@@ -6,7 +6,6 @@ PORT=3000
 WEB_URL=http://localhost:3000
 
 WEB_SERVER=true
-SCHEDULER=true
 WORKERS=1
 SERVER_TOKEN=my-serer-token
 

--- a/core/__tests__/bin/run.ts
+++ b/core/__tests__/bin/run.ts
@@ -20,9 +20,8 @@ describe("bin/run", () => {
     spy.mockRestore();
   });
 
-  test("workers and scheduler are required", async () => {
+  test("workers are required", async () => {
     process.env.WORKERS = "0";
-    process.env.SCHEDULER = "false";
 
     const command = new RunCLI();
     await expect(command.run({ params: {} })).rejects.toThrow();

--- a/core/src/config/tasks.ts
+++ b/core/src/config/tasks.ts
@@ -5,7 +5,7 @@ export const DEFAULT = {
 
       // Run node as a scheduler to promote delayed tasks if there is at least
       // one worker.
-      scheduler: (parseInt(process.env.WORKERS) || 0) > 0,
+      scheduler: (process.env.WORKERS ? parseInt(process.env.WORKERS) : 0) > 0,
       // what queues should the taskProcessors work?
       queues: async () => {
         const { api } = await import("actionhero"); // this needs to be async loaded as we are within the config system, to avoid circular dependencies

--- a/core/src/config/tasks.ts
+++ b/core/src/config/tasks.ts
@@ -4,7 +4,7 @@ export const DEFAULT = {
       _toExpand: false,
 
       // Should this node run a scheduler to promote delayed tasks?
-      scheduler: process.env.SCHEDULER === "true",
+      scheduler: true,
       // what queues should the taskProcessors work?
       queues: async () => {
         const { api } = await import("actionhero"); // this needs to be async loaded as we are within the config system, to avoid circular dependencies

--- a/core/src/config/tasks.ts
+++ b/core/src/config/tasks.ts
@@ -3,8 +3,9 @@ export const DEFAULT = {
     return {
       _toExpand: false,
 
-      // Should this node run a scheduler to promote delayed tasks?
-      scheduler: true,
+      // Run node as a scheduler to promote delayed tasks if there is at least
+      // one worker.
+      scheduler: (parseInt(process.env.WORKERS) || 0) > 0,
       // what queues should the taskProcessors work?
       queues: async () => {
         const { api } = await import("actionhero"); // this needs to be async loaded as we are within the config system, to avoid circular dependencies

--- a/tools/merger/data/ci/apps/job.yml.template
+++ b/tools/merger/data/ci/apps/job.yml.template
@@ -1,4 +1,4 @@
-{{{job_name}}}:
+  {{{job_name}}}:
     docker:
       - image: circleci/node:14
         auth:

--- a/tools/merger/data/ci/apps/job.yml.template
+++ b/tools/merger/data/ci/apps/job.yml.template
@@ -1,4 +1,4 @@
-  {{{job_name}}}:
+{{{job_name}}}:
     docker:
       - image: circleci/node:14
         auth:
@@ -42,6 +42,5 @@
             PORT: 3000
             GROUPAROO_TELEMETRY_ENABLED: "false"
             WEB_SERVER: "true"
-            SCHEDULER: "true"
             WORKERS: 1
 {{{custom_test}}}


### PR DESCRIPTION
In digging through this, it seems like we're using `SCHEDULER` as `false` when running for the web, and `true` when using for web workers. This makes me wonder if this is actually a good/safe move? (I left inline comments.)

---

Other PRs to merge **after** this one:

- grouparoo/www.grouparoo.com#226 (doc references)
- grouparoo/app-example#108 (example app)

Though we may want to hold on merging those two until 0.2.2 is released since the absence of `SCHEDULER` will cause problems with previous versions.

