### PR TITLE
Display a loading animation if page transitions are slow

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,6 +1014,7 @@ importers:
       moment: 2.29.1
       next: 10.0.7_a2387ec113d27ac26ce0a241efd8d4d6
       node-sass: 5.0.0
+      nprogress: 0.2.0
       pluralize: 8.0.0
       react: 17.0.1
       react-bootstrap: 1.5.0_react-dom@17.0.1+react@17.0.1
@@ -1064,6 +1065,7 @@ importers:
       moment: 2.29.1
       next: 10.0.7
       node-sass: 5.0.0
+      nprogress: 0.2.0
       pluralize: 8.0.0
       prettier: 2.2.1
       prop-types: 15.7.2
@@ -1104,6 +1106,7 @@ importers:
       moment: 2.29.1
       next: 10.0.7_a2387ec113d27ac26ce0a241efd8d4d6
       node-sass: 5.0.0
+      nprogress: 0.2.0
       pluralize: 8.0.0
       prettier: 2.2.1
       prop-types: 15.7.2
@@ -1143,6 +1146,7 @@ importers:
       moment: 2.29.1
       next: 10.0.7
       node-sass: 5.0.0
+      nprogress: 0.2.0
       pluralize: 8.0.0
       prettier: 2.2.1
       prop-types: 15.7.2
@@ -1173,6 +1177,7 @@ importers:
       moment: 2.29.1
       next: 10.0.7_a2387ec113d27ac26ce0a241efd8d4d6
       node-sass: 5.0.0
+      nprogress: 0.2.0
       pluralize: 8.0.0
       react: 17.0.1
       react-bootstrap: 1.5.0_react-dom@17.0.1+react@17.0.1
@@ -1223,6 +1228,7 @@ importers:
       moment: 2.29.1
       next: 10.0.7
       node-sass: 5.0.0
+      nprogress: 0.2.0
       pluralize: 8.0.0
       prettier: 2.2.1
       prop-types: 15.7.2
@@ -10670,6 +10676,9 @@ packages:
       set-blocking: 2.0.0
     resolution:
       integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
+  /nprogress/0.2.0:
+    resolution:
+      integrity: sha1-y480xTIT2JVyP8urkH6UIq28r7E=
   /nth-check/2.0.0:
     dependencies:
       boolbase: 1.0.0

--- a/ui/ui-community/package.json
+++ b/ui/ui-community/package.json
@@ -39,6 +39,7 @@
     "md5": "2.3.0",
     "moment": "2.29.1",
     "next": "10.0.7",
+    "nprogress": "0.2.0",
     "node-sass": "5.0.0",
     "pluralize": "8.0.0",
     "react": "17.0.1",

--- a/ui/ui-components/components/pageTransition.tsx
+++ b/ui/ui-components/components/pageTransition.tsx
@@ -1,0 +1,34 @@
+import { useRouter } from "next/router";
+import NProgress from "nprogress";
+import { useEffect } from "react";
+
+export default function PageTransition() {
+  const router = useRouter();
+  const delay = 1000 * 2; // 2 seconds
+  let timer: NodeJS.Timeout;
+
+  useEffect(() => {
+    router.events.on("routeChangeStart", start);
+    router.events.on("routeChangeComplete", stop);
+    router.events.on("routeChangeError", stop);
+
+    () => {
+      stop();
+      router.events.off("routeChangeStart", start);
+      router.events.off("routeChangeComplete", stop);
+      router.events.off("routeChangeError", stop);
+    };
+  }, []);
+
+  function start() {
+    timer = setTimeout(NProgress.start, delay);
+  }
+
+  function stop() {
+    clearTimeout(timer);
+    NProgress.done();
+    NProgress.remove();
+  }
+
+  return null;
+}

--- a/ui/ui-components/package.json
+++ b/ui/ui-components/package.json
@@ -47,6 +47,7 @@
     "moment": "2.29.1",
     "next": "10.0.7",
     "node-sass": "5.0.0",
+    "nprogress": "0.2.0",
     "pluralize": "8.0.0",
     "prettier": "2.2.1",
     "prop-types": "15.7.2",

