### PR TITLE
Separate Arguments from Options in `grouparoo generate --describe`

### DIFF
--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -135,7 +135,7 @@ Commands:
 
   async generate(params) {
     const learnMoreText =
-      "Learn more with `grouparoo generate --help` and `grouparoo generate --list`";
+      "Learn more with `grouparoo generate --help`, `grouparoo generate --list`, and `grouparoo generate [template] --describe`";
 
     if (!params.template) {
       return this.fatalError(`template is required. ${learnMoreText}`);
@@ -238,6 +238,7 @@ Commands:
     } else {
       const requiredInputs = Object.keys(template.inputs)
         .filter((i) => template.inputs[i].required)
+        .filter((i) => i !== "id")
         .sort();
       const optionalInputs = Object.keys(template.inputs)
         .filter((i) => !template.inputs[i].required)
@@ -263,12 +264,19 @@ Commands:
 
       console.log(`${template.description}`);
       console.log("");
-      console.log("Required Inputs:");
+
+      if (template.inputs.id) {
+        console.log("Required Arguments:");
+        console.log(`  * id (required) - ${inputs.id.description}`);
+        console.log("");
+      }
+
+      console.log("Required Options:");
       requiredInputs.length > 0
         ? requiredInputs.forEach((k) => displayInput(k))
         : console.log("  None");
       console.log("");
-      console.log("Optional Inputs:");
+      console.log("Optional Options:");
       optionalInputs.length > 0
         ? optionalInputs.forEach((k) => displayInput(k))
         : console.log("  None");


### PR DESCRIPTION
```
$ grouparoo generate postgres:table:source --describe

notice: Modified your runtime environment with /Users/evan/workspace/grouparoo/grouparoo/apps/staging-enterprise/.env
info: active plugins: @grouparoo/core, @grouparoo/core/manual, @grouparoo/ui-enterprise, @grouparoo/core/events, @grouparoo/bigquery, @grouparoo/csv, @grouparoo/customerio, @grouparoo/facebook, @grouparoo/files-s3, @grouparoo/google-sheets, @grouparoo/hubspot, @grouparoo/intercom, @grouparoo/iterable, @grouparoo/logger, @grouparoo/mailchimp, @grouparoo/marketo, @grouparoo/mysql, @grouparoo/postgres, @grouparoo/redshift, @grouparoo/sailthru, @grouparoo/salesforce, @grouparoo/sendgrid, @grouparoo/snowflake, @grouparoo/zendesk

🦘 Grouparoo: generate postgres:table:source

Config for a postgres table Source. Construct Sources and Properties without writing SQL.

Required Arguments:
  * id (required) - The id of this new Source

Required Options:
  * parent (required) - The id of the postgres App to use for this Source, e.g: `--parent data_warehouse`

Optional Options:
  * from - The table to use for this source, e.g: `--from users`
  * high-water-mark - The name of the column to uses for this Source's Schedule, e.g: `--high-water-mark updated_at`.
  * mapping - The mapping between a column in this table and a Grouparoo Property, e.g: `--mapping "id=user_id"`
  * with - The names of the columns to create properties from, e.g: `--with users,id,first_name,last_name`. Defaults to '*'
```

```
$ grouparoo generate postgres:app --describe

notice: Modified your runtime environment with /Users/evan/workspace/grouparoo/grouparoo/apps/staging-enterprise/.env
info: active plugins: @grouparoo/core, @grouparoo/core/manual, @grouparoo/ui-enterprise, @grouparoo/core/events, @grouparoo/bigquery, @grouparoo/csv, @grouparoo/customerio, @grouparoo/facebook, @grouparoo/files-s3, @grouparoo/google-sheets, @grouparoo/hubspot, @grouparoo/intercom, @grouparoo/iterable, @grouparoo/logger, @grouparoo/mailchimp, @grouparoo/marketo, @grouparoo/mysql, @grouparoo/postgres, @grouparoo/redshift, @grouparoo/sailthru, @grouparoo/salesforce, @grouparoo/sendgrid, @grouparoo/snowflake, @grouparoo/zendesk

🦘 Grouparoo: generate postgres:app

Config for a Grouparoo postgres App

Required Arguments:
  * id (required) - The name of this new App

Required Options:
  None

Optional Options:
  None
```