### PR TITLE
If a .env file is present, load it in all environments + Testing Updates

### DIFF
--- a/apps/staging-community/package.json
+++ b/apps/staging-community/package.json
@@ -33,6 +33,10 @@
     "@grouparoo/ui-community": "0.2.3-alpha.4",
     "@grouparoo/zendesk": "0.2.3-alpha.4"
   },
+  "devDependencies": {
+    "@grouparoo/spec-helper": "0.2.3-alpha.4",
+    "jest": "26.6.3"
+  },
   "scripts": {
     "start": "cd node_modules/@grouparoo/core && ./bin/start",
     "dev": "cd node_modules/@grouparoo/core && ./bin/dev"

--- a/apps/staging-enterprise/package.json
+++ b/apps/staging-enterprise/package.json
@@ -33,6 +33,10 @@
     "@grouparoo/ui-enterprise": "0.2.3-alpha.4",
     "@grouparoo/zendesk": "0.2.3-alpha.4"
   },
+  "devDependencies": {
+    "@grouparoo/spec-helper": "0.2.3-alpha.4",
+    "jest": "26.6.3"
+  },
   "scripts": {
     "start": "cd node_modules/@grouparoo/core && ./bin/start",
     "dev": "cd node_modules/@grouparoo/core && ./bin/dev"

--- a/core/src/config/environment.ts
+++ b/core/src/config/environment.ts
@@ -2,16 +2,10 @@ import fs from "fs";
 import path from "path";
 import { getParentPath } from "../utils/pluginDetails";
 
-// load env from .env in development
-// this needs to be done before requiring any part of actionhero
-const env = process.env.NODE_ENV || "development";
-
-if (env === "development" || process.env.GROUPAROO_ENV_CONFIG_FILE) {
-  const envFile =
-    process.env.GROUPAROO_ENV_CONFIG_FILE ||
-    path.resolve(path.join(getParentPath(), ".env"));
-  if (fs.existsSync(envFile)) {
-    require("dotenv").config({ path: envFile });
-    process.env.GROUPAROO_ENV_CONFIG_FILE = envFile;
-  }
+const envFile =
+  process.env.GROUPAROO_ENV_CONFIG_FILE ||
+  path.resolve(path.join(getParentPath(), ".env"));
+if (fs.existsSync(envFile)) {
+  require("dotenv").config({ path: envFile });
+  process.env.GROUPAROO_ENV_CONFIG_FILE = envFile;
 }

--- a/core/src/config/environment.ts
+++ b/core/src/config/environment.ts
@@ -2,10 +2,19 @@ import fs from "fs";
 import path from "path";
 import { getParentPath } from "../utils/pluginDetails";
 
-const envFile =
-  process.env.GROUPAROO_ENV_CONFIG_FILE ||
-  path.resolve(path.join(getParentPath(), ".env"));
-if (fs.existsSync(envFile)) {
-  require("dotenv").config({ path: envFile });
-  process.env.GROUPAROO_ENV_CONFIG_FILE = envFile;
+const envFileAttempts = [path.resolve(path.join(getParentPath(), ".env"))];
+if (process.env.GROUPAROO_ENV_CONFIG_FILE) {
+  envFileAttempts.unshift(process.env.GROUPAROO_ENV_CONFIG_FILE);
+  envFileAttempts.unshift(
+    path.join(getParentPath(), process.env.GROUPAROO_ENV_CONFIG_FILE)
+  );
 }
+
+let found = false;
+envFileAttempts.forEach((file) => {
+  if (!found && fs.existsSync(file)) {
+    require("dotenv").config({ path: file });
+    process.env.GROUPAROO_ENV_CONFIG_FILE = file;
+    found = true;
+  }
+});

--- a/core/src/config/logger.ts
+++ b/core/src/config/logger.ts
@@ -24,8 +24,7 @@ export const DEFAULT = {
 export const test = {
   logger: (config) => {
     const loggers = [];
-
-    loggers.push(buildConsoleLogger("crit"));
+    loggers.push(buildConsoleLogger(process.env.GROUPAROO_LOG_LEVEL || "crit"));
     config.general.paths.log.forEach((p) => {
       loggers.push(buildFileLogger(p, "debug", 1));
     });

--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -74,8 +74,12 @@ export const DEFAULT = {
         storage = `${parsed.hostname}${parsed.pathname}`;
       }
 
-      if (process.env.NODE_ENV === "test") {
-        storage = join(getCoreRootPath(), `${database}.sqlite`);
+      if (
+        process.env.NODE_ENV === "test" &&
+        !parsed.hostname &&
+        !parsed.pathname
+      ) {
+        storage = join(getParentPath(), `${database}.sqlite`);
       }
 
       // without a starting "/" we assume relative locations are against project root

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -186,7 +186,7 @@ export async function processConfigObjects(
         configObject.key || configObject.name
       }\` (${configObject.id}): ${error}`;
       errors.push(errorMessage);
-      log(errorMessage, env === "test" ? "info" : "error");
+      log(errorMessage, "warning");
       continue;
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@grouparoo/snowflake': link:../../plugins/@grouparoo/snowflake
       '@grouparoo/ui-community': link:../../ui/ui-community
       '@grouparoo/zendesk': link:../../plugins/@grouparoo/zendesk
+    devDependencies:
+      '@grouparoo/spec-helper': link:../../plugins/@grouparoo/spec-helper
+      jest: 26.6.3
     specifiers:
       '@grouparoo/bigquery': 0.2.3-alpha.4
       '@grouparoo/core': 0.2.3-alpha.4
@@ -61,8 +64,10 @@ importers:
       '@grouparoo/salesforce': 0.2.3-alpha.4
       '@grouparoo/sendgrid': 0.2.3-alpha.4
       '@grouparoo/snowflake': 0.2.3-alpha.4
+      '@grouparoo/spec-helper': 0.2.3-alpha.4
       '@grouparoo/ui-community': 0.2.3-alpha.4
       '@grouparoo/zendesk': 0.2.3-alpha.4
+      jest: 26.6.3
   apps/staging-enterprise:
     dependencies:
       '@grouparoo/bigquery': link:../../plugins/@grouparoo/bigquery
@@ -88,6 +93,9 @@ importers:
       '@grouparoo/snowflake': link:../../plugins/@grouparoo/snowflake
       '@grouparoo/ui-enterprise': link:../../ui/ui-enterprise
       '@grouparoo/zendesk': link:../../plugins/@grouparoo/zendesk
+    devDependencies:
+      '@grouparoo/spec-helper': link:../../plugins/@grouparoo/spec-helper
+      jest: 26.6.3
     specifiers:
       '@grouparoo/bigquery': 0.2.3-alpha.4
       '@grouparoo/core': 0.2.3-alpha.4
@@ -110,8 +118,10 @@ importers:
       '@grouparoo/salesforce': 0.2.3-alpha.4
       '@grouparoo/sendgrid': 0.2.3-alpha.4
       '@grouparoo/snowflake': 0.2.3-alpha.4
+      '@grouparoo/spec-helper': 0.2.3-alpha.4
       '@grouparoo/ui-enterprise': 0.2.3-alpha.4
       '@grouparoo/zendesk': 0.2.3-alpha.4
+      jest: 26.6.3
   cli:
     dependencies:
       chalk: 4.1.0


### PR DESCRIPTION
Prior to this PR, Grouparoo only loaded the `.env` file in the `development` environment (process.env.NODE_ENV = "development" or unset).  This PR will load the .env file in all environments.  This PR also makes it possible to set a specific `.env.test` file in your tests.

Grouparoo still recommends that you DO NOT use a `.env` file for your production deployments, and continue to rely on your system/PaaS/Docker environment directly. 

Related docs in https://github.com/grouparoo/www.grouparoo.com/pull/252