### PR TITLE
Recover stuck Imports - `imports:associateProfiles`

### DIFF
--- a/core/__tests__/models/schedule.ts
+++ b/core/__tests__/models/schedule.ts
@@ -387,28 +387,6 @@ describe("models/schedule", () => {
       await schedule.destroy();
     });
 
-    test("running a schedule will save the highWaterMark sourceOffset on the run", async () => {
-      const schedule = await Schedule.create({
-        name: "test plugin schedule",
-        sourceId: source.id,
-      });
-      await schedule.setOptions({ maxColumn: "col" });
-      await schedule.update({ state: "ready" });
-
-      const run = await Run.create({
-        creatorId: schedule.id,
-        creatorType: "schedule",
-        state: "running",
-      });
-
-      await schedule.run(run);
-      await run.reload();
-      expect(run.highWaterMark).toEqual({ updated_at: 200 });
-      expect(run.sourceOffset).toBe("100");
-
-      await schedule.destroy();
-    });
-
     test("the source can provide the percentComplete via sourceRunPercentComplete", async () => {
       const schedule = await Schedule.create({
         name: "test plugin schedule",

--- a/core/__tests__/tasks/import/associateProfiles.ts
+++ b/core/__tests__/tasks/import/associateProfiles.ts
@@ -1,0 +1,50 @@
+import { helper } from "@grouparoo/spec-helper";
+import { api, task, specHelper } from "actionhero";
+
+describe("tasks/import:associateProfiles", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  beforeAll(async () => await helper.factories.properties());
+
+  beforeEach(async () => {
+    await api.resque.queue.connection.redis.flushdb();
+  });
+
+  test("can be enqueued", async () => {
+    await task.enqueue("import:associateProfiles", {});
+    const foundTasks = await specHelper.findEnqueuedTasks(
+      "import:associateProfiles"
+    );
+    expect(foundTasks.length).toEqual(1);
+  });
+
+  test("it will enqueue new tasks to associate not-yet associated imports", async () => {
+    const _import = await helper.factories.import();
+
+    // delete the associate task that was created along with the import
+    await api.resque.queue.connection.redis.flushdb();
+
+    await specHelper.runTask("import:associateProfiles", {});
+
+    const foundTasks = await specHelper.findEnqueuedTasks(
+      "import:associateProfile"
+    );
+    expect(foundTasks.length).toBe(1);
+    expect(foundTasks[0].args[0].importId).toBe(_import.id);
+  });
+
+  test("previously complete runs will be moved back to running if an import they created is found", async () => {
+    const schedule = await helper.factories.schedule();
+    const run = await helper.factories.run(schedule);
+    const _import = await helper.factories.import(run);
+    await run.update({ state: "complete" });
+
+    await run.reload();
+    expect(run.state).toBe("complete");
+
+    await api.resque.queue.connection.redis.flushdb();
+    await specHelper.runTask("import:associateProfiles", {});
+
+    await run.reload();
+    expect(run.state).toBe("running");
+  });
+});

--- a/core/src/modules/ops/schedule.ts
+++ b/core/src/modules/ops/schedule.ts
@@ -37,14 +37,10 @@ export namespace ScheduleOps {
       highWaterMark = run.highWaterMark;
     } else {
       const previousRun = await run.previousRun();
-      if (previousRun?.highWaterMark) {
-        highWaterMark = previousRun.highWaterMark;
-      }
+      if (previousRun?.highWaterMark) highWaterMark = previousRun.highWaterMark;
     }
 
-    if (run.sourceOffset) {
-      sourceOffset = run.sourceOffset;
-    }
+    if (run.sourceOffset) sourceOffset = run.sourceOffset;
 
     let importsCount = 0;
     let nextHighWaterMark: HighWaterMark;

--- a/core/src/modules/ops/schedule.ts
+++ b/core/src/modules/ops/schedule.ts
@@ -30,17 +30,15 @@ export namespace ScheduleOps {
       (await plugin.readSetting("core", "runs-profile-batch-size")).value
     );
 
-    let highWaterMark = {};
-    let sourceOffset: number | string = 0;
+    const sourceOffset: number | string = run.sourceOffset || 0;
 
+    let highWaterMark = {};
     if (run.highWaterMark && Object.keys(run.highWaterMark).length > 0) {
       highWaterMark = run.highWaterMark;
     } else {
       const previousRun = await run.previousRun();
       if (previousRun?.highWaterMark) highWaterMark = previousRun.highWaterMark;
     }
-
-    if (run.sourceOffset) sourceOffset = run.sourceOffset;
 
     let importsCount = 0;
     let nextHighWaterMark: HighWaterMark;
@@ -70,10 +68,6 @@ export namespace ScheduleOps {
       importsCount = response.importsCount || 0;
       nextHighWaterMark = response.highWaterMark || {};
       nextSourceOffset = response.sourceOffset || 0;
-      await run.update({
-        highWaterMark: nextHighWaterMark,
-        sourceOffset: nextSourceOffset,
-      });
     } catch (error) {
       log(
         `failed run ${run.id} for schedule ${schedule.id}: ${error}`,

--- a/core/src/tasks/import/associateProfiles.ts
+++ b/core/src/tasks/import/associateProfiles.ts
@@ -1,0 +1,57 @@
+import { log } from "actionhero";
+import { plugin } from "../../modules/plugin";
+import { Import } from "../../models/Import";
+import { Run } from "../../models/Run";
+import { CLSTask } from "../../classes/tasks/clsTask";
+import { CLS } from "../../modules/cls";
+import { Op } from "sequelize";
+
+export class ImportAssociateProfiles extends CLSTask {
+  constructor() {
+    super();
+    this.name = "import:associateProfiles";
+    this.description = "ensure that imports are associated to profiles";
+    this.frequency = 30 * 1000;
+    this.queue = "imports";
+    this.inputs = {};
+  }
+
+  async runWithinTransaction() {
+    const limit = parseInt(
+      (await plugin.readSetting("core", "runs-profile-batch-size")).value
+    );
+
+    const imports = await Import.findAll({
+      where: { profileId: null },
+      limit,
+      order: [["createdAt", "asc"]],
+    });
+
+    const runIds: string[] = [];
+    console.log(imports);
+    for (const i in imports) {
+      const _import = imports[i];
+      await CLS.enqueueTask("import:associateProfile", {
+        importId: _import.id,
+      });
+
+      if (
+        _import.creatorType === "run" &&
+        !runIds.includes(_import.creatorId)
+      ) {
+        runIds.push(_import.creatorId);
+      }
+    }
+
+    if (runIds.length > 0) {
+      await Run.update(
+        { state: "running" },
+        { where: { state: "complete", id: { [Op.in]: runIds } }, logging: true }
+      );
+    }
+
+    if (imports.length > 0) {
+      log(`enqueued ${imports.length} imports for association`);
+    }
+  }
+}

--- a/core/src/tasks/import/associateProfiles.ts
+++ b/core/src/tasks/import/associateProfiles.ts
@@ -46,7 +46,7 @@ export class ImportAssociateProfiles extends CLSTask {
     if (runIds.length > 0) {
       await Run.update(
         { state: "running" },
-        { where: { state: "complete", id: { [Op.in]: runIds } }, logging: true }
+        { where: { state: "complete", id: { [Op.in]: runIds } } }
       );
     }
 

--- a/core/src/tasks/run/internalRun.ts
+++ b/core/src/tasks/run/internalRun.ts
@@ -87,10 +87,12 @@ export class RunInternalRun extends CLSTask {
       groupMemberOffset: offset + limit,
     });
 
-    await run.afterBatch();
-
     if (profiles.length === 0) {
       await run.afterBatch("complete");
+    } else {
+      await run.afterBatch();
     }
+
+    return profiles.length;
   }
 }

--- a/core/src/tasks/schedule/run.ts
+++ b/core/src/tasks/schedule/run.ts
@@ -28,10 +28,12 @@ export class ScheduleRun extends RetryableTask {
 
     const { importsCount } = await schedule.run(run);
 
-    await run.afterBatch();
-
     if (importsCount === 0) {
       await run.afterBatch("complete");
+    } else {
+      await run.afterBatch();
     }
+
+    return importsCount;
   }
 }


### PR DESCRIPTION
This PR adds another preventative measure for `mockredis` - the task `imports:associateProfiles`.  If the server is shut down without task persistence and there are imports created but not use processed, they will loose their `import:associateProfile` (singular) task and never be processed.  This PR adds a periodic task to look for these "lost" Imports and re-try them periodically.   This is similar behavior to how we handle externally-created Events.