### PR TITLE
`grouparoo apply` command creates runs + run resilience via the `run:tick` task

### DIFF
--- a/cli/src/utils/loadLocalCommands.ts
+++ b/cli/src/utils/loadLocalCommands.ts
@@ -183,6 +183,10 @@ async function runCommand(instance, _arg1, _arg2, _arg3, _arg4) {
     toStop = await instance.run({ params });
   } else {
     try {
+      if (typeof instance.preInitialize === "function") {
+        await instance.preInitialize();
+      }
+
       const { Process } = getActionhero();
       const actionHeroProcess = new Process();
 

--- a/core/__tests__/actions/destinations.ts
+++ b/core/__tests__/actions/destinations.ts
@@ -460,18 +460,15 @@ describe("actions/destinations", () => {
           connection
         );
 
-        const foundTasks = await specHelper.findEnqueuedTasks("group:run");
-        const runs = await Run.scope(null).findAll();
-        const runningRunTasks = foundTasks.filter((t) => {
-          const run = runs.filter((r) => r.id === t.args[0].runId)[0];
-          return run.state === "running";
+        const runningRuns = await Run.findAll({
+          where: { state: "running", creatorType: "group" },
         });
 
-        expect(runningRunTasks.length).toBe(1);
-        expect(runningRunTasks[0].args[0]).toEqual(
+        expect(runningRuns.length).toBe(1);
+        expect(runningRuns[0]).toEqual(
           expect.objectContaining({
             destinationId: id,
-            groupId: destination.destinationGroup.id,
+            creatorId: destination.destinationGroup.id,
             force: true,
           })
         );

--- a/core/__tests__/actions/profiles.ts
+++ b/core/__tests__/actions/profiles.ts
@@ -1,6 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { specHelper } from "actionhero";
-import { Profile, Group, Team, TeamMember, Property } from "../../src";
+import { Profile, Group, Team, TeamMember, Property, Run } from "../../src";
 
 function simpleProfileValues(complexProfileValues): { [key: string]: any } {
   const keys = Object.keys(complexProfileValues);
@@ -208,9 +208,10 @@ describe("actions/profiles", () => {
       expect(error).toBeUndefined();
       expect(run.id).toBeTruthy();
 
-      const foundTasks = await specHelper.findEnqueuedTasks("run:internalRun");
-      const rulesCount = await Property.count();
-      expect(foundTasks.length).toBe(rulesCount + 1);
+      const runningRuns = await Run.findAll({
+        where: { state: "running", creatorType: "teamMember" },
+      });
+      expect(runningRuns.length).toBe(1);
     });
 
     test("a writer can destroy a profile", async () => {

--- a/core/__tests__/integration/happyPath.ts
+++ b/core/__tests__/integration/happyPath.ts
@@ -1,5 +1,6 @@
 import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
 import { specHelper } from "actionhero";
+import { Run } from "../../src";
 
 function simpleProfileValues(complexProfileValues): { [key: string]: any } {
   const keys = Object.keys(complexProfileValues);
@@ -307,14 +308,16 @@ describe("integration/happyPath", () => {
       groupId = group.id;
     });
 
-    test("the group#run task can be run, along with the associated import chain", async () => {
+    test("the run can be processed, along with the associated import chain", async () => {
       let tasks = [];
 
       // group
-      tasks = await specHelper.findEnqueuedTasks("group:run");
-      expect(tasks.length).toBe(1);
-      await specHelper.runTask("group:run", tasks[0].args[0]);
+      const runningRuns = await Run.findAll({
+        where: { state: "running", creatorType: "group" },
+      });
+      expect(runningRuns.length).toBe(1);
 
+      await specHelper.runTask("runs:tick", {});
       await ImportWorkflow();
     });
 

--- a/core/__tests__/integration/happyPath.ts
+++ b/core/__tests__/integration/happyPath.ts
@@ -317,7 +317,7 @@ describe("integration/happyPath", () => {
       });
       expect(runningRuns.length).toBe(1);
 
-      await specHelper.runTask("runs:tick", {});
+      await specHelper.runTask("run:tick", {});
       await ImportWorkflow();
     });
 

--- a/core/__tests__/integration/runs/internalRun.ts
+++ b/core/__tests__/integration/runs/internalRun.ts
@@ -33,9 +33,6 @@ describe("integration/runs/internalRun", () => {
       await property.setOptions({ column: "email" });
       await property.update({ state: "ready" });
 
-      const foundTasks = await specHelper.findEnqueuedTasks("run:internalRun");
-      expect(foundTasks.length).toBe(1);
-
       const runs = await Run.findAll();
       expect(runs.length).toBe(1);
       expect(runs[0].creatorType).toBe("property");
@@ -45,14 +42,10 @@ describe("integration/runs/internalRun", () => {
     });
 
     test("the internalRun task will create an import for every profile", async () => {
-      const foundTasks = await specHelper.findEnqueuedTasks("run:internalRun");
-      expect(foundTasks.length).toBe(1);
-
-      await specHelper.deleteEnqueuedTasks(
-        "run:internalRun",
-        foundTasks[0].args[0]
-      );
-      await specHelper.runTask("run:internalRun", foundTasks[0].args[0]);
+      await specHelper.deleteEnqueuedTasks("run:internalRun", {
+        runId: run.id,
+      });
+      await specHelper.runTask("run:internalRun", { runId: run.id });
 
       const imports = await Import.findAll();
       expect(imports.length).toBe(1);
@@ -60,14 +53,10 @@ describe("integration/runs/internalRun", () => {
     });
 
     test("the run will be complete when all imports are created", async () => {
-      const foundTasks = await specHelper.findEnqueuedTasks("run:internalRun");
-      expect(foundTasks.length).toBe(2);
-
-      await specHelper.deleteEnqueuedTasks(
-        "run:internalRun",
-        foundTasks[1].args[0]
-      );
-      await specHelper.runTask("run:internalRun", foundTasks[1].args[0]);
+      await specHelper.deleteEnqueuedTasks("run:internalRun", {
+        runId: run.id,
+      });
+      await specHelper.runTask("run:internalRun", { runId: run.id });
 
       await run.reload();
       expect(run.state).toBe("complete");
@@ -121,9 +110,6 @@ describe("integration/runs/internalRun", () => {
       });
       await lastNameProperty.setOptions({ column: "lastName" });
       await lastNameProperty.update({ state: "ready" });
-
-      const foundTasks = await specHelper.findEnqueuedTasks("run:internalRun");
-      expect(foundTasks.length).toBe(2);
 
       const runs = await Run.findAll();
       const firstNameRun = runs.find(

--- a/core/__tests__/models/group/calculatedGroup.ts
+++ b/core/__tests__/models/group/calculatedGroup.ts
@@ -72,9 +72,11 @@ describe("models/group", () => {
       await specHelper.runTask("group:run", { runId: run.id }); // first run to check additions
       await specHelper.runTask("group:run", { runId: run.id }); // second run to check subtractions
       await specHelper.runTask("group:run", { runId: run.id }); // third run to check old group members
+      await specHelper.runTask("group:run", { runId: run.id }); // final run to mark complete
 
       await run.reload();
       expect(run.state).toBe("complete");
+      expect(run.groupMethod).toBe("complete");
 
       await group.reload();
       expect(group.state).toBe("ready");

--- a/core/__tests__/models/run/isRunEnqueued.ts
+++ b/core/__tests__/models/run/isRunEnqueued.ts
@@ -1,0 +1,43 @@
+import { helper } from "@grouparoo/spec-helper";
+import { Run, Schedule } from "../../../src";
+import { RunOps } from "../../../src/modules/ops/runs";
+import { api, task } from "actionhero";
+
+describe("models/run/isRunEnqueued", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
+  let run: Run;
+  let schedule: Schedule;
+  beforeAll(async () => {
+    await helper.factories.properties();
+    schedule = await helper.factories.schedule();
+    run = await helper.factories.run(schedule);
+  });
+
+  beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
+
+  test("with nothing enqueued", async () => {
+    const enqueued = await RunOps.isRunEnqueued("schedule:run", run.id);
+    expect(enqueued).toBe(false);
+  });
+
+  test("with a task enqueued", async () => {
+    await task.enqueue("schedule:run", { runId: run.id });
+    const enqueued = await RunOps.isRunEnqueued("schedule:run", run.id);
+    expect(enqueued).toBe(true);
+  });
+
+  test("with a task delayed", async () => {
+    await task.enqueueIn(1000, "schedule:run", { runId: run.id });
+    const enqueued = await RunOps.isRunEnqueued("schedule:run", run.id);
+    expect(enqueued).toBe(true);
+  });
+
+  // TODO: This is hard to test...
+  // test("with a task being worked on", async (done) => {
+  //   const worker = specHelper.runFullTask("schedule:run", { runId: run.id });
+  //   const enqueued = await RunOps.isRunEnqueued("schedule:run", run.id);
+  //   expect(enqueued).toBe(true);
+  //   worker.then(() => done());
+  // });
+});

--- a/core/__tests__/models/run/run.ts
+++ b/core/__tests__/models/run/run.ts
@@ -11,7 +11,8 @@ import {
   Team,
   TeamMember,
   Profile,
-} from "../../src";
+} from "../../../src";
+import { utils } from "actionhero";
 
 describe("models/run", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -22,12 +23,6 @@ describe("models/run", () => {
     await helper.factories.properties();
     schedule = await helper.factories.schedule();
   });
-
-  const sleep = (t) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, t);
-    });
-  };
 
   test("a run can be created", async () => {
     const run = new Run({
@@ -455,7 +450,7 @@ describe("models/run", () => {
         state: "running",
       });
 
-      await sleep(100);
+      await utils.sleep(100);
 
       await Import.create({
         profileId: "a",
@@ -468,7 +463,7 @@ describe("models/run", () => {
         createdProfile: true,
       });
 
-      await sleep(100);
+      await utils.sleep(100);
 
       await Import.create({
         profileId: "a",
@@ -480,7 +475,7 @@ describe("models/run", () => {
         exportedAt: new Date(),
       });
 
-      await sleep(100);
+      await utils.sleep(100);
 
       await Import.create({
         profileId: "b",
@@ -492,7 +487,7 @@ describe("models/run", () => {
         exportedAt: new Date(),
       });
 
-      await sleep(100);
+      await utils.sleep(100);
 
       await run.update({ state: "complete", completedAt: new Date() });
     });

--- a/core/__tests__/modules/internalRun.ts
+++ b/core/__tests__/modules/internalRun.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { api, specHelper } from "actionhero";
+import { api } from "actionhero";
 import { internalRun } from "./../../src/modules/internalRun";
 import { Run } from "../../src";
 
@@ -18,10 +18,6 @@ describe("modules/internalRun", () => {
     const runs = await Run.findAll();
     expect(runs.length).toBe(1);
     expect(runs[0].creatorId).toBe("abc123");
-
-    const found = await specHelper.findEnqueuedTasks("run:internalRun");
-    expect(found.length).toEqual(1);
-    expect(found[0].args[0].runId).toBe(runs[0].id);
   });
 
   test("adding a new internal run will stop other internal runs for the same creator type", async () => {

--- a/core/__tests__/tasks/destination/destroy.ts
+++ b/core/__tests__/tasks/destination/destroy.ts
@@ -64,6 +64,7 @@ describe("tasks/destination:destroy", () => {
       });
 
       run = await Run.findOne({ where: { creatorId: group.id } });
+      expect(run.state).toBe("running");
 
       const foundTasks = await specHelper.findEnqueuedTasks(
         "destination:destroy"
@@ -91,27 +92,16 @@ describe("tasks/destination:destroy", () => {
     });
 
     test("the group run can be completed and create exports", async () => {
-      // add
-      let foundTasks = await specHelper.findEnqueuedTasks("group:run");
-      await specHelper.deleteEnqueuedTasks("group:run", foundTasks[0].args[0]);
-      await specHelper.runTask("group:run", foundTasks[0].args[0]);
-      // remove
-      foundTasks = await specHelper.findEnqueuedTasks("group:run");
-      await specHelper.deleteEnqueuedTasks("group:run", foundTasks[0].args[0]);
-      await specHelper.runTask("group:run", foundTasks[0].args[0]);
-      // removeOld
-      foundTasks = await specHelper.findEnqueuedTasks("group:run");
-      await specHelper.deleteEnqueuedTasks("group:run", foundTasks[0].args[0]);
-      await specHelper.runTask("group:run", foundTasks[0].args[0]);
+      await specHelper.runTask("group:run", { runId: run.id });
+      await specHelper.runTask("group:run", { runId: run.id });
+      await specHelper.runTask("group:run", { runId: run.id });
+      await specHelper.runTask("group:run", { runId: run.id });
 
       await ImportWorkflow();
 
-      // complete
-      foundTasks = await specHelper.findEnqueuedTasks("group:run");
-      await specHelper.deleteEnqueuedTasks("group:run", foundTasks[0].args[0]);
-      await specHelper.runTask("group:run", foundTasks[0].args[0]);
+      await specHelper.runTask("group:run", { runId: run.id });
 
-      run = await Run.findById(run.id);
+      run = await run.reload();
       group = await Group.findById(group.id);
       expect(group.state).toBe("ready");
       expect(run.state).toBe("complete");

--- a/core/__tests__/tasks/export/send.ts
+++ b/core/__tests__/tasks/export/send.ts
@@ -39,15 +39,11 @@ describe("tasks/export:send", () => {
       await destination.update({ state: "ready" });
 
       await destination.exportGroupMembers(true);
-      const foundGroupRunTasks = await specHelper.findEnqueuedTasks(
-        "group:run"
-      );
-      expect(foundGroupRunTasks.length).toBe(1);
-      await specHelper.runTask("group:run", foundGroupRunTasks[0].args[0]);
 
       run = await Run.findOne({
         where: { creatorId: group.id },
       });
+      await specHelper.runTask("group:run", { runId: run.id });
 
       await run.updateTotals();
 

--- a/core/__tests__/tasks/export/sendBatch.ts
+++ b/core/__tests__/tasks/export/sendBatch.ts
@@ -41,15 +41,11 @@ describe("tasks/export:sendBatch", () => {
       await destination.update({ state: "ready" });
 
       await destination.exportGroupMembers(true);
-      const foundGroupRunTasks = await specHelper.findEnqueuedTasks(
-        "group:run"
-      );
-      expect(foundGroupRunTasks.length).toBe(1);
-      await specHelper.runTask("group:run", foundGroupRunTasks[0].args[0]);
 
       run = await Run.findOne({
         where: { creatorId: group.id },
       });
+      await specHelper.runTask("group:run", { runId: run.id });
 
       await run.updateTotals();
 

--- a/core/__tests__/tasks/group/updateCalculatedGroups.ts
+++ b/core/__tests__/tasks/group/updateCalculatedGroups.ts
@@ -1,6 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { api, specHelper } from "actionhero";
-import { plugin, Group } from "../../../src";
+import { plugin, Group, Run } from "../../../src";
 
 let group: Group;
 
@@ -16,6 +16,10 @@ describe("tasks/group:updateCalculatedGroups", () => {
       await group.save();
     });
 
+    beforeEach(async () => {
+      await Run.truncate();
+    });
+
     test("the setting is present", async () => {
       const setting = await plugin.readSetting(
         "core",
@@ -26,38 +30,34 @@ describe("tasks/group:updateCalculatedGroups", () => {
 
     test("running it will enqueue an update for groups that have never been calculated", async () => {
       await group.update({ state: "ready", calculatedAt: null });
-
       await specHelper.runTask("group:updateCalculatedGroups", {});
-      const enqueuedTasks = await specHelper.findEnqueuedTasks("group:run");
 
-      expect(enqueuedTasks.length).toBe(1);
+      const runs = await Run.findAll({ where: { creatorId: group.id } });
+      expect(runs.length).toBe(1);
     });
 
     test("running it will enqueue an update for groups that were last recalculated in the far past", async () => {
       await group.update({ state: "ready", calculatedAt: new Date(0) }); // ~1970 or so
-
       await specHelper.runTask("group:updateCalculatedGroups", {});
-      const enqueuedTasks = await specHelper.findEnqueuedTasks("group:run");
 
-      expect(enqueuedTasks.length).toBe(1);
+      const runs = await Run.findAll({ where: { creatorId: group.id } });
+      expect(runs.length).toBe(1);
     });
 
     test("running it will not enqueue an update for groups that were last recalculated recently", async () => {
       await group.update({ state: "ready", calculatedAt: new Date() }); // now
-
       await specHelper.runTask("group:updateCalculatedGroups", {});
-      const enqueuedTasks = await specHelper.findEnqueuedTasks("group:run");
 
-      expect(enqueuedTasks.length).toBe(0);
+      const runs = await Run.findAll({ where: { creatorId: group.id } });
+      expect(runs.length).toBe(0);
     });
 
     test("groups already calculating will not be calculated again", async () => {
       await group.update({ state: "updating", calculatedAt: new Date(0) }); // ~1970 or so
-
       await specHelper.runTask("group:updateCalculatedGroups", {});
-      const enqueuedTasks = await specHelper.findEnqueuedTasks("group:run");
 
-      expect(enqueuedTasks.length).toBe(0);
+      const runs = await Run.findAll({ where: { creatorId: group.id } });
+      expect(runs.length).toBe(0);
     });
   });
 });

--- a/core/__tests__/tasks/run/internalRun.ts
+++ b/core/__tests__/tasks/run/internalRun.ts
@@ -12,20 +12,19 @@ describe("tasks/run:internalRun", () => {
 
   describe("run:internalRun", () => {
     beforeAll(async () => {
+      await Run.truncate();
       profile = await helper.factories.profile();
     });
 
     test("the task will create an import for every profile", async () => {
       await internalRun("test", "testId");
 
-      const foundTasks = await specHelper.findEnqueuedTasks("run:internalRun");
-      expect(foundTasks.length).toBe(1);
-      const run = await Run.findById(foundTasks[0].args[0].runId);
-      await specHelper.runTask("run:internalRun", foundTasks[0].args[0]);
+      const run = await Run.findOne({ where: { state: "running" } });
+      await specHelper.runTask("run:internalRun", { runId: run.id });
 
       await run.reload();
       expect(run.groupMemberLimit).toBe(100);
-      expect(run.groupMemberOffset).toBe(0);
+      expect(run.groupMemberOffset).toBe(100);
       expect(run.groupMethod).toBe("internalRun");
 
       const imports = await Import.findAll();

--- a/core/__tests__/tasks/run/tick.ts
+++ b/core/__tests__/tasks/run/tick.ts
@@ -1,0 +1,86 @@
+import { helper } from "@grouparoo/spec-helper";
+import { task, api, specHelper } from "actionhero";
+import { Run } from "../../../src";
+import { internalRun } from "../../../src/modules/internalRun";
+
+describe("tasks/run:tick", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  beforeAll(async () => await helper.factories.properties());
+  beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
+  beforeEach(async () => await Run.truncate());
+
+  test("complete runs will not be run", async () => {
+    const run = await helper.factories.run(null, { state: "complete" });
+    await setUpdatedAt(run);
+
+    const enqueued = await specHelper.runTask("run:tick", {});
+    expect(enqueued).toBe(0);
+  });
+
+  test("stopped runs will not be run", async () => {
+    const run = await helper.factories.run(null, { state: "stopped" });
+    await setUpdatedAt(run);
+
+    const enqueued = await specHelper.runTask("run:tick", {});
+    expect(enqueued).toBe(0);
+  });
+
+  test("running runs run recently will not be enqueued", async () => {
+    const run = await helper.factories.run(null, { state: "running" });
+    const enqueued = await specHelper.runTask("run:tick", {});
+    expect(enqueued).toBe(0);
+  });
+
+  test("running runs which are being worked on will not be enqueued", async () => {
+    const run = await helper.factories.run(null, { state: "running" });
+    await setUpdatedAt(run);
+
+    await task.enqueue("schedule:run", { runId: run.id });
+    const enqueued = await specHelper.runTask("run:tick", {});
+    expect(enqueued).toBe(0);
+  });
+
+  test("running group runs will be enqueued", async () => {
+    const group = await helper.factories.group();
+    const run = await helper.factories.run(group, { state: "running" });
+    await setUpdatedAt(run);
+
+    const enqueued = await specHelper.runTask("run:tick", {});
+    expect(enqueued).toBe(1);
+
+    const foundTasks = await specHelper.findEnqueuedTasks("group:run");
+    expect(foundTasks.length).toBe(1);
+    expect(foundTasks[0].args[0].runId).toBe(run.id);
+  });
+
+  test("running schedule runs will be enqueued", async () => {
+    const schedule = await helper.factories.schedule();
+    const run = await helper.factories.run(schedule, { state: "running" });
+    await setUpdatedAt(run);
+
+    const enqueued = await specHelper.runTask("run:tick", {});
+    expect(enqueued).toBe(1);
+
+    const foundTasks = await specHelper.findEnqueuedTasks("schedule:run");
+    expect(foundTasks.length).toBe(1);
+    expect(foundTasks[0].args[0].runId).toBe(run.id);
+  });
+
+  test("running internal runs will be enqueued", async () => {
+    const run = await internalRun("test", "test");
+    await setUpdatedAt(run);
+
+    const enqueued = await specHelper.runTask("run:tick", {});
+    expect(enqueued).toBe(1);
+
+    const foundTasks = await specHelper.findEnqueuedTasks("run:internalRun");
+    expect(foundTasks.length).toBe(1);
+    expect(foundTasks[0].args[0].runId).toBe(run.id);
+  });
+});
+
+async function setUpdatedAt(run: Run, timestamp = "1900-01-01 12:13:14") {
+  return api.sequelize.query(
+    `UPDATE runs SET "updatedAt" = '${timestamp}' WHERE id = '${run.id}'`
+  );
+}

--- a/core/__tests__/tasks/schedule/run.ts
+++ b/core/__tests__/tasks/schedule/run.ts
@@ -22,21 +22,7 @@ describe("tasks/schedule:run", () => {
 
   describe("schedule:run", () => {
     test("can be enqueued", async () => {
-      await task.enqueue("schedule:run", {
-        scheduleId: "abc123",
-        runId: "abc123",
-      });
-      const found = await specHelper.findEnqueuedTasks("schedule:run");
-      expect(found.length).toEqual(1);
-      expect(found[0].timestamp).toBeNull();
-    });
-
-    test("throws without a scheduleId", async () => {
-      await expect(
-        task.enqueue("schedule:run", {
-          runId: "abc123",
-        })
-      ).rejects.toThrow(/scheduleId is a required input/);
+      await task.enqueue("schedule:run", { runId: "12345" }); // does not throw
     });
 
     test("throws without a runId", async () => {
@@ -57,9 +43,11 @@ describe("tasks/schedule:run", () => {
     });
 
     test("doesn't throw when scheduleId is **not found** in DB", async () => {
+      const run = await helper.factories.run(schedule);
+
       specHelper.runTask("schedule:run", {
         scheduleId: "abc123",
-        runId: "abc123",
+        runId: run.id,
       }); // doesn't throw
     });
   });

--- a/core/src/bin/apply.ts
+++ b/core/src/bin/apply.ts
@@ -22,9 +22,12 @@ export class Apply extends CLI {
       },
     };
 
-    GrouparooCLI.setGrouparooRunMode(this);
     GrouparooCLI.timestampOption(this);
   }
+
+  preInitialize = () => {
+    GrouparooCLI.setGrouparooRunMode(this);
+  };
 
   async run({ params }) {
     GrouparooCLI.logCLI(this.name);

--- a/core/src/bin/console.ts
+++ b/core/src/bin/console.ts
@@ -9,9 +9,12 @@ export class Console extends CLI {
     this.description =
       "Start an interactive REPL session with the api object in-scope";
 
-    GrouparooCLI.setGrouparooRunMode(this);
     GrouparooCLI.timestampOption(this);
   }
+
+  preInitialize = () => {
+    GrouparooCLI.setGrouparooRunMode(this);
+  };
 
   async run() {
     GrouparooCLI.logCLI(this.name);

--- a/core/src/bin/destroy.ts
+++ b/core/src/bin/destroy.ts
@@ -8,9 +8,12 @@ export class Destroy extends CLI {
     this.description =
       "Remove imported Profiles, Groups, Imports, and Exports from your cluster.  Properties, Groups and other configuration will remain.";
 
-    GrouparooCLI.setGrouparooRunMode(this);
     GrouparooCLI.timestampOption(this);
   }
+
+  preInitialize = () => {
+    GrouparooCLI.setGrouparooRunMode(this);
+  };
 
   async run() {
     GrouparooCLI.logCLI(this.name, false);

--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -97,9 +97,11 @@ Commands:
       --mapping 'id=user_id' \\
       --high-water-mark updated_at
     `;
-
-    GrouparooCLI.setGrouparooRunMode(this);
   }
+
+  preInitialize = () => {
+    GrouparooCLI.setGrouparooRunMode(this);
+  };
 
   async run({ params }) {
     const [template, id] = params._arguments || [];

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -46,9 +46,12 @@ export class RunCLI extends CLI {
       },
     };
 
-    GrouparooCLI.setGrouparooRunMode(this);
     GrouparooCLI.timestampOption(this);
   }
+
+  preInitialize = () => {
+    GrouparooCLI.setGrouparooRunMode(this);
+  };
 
   async run({ params }) {
     GrouparooCLI.logCLI(this.name, false);

--- a/core/src/bin/start.ts
+++ b/core/src/bin/start.ts
@@ -8,9 +8,12 @@ export class Start extends CLI {
     this.description =
       "Run the Grouparoo server.  Use GROUPAROO_LOG_LEVEL env to set log level.";
 
-    GrouparooCLI.setGrouparooRunMode(this);
     GrouparooCLI.timestampOption(this);
   }
+
+  preInitialize = () => {
+    GrouparooCLI.setGrouparooRunMode(this);
+  };
 
   async run() {
     GrouparooCLI.logCLI(this.name, false);

--- a/core/src/bin/status.ts
+++ b/core/src/bin/status.ts
@@ -11,9 +11,12 @@ export class Status extends CLI {
     this.name = "status";
     this.description = "Display the status of your Grouparoo cluster";
 
-    GrouparooCLI.setGrouparooRunMode(this);
     GrouparooCLI.timestampOption(this);
   }
+
+  preInitialize = () => {
+    GrouparooCLI.setGrouparooRunMode(this);
+  };
 
   async run() {
     GrouparooCLI.logCLI(this.name);

--- a/core/src/bin/sync.ts
+++ b/core/src/bin/sync.ts
@@ -24,10 +24,13 @@ export class SyncCLI extends CLI {
     };
     this.example = `grouparoo sync person@example.com --property email`;
 
-    GrouparooCLI.setGrouparooRunMode(this);
     GrouparooCLI.timestampOption(this);
     GrouparooCLI.jsonOption(this);
   }
+
+  preInitialize = () => {
+    GrouparooCLI.setGrouparooRunMode(this);
+  };
 
   async run({ params }) {
     const [profileProperty] = params._arguments || [];

--- a/core/src/bin/validate.ts
+++ b/core/src/bin/validate.ts
@@ -22,9 +22,12 @@ export class Validate extends CLI {
       },
     };
 
-    GrouparooCLI.setGrouparooRunMode(this);
     GrouparooCLI.timestampOption(this);
   }
+
+  preInitialize = () => {
+    GrouparooCLI.setGrouparooRunMode(this);
+  };
 
   async run({ params }) {
     GrouparooCLI.logCLI(this.name);

--- a/core/src/migrations/000058-runDestinationId.ts
+++ b/core/src/migrations/000058-runDestinationId.ts
@@ -1,0 +1,13 @@
+export default {
+  up: async function (migration, DataTypes) {
+    await migration.addColumn("runs", "destinationId", {
+      type: DataTypes.STRING(40),
+      allowNull: true,
+      defaultValue: null,
+    });
+  },
+
+  down: async function (migration) {
+    await migration.removeColumn("runs", "destinationId");
+  },
+};

--- a/core/src/models/Run.ts
+++ b/core/src/models/Run.ts
@@ -130,6 +130,10 @@ export class Run extends Model {
   @Column
   force: boolean;
 
+  @AllowNull(true)
+  @Column
+  destinationId: string;
+
   @BelongsTo(() => Schedule)
   schedule: Schedule;
 
@@ -278,6 +282,7 @@ export class Run extends Model {
       groupHighWaterMark: this.groupHighWaterMark,
       groupMethod: this.groupMethod,
       force: this.force,
+      destinationId: this.destinationId,
       completedAt: this.completedAt ? this.completedAt.getTime() : null,
       createdAt: this.createdAt ? this.createdAt.getTime() : null,
       updatedAt: this.updatedAt ? this.updatedAt.getTime() : null,

--- a/core/src/modules/internalRun.ts
+++ b/core/src/modules/internalRun.ts
@@ -1,5 +1,4 @@
 import { log, config } from "actionhero";
-import { CLS } from "./cls";
 import { Run } from "../models/Run";
 
 /**
@@ -23,6 +22,7 @@ export async function internalRun(creatorType: string, creatorId: string) {
     creatorType,
     creatorId,
     state: "running",
+    groupMethod: "internalRun",
   });
 
   log(
@@ -31,11 +31,6 @@ export async function internalRun(creatorType: string, creatorId: string) {
     } for ${creatorType} ${await run.getCreatorName()} (${creatorId})`,
     "notice"
   );
-
-  // we need to allow time to for the rest of the model update to complete (ie: this could be run after Property#updateOptions and we still need to wait for the state to change)
-  await CLS.enqueueTaskIn(config.tasks.timeout + 1, "run:internalRun", {
-    runId: run.id,
-  });
 
   return run;
 }

--- a/core/src/modules/ops/group.ts
+++ b/core/src/modules/ops/group.ts
@@ -6,7 +6,6 @@ import { ProfileMultipleAssociationShim } from "../../models/ProfileMultipleAsso
 import { Import } from "../../models/Import";
 import { Op } from "sequelize";
 import { api, log } from "actionhero";
-import { CLS } from "../../modules/cls";
 
 export namespace GroupOps {
   /**
@@ -26,6 +25,7 @@ export namespace GroupOps {
       creatorId: group.id,
       creatorType: "group",
       state: "running",
+      destinationId,
       force,
     });
 
@@ -33,13 +33,6 @@ export namespace GroupOps {
       `[ run ] starting run ${run.id} for group ${group.name} (${group.id})`,
       "notice"
     );
-
-    await CLS.enqueueTask("group:run", {
-      groupId: group.id,
-      runId: run.id,
-      force,
-      destinationId,
-    });
 
     return run;
   }

--- a/core/src/modules/ops/group.ts
+++ b/core/src/modules/ops/group.ts
@@ -17,7 +17,8 @@ export namespace GroupOps {
     force = false,
     destinationId?: string
   ) {
-    if (!api.process.running) return; // we are in an initializer (validating)
+    if (process.env.GROUPAROO_RUN_MODE === "cli:validate") return;
+
     await group.stopPreviousRuns();
     await group.update({ state: "updating" });
 

--- a/core/src/modules/ops/property.ts
+++ b/core/src/modules/ops/property.ts
@@ -12,7 +12,8 @@ export namespace PropertyOps {
    * Enqueue Runs to update all Groups that rely on this Property
    */
   export async function enqueueRuns(property: Property) {
-    if (!api.process.running) return; // we are in an initializer (validating)
+    if (process.env.GROUPAROO_RUN_MODE === "cli:validate") return;
+
     await internalRun("property", property.id); // update *all* profiles
 
     const groups = await Group.findAll({

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -80,8 +80,6 @@ export class RunGroup extends CLSTask {
       }
     }
 
-    console.log({ method, nextMethod, groupMembersCount });
-
     await run.update({
       groupMemberLimit: limit,
       groupMemberOffset: nextOffset,

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -65,6 +65,8 @@ export class RunGroup extends CLSTask {
       );
     } else if (method === "removePreviousRunGroupMembers") {
       groupMembersCount = await group.removePreviousRunGroupMembers(run, limit);
+    } else if (method === "complete") {
+      // waiting for imports...
     } else {
       throw new Error(`${method} is not now a known method`);
     }
@@ -76,7 +78,7 @@ export class RunGroup extends CLSTask {
       } else if (method === "runRemoveGroupMembers") {
         nextMethod = "removePreviousRunGroupMembers";
       } else if (method === "removePreviousRunGroupMembers") {
-        nextMethod = "";
+        nextMethod = "complete";
       }
     }
 
@@ -93,7 +95,11 @@ export class RunGroup extends CLSTask {
     });
 
     // we don't want to denote the group as ready until all the imports are imported
-    if (pendingImports === 0 && groupMembersCount === 0) {
+    if (
+      method === "complete" &&
+      pendingImports === 0 &&
+      groupMembersCount === 0
+    ) {
       await run.afterBatch("complete");
       await group.update({ state: "ready" });
     } else {

--- a/core/src/tasks/run/tick.ts
+++ b/core/src/tasks/run/tick.ts
@@ -1,0 +1,43 @@
+import { Run } from "../../models/Run";
+import { CLSTask } from "../../classes/tasks/clsTask";
+import { config } from "actionhero";
+import { CLS } from "../../modules/cls";
+import { Op } from "sequelize";
+import { RunOps } from "../../modules/ops/runs";
+
+export class RunsTick extends CLSTask {
+  constructor() {
+    super();
+    this.name = "runs:tick";
+    this.description = "process pending runs and enqueue the next batch";
+    this.frequency = config.tasks.timeout + 1;
+    this.queue = "runs";
+  }
+
+  async runWithinTransaction() {
+    const lastCheck = new Date().getTime() - this.frequency;
+    const runs = await Run.findAll({
+      where: { state: "running", updatedAt: { [Op.lt]: lastCheck } },
+    });
+
+    for (const i in runs) {
+      const run = runs[i];
+
+      const args = { runId: run.id };
+      let taskName = "";
+
+      if (run.groupMethod === "internalRun") {
+        taskName = "run:internalRun";
+      } else if (run.creatorType === "group") {
+        taskName = "group:run";
+      } else if (run.creatorType === "schedule") {
+        taskName = "schedule:run";
+      } else {
+        throw new Error(`cannot tick run ${run.id}`);
+      }
+
+      const enqueued = await RunOps.isRunEnqueued(taskName, run.id);
+      if (!enqueued) CLS.enqueueTask(taskName, args);
+    }
+  }
+}

--- a/core/src/tasks/run/updateCounts.ts
+++ b/core/src/tasks/run/updateCounts.ts
@@ -9,7 +9,7 @@ export class UpdateRunCounts extends CLSTask {
     super();
     this.name = "runs:updateCounts";
     this.description = "Update the counts of imports and profiles for runs";
-    this.frequency = 1000 * 10;
+    this.frequency = 1000 * 15;
     this.queue = "runs";
     this.inputs = {};
   }

--- a/core/src/tasks/schedule/updateSchedules.ts
+++ b/core/src/tasks/schedule/updateSchedules.ts
@@ -2,7 +2,6 @@ import { log } from "actionhero";
 import { Schedule } from "../../models/Schedule";
 import { Run } from "../../models/Run";
 import { CLSTask } from "../../classes/tasks/clsTask";
-import { CLS } from "../../modules/cls";
 
 export class UpdateSchedules extends CLSTask {
   constructor() {
@@ -64,11 +63,6 @@ export class UpdateSchedules extends CLSTask {
           creatorId: schedule.id,
           creatorType: "schedule",
           state: "running",
-        });
-
-        await CLS.enqueueTask("schedule:run", {
-          scheduleId: schedule.id,
-          runId: run.id,
         });
 
         log(

--- a/plugins/@grouparoo/csv/__tests__/integration/csv.ts
+++ b/plugins/@grouparoo/csv/__tests__/integration/csv.ts
@@ -236,15 +236,10 @@ describe("integration/runs/csv", () => {
           creatorType: "schedule",
           state: "running",
         });
-        await specHelper.runTask("schedule:run", {
-          runId: run.id,
-          scheduleId: schedule.id,
-        });
 
-        // run the schedule task again to enqueue the determineState task
-        const foundAgain = await specHelper.findEnqueuedTasks("schedule:run");
-        expect(foundAgain.length).toEqual(2);
-        await specHelper.runTask("schedule:run", foundAgain[1].args[0]);
+        // run the schedule twice to complete the run
+        await specHelper.runTask("schedule:run", { runId: run.id });
+        await specHelper.runTask("schedule:run", { runId: run.id });
 
         // run all enqueued associateProfile tasks
         const foundAssociateTasks = await specHelper.findEnqueuedTasks(
@@ -318,7 +313,7 @@ describe("integration/runs/csv", () => {
 
         // check that the run is enqueued
         const found = await specHelper.findEnqueuedTasks("schedule:run");
-        expect(found.length).toEqual(3);
+        expect(found.length).toEqual(2);
         expect(found[1].args[0].scheduleId).toBe(schedule.id);
 
         // run the schedule
@@ -327,15 +322,10 @@ describe("integration/runs/csv", () => {
           creatorType: "schedule",
           state: "running",
         });
-        await specHelper.runTask("schedule:run", {
-          scheduleId: schedule.id,
-          runId: run.id,
-        });
 
-        // run the schedule task again to enqueue the determineState task
-        const foundAgain = await specHelper.findEnqueuedTasks("schedule:run");
-        expect(foundAgain.length).toEqual(4);
-        await specHelper.runTask("schedule:run", foundAgain[3].args[0]);
+        // run the schedule twice to complete the run
+        await specHelper.runTask("schedule:run", { runId: run.id });
+        await specHelper.runTask("schedule:run", { runId: run.id });
 
         // run all enqueued associateProfile tasks
         const foundAssociateTasks = await specHelper.findEnqueuedTasks(

--- a/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
+++ b/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
@@ -243,15 +243,10 @@ describe("integration/runs/google-sheets", () => {
           creatorType: "schedule",
           state: "running",
         });
-        await specHelper.runTask("schedule:run", {
-          runId: run.id,
-          scheduleId: schedule.id,
-        });
 
-        // run the schedule task again to enqueue the determineState task
-        const foundAgain = await specHelper.findEnqueuedTasks("schedule:run");
-        expect(foundAgain.length).toEqual(2);
-        await specHelper.runTask("schedule:run", foundAgain[1].args[0]);
+        // run the schedule twice to complete the run
+        await specHelper.runTask("schedule:run", { runId: run.id });
+        await specHelper.runTask("schedule:run", { runId: run.id });
 
         // run all enqueued associateProfile tasks
         const foundAssociateTasks = await specHelper.findEnqueuedTasks(
@@ -279,6 +274,8 @@ describe("integration/runs/google-sheets", () => {
           )
         );
 
+        // check the run's completion percentage (before the run is complete)
+        await specHelper.runTask("schedule:run", { runId: run.id });
         await run.afterBatch();
         expect(run.percentComplete).toBe(100);
 
@@ -333,26 +330,16 @@ describe("integration/runs/google-sheets", () => {
         expect(error).toBeUndefined();
         expect(success).toBe(true);
 
-        // check that the run is enqueued
-        const found = await specHelper.findEnqueuedTasks("schedule:run");
-        expect(found.length).toEqual(3);
-        expect(found[1].args[0].scheduleId).toBe(schedule.id);
-
         // run the schedule
         const run = await Run.create({
           creatorId: schedule.id,
           creatorType: "schedule",
           state: "running",
         });
-        await specHelper.runTask("schedule:run", {
-          runId: run.id,
-          scheduleId: schedule.id,
-        });
 
-        // run the schedule task again to enqueue the determineState task
-        const foundAgain = await specHelper.findEnqueuedTasks("schedule:run");
-        expect(foundAgain.length).toEqual(4);
-        await specHelper.runTask("schedule:run", foundAgain[3].args[0]);
+        // run the schedule twice to complete the run
+        await specHelper.runTask("schedule:run", { runId: run.id });
+        await specHelper.runTask("schedule:run", { runId: run.id });
 
         // run all enqueued associateProfile tasks
         const foundAssociateTasks = await specHelper.findEnqueuedTasks(

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -347,21 +347,10 @@ describe("integration/runs/mysql", () => {
         creatorType: "schedule",
         state: "running",
       });
-      await specHelper.runTask("schedule:run", {
-        runId: run.id,
-        scheduleId: schedule.id,
-      });
 
-      // run the schedule task again to enqueue the determineState task
-      await helper.sleep();
-      let foundAgain = await specHelper.findEnqueuedTasks("schedule:run");
-      expect(foundAgain.length).toEqual(2);
-      await specHelper.runTask("schedule:run", foundAgain[1].args[0]);
-
-      await helper.sleep();
-      foundAgain = await specHelper.findEnqueuedTasks("schedule:run");
-      expect(foundAgain.length).toEqual(3);
-      await specHelper.runTask("schedule:run", foundAgain[1].args[0]);
+      // run the schedule twice to complete the run
+      await specHelper.runTask("schedule:run", { runId: run.id });
+      await specHelper.runTask("schedule:run", { runId: run.id });
 
       // run all enqueued associateProfile tasks
       const foundAssociateTasks = await specHelper.findEnqueuedTasks(
@@ -401,6 +390,7 @@ describe("integration/runs/mysql", () => {
       );
 
       // check the run's completion percentage (before the run is complete)
+      await specHelper.runTask("schedule:run", { runId: run.id });
       await run.determinePercentComplete();
       expect(run.percentComplete).toBe(100);
 
@@ -477,15 +467,10 @@ describe("integration/runs/mysql", () => {
         creatorType: "schedule",
         state: "running",
       });
-      await specHelper.runTask("schedule:run", {
-        runId: run.id,
-        scheduleId: schedule.id,
-      });
 
-      // run the schedule task again to enqueue the determineState task
-      const foundAgain = await specHelper.findEnqueuedTasks("schedule:run");
-      expect(foundAgain.length).toEqual(5);
-      await specHelper.runTask("schedule:run", foundAgain[4].args[0]);
+      // run the schedule twice to complete the run
+      await specHelper.runTask("schedule:run", { runId: run.id });
+      await specHelper.runTask("schedule:run", { runId: run.id });
 
       // run all enqueued associateProfile tasks
       const foundAssociateTasks = await specHelper.findEnqueuedTasks(

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
@@ -341,21 +341,10 @@ describe("integration/runs/postgres", () => {
         creatorType: "schedule",
         state: "running",
       });
-      await specHelper.runTask("schedule:run", {
-        runId: run.id,
-        scheduleId: schedule.id,
-      });
 
-      // run the schedule task again to enqueue the determineState task
-      await helper.sleep();
-      let foundAgain = await specHelper.findEnqueuedTasks("schedule:run");
-      expect(foundAgain.length).toEqual(2);
-      await specHelper.runTask("schedule:run", foundAgain[1].args[0]);
-
-      await helper.sleep();
-      foundAgain = await specHelper.findEnqueuedTasks("schedule:run");
-      expect(foundAgain.length).toEqual(3);
-      await specHelper.runTask("schedule:run", foundAgain[1].args[0]);
+      // run the schedule twice to complete the run
+      await specHelper.runTask("schedule:run", { runId: run.id });
+      await specHelper.runTask("schedule:run", { runId: run.id });
 
       // run all enqueued associateProfile tasks
       const foundAssociateTasks = await specHelper.findEnqueuedTasks(
@@ -396,6 +385,7 @@ describe("integration/runs/postgres", () => {
       );
 
       // check the run's completion percentage (before the run is complete)
+      await specHelper.runTask("schedule:run", { runId: run.id });
       await run.determinePercentComplete();
       expect(run.percentComplete).toBe(100);
 
@@ -472,15 +462,10 @@ describe("integration/runs/postgres", () => {
         creatorType: "schedule",
         state: "running",
       });
-      await specHelper.runTask("schedule:run", {
-        runId: run.id,
-        scheduleId: schedule.id,
-      });
 
-      // run the schedule task again to enqueue the determineState task
-      const foundAgain = await specHelper.findEnqueuedTasks("schedule:run");
-      expect(foundAgain.length).toEqual(5);
-      await specHelper.runTask("schedule:run", foundAgain[4].args[0]);
+      // run the schedule twice to complete the run
+      await specHelper.runTask("schedule:run", { runId: run.id });
+      await specHelper.runTask("schedule:run", { runId: run.id });
 
       // run all enqueued associateProfile tasks
       const foundAssociateTasks = await specHelper.findEnqueuedTasks(


### PR DESCRIPTION
This PR makes running Grouparoo easier against mock redis, and more stable in general.

1. The `grouparoo apply` command now correctly creates runs when there are new or updated Properties.  
2. The Runs batching system has been reworked so that we no longer rely on a chain of tasks to process each chunk of a run.  Instead, there is a new periodic task, `run:tick` that will look for all running runs and enqueue their next batch.  This makes runs more resilient.  There may be a slight slowdown in Run processing time, and a risk of double-processing some Profiles in exchange for this resilience.

Of note, `run:tick` introduced a number of helpful things:
* We now store all relevant run information on the runs table (all that was missing and stored int the task was the `destinationId` for a Group run)
* The only argument to our Run processing tasks are now just a runId (`schedule:run`, `group:run` and `run:internalRun`)
* To attempt not to run 2 chunks of a Run at once, `RunOps.isRunEnqueued()` was added to use in addition with `run.updatedAt`.  This method looks into resque's queues and running workers and tries to see if a task is already enqueued or being worked on for this run.  But, it's not a locking check, and not a guarantee - this is where double-processing might happen