### PR TITLE
Sessions are stored in the database + Better Auth errors

### DIFF
--- a/core/__tests__/actions/apiKey.ts
+++ b/core/__tests__/actions/apiKey.ts
@@ -103,9 +103,9 @@ describe("actions/apiKeys", () => {
         apiKey: key,
       });
       expect(error).toEqual({
-        code: "AUTHENTICATION_ERROR",
+        code: "AUTHORIZATION_ERROR",
         fields: [],
-        message: 'not authorized for mode "read" on topic "apiKey"',
+        message: 'Not authorized for mode "read" on topic "apiKey"',
       });
     });
 

--- a/core/__tests__/actions/groups.ts
+++ b/core/__tests__/actions/groups.ts
@@ -392,9 +392,7 @@ describe("actions/groups", () => {
         type: "manual",
       };
       const { error } = await specHelper.runAction("group:create", connection);
-      expect(error.message).toBe(
-        'not authorized for mode "write" on topic "group"'
-      );
+      expect(error.code).toBe("AUTHORIZATION_ERROR");
     });
 
     test("a reader can list all the groups", async () => {
@@ -448,9 +446,7 @@ describe("actions/groups", () => {
         name: "new group name",
       };
       const { error } = await specHelper.runAction("group:edit", connection);
-      expect(error.message).toBe(
-        'not authorized for mode "write" on topic "group"'
-      );
+      expect(error.code).toBe("AUTHORIZATION_ERROR");
     });
 
     test("a reader can view a team", async () => {
@@ -477,9 +473,7 @@ describe("actions/groups", () => {
         connection
       );
 
-      expect(destroyResponse.error.message).toBe(
-        'not authorized for mode "write" on topic "group"'
-      );
+      expect(destroyResponse.error.code).toBe("AUTHORIZATION_ERROR");
     });
   });
 });

--- a/core/__tests__/actions/profiles.ts
+++ b/core/__tests__/actions/profiles.ts
@@ -718,9 +718,7 @@ describe("actions/profiles", () => {
         "profile:create",
         connection
       );
-      expect(error.message).toMatch(
-        /not authorized for mode "write" on topic "profile"/
-      );
+      expect(error.code).toBe("AUTHORIZATION_ERROR");
     });
 
     test("a reader can list all the profiles", async () => {
@@ -741,9 +739,7 @@ describe("actions/profiles", () => {
         id,
       };
       const { error } = await specHelper.runAction("profile:edit", connection);
-      expect(error.message).toMatch(
-        /not authorized for mode "write" on topic "profile"/
-      );
+      expect(error.code).toBe("AUTHORIZATION_ERROR");
     });
 
     test("a reader can view a profile", async () => {
@@ -780,9 +776,7 @@ describe("actions/profiles", () => {
         connection
       );
 
-      expect(destroyResponse.error.message).toMatch(
-        /not authorized for mode "write" on topic "profile"/
-      );
+      expect(destroyResponse.error.code).toBe("AUTHORIZATION_ERROR");
     });
   });
 });

