### PR TITLE
Get core version exactly from installed package.json for `grouparoo install`

### DIFF
--- a/cli/src/lib/install.ts
+++ b/cli/src/lib/install.ts
@@ -7,8 +7,7 @@ import { ensurePackageJSON } from "../utils/ensurePackageJSON";
 import { readPackageJSON } from "../utils/readPackageJSON";
 import { isGrouparooPlugin } from "../utils/isGrouparooPlugin";
 import { getCoreVersion } from "../utils/getCoreVersion";
-
-const JSON_SPACER = 2;
+import { JSONUtils } from "../utils/JSONUtils";
 
 export default async function Update(pkg: string) {
   const workDir: string = process.env.INIT_CWD;
@@ -58,7 +57,7 @@ export default async function Update(pkg: string) {
       plugins.sort();
       fs.writeFileSync(
         packageFile,
-        JSON.stringify(pkgJSONContents, null, JSON_SPACER)
+        JSON.stringify(pkgJSONContents, null, JSONUtils.spacer)
       );
     }
   }

--- a/cli/src/lib/uninstall.ts
+++ b/cli/src/lib/uninstall.ts
@@ -5,8 +5,7 @@ import { buildLogger } from "../utils/logger";
 import { ensurePath } from "../utils/ensurePath";
 import { ensurePackageJSON } from "../utils/ensurePackageJSON";
 import { readPackageJSON } from "../utils/readPackageJSON";
-
-const JSON_SPACER = 2;
+import { JSONUtils } from "../utils/JSONUtils";
 
 export default async function Update(pkg: string) {
   const workDir: string = process.env.INIT_CWD;
@@ -37,7 +36,7 @@ export default async function Update(pkg: string) {
     plugins.sort();
     fs.writeFileSync(
       packageFile,
-      JSON.stringify(pkgJSONContents, null, JSON_SPACER)
+      JSON.stringify(pkgJSONContents, null, JSONUtils.spacer)
     );
   }
 

--- a/cli/src/utils/JSONUtils.ts
+++ b/cli/src/utils/JSONUtils.ts
@@ -1,0 +1,3 @@
+export namespace JSONUtils {
+  export const spacer = 2;
+}

--- a/cli/src/utils/getCoreVersion.ts
+++ b/cli/src/utils/getCoreVersion.ts
@@ -2,13 +2,27 @@ import path from "path";
 import fs from "fs";
 import { readPackageJSON } from "./readPackageJSON";
 
+/**
+ * Get the exact version of @grouparoo/core installed in this project.  Defaults to 'latest'
+ * @param workDir
+ */
 export function getCoreVersion(workDir: string) {
   let coreVersion = "latest";
-  const packageFile = path.join(workDir, "package.json");
-  if (fs.existsSync(packageFile)) {
-    let pkgJSONContents = readPackageJSON(packageFile);
-    if (pkgJSONContents.dependencies["@grouparoo/core"]) {
-      coreVersion = pkgJSONContents.dependencies["@grouparoo/core"].trim();
+
+  try {
+    // prefer to get the exact version installed
+    const corePath = require.resolve("@grouparoo/core", { paths: [workDir] });
+    const corePackageFile = path.join(corePath, "..", "..", "package.json");
+    const corePkgJSONContents = readPackageJSON(corePackageFile);
+    coreVersion = corePkgJSONContents.version;
+  } catch (error) {
+    // otherwise get the version listed in the top-level package.json
+    const localPackageFile = path.join(workDir, "package.json");
+    if (fs.existsSync(localPackageFile)) {
+      let pkgJSONContents = readPackageJSON(localPackageFile);
+      if (pkgJSONContents.dependencies["@grouparoo/core"]) {
+        coreVersion = pkgJSONContents.dependencies["@grouparoo/core"].trim();
+      }
     }
   }
 


### PR DESCRIPTION
When `grouparoo install` is run, we will match the version of the plugin being installed with that of `@grouparoo/core` exactly, ignoring `^`, `~`, or other range identifiers in `package.json`.