### PR TITLE
import:associateProfile needs to be unique and return early if import already associated

### DIFF
--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -401,7 +401,7 @@ export namespace ProfileOps {
     [key: string]: Array<string | number | boolean | Date>;
   }) {
     let profile: Profile;
-    let isNew: boolean;
+    let isNew = false;
     let profileProperty: ProfileProperty;
     const uniqueProperties = await Property.findAll({
       where: { unique: true },
@@ -433,7 +433,6 @@ export namespace ProfileOps {
       });
 
       if (profile) {
-        isNew = false;
         return { profile, isNew };
       } else {
         throw new Error(
@@ -470,7 +469,6 @@ export namespace ProfileOps {
         profile = await Profile.findOne({
           where: { id: profileProperty.profileId },
         });
-        isNew = false;
       } else {
         profile = await Profile.create();
         profile = await profile.reload();

--- a/core/src/tasks/import/associateProfiles.ts
+++ b/core/src/tasks/import/associateProfiles.ts
@@ -28,7 +28,6 @@ export class ImportAssociateProfiles extends CLSTask {
     });
 
     const runIds: string[] = [];
-    console.log(imports);
     for (const i in imports) {
       const _import = imports[i];
       await CLS.enqueueTask("import:associateProfile", {
@@ -45,7 +44,7 @@ export class ImportAssociateProfiles extends CLSTask {
 
     if (runIds.length > 0) {
       await Run.update(
-        { state: "running" },
+        { state: "running", completedAt: null },
         { where: { state: "complete", id: { [Op.in]: runIds } } }
       );
     }


### PR DESCRIPTION
This PR ensures that the `import:associateProfile` task is  uniquely run, and won't overwrite an import's `createdProfile:boolean` status by running twice.  This in turn effects the related Run's `profileCreated` count.