### PR TITLE
In-app help page

### DIFF
--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -176,6 +176,7 @@ export class NavigationList extends OptionallyAuthenticatedAction {
         href: "/account",
       });
       bottomMenuItems.push({ type: "link", title: "About", href: "/about" });
+      bottomMenuItems.push({ type: "link", title: "Help", href: "/help" });
 
       bottomMenuItems.push({ type: "divider" });
 

--- a/ui/ui-community/pages/help.tsx
+++ b/ui/ui-community/pages/help.tsx
@@ -1,0 +1,1 @@
+export { default } from "@grouparoo/ui-components/pages/help";

--- a/ui/ui-components/pages/help.tsx
+++ b/ui/ui-components/pages/help.tsx
@@ -1,0 +1,84 @@
+import Head from "next/head";
+import { Row, Col, Alert, Button } from "react-bootstrap";
+
+export default function Page() {
+  const supportPageURL = "https://www.grouparoo.com/support";
+
+  return (
+    <>
+      <Head>
+        <title>Grouparoo: Help</title>
+      </Head>
+      <h1>Need Help?</h1>
+      <Row>
+        <Col>
+          <p>
+            Grouparoo is an open-source project.{" "}
+            <b>
+              We strive to respond to bugs, questions, and problems
+              transparently in the open
+            </b>
+            . We believe this this is important so that future Grouparoo users
+            can find previous questions and answers to help themselves,
+            ultimately leading to a stronger and more informed community.
+          </p>
+        </Col>
+      </Row>
+      <h3>Support Channels:</h3>
+      <br />
+      <Row style={{ textAlign: "center" }}>
+        <Col>
+          <Button
+            size="sm"
+            variant="outline-primary"
+            href="https://www.grouparoo.com/docs"
+            target="_blank"
+          >
+            Documentation
+          </Button>
+        </Col>
+        <Col>
+          <Button
+            size="sm"
+            variant="outline-primary"
+            href="https://github.com/grouparoo/grouparoo/issues/new/choose"
+            target="_blank"
+          >
+            Github Issue
+          </Button>
+        </Col>
+        <Col>
+          <Button
+            size="sm"
+            variant="outline-primary"
+            href="https://github.com/grouparoo/grouparoo/discussions"
+            target="_blank"
+          >
+            Forum
+          </Button>
+        </Col>
+        <Col>
+          <Button
+            size="sm"
+            variant="outline-primary"
+            href="https://www.grouparoo.com/docs/community"
+            target="_blank"
+          >
+            Grouparoo Community
+          </Button>
+        </Col>
+      </Row>
+      <br /> <br />
+      <Row style={{ textAlign: "center" }}>
+        <Col>
+          <Alert variant="warning">
+            You can learn more about obtaining support for Grouparoo at{" "}
+            <a target="_blank" href={supportPageURL}>
+              {supportPageURL}
+            </a>
+          </Alert>
+        </Col>
+      </Row>
+    </>
+  );
+}

--- a/ui/ui-components/pages/help.tsx
+++ b/ui/ui-components/pages/help.tsx
@@ -18,7 +18,7 @@ export default function Page() {
               We strive to respond to bugs, questions, and problems
               transparently in the open
             </b>
-            . We believe this this is important so that future Grouparoo users
+            . We believe that this is important so that future Grouparoo users
             can find previous questions and answers to help themselves,
             ultimately leading to a stronger and more informed community.
           </p>

--- a/ui/ui-enterprise/pages/help.tsx
+++ b/ui/ui-enterprise/pages/help.tsx
@@ -1,0 +1,1 @@
+export { default } from "@grouparoo/ui-components/pages/help";


### PR DESCRIPTION
<img width="1178" alt="Screen Shot 2021-02-19 at 2 55 19 PM" src="https://user-images.githubusercontent.com/303226/108570341-7cec1280-72c2-11eb-894b-57362b9638b6.png">

This PR adds a `/help` page to the app, and adds a link to the navigation.  This new page is available in both the community and enterprise editions of the UI