--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -3,6 +3,7 @@ import { useApi } from "../hooks/useApi";
 
 import Injection from "../components/componentInjection";
 import Layout from "../components/layouts/main";
+import PageTransition from "../components/pageTransition";
 import "../components/icons";
 
 import { AxiosError } from "axios";
@@ -71,6 +72,7 @@ export default function GrouparooWebApp(props) {
 
   return (
     <Injection {...combinedProps}>
+      <PageTransition />
       <Layout hydrationError={hydrationError} {...combinedProps}>
         <Component {...combinedProps} err={err} />
       </Layout>

--- a/ui/ui-components/scss/grouparoo.scss
+++ b/ui/ui-components/scss/grouparoo.scss
@@ -148,6 +148,7 @@ hr {
 @import "~swagger-ui-dist/swagger-ui.css";
 @import "~react-date-range/dist/styles.css";
 @import "~react-date-range/dist/theme/default.css";
+@import "./nprogress.scss";
 
 // -- Theme Overrides
 

--- a/ui/ui-components/scss/nprogress.scss
+++ b/ui/ui-components/scss/nprogress.scss
@@ -1,0 +1,83 @@
+$progress-bar-color: $grouparoo-blue;
+
+/* Make clicks pass-through */
+#nprogress {
+  pointer-events: none;
+}
+
+#nprogress .bar {
+  background: $progress-bar-color;
+
+  position: fixed;
+  z-index: 1031;
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: 2px;
+}
+
+/* Fancy blur effect */
+#nprogress .peg {
+  display: block;
+  position: absolute;
+  right: 0px;
+  width: 100px;
+  height: 100%;
+  box-shadow: 0 0 10px $progress-bar-color, 0 0 5px $progress-bar-color;
+  opacity: 1;
+
+  -webkit-transform: rotate(3deg) translate(0px, -4px);
+  -ms-transform: rotate(3deg) translate(0px, -4px);
+  transform: rotate(3deg) translate(0px, -4px);
+}
+
+/* Remove these to get rid of the spinner */
+#nprogress .spinner {
+  display: block;
+  position: fixed;
+  z-index: 1031;
+  top: 15px;
+  right: 15px;
+}
+
+#nprogress .spinner-icon {
+  width: 18px;
+  height: 18px;
+  box-sizing: border-box;
+
+  border: solid 2px transparent;
+  border-top-color: $progress-bar-color;
+  border-left-color: $progress-bar-color;
+  border-radius: 50%;
+
+  -webkit-animation: nprogress-spinner 400ms linear infinite;
+  animation: nprogress-spinner 400ms linear infinite;
+}
+
+.nprogress-custom-parent {
+  overflow: hidden;
+  position: relative;
+}
+
+.nprogress-custom-parent #nprogress .spinner,
+.nprogress-custom-parent #nprogress .bar {
+  position: absolute;
+}
+
+@-webkit-keyframes nprogress-spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}
+@keyframes nprogress-spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/ui/ui-enterprise/package.json
+++ b/ui/ui-enterprise/package.json
@@ -39,6 +39,7 @@
     "md5": "2.3.0",
     "moment": "2.29.1",
     "next": "10.0.7",
+    "nprogress": "0.2.0",
     "node-sass": "5.0.0",
     "pluralize": "8.0.0",
     "react": "17.0.1",


### PR DESCRIPTION
Grouparoo uses Next.js `getInitialProps` to hydrate our pages before they are displayed.  This allows us ensure that pages come from the server with at least the first version of the data you requested.  This is great for SEO and accessibility, but bad for caching and page speed.  If you were loading a particularly slow page, it was hard to tell that Grouparoo was 'working on it'.

This PR introduces a loading bar + spinner, curtesy of the popular [`nprogress`](https://github.com/rstacruz/nprogress) package.  It appears if a page has been loading for more than 2 seconds, and hides itself once the new page has loaded. 

![Screen Shot 2021-02-25 at 1 58 38 PM](https://user-images.githubusercontent.com/303226/109225336-ff1c8100-7771-11eb-98cc-42d2bbec20a6.png)