--- a/core/__tests__/actions/sessions.ts
+++ b/core/__tests__/actions/sessions.ts
@@ -287,7 +287,7 @@ describe("session", () => {
           "appReadAction",
           Object.assign({}, connection, { params: { csrfToken } })
         );
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
 
         await signIn();
@@ -295,7 +295,7 @@ describe("session", () => {
           "appWriteAction",
           Object.assign({}, connection, { params: { csrfToken } })
         );
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
 
         await signIn();
@@ -303,7 +303,7 @@ describe("session", () => {
           "systemReadAction",
           Object.assign({}, connection, { params: { csrfToken } })
         );
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
       });
 
@@ -327,7 +327,7 @@ describe("session", () => {
           "appWriteAction",
           Object.assign({}, connection, { params: { csrfToken } })
         );
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
 
         await signIn();
@@ -335,7 +335,7 @@ describe("session", () => {
           "systemReadAction",
           Object.assign({}, connection, { params: { csrfToken } })
         );
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
       });
 
@@ -352,7 +352,7 @@ describe("session", () => {
           "appReadAction",
           Object.assign({}, connection, { params: { csrfToken } })
         );
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
 
         await signIn();
@@ -368,7 +368,7 @@ describe("session", () => {
           "systemReadAction",
           Object.assign({}, connection, { params: { csrfToken } })
         );
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
       });
 
@@ -529,19 +529,19 @@ describe("session", () => {
         let response = await specHelper.runAction("appReadAction", {
           apiKey: apiKey.apiKey,
         });
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
 
         response = await specHelper.runAction("appWriteAction", {
           apiKey: apiKey.apiKey,
         });
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
 
         response = await specHelper.runAction("systemReadAction", {
           apiKey: apiKey.apiKey,
         });
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
       });
 
@@ -560,13 +560,13 @@ describe("session", () => {
         response = await specHelper.runAction("appWriteAction", {
           apiKey: apiKey.apiKey,
         });
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
 
         response = await specHelper.runAction("systemReadAction", {
           apiKey: apiKey.apiKey,
         });
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
       });
 
@@ -579,7 +579,7 @@ describe("session", () => {
         let response = await specHelper.runAction("appReadAction", {
           apiKey: apiKey.apiKey,
         });
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
 
         response = await specHelper.runAction("appWriteAction", {
@@ -591,7 +591,7 @@ describe("session", () => {
         response = await specHelper.runAction("systemReadAction", {
           apiKey: apiKey.apiKey,
         });
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
         expect(response.success).toBeFalsy();
       });
     });

--- a/core/__tests__/actions/teams.ts
+++ b/core/__tests__/actions/teams.ts
@@ -332,9 +332,7 @@ describe("actions/teams", () => {
         name: "team wario",
       };
       const { error } = await specHelper.runAction("team:create", connection);
-      expect(error.message).toEqual(
-        'not authorized for mode "write" on topic "team"'
-      );
+      expect(error.code).toEqual("AUTHORIZATION_ERROR");
     });
 
     test("a non-administrator cannot edit a team", async () => {
@@ -344,9 +342,7 @@ describe("actions/teams", () => {
         name: "team wario",
       };
       const { error } = await specHelper.runAction("team:edit", connection);
-      expect(error.message).toEqual(
-        'not authorized for mode "write" on topic "team"'
-      );
+      expect(error.code).toEqual("AUTHORIZATION_ERROR");
     });
 
     test("a non-administrator cannot destroy a team", async () => {
@@ -355,9 +351,7 @@ describe("actions/teams", () => {
         id,
       };
       const { error } = await specHelper.runAction("team:destroy", connection);
-      expect(error.message).toEqual(
-        'not authorized for mode "write" on topic "team"'
-      );
+      expect(error.code).toEqual("AUTHORIZATION_ERROR");
     });
   });
 });

--- a/core/src/actions/session.ts
+++ b/core/src/actions/session.ts
@@ -30,12 +30,12 @@ export class SessionCreate extends CLSAction {
     const match = await teamMember.checkPassword(params.password);
     if (!match) throw new Error("password does not match");
 
-    const sessionData = await api.session.create(connection, teamMember);
+    const session = await api.session.create(connection, teamMember);
 
     return {
       success: true,
       teamMember: await teamMember.apiData(),
-      csrfToken: sessionData.csrfToken,
+      csrfToken: session.id,
     };
   }
 }
@@ -56,13 +56,13 @@ export class SessionView extends AuthenticatedAction {
     connection: Connection;
     session: { teamMember: TeamMember };
   }) {
-    const sessionData = await api.session.load(connection);
-    if (sessionData) {
-      return {
-        teamMember: await teamMember.apiData(),
-        csrfToken: sessionData.csrfToken,
-      };
-    }
+    const session = await api.session.load(connection);
+    if (!session) throw new Error("session not found");
+
+    return {
+      teamMember: await teamMember.apiData(),
+      csrfToken: session.id,
+    };
   }
 }
 

--- a/core/src/initializers/session.ts
+++ b/core/src/initializers/session.ts
@@ -6,194 +6,13 @@ import {
   Connection,
   chatRoom,
 } from "actionhero";
