### PR TITLE
Batch Generator Descriptions

### DIFF
--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -220,17 +220,11 @@ Commands:
   logTemplateAndOptions(template: ConfigTemplate, compact = false) {
     const inputs = template.inputs;
 
-    if (!compact) {
+    if (!inputs["id"]) {
       inputs["id"] = {
         required: true,
         description: "The id to use for this new object.",
       };
-      if (template.parentId) {
-        inputs["parent"] = {
-          required: true,
-          description: this.inputs["parent"].description,
-        };
-      }
     }
 
     if (compact) {

--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -59,7 +59,7 @@ Commands:
         required: false,
         letter: "w",
         description:
-          'For batch generators, what additional objects should we create? Use commas to separate names (--with "id,first_name,last_name") or * for all (`--with *`). Default is ``',
+          'For batch generators, what additional objects should we create? Use commas to separate names (--with "id,first_name,last_name") or "*" for all (`--with "*"`). Default is ``',
         default: "",
       },
       mapping: {

--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -59,8 +59,8 @@ Commands:
         required: false,
         letter: "w",
         description:
-          'For batch generators, what additional objects should we create? Use commas to separate names (--with "id,first_name,last_name"). Default  is `*`',
-        default: "*",
+          'For batch generators, what additional objects should we create? Use commas to separate names (--with "id,first_name,last_name") or * for all (`--with *`). Default is ``',
+        default: "",
       },
       mapping: {
         required: false,

--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -53,26 +53,26 @@ Commands:
         required: false,
         letter: "f",
         description:
-          "For complex generators, where should we source the objects from?",
+          "For batch generators, where should we read the objects from?",
       },
       with: {
         required: false,
         letter: "w",
         description:
-          'For complex generators, what additional objects should we create? Use commas to separate names (--with "id,first_name,last_name").',
+          'For batch generators, what additional objects should we create? Use commas to separate names (--with "id,first_name,last_name"). Default  is `*`',
         default: "*",
       },
       mapping: {
         required: false,
         letter: "m",
         description:
-          'For complex generators, how should we map this object? The remote key precedes the Grouparoo Property name. Use = to set the pair (--mapping "id=user_id").',
+          'For batch generators, how should we map this object? The remote key precedes the Grouparoo Property name. Use = to set the pair (--mapping "id=user_id").',
       },
       "high-water-mark": {
         required: false,
         letter: "H",
         description:
-          "For complex generators, what should we use for the high-water-mark?",
+          "For batch generators, what should we use for the high-water-mark?",
       },
       overwrite: {
         required: true,
@@ -89,7 +89,7 @@ Commands:
     grouparoo generate postgres:table:source users_table \\
       --parent data_warehouse
 
-  Complex Source Generation (needs parent app to be \`applied\`):
+  Batch Source Generation (needs parent app to be applied first):
     grouparoo generate postgres:table:source users_table \\
       --parent data_warehouse \\
       --from users \\

--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -161,7 +161,7 @@ Commands:
     try {
       fileData = await template.run({ params: preparedParams });
     } catch (error) {
-      console.error(error);
+      // console.error(error);
       return this.fatalError(error.message);
     }
 

--- a/core/src/classes/configTemplate.ts
+++ b/core/src/classes/configTemplate.ts
@@ -34,14 +34,7 @@ export abstract class ConfigTemplate {
 
   constructor() {
     this.params = {};
-    this.inputs = {
-      id: {
-        required: true,
-        description:
-          "The ID of the new object being generated.  Will be used to construct the object's id",
-        formatter: (p) => this.formatId(p),
-      },
-    };
+    this.inputs = {};
   }
 
   /** The main 'do something' method.  Throw is there was an error */

--- a/core/src/templates/apiKey.ts
+++ b/core/src/templates/apiKey.ts
@@ -6,6 +6,13 @@ export class ApiKeyTemplate extends ConfigTemplate {
     super();
     this.name = "apikey";
     this.description = "Config for a Grouparoo API Key";
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new API Key`,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [
       path.join(
         __dirname,

--- a/core/src/templates/events.ts
+++ b/core/src/templates/events.ts
@@ -16,6 +16,13 @@ export class EventsAppTemplate extends ConfigTemplate {
     super();
     this.name = "events:app";
     this.description = "Config for a Grouparoo App based on Events";
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new App`,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [path.join(templateRoot, "app", "*.template")];
     this.destinationDir = "apps";
   }
@@ -30,6 +37,18 @@ export class EventsSourceTemplate extends ConfigTemplate {
     super();
     this.name = "events:source";
     this.description = "Config for a Grouparoo Source based on an Events App";
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new App`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of the Events App to use, e.g: \`--parent events_app\``,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [path.join(templateRoot, "source", "*.template")];
     this.destinationDir = "sources";
     this.parentId = "appId";
@@ -46,6 +65,18 @@ export class EventsPropertyTemplate extends ConfigTemplate {
     this.name = "events:property";
     this.description =
       "Config for a Grouparoo Property based on an Events Source";
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Property`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of Source to use, e.g: \`--parent events_source`,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [path.join(templateRoot, "property", "*.template")];
     this.destinationDir = "properties";
     this.parentId = "sourceId";

--- a/core/src/templates/group.ts
+++ b/core/src/templates/group.ts
@@ -6,6 +6,13 @@ export class CalculatedGroupTemplate extends ConfigTemplate {
     super();
     this.name = "group:calculated";
     this.description = "Config for a calculated Grouparoo Group";
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Property`,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [
       path.join(
         __dirname,
@@ -33,6 +40,13 @@ export class ManualGroupTemplate extends ConfigTemplate {
     super();
     this.name = "group:manual";
     this.description = "Config for a manual Grouparoo Group";
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Property`,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [
       path.join(
         __dirname,

--- a/core/src/templates/manual.ts
+++ b/core/src/templates/manual.ts
@@ -16,6 +16,13 @@ export class ManualAppTemplate extends ConfigTemplate {
     super();
     this.name = "manual:app";
     this.description = "Config for a Grouparoo App with manual property values";
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The name of this new App`,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [path.join(templateRoot, "app", "*.template")];
     this.destinationDir = "apps";
   }
@@ -30,6 +37,18 @@ export class ManualSourceTemplate extends ConfigTemplate {
     super();
     this.name = "manual:source";
     this.description = "Config for a Grouparoo Source based on a Manual App";
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Source`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of App to use, e.g: \`--parent manual_app\``,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [path.join(templateRoot, "source", "*.template")];
     this.destinationDir = "sources";
     this.parentId = "appId";
@@ -46,6 +65,18 @@ export class ManualPropertyTemplate extends ConfigTemplate {
     this.name = "manual:property";
     this.description =
       "Config for a Grouparoo Property based on a Manual Source";
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Property`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of Source to use, e.g: \`--parent manual_source\``,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [path.join(templateRoot, "property", "*.template")];
     this.destinationDir = "properties";
     this.parentId = "sourceId";

--- a/core/src/templates/team.ts
+++ b/core/src/templates/team.ts
@@ -6,6 +6,13 @@ export class TeamTemplate extends ConfigTemplate {
     super();
     this.name = "team";
     this.description = "Config for a Grouparoo Team";
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Team`,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [
       path.join(
         __dirname,

--- a/core/src/templates/teamMember.ts
+++ b/core/src/templates/teamMember.ts
@@ -6,6 +6,18 @@ export class TeamMemberTemplate extends ConfigTemplate {
     super();
     this.name = "team:member";
     this.description = "Config for a Grouparoo Team Member";
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Team Member`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of Team to use, e.g: \`--parent admin_team\``,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [
       path.join(
         __dirname,

--- a/plugins/@grouparoo/app-templates/src/app/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/app/templates.ts
@@ -5,6 +5,12 @@ export class AppTemplate extends ConfigTemplate {
     super();
     this.name = `${name}:app`;
     this.description = `Config for a Grouparoo ${name} App`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The name of this new App`,
+      },
+    };
     this.files = files;
     this.destinationDir = "apps";
   }

--- a/plugins/@grouparoo/app-templates/src/app/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/app/templates.ts
@@ -9,6 +9,7 @@ export class AppTemplate extends ConfigTemplate {
       id: {
         required: true,
         description: `The name of this new App`,
+        formatter: (p) => this.formatId(p),
       },
     };
     this.files = files;

--- a/plugins/@grouparoo/app-templates/src/destination/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/destination/templates.ts
@@ -9,6 +9,7 @@ export class DestinationTemplate extends ConfigTemplate {
       id: {
         required: true,
         description: `The name of this new Destination`,
+        formatter: (p) => this.formatId(p),
       },
       parent: {
         required: true,

--- a/plugins/@grouparoo/app-templates/src/destination/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/destination/templates.ts
@@ -5,6 +5,16 @@ export class DestinationTemplate extends ConfigTemplate {
     super();
     this.name = `${name}:destination`;
     this.description = `Config for a ${name} Destination`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The name of this new Destination`,
+      },
+      parent: {
+        required: true,
+        description: `The name of the ${name} App to use for this Source, e.g: \`--parent data_warehouse\``,
+      },
+    };
     this.files = files;
     this.destinationDir = "destinations";
     this.parentId = "appId";

--- a/plugins/@grouparoo/app-templates/src/destination/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/destination/templates.ts
@@ -8,12 +8,12 @@ export class DestinationTemplate extends ConfigTemplate {
     this.inputs = {
       id: {
         required: true,
-        description: `The name of this new Destination`,
+        description: `The id of this new Destination`,
         formatter: (p) => this.formatId(p),
       },
       parent: {
         required: true,
-        description: `The name of the ${name} App to use for this Source, e.g: \`--parent data_warehouse\``,
+        description: `The id of the ${name} App to use for this Destination, e.g: \`--parent data_warehouse\``,
       },
     };
     this.files = files;

--- a/plugins/@grouparoo/app-templates/src/source/query/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/query/templates.ts
@@ -17,7 +17,7 @@ export class QuerySourceTemplate extends ConfigTemplate {
   ) {
     super();
     this.name = `${name}:query:source`;
-    this.description = `Config for a ${name} Query Source. Work with multiple tables and build custom queries for its properties.`;
+    this.description = `Config for a ${name} query Source. Work with multiple tables and build custom queries for its properties.`;
     this.files = files;
     this.destinationDir = "sources";
     this.parentId = "appId";

--- a/plugins/@grouparoo/app-templates/src/source/query/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/query/templates.ts
@@ -18,7 +18,16 @@ export class QuerySourceTemplate extends ConfigTemplate {
     super();
     this.name = `${name}:query:source`;
     this.description = `Config for a ${name} query Source. Work with multiple tables and build custom queries for its properties.`;
-    this.files = files;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The name of this new Source`,
+      },
+      parent: {
+        required: true,
+        description: `The name of the ${name} App to use for this Source, e.g: \`--parent data_warehouse\``,
+      },
+    };
     this.destinationDir = "sources";
     this.parentId = "appId";
   }
@@ -38,6 +47,16 @@ export class QueryPropertyTemplate extends ConfigTemplate {
     super();
     this.name = `${name}:query:property`;
     this.description = `Config for a ${name} Query Property`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The name of this new Property`,
+      },
+      parent: {
+        required: true,
+        description: `The name of the ${name} App to use for this Source, e.g: \`--parent data_warehouse\``,
+      },
+    };
     this.files = files;
     this.destinationDir = "properties";
     this.parentId = "sourceId";

--- a/plugins/@grouparoo/app-templates/src/source/query/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/query/templates.ts
@@ -21,12 +21,12 @@ export class QuerySourceTemplate extends ConfigTemplate {
     this.inputs = {
       id: {
         required: true,
-        description: `The name of this new Source`,
+        description: `The id of this new Source`,
         formatter: (p) => this.formatId(p),
       },
       parent: {
         required: true,
-        description: `The name of the ${name} App to use for this Source, e.g: \`--parent data_warehouse\``,
+        description: `The id of the ${name} App to use for this Source, e.g: \`--parent data_warehouse\``,
       },
     };
     this.destinationDir = "sources";
@@ -51,12 +51,12 @@ export class QueryPropertyTemplate extends ConfigTemplate {
     this.inputs = {
       id: {
         required: true,
-        description: `The name of this new Property`,
+        description: `The id of this new Property`,
         formatter: (p) => this.formatId(p),
       },
       parent: {
         required: true,
-        description: `The name of the ${name} App to use for this Source, e.g: \`--parent data_warehouse\``,
+        description: `The id of the ${name} Source to use for this Property, e.g: \`--parent query_source\``,
       },
     };
     this.files = files;

--- a/plugins/@grouparoo/app-templates/src/source/query/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/query/templates.ts
@@ -22,6 +22,7 @@ export class QuerySourceTemplate extends ConfigTemplate {
       id: {
         required: true,
         description: `The name of this new Source`,
+        formatter: (p) => this.formatId(p),
       },
       parent: {
         required: true,
@@ -51,6 +52,7 @@ export class QueryPropertyTemplate extends ConfigTemplate {
       id: {
         required: true,
         description: `The name of this new Property`,
+        formatter: (p) => this.formatId(p),
       },
       parent: {
         required: true,

--- a/plugins/@grouparoo/app-templates/src/source/table/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/templates.ts
@@ -47,12 +47,12 @@ export class TableSourceTemplate extends ConfigTemplateWithGetters {
     this.inputs = {
       id: {
         required: true,
-        description: `The name of this new Source`,
+        description: `The id of this new Source`,
         formatter: (p) => this.formatId(p),
       },
       parent: {
         required: true,
-        description: `The name of the ${name} App to use for this Source, e.g: \`--parent data_warehouse\``,
+        description: `The id of the ${name} App to use for this Source, e.g: \`--parent data_warehouse\``,
       },
       from: {
         required: false,
@@ -152,12 +152,12 @@ export class TablePropertyTemplate extends ConfigTemplate {
     this.inputs = {
       id: {
         required: true,
-        description: `The name of this new Property`,
+        description: `The id of this new Property`,
         formatter: (p) => this.formatId(p),
       },
       parent: {
         required: true,
-        description: `The name of the ${name} App to use for this Source, e.g: \`--parent data_warehouse\``,
+        description: `The id of the ${name} Source to use for this Property, e.g: \`--parent table_source\``,
       },
     };
     this.files = files;

--- a/plugins/@grouparoo/app-templates/src/source/table/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/templates.ts
@@ -190,7 +190,7 @@ async function loadTablesAndColumns(
     ? JSON.parse(params.with)
         .split(",")
         .map((e) => e.trim())
-    : ["*"];
+    : []; // by default, we use no columns from the source table
 
   if (!appId || !tableName) return map;
 

--- a/plugins/@grouparoo/app-templates/src/source/table/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/templates.ts
@@ -48,6 +48,7 @@ export class TableSourceTemplate extends ConfigTemplateWithGetters {
       id: {
         required: true,
         description: `The name of this new Source`,
+        formatter: (p) => this.formatId(p),
       },
       parent: {
         required: true,
@@ -152,6 +153,7 @@ export class TablePropertyTemplate extends ConfigTemplate {
       id: {
         required: true,
         description: `The name of this new Property`,
+        formatter: (p) => this.formatId(p),
       },
       parent: {
         required: true,

--- a/plugins/@grouparoo/app-templates/src/source/table/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/templates.ts
@@ -42,8 +42,29 @@ export class TableSourceTemplate extends ConfigTemplateWithGetters {
   ) {
     super();
     this.name = `${name}:table:source`;
-    this.description = `Config for a ${name} Table Source. Construct properties from the data in the table without writing SQL.`;
+    this.description = `Config for a ${name} table Source. Construct Sources and Properties without writing SQL.`;
     this.parentId = "appId";
+    this.inputs = {
+      from: {
+        required: false,
+        description: "The table to use for this source, e.g: `--from users`",
+      },
+      mapping: {
+        required: false,
+        description:
+          'The mapping between a column in this table and a Grouparoo Property, e.g: `--mapping "id=user_id"`',
+      },
+      with: {
+        required: false,
+        description:
+          "The names of the columns to create properties from, e.g: `--with users,id,first_name,last_name`. Defaults to '*'",
+      },
+      "high-water-mark": {
+        required: false,
+        description:
+          "The name of the column to uses for this Source's Schedule, e.g: `--high-water-mark updated_at`.",
+      },
+    };
     this.getters = getters;
   }
 

--- a/plugins/@grouparoo/app-templates/src/source/table/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/templates.ts
@@ -45,6 +45,14 @@ export class TableSourceTemplate extends ConfigTemplateWithGetters {
     this.description = `Config for a ${name} table Source. Construct Sources and Properties without writing SQL.`;
     this.parentId = "appId";
     this.inputs = {
+      id: {
+        required: true,
+        description: `The name of this new Source`,
+      },
+      parent: {
+        required: true,
+        description: `The name of the ${name} App to use for this Source, e.g: \`--parent data_warehouse\``,
+      },
       from: {
         required: false,
         description: "The table to use for this source, e.g: `--from users`",
@@ -140,6 +148,16 @@ export class TablePropertyTemplate extends ConfigTemplate {
     super();
     this.name = `${name}:table:property`;
     this.description = `Config for a ${name} Table Property`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The name of this new Property`,
+      },
+      parent: {
+        required: true,
+        description: `The name of the ${name} App to use for this Source, e.g: \`--parent data_warehouse\``,
+      },
+    };
     this.files = files;
     this.destinationDir = "properties";
     this.parentId = "sourceId";

--- a/plugins/@grouparoo/app-templates/src/source/table/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/templates.ts
@@ -194,7 +194,13 @@ async function loadTablesAndColumns(
 
   if (!appId || !tableName) return map;
 
-  const app = await App.findById(appId);
+  let app: App;
+  try {
+    app = await App.findById(appId);
+  } catch (error) {
+    error.message += ".  Did you `grouparoo apply` to add your parent?";
+    throw error;
+  }
   const appOptions = await app.getOptions();
   const connection = await app.getConnection();
 

--- a/plugins/@grouparoo/csv/src/lib/templates.ts
+++ b/plugins/@grouparoo/csv/src/lib/templates.ts
@@ -8,6 +8,13 @@ export class CSVAppTemplate extends ConfigTemplate {
     super();
     this.name = `csv:app`;
     this.description = `Config for a CSV App`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new App`,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [path.join(templateRoot, "app", "*.template")];
     this.destinationDir = "apps";
   }
@@ -23,6 +30,17 @@ export class CSVSourceTemplate extends ConfigTemplate {
     super();
     this.name = `csv:source`;
     this.description = `Config for a CSV Source`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Source`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of the App to use for this Source, e.g: \`--parent csv_app\``,
+      },
+    };
     this.files = [path.join(templateRoot, "source", "*.template")];
     this.destinationDir = "sources";
     this.parentId = "appId";
@@ -40,6 +58,17 @@ export class CSVPropertyTemplate extends ConfigTemplate {
     super();
     this.name = `csv:property`;
     this.description = `Config for a CSV Property`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Property`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of the Source to use for this Property, e.g: \`--parent csv_source\``,
+      },
+    };
     this.files = [path.join(templateRoot, "property", "*.template")];
     this.destinationDir = "properties";
     this.parentId = "sourceId";

--- a/plugins/@grouparoo/google-sheets/src/lib/sheet-import/templates.ts
+++ b/plugins/@grouparoo/google-sheets/src/lib/sheet-import/templates.ts
@@ -15,6 +15,13 @@ export class GoogleSheetAppTemplate extends ConfigTemplate {
     super();
     this.name = `google-sheets:app`;
     this.description = `Config for a Google Sheets App`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new App`,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [path.join(templateRoot, "app", "*.template")];
     this.destinationDir = "apps";
   }
@@ -30,6 +37,17 @@ export class GoogleSheetSourceTemplate extends ConfigTemplate {
     super();
     this.name = `google-sheets:source`;
     this.description = `Config for a Google Sheets Source`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Source`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of the App to use for this Source, e.g: \`--parent google_sheet_app\``,
+      },
+    };
     this.files = [path.join(templateRoot, "source", "*.template")];
     this.destinationDir = "sources";
     this.parentId = "appId";
@@ -47,6 +65,17 @@ export class GoogleSheetPropertyTemplate extends ConfigTemplate {
     super();
     this.name = `google-sheets:property`;
     this.description = `Config for a Google Sheets Property`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Property`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of the Source to use for this Property, e.g: \`--parent google_sheet_source\``,
+      },
+    };
     this.files = [path.join(templateRoot, "property", "*.template")];
     this.destinationDir = "properties";
     this.parentId = "sourceId";

--- a/plugins/@grouparoo/mailchimp/src/lib/templates.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/templates.ts
@@ -8,6 +8,13 @@ export class MailchimpAppTemplate extends ConfigTemplate {
     super();
     this.name = `mailchimp:app`;
     this.description = `Config for a Mailchimp App`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new App`,
+        formatter: (p) => this.formatId(p),
+      },
+    };
     this.files = [path.join(templateRoot, "app", "*.template")];
     this.destinationDir = "apps";
   }

--- a/plugins/@grouparoo/mailchimp/src/lib/templates.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/templates.ts
@@ -23,6 +23,17 @@ export class MailchimpSourceTemplate extends ConfigTemplate {
     super();
     this.name = `mailchimp:source`;
     this.description = `Config for a Mailchimp Source`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Source`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of the App to use for this Source, e.g: \`--parent mailchimp_app\``,
+      },
+    };
     this.files = [path.join(templateRoot, "source", "*.template")];
     this.destinationDir = "sources";
     this.parentId = "appId";
@@ -40,6 +51,17 @@ export class MailchimpPropertyTemplate extends ConfigTemplate {
     super();
     this.name = `mailchimp:property`;
     this.description = `Config for a Mailchimp Property`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Property`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of the Source to use for this Property, e.g: \`--parent mailchimp_source\``,
+      },
+    };
     this.files = [path.join(templateRoot, "property", "*.template")];
     this.destinationDir = "properties";
     this.parentId = "sourceId";
@@ -57,6 +79,17 @@ export class MailchimpIdDestinationTemplate extends ConfigTemplate {
     super();
     this.name = `mailchimp:id:destination`;
     this.description = `Config for a Mailchimp ID Destination. Note: Use the email destination unless you know you need this.`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Destination`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of App to use for this Destination, e.g: \`--parent mailchimp_app\``,
+      },
+    };
     this.files = [path.join(templateRoot, "destination", "id", "*.template")];
     this.destinationDir = "destinations";
     this.parentId = "appId";
@@ -73,6 +106,17 @@ export class MailchimpEmailDestinationTemplate extends ConfigTemplate {
     super();
     this.name = `mailchimp:email:destination`;
     this.description = `Config for a Mailchimp Email Destination`;
+    this.inputs = {
+      id: {
+        required: true,
+        description: `The id of this new Destination`,
+        formatter: (p) => this.formatId(p),
+      },
+      parent: {
+        required: true,
+        description: `The id of App to use for this Destination, e.g: \`--parent mailchimp_app\``,
+      },
+    };
     this.files = [
       path.join(templateRoot, "destination", "email", "*.template"),
     ];


### PR DESCRIPTION
This PR re-introduces the input descriptions to the specific generate templates and provides a place for per-template descriptions.


```bash
# the `--list` flag shows a shrunk version of the inputs

$ grouparoo generate postgres --list

Modified your runtime environment with /Users/evan/workspace/grouparoo/grouparoo/apps/staging-enterprise/.env
active plugins: @grouparoo/core, @grouparoo/core/manual, @grouparoo/ui-enterprise, @grouparoo/core/events, @grouparoo/bigquery, @grouparoo/csv, @grouparoo/facebook, @grouparoo/files-s3, @grouparoo/google-sheets, @grouparoo/hubspot, @grouparoo/intercom, @grouparoo/iterable, @grouparoo/logger, @grouparoo/mailchimp, @grouparoo/marketo, @grouparoo/mysql, @grouparoo/postgres, @grouparoo/redshift, @grouparoo/sailthru, @grouparoo/salesforce, @grouparoo/sendgrid, @grouparoo/snowflake, @grouparoo/zendesk

🦘 Grouparoo: generate postgres

Available Templates: matching "postgres"

  postgres:app (id) - Config for a Grouparoo postgres App
  postgres:destination (id, parent) - Config for a postgres Destination
  postgres:query:property (id, parent) - Config for a postgres Query Property
  postgres:query:source (id, parent) - Config for a postgres query Source. Work with multiple tables and build custom queries for its properties.
  postgres:table:property (id, parent) - Config for a postgres Table Property
  postgres:table:source (id, parent, from, mapping, with, high-water-mark) - Config for a postgres table Source. Construct Sources and Properties without writing SQL.
```

```bash
# the `--describe` flag shows more detail about the inputs

$ grouparoo generate postgres:app --describe
notice: Modified your runtime environment with /Users/evan/workspace/grouparoo/grouparoo/apps/staging-enterprise/.env
info: active plugins: @grouparoo/core, @grouparoo/core/manual, @grouparoo/ui-enterprise, @grouparoo/core/events, @grouparoo/bigquery, @grouparoo/csv, @grouparoo/facebook, @grouparoo/files-s3, @grouparoo/google-sheets, @grouparoo/hubspot, @grouparoo/intercom, @grouparoo/iterable, @grouparoo/logger, @grouparoo/mailchimp, @grouparoo/marketo, @grouparoo/mysql, @grouparoo/postgres, @grouparoo/redshift, @grouparoo/sailthru, @grouparoo/salesforce, @grouparoo/sendgrid, @grouparoo/snowflake, @grouparoo/zendesk

🦘 Grouparoo: generate postgres:app

Config for a Grouparoo postgres App

Required Inputs:
  * id (required) - The name of this new App

Optional Inputs:
  None
```

```bash
# the `--describe` flag shows more detail about the inputs

$ grouparoo generate postgres:table:source --describe

notice: Modified your runtime environment with /Users/evan/workspace/grouparoo/grouparoo/apps/staging-enterprise/.env
info: active plugins: @grouparoo/core, @grouparoo/core/manual, @grouparoo/ui-enterprise, @grouparoo/core/events, @grouparoo/bigquery, @grouparoo/csv, @grouparoo/facebook, @grouparoo/files-s3, @grouparoo/google-sheets, @grouparoo/hubspot, @grouparoo/intercom, @grouparoo/iterable, @grouparoo/logger, @grouparoo/mailchimp, @grouparoo/marketo, @grouparoo/mysql, @grouparoo/postgres, @grouparoo/redshift, @grouparoo/sailthru, @grouparoo/salesforce, @grouparoo/sendgrid, @grouparoo/snowflake, @grouparoo/zendesk

🦘 Grouparoo: generate postgres:table:source

Config for a postgres table Source. Construct Sources and Properties without writing SQL.

Required Inputs:
  * id (required) - The name of this new Source
  * parent (required) - The name of the postgres App to use for this Source, e.g: `--parent data_warehouse`

Optional Inputs:
  * from - The table to use for this source, e.g: `--from users`
  * high-water-mark - The name of the column to uses for this Source's Schedule, e.g: `--high-water-mark updated_at`.
  * mapping - The mapping between a column in this table and a Grouparoo Property, e.g: `--mapping "id=user_id"`
  * with - The names of the columns to create properties from, e.g: `--with users,id,first_name,last_name`. Defaults to '*'

```


Also: 
* when talking about generators (`grouparoo generate`) that make more than one thing, use the language `batch generators` rather than complex - which sounds unnecessarily complex.
* by default, the `--with` flag includes no columns.  You can use `--with *` for all columns, which prior to this PR was the default behavior