### PR TITLE
Show Identifying Property Name on Profile Pages

### DIFF
--- a/ui/ui-components/components/profile/getProfileDisplayName.ts
+++ b/ui/ui-components/components/profile/getProfileDisplayName.ts
@@ -1,6 +1,6 @@
 import { Models } from "../../utils/apiData";
 
-export default function getProfileDisplayName(profile: Models.ProfileType) {
+export function getProfileDisplayName(profile: Models.ProfileType) {
   let displayName = "";
 
   for (const key in profile.properties) {
@@ -12,4 +12,18 @@ export default function getProfileDisplayName(profile: Models.ProfileType) {
   if (displayName === "") displayName = profile.id;
 
   return displayName;
+}
+
+export function getProfilePageTitle(profile: Models.ProfileType) {
+  let title = "";
+
+  for (const key in profile.properties) {
+    if (profile.properties[key].identifying) {
+      title = `${key} - ${profile.properties[key].values.join(", ")}`;
+    }
+  }
+
+  if (title === "") title = `Profile - ${profile.id}`;
+
+  return title;
 }

--- a/ui/ui-components/components/tabs/profile.tsx
+++ b/ui/ui-components/components/tabs/profile.tsx
@@ -1,6 +1,6 @@
 import Tabs from "../tabs";
 import { Models } from "../../utils/apiData";
-import getProfileDisplayName from "../profile/getProfileDisplayName";
+import { getProfileDisplayName } from "../profile/getProfileDisplayName";
 
 export default function ProfileTabs({
   profile,

--- a/ui/ui-components/pages/profile/[id]/edit.tsx
+++ b/ui/ui-components/pages/profile/[id]/edit.tsx
@@ -9,7 +9,7 @@ import { useRouter } from "next/router";
 import ProfileImageFromEmail from "../../../components/visualizations/profileImageFromEmail";
 import Moment from "react-moment";
 import LoadingTable from "../../../components/loadingTable";
-import getProfileDisplayName from "../../../components/profile/getProfileDisplayName";
+import { getProfilePageTitle } from "../../../components/profile/getProfileDisplayName";
 import ArrayProfilePropertyList from "../../../components/profile/arrayProfilePropertyList";
 import { Models, Actions } from "../../../utils/apiData";
 import { ErrorHandler } from "../../../utils/errorHandler";
@@ -190,7 +190,7 @@ export default function Page(props) {
   return (
     <>
       <Head>
-        <title>Grouparoo: {getProfileDisplayName(profile)}</title>
+        <title>Grouparoo: {getProfilePageTitle(profile)}</title>
       </Head>
 
       <ProfileTabs profile={profile} />

--- a/ui/ui-components/pages/profile/[id]/events.tsx
+++ b/ui/ui-components/pages/profile/[id]/events.tsx
@@ -2,7 +2,10 @@ import Head from "next/head";
 import EventsList from "../../../components/events/list";
 import ProfileTabs from "../../../components/tabs/profile";
 import { useApi } from "../../../hooks/useApi";
-import getProfileDisplayName from "../../../components/profile/getProfileDisplayName";
+import {
+  getProfileDisplayName,
+  getProfilePageTitle,
+} from "../../../components/profile/getProfileDisplayName";
 
 export default function Page(props) {
   const { profile } = props;
@@ -10,7 +13,7 @@ export default function Page(props) {
   return (
     <>
       <Head>
-        <title>Grouparoo: {getProfileDisplayName(profile)}</title>
+        <title>Grouparoo: {getProfilePageTitle(profile)}</title>
       </Head>
 
       <ProfileTabs profile={profile} />

--- a/ui/ui-components/pages/profile/[id]/exports.tsx
+++ b/ui/ui-components/pages/profile/[id]/exports.tsx
@@ -1,7 +1,10 @@
 import Head from "next/head";
 import { useApi } from "../../../hooks/useApi";
 import ExportsList from "../../../components/export/list";
-import getProfileDisplayName from "../../../components/profile/getProfileDisplayName";
+import {
+  getProfileDisplayName,
+  getProfilePageTitle,
+} from "../../../components/profile/getProfileDisplayName";
 import ProfileTabs from "../../../components/tabs/profile";
 
 export default function Page(props) {
@@ -10,7 +13,7 @@ export default function Page(props) {
   return (
     <>
       <Head>
-        <title>Grouparoo: {getProfileDisplayName(profile)}</title>
+        <title>Grouparoo: {getProfilePageTitle(profile)}</title>
       </Head>
 
       <ProfileTabs profile={profile} />

--- a/ui/ui-components/pages/profile/[id]/imports.tsx
+++ b/ui/ui-components/pages/profile/[id]/imports.tsx
@@ -1,6 +1,9 @@
 import Head from "next/head";
 import { useApi } from "../../../hooks/useApi";
-import getProfileDisplayName from "../../../components/profile/getProfileDisplayName";
+import {
+  getProfileDisplayName,
+  getProfilePageTitle,
+} from "../../../components/profile/getProfileDisplayName";
 import ProfileTabs from "../../../components/tabs/profile";
 import ImportList from "../../../components/import/list";
 
@@ -10,7 +13,7 @@ export default function Page(props) {
   return (
     <>
       <Head>
-        <title>Grouparoo: {getProfileDisplayName(profile)}</title>
+        <title>Grouparoo: {getProfilePageTitle(profile)}</title>
       </Head>
 
       <ProfileTabs profile={profile} />

--- a/ui/ui-components/pages/profile/[id]/logs.tsx
+++ b/ui/ui-components/pages/profile/[id]/logs.tsx
@@ -2,7 +2,10 @@ import Head from "next/head";
 import { useApi } from "../../../hooks/useApi";
 import LogsList from "../../../components/log/list";
 import ProfileTabs from "../../../components/tabs/profile";
-import getProfileDisplayName from "../../../components/profile/getProfileDisplayName";
+import {
+  getProfileDisplayName,
+  getProfilePageTitle,
+} from "../../../components/profile/getProfileDisplayName";
 
 export default function Page(props) {
   const { profile } = props;
@@ -10,7 +13,7 @@ export default function Page(props) {
   return (
     <>
       <Head>
-        <title>Grouparoo: Logs</title>
+        <title>Grouparoo: {getProfilePageTitle(profile)}</title>
       </Head>
 
       <ProfileTabs profile={profile} />


### PR DESCRIPTION
For Profile pages, the page title contains the Identifying Property's Key and value, e.g. `email - person@example.com`

![Screen Shot 2021-02-25 at 2 41 37 PM](https://user-images.githubusercontent.com/303226/109229249-e44d0b00-7777-11eb-8cf4-47e68deef029.png)
