### PR TITLE
`grouparoo status` can output JSON

### DIFF
--- a/core/__tests__/bin/statuts.ts
+++ b/core/__tests__/bin/statuts.ts
@@ -26,7 +26,7 @@ describe("bin/status", () => {
 
   test("the status command can be run", async () => {
     const command = new Status();
-    const toStop = await command.run();
+    const toStop = await command.run({ params: {} });
     expect(toStop).toBe(true);
 
     const output = messages.join(" ");
@@ -37,11 +37,23 @@ describe("bin/status", () => {
     expect(output).toContain("Pending Exports: 0");
   });
 
+  test("the status command can output json", async () => {
+    const command = new Status();
+    const toStop = await command.run({ params: { json: true } });
+    expect(toStop).toBe(true);
+
+    const output = messages.join(" ");
+    expect(spy).toHaveBeenCalled();
+    expect(output).not.toContain("Cluster Status @");
+    expect(output).toContain('"ClusterName":["My Grouparoo Cluster","test"]');
+    expect(output).toContain('"PendingExports":[0]');
+  });
+
   test("with a group", async () => {
     const group = await helper.factories.group();
 
     const command = new Status();
-    await command.run();
+    await command.run({ params: {} });
 
     const output = messages.join(" ");
     expect(output).toContain("Groups: 1");

--- a/core/src/bin/status.ts
+++ b/core/src/bin/status.ts
@@ -12,14 +12,15 @@ export class Status extends CLI {
     this.description = "Display the status of your Grouparoo cluster";
 
     GrouparooCLI.timestampOption(this);
+    GrouparooCLI.jsonOption(this);
   }
 
   preInitialize = () => {
     GrouparooCLI.setGrouparooRunMode(this);
   };
 
-  async run() {
-    GrouparooCLI.logCLI(this.name);
+  async run({ params }) {
+    if (!params.json) GrouparooCLI.logCLI(this.name);
 
     const { value: clusterName } = await plugin.readSetting(
       "core",
@@ -53,12 +54,22 @@ export class Status extends CLI {
     const pendingStatus = await GrouparooCLI.getPendingStatus();
     const runStatus = await GrouparooCLI.getRunsStatus();
 
-    GrouparooCLI.logStatus("Cluster Status", [
+    const data = [
       { header: "Overview", status: overview },
       { header: "Groups", status: groupsStatus },
       { header: "Active Runs", status: runStatus },
       { header: "Pending Items", status: pendingStatus },
-    ]);
+    ];
+
+    if (params.json) {
+      const jsonData = {};
+      data.map((collection) => {
+        jsonData[collection.header] = collection.status;
+      });
+      console.log(JSON.stringify(jsonData));
+    } else {
+      GrouparooCLI.logStatus("Cluster Status", data);
+    }
 
     return true;
   }


### PR DESCRIPTION
```
$ grouparoo status --json

{"Overview":{"ClusterName":["evan's dev cluster","development"],"TotalProfiles":[1000],"TotalGroups":[3]},"Groups":{"People with Email Addresses":["1000 members","newest member: 2021-02-25T04:51:25.015Z"],"A Small Group":["50 members","newest member: 2021-02-25T04:51:25.004Z"],"High Value Customers":["185 members","newest member: 2021-02-25T04:51:13.648Z"]},"Active Runs":{"None":[null]},"Pending Items":{"ActiveRuns":[0],"PendingProfiles":[0,1000],"PendingImports":[0],"PendingExports":[0]}}
```

or, with `jq` making things look good:

```
$ grouparoo status --json | jq


{
  "Overview": {
    "ClusterName": [
      "evan's dev cluster",
      "development"
    ],
    "TotalProfiles": [
      1000
    ],
    "TotalGroups": [
      3
    ]
  },
  "Groups": {
    "People with Email Addresses": [
      "1000 members",
      "newest member: 2021-02-25T04:51:25.015Z"
    ],
    "A Small Group": [
      "50 members",
      "newest member: 2021-02-25T04:51:25.004Z"
    ],
    "High Value Customers": [
      "185 members",
      "newest member: 2021-02-25T04:51:13.648Z"
    ]
  },
  "Active Runs": {
    "None": [
      null
    ]
  },
  "Pending Items": {
    "ActiveRuns": [
      0
    ],
    "PendingProfiles": [
      0,
      1000
    ],
    "PendingImports": [
      0
    ],
    "PendingExports": [
      0
    ]
  }
}
```