### PR TITLE
Prevent the application from starting if there are code-config errors

### DIFF
--- a/core/__tests__/bin/validate.ts
+++ b/core/__tests__/bin/validate.ts
@@ -62,6 +62,8 @@ describe("bin/config-validate", () => {
       const command = new Validate();
       const toStop = await command.run({ params: {} });
       expect(toStop).toBe(true);
+      await helper.sleep(100);
+
       const output = readLogFile().join(" ");
       expect(output).toContain(
         "✅ Validation succeeded - 13 config objects OK!"
@@ -87,6 +89,8 @@ describe("bin/config-validate", () => {
       const command = new Validate();
       const toStop = await command.run({ params: {} });
       expect(toStop).toBe(true);
+      await helper.sleep(100);
+
       const output = readLogFile().join(" ");
       expect(output).toContain("❌ Validation failed - 1 validation error");
     });

--- a/core/__tests__/bin/validate.ts
+++ b/core/__tests__/bin/validate.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { readFileSync, unlinkSync, existsSync } from "fs";
+import { readFileSync, existsSync, writeFileSync } from "fs";
 import { Validate } from "../../src/bin/validate";
 import os from "os";
 import { join } from "path";
@@ -19,18 +19,15 @@ function readLogFile() {
   return messages.slice(Math.max(messages.length - 100, 1));
 }
 function clearTestLog() {
-  if (!existsSync(filename)) return;
-  return unlinkSync(filename);
+  writeFileSync(filename, "");
 }
 
 describe("bin/config-validate", () => {
   beforeAll(async () => {
-    clearTestLog();
     const { Process } = await import("actionhero");
     actionhero = new Process();
     await actionhero.initialize();
     await helper.enableTestPlugin();
-    await helper.truncate();
   }, helper.setupTime);
 
   let messages = [];
@@ -57,6 +54,8 @@ describe("bin/config-validate", () => {
         __dirname,
         "../fixtures/codeConfig/initial"
       );
+      await helper.truncate();
+      clearTestLog();
     });
 
     test("the validate command can be run", async () => {
@@ -80,6 +79,8 @@ describe("bin/config-validate", () => {
         __dirname,
         "../fixtures/codeConfig/error-app"
       );
+      await helper.truncate();
+      clearTestLog();
     });
 
     test("the validate command will fail for invalid configs", async () => {

--- a/core/src/grouparoo.ts
+++ b/core/src/grouparoo.ts
@@ -4,7 +4,7 @@ async function main() {
   const { Process, log, api } = await import("actionhero");
 
   log(
-    `Starting Grouparoo ${getCoreVersion()} on node.js ${getNodeVersion()}`,
+    `Starting Grouparoo v${getCoreVersion()} on node.js ${getNodeVersion()}`,
     "notice"
   );
 

--- a/core/src/initializers/codeConfig.ts
+++ b/core/src/initializers/codeConfig.ts
@@ -26,7 +26,10 @@ export class CodeConfig extends Initializer {
 
   async start() {
     const configDir = getConfigDir();
-    await CLS.wrap(async () => loadConfigDirectory(configDir));
+    await CLS.wrap(async () => {
+      const { errors } = await loadConfigDirectory(configDir);
+      if (errors.length > 0) throw new Error("code config error");
+    });
 
     // after this point in the Actionhero boot lifecycle, locked models cannot be changed
     api.codeConfig.allowLockedModelChanges = false;


### PR DESCRIPTION
```
$ grouparoo start

notice: Modified your runtime environment with /Users/evan/workspace/grouparoo/grouparoo/apps/staging-enterprise/.env

🦘 Grouparoo: start

notice: Starting Grouparoo 0.2.2 on node.js v14.12.0
notice: pid: 95535
notice: environment: development
info: *** Starting Actionhero ***
notice: [ app ] testing app data_warehouse (data_warehouse) threw error: getaddrinfo ENOTFOUND localhostX
error: [ config ] error with app `data_warehouse` (data_warehouse): Error: error testing app data_warehouse (data_warehouse) - getaddrinfo ENOTFOUND localhostX
emerg: Exception occurred in initializer `codeConfig` during start
emerg: Error with initializer step: "start"
notice: stopping process...
notice: Stopping server: web
notice: Stopping server: websocket
notice: *** Actionhero Stopped ***
```