-import { Team, TeamMember, ApiKey } from "../index";
-import crypto from "crypto";
-
-class AuthenticationError extends Error {
-  code: string;
-
-  constructor(message, code = "AUTHENTICATION_ERROR") {
-    super(message);
-    this.code = code;
-  }
-}
-
-const authenticatedActionMiddleware: action.ActionMiddleware = {
-  name: "authenticated-action",
-  global: false,
-  priority: 1000,
-  preProcessor: async (data) => {
-    // authenticate a web user with session cookie & csrfToken
-    async function authenticateTeamMember() {
-      const sessionData = await api.session.load(data.connection);
-      if (!sessionData || !sessionData.id) {
-        throw new AuthenticationError("Please log in to continue");
-      } else if (
-        (data.params.csrfToken &&
-          data.params.csrfToken !== sessionData.csrfToken) ||
-        (!data.params.csrfToken &&
-          data.connection.rawConnection?.req?.headers[
-            "x-grouparoo-server_token"
-          ] !== config.general.serverToken)
-      ) {
-        await api.session.destroy(data.connection);
-        throw new AuthenticationError("CSRF error");
-      } else {
-        const teamMember = await TeamMember.findOne({
-          where: { id: sessionData.id },
-          include: [Team],
-        });
-
-        if (!teamMember) throw new AuthenticationError("Team member not found");
-
-        const team = await teamMember.$get("team");
-        const authorized = await team.authorizeAction(
-          data.actionTemplate.permission.topic,
-          data.actionTemplate.permission.mode
-        );
-        if (!authorized) {
-          throw new AuthenticationError(
-            `not authorized for mode "${data.actionTemplate.permission.mode}" on topic "${data.actionTemplate.permission.topic}"`
-          );
-        }
-
-        data.session.data = sessionData;
-        data.session.teamMember = teamMember;
-      }
-    }
-
-    // authenticate an API Request
-    async function authenticateApiKey() {
-      const apiKey = await ApiKey.findOne({
-        where: { apiKey: data.params.apiKey },
-      });
-      if (!apiKey) throw new AuthenticationError("apiKey not found");
-
-      const authorized = await apiKey.authorizeAction(
-        data.actionTemplate.permission.topic,
-        data.actionTemplate.permission.mode
-      );
-      if (!authorized) {
-        throw new AuthenticationError(
-          `not authorized for mode "${data.actionTemplate.permission.mode}" on topic "${data.actionTemplate.permission.topic}"`
-        );
-      }
-
-      data.session.apiKey = apiKey;
-    }
-
-    // choose which mode to authenticate with
-    if (data.params.apiKey) {
-      return authenticateApiKey();
-    } else {
-      return authenticateTeamMember();
-    }
-  },
-};
-
-const optionallyAuthenticatedActionMiddleware: action.ActionMiddleware = {
-  name: "optionally-authenticated-action",
-  global: false,
-  priority: 1000,
-  preProcessor: async (data) => {
-    // authenticate a web user with session cookie & csrfToken
-    async function authenticateTeamMember() {
-      const sessionData = await api.session.load(data.connection);
-      if (sessionData) {
-        if (
-          (data.params.csrfToken &&
-            data.params.csrfToken !== sessionData.csrfToken) ||
-          (!data.params.csrfToken &&
-            data.connection.rawConnection?.req?.headers[
-              "x-grouparoo-server_token"
-            ] !== config.general.serverToken)
-        ) {
-          await api.session.destroy(data.connection);
-          throw new AuthenticationError("CSRF error");
-        } else if (!sessionData.id) {
-          throw new AuthenticationError("Please log in to continue");
-        } else {
-          const teamMember = await TeamMember.findOne({
-            where: { id: sessionData.id },
-            include: [Team],
-          });
-
-          if (teamMember) {
-            const team = await teamMember.$get("team");
-            const authorized = await team.authorizeAction(
-              data.actionTemplate.permission.topic,
-              data.actionTemplate.permission.mode
-            );
-            if (!authorized) {
-              throw new AuthenticationError(
-                `not authorized for mode "${data.actionTemplate.permission.mode}" on topic "${data.actionTemplate.permission.topic}"`
-              );
-            }
-
-            data.session.data = sessionData;
-            data.session.teamMember = teamMember;
-          }
-        }
-      }
-    }
-
-    // authenticate an API Request
-    async function authenticateApiKey() {
-      const apiKey = await ApiKey.findOne({
-        where: { apiKey: data.params.apiKey },
-      });
-      if (!apiKey) throw new AuthenticationError("apiKey not found");
-
-      const authorized = await apiKey.authorizeAction(
-        data.actionTemplate.permission.topic,
-        data.actionTemplate.permission.mode
-      );
-      if (!authorized) {
-        throw new AuthenticationError(
-          `not authorized for mode "${data.actionTemplate.permission.mode}" on topic "${data.actionTemplate.permission.topic}"`
-        );
-      }
-    }
-
-    // choose which mode to authenticate with
-    if (data.params.apiKey) {
-      return authenticateApiKey();
-    } else {
-      return authenticateTeamMember();
-    }
-  },
-};
-
-const modelChatRoomMiddleware: chatRoom.ChatMiddleware = {
-  name: "model chat room middleware",
-  join: async (connection: Connection, room: string) => {
-    if (!room.match(/^model:/)) {
-      return;
-    }
-
-    const topic = room.split(":")[1];
-    const mode = "read";
-    const sessionData = await api.session.load(connection);
-    if (!sessionData || !sessionData.id) {
-      throw new AuthenticationError("Please log in to continue");
-    } else {
-      const teamMember = await TeamMember.findOne({
-        where: { id: sessionData.id },
-        include: [Team],
-      });
-
-      if (!teamMember) throw new AuthenticationError("Team member not found");
-
-      const team = await teamMember.$get("team");
-      const authorized = await team.authorizeAction(topic, "read");
-      if (!authorized) {
-        throw new AuthenticationError(
-          `not authorized for mode "${mode}" on topic "${topic}"`
-        );
-      }
-    }
-  },
-};
+import { TeamMember } from "../index";
+import { Session } from "../models/Session";
+import {
+  ModelChatRoomMiddleware,
+  AuthenticatedActionMiddleware,
+  OptionallyAuthenticatedActionMiddleware,
+} from "../modules/middleware/authentication";
 
 interface SessionData {
   id: string;
@@ -206,18 +25,18 @@ declare module "actionhero" {
     session: {
       prefix: string;
       ttl: number;
-      key: (connection: Connection) => string;
-      load: (connection: Connection) => Promise<SessionData>;
+      // key: (connection: Connection) => string;
+      load: (connection: Connection) => Promise<Session>;
       destroy: (connection: Connection) => Promise<void>;
       create: (
         connection: Connection,
         teamMember: TeamMember
-      ) => Promise<SessionData>;
+      ) => Promise<Session>;
     };
   }
 }
 
-export class Session extends Initializer {
+export class SessionInitializer extends Initializer {
   constructor() {
     super();
     this.name = "session";
@@ -229,41 +48,34 @@ export class Session extends Initializer {
 
     api.session = {
       prefix: "session",
-      ttl: 60 * 60 * 24 * 30, // 1 month; in seconds
-
-      key: (connection: Connection) => {
-        return `${api.session.prefix}:${connection.fingerprint}`;
-      },
+      ttl: 1000 * 60 * 60 * 24 * 30, // 30 days; in milliseconds
 
       load: async (connection: Connection) => {
-        const key = api.session.key(connection);
-        const data = await redis.get(key);
-        if (!data) {
-          return false;
-        }
-        await redis.expire(key, api.session.ttl);
-        return JSON.parse(data);
+        const session = await Session.findOne({
+          where: { fingerprint: connection.fingerprint },
+        });
+        if (!session) return null;
+        await session.update({
+          expiresAt: new Date().getTime() + api.session.ttl,
+        });
+        return session;
       },
 
-      create: async (connection: Connection, teamMember) => {
-        const key = api.session.key(connection);
-        const csrfToken = await randomBytesAsync();
-
-        const sessionData = {
-          id: teamMember.id,
-          csrfToken: csrfToken,
-          createdAt: new Date().getTime(),
-        };
-
+      create: async (connection, teamMember) => {
+        const session = await Session.create({
+          fingerprint: connection.fingerprint,
+          teamMemberId: teamMember.id,
+          expiresAt: new Date().getTime() + api.session.ttl,
+        });
         await teamMember.update({ lastLoginAt: new Date() });
-        await redis.set(key, JSON.stringify(sessionData));
-        await redis.expire(key, api.session.ttl);
-        return sessionData;
+
+        return session;
       },
 
       destroy: async (connection: Connection) => {
-        const key = api.session.key(connection);
-        await redis.del(key);
+        await Session.destroy({
+          where: { fingerprint: connection.fingerprint },
+        });
       },
     };
   }
@@ -273,22 +85,11 @@ export class Session extends Initializer {
       throw new Error("SERVER_TOKEN environment variable missing");
     }
 
-    action.addMiddleware(authenticatedActionMiddleware);
-    action.addMiddleware(optionallyAuthenticatedActionMiddleware);
-    chatRoom.addMiddleware(modelChatRoomMiddleware);
+    action.addMiddleware(AuthenticatedActionMiddleware);
+    action.addMiddleware(OptionallyAuthenticatedActionMiddleware);
+    chatRoom.addMiddleware(ModelChatRoomMiddleware);
 
     api.params.globalSafeParams.push("csrfToken");
     api.params.globalSafeParams.push("apiKey");
   }
 }
-
-const randomBytesAsync = function (bytes = 64): Promise<string> {
-  return new Promise((resolve, reject) => {
-    crypto.randomBytes(bytes, (error, buf) => {
-      if (error) {
-        return reject(error);
-      }
-      return resolve(buf.toString("hex"));
-    });
-  });
-};

--- a/core/src/initializers/session.ts
+++ b/core/src/initializers/session.ts
@@ -62,11 +62,16 @@ export class SessionInitializer extends Initializer {
       },
 
       create: async (connection, teamMember) => {
+        await Session.destroy({
+          where: { fingerprint: connection.fingerprint },
+        });
+
         const session = await Session.create({
           fingerprint: connection.fingerprint,
           teamMemberId: teamMember.id,
           expiresAt: new Date().getTime() + api.session.ttl,
         });
+
         await teamMember.update({ lastLoginAt: new Date() });
 
         return session;

--- a/core/src/migrations/000059-createSessions.ts
+++ b/core/src/migrations/000059-createSessions.ts
@@ -1,0 +1,44 @@
+export default {
+  up: async function (migration, DataTypes) {
+    await migration.createTable("sessions", {
+      id: {
+        type: DataTypes.STRING(40),
+        primaryKey: true,
+      },
+
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+
+      teamMemberId: {
+        type: DataTypes.STRING(191),
+        allowNull: false,
+      },
+
+      fingerprint: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+      },
+
+      expiresAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+    });
+
+    await migration.addIndex("sessions", ["fingerprint"], {
+      unique: true,
+      fields: ["fingerprint"],
+    });
+  },
+
+  down: async function (migration) {
+    await migration.dropTable("sessions");
+  },
+};

--- a/core/src/models/Session.ts
+++ b/core/src/models/Session.ts
@@ -1,15 +1,33 @@
-import { Table, Column, AllowNull, ForeignKey } from "sequelize-typescript";
-import { LoggedModel } from "../classes/loggedModel";
+import {
+  Model,
+  Table,
+  Column,
+  AllowNull,
+  ForeignKey,
+  CreatedAt,
+  UpdatedAt,
+  BeforeCreate,
+} from "sequelize-typescript";
+import * as uuid from "uuid";
 import { TeamMember } from "./TeamMember";
 import { APIData } from "../modules/apiData";
 import { Op } from "sequelize";
 import { api } from "actionhero";
 
 @Table({ tableName: "sessions", paranoid: false })
-export class Session extends LoggedModel<Session> {
+export class Session extends Model {
+  @Column({ primaryKey: true })
+  id: string;
+
   idPrefix() {
     return "ses";
   }
+
+  @CreatedAt
+  createdAt: Date;
+
+  @UpdatedAt
+  updatedAt: Date;
 
   @AllowNull(false)
   @Column
@@ -41,6 +59,13 @@ export class Session extends LoggedModel<Session> {
     const instance = await this.scope(null).findOne({ where: { id } });
     if (!instance) throw new Error(`cannot find ${this.name} ${id}`);
     return instance;
+  }
+
+  @BeforeCreate
+  static generateId(instance) {
+    if (!instance.id) {
+      instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
+    }
   }
 
   static async sweep() {

--- a/core/src/modules/middleware/authentication.ts
+++ b/core/src/modules/middleware/authentication.ts
@@ -10,6 +10,16 @@ export class AuthenticationError extends Error {
   }
 }
 
+export class AuthorizationError extends Error {
+  code: string;
+
+  constructor(mode: string, topic: string, code = "AUTHORIZATION_ERROR") {
+    const message = `Not authorized for mode "${mode}" on topic "${topic}"`;
+    super(message);
+    this.code = code;
+  }
+}
+
 export const AuthenticatedActionMiddleware: action.ActionMiddleware = {
   name: "authenticated-action",
   global: false,
@@ -59,9 +69,7 @@ export const ModelChatRoomMiddleware: chatRoom.ChatMiddleware = {
       const team = await teamMember.$get("team");
       const authorized = await team.authorizeAction(topic, "read");
       if (!authorized) {
-        throw new AuthenticationError(
-          `not authorized for mode "${mode}" on topic "${topic}"`
-        );
+        throw new AuthorizationError(mode, topic);
       }
     }
   },
@@ -101,8 +109,9 @@ async function authenticateTeamMember(
       data.actionTemplate.permission.mode
     );
     if (!authorized) {
-      throw new AuthenticationError(
-        `not authorized for mode "${data.actionTemplate.permission.mode}" on topic "${data.actionTemplate.permission.topic}"`
+      throw new AuthorizationError(
+        data.actionTemplate.permission.mode,
+        data.actionTemplate.permission.topic
       );
     }
 
@@ -123,8 +132,9 @@ async function authenticateApiKey(data: { [key: string]: any }) {
     data.actionTemplate.permission.mode
   );
   if (!authorized) {
-    throw new AuthenticationError(
-      `not authorized for mode "${data.actionTemplate.permission.mode}" on topic "${data.actionTemplate.permission.topic}"`
+    throw new AuthorizationError(
+      data.actionTemplate.permission.mode,
+      data.actionTemplate.permission.topic
     );
   }
 

--- a/core/src/modules/middleware/authentication.ts
+++ b/core/src/modules/middleware/authentication.ts
@@ -1,0 +1,132 @@
+import { api, config, action, Connection, chatRoom } from "actionhero";
+import { Team, TeamMember, ApiKey } from "../../index";
+
+export class AuthenticationError extends Error {
+  code: string;
+
+  constructor(message, code = "AUTHENTICATION_ERROR") {
+    super(message);
+    this.code = code;
+  }
+}
+
+export const AuthenticatedActionMiddleware: action.ActionMiddleware = {
+  name: "authenticated-action",
+  global: false,
+  priority: 1000,
+  preProcessor: async (data) => {
+    if (data.params.apiKey) {
+      return authenticateApiKey(data);
+    } else {
+      return authenticateTeamMember(data, false);
+    }
+  },
+};
+
+export const OptionallyAuthenticatedActionMiddleware: action.ActionMiddleware = {
+  name: "optionally-authenticated-action",
+  global: false,
+  priority: 1000,
+  preProcessor: async (data) => {
+    if (data.params.apiKey) {
+      return authenticateApiKey(data);
+    } else {
+      return authenticateTeamMember(data, true);
+    }
+  },
+};
+
+export const ModelChatRoomMiddleware: chatRoom.ChatMiddleware = {
+  name: "model chat room middleware",
+  join: async (connection: Connection, room: string) => {
+    if (!room.match(/^model:/)) {
+      return;
+    }
+
+    const topic = room.split(":")[1];
+    const mode = "read";
+    const session = await api.session.load(connection);
+    if (!session || !session.id) {
+      throw new AuthenticationError("Please log in to continue");
+    } else {
+      const teamMember = await TeamMember.findOne({
+        where: { id: session.teamMemberId },
+        include: [Team],
+      });
+
+      if (!teamMember) throw new AuthenticationError("Team member not found");
+
+      const team = await teamMember.$get("team");
+      const authorized = await team.authorizeAction(topic, "read");
+      if (!authorized) {
+        throw new AuthenticationError(
+          `not authorized for mode "${mode}" on topic "${topic}"`
+        );
+      }
+    }
+  },
+};
+
+// authenticate a web user with session cookie & csrfToken
+async function authenticateTeamMember(
+  data: { [key: string]: any },
+  optional: boolean
+) {
+  const session = await api.session.load(data.connection);
+  if (!session && optional) return;
+  if (!session || !session.id) {
+    throw new AuthenticationError("Please log in to continue");
+  } else if (
+    (data.params.csrfToken && data.params.csrfToken !== session.id) ||
+    (!data.params.csrfToken &&
+      data.connection.rawConnection?.req?.headers[
+        "x-grouparoo-server_token"
+      ] !== config.general.serverToken)
+  ) {
+    await api.session.destroy(data.connection);
+    throw new AuthenticationError("CSRF error");
+  } else {
+    const teamMember = await TeamMember.findOne({
+      where: { id: session.teamMemberId },
+      include: [Team],
+    });
+
+    if (!teamMember) {
+      throw new AuthenticationError("Team member not found");
+    }
+
+    const team = await teamMember.$get("team");
+    const authorized = await team.authorizeAction(
+      data.actionTemplate.permission.topic,
+      data.actionTemplate.permission.mode
+    );
+    if (!authorized) {
+      throw new AuthenticationError(
+        `not authorized for mode "${data.actionTemplate.permission.mode}" on topic "${data.actionTemplate.permission.topic}"`
+      );
+    }
+
+    data.session.data = session;
+    data.session.teamMember = teamMember;
+  }
+}
+
+// authenticate an API Request
+async function authenticateApiKey(data: { [key: string]: any }) {
+  const apiKey = await ApiKey.findOne({
+    where: { apiKey: data.params.apiKey },
+  });
+  if (!apiKey) throw new AuthenticationError("apiKey not found");
+
+  const authorized = await apiKey.authorizeAction(
+    data.actionTemplate.permission.topic,
+    data.actionTemplate.permission.mode
+  );
+  if (!authorized) {
+    throw new AuthenticationError(
+      `not authorized for mode "${data.actionTemplate.permission.mode}" on topic "${data.actionTemplate.permission.topic}"`
+    );
+  }
+
+  data.session.apiKey = apiKey;
+}

--- a/core/src/tasks/sweeper.ts
+++ b/core/src/tasks/sweeper.ts
@@ -3,6 +3,7 @@ import { Run } from "../models/Run";
 import { Import } from "../models/Import";
 import { Export } from "../models/Export";
 import { Log } from "../models/Log";
+import { Session } from "../models/Session";
 import { CLSTask } from "../classes/tasks/clsTask";
 
 export class Sweeper extends CLSTask {
@@ -56,5 +57,9 @@ export class Sweeper extends CLSTask {
     // --- LOGS ---
     response = await Log.sweep();
     this.log("log", response.count, response.days);
+
+    // --- Sessions ---
+    response = await Session.sweep();
+    this.log("session", response.count, response.days);
   }
 }

--- a/ui/ui-components/client/client.ts
+++ b/ui/ui-components/client/client.ts
@@ -85,6 +85,8 @@ export class Client {
           res.end();
         }
       }
+    } else if (code === "AUTHORIZATION_ERROR") {
+      // ok, it will be rendered on the page
     }
   }
 

--- a/ui/ui-components/components/visualizations/grouparooChart.tsx
+++ b/ui/ui-components/components/visualizations/grouparooChart.tsx
@@ -31,12 +31,17 @@ export function GrouparooChart({
     | "cardinalClosed"
     | "cardinalOpen";
 }) {
+  if (!data || data.length < 1) return null;
+
   let yMax = 1.25;
 
-  data.forEach((line) => {
+  data.forEach((line, idx) => {
     line.forEach((point) => {
       if (point.y > yMax) yMax = point.y + 0.25;
     });
+
+    if (line.length === 1)
+      data[idx].push({ x: data[idx][0].x + 1, y: data[idx][0].y });
   });
 
   return (


### PR DESCRIPTION
This PR moves Grouparoo's Session Storage from Redis to the Porstgres/SQLlise database in use by the application.  This means that your session data will persist even if your redis data doesn't. 

This PR also distinguishes between `AUTHENTICATION_ERROR` (things like bad password or API Key not found) and `AUTHORIZATION_ERROR` (you don't have permission to do that).  This lets us update the behavior when the UI sees an authorization error and displays it (`AUTHORIZATION_ERROR`), rather than assuming you want to sign in again (`AUTHENTICATION_ERROR`)