### PR TITLE
Maintain Option Types

### DIFF
--- a/core/__tests__/models/option.ts
+++ b/core/__tests__/models/option.ts
@@ -1,0 +1,150 @@
+import { helper } from "@grouparoo/spec-helper";
+import { Option, App } from "../../src";
+import { OptionHelper } from "../../src/modules/optionHelper";
+
+describe("models/option", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
+  test("an option must have a valid type", async () => {
+    const option = Option.build({
+      ownerId: "abc",
+      ownerType: "app",
+      key: "k",
+      value: "string",
+      type: "string",
+    });
+
+    await option.save(); // ok
+
+    await option.update({ value: 123, type: "number" }); // ok
+    await option.update({ value: true, type: "boolean" }); // ok
+
+    await expect(option.update({ value: "foo", type: "foo" })).rejects.toThrow(
+      /foo is not a valid type for an Option/
+    );
+
+    await expect(option.update({ value: "foo", type: null })).rejects.toThrow(
+      /Option.type cannot be null/
+    );
+
+    await option.destroy();
+  });
+
+  describe("types", () => {
+    let option: Option;
+
+    beforeAll(async () => {
+      option = await Option.create({
+        ownerId: "abc",
+        ownerType: "app",
+        key: "k",
+        value: "string",
+        type: "string",
+      });
+    });
+
+    async function _test(type: string, data: { in: any; out: any }[]) {
+      for (const i in data) {
+        const value = data[i].in;
+        await option.update({ type, value });
+        expect(option.typedValue()).toEqual(data[i].out);
+      }
+    }
+
+    test("strings", async () => {
+      await _test("string", [
+        { in: "abc", out: "abc" },
+        { in: "123", out: "123" },
+        { in: 123, out: "123" },
+        { in: "1.23", out: "1.23" },
+        { in: 1.23, out: "1.23" },
+        { in: true, out: "true" },
+        { in: "true", out: "true" },
+        { in: false, out: "false" },
+        { in: "false", out: "false" },
+        { in: "", out: "" },
+      ]);
+    });
+
+    test("numbers", async () => {
+      await _test("number", [
+        { in: "abc", out: NaN },
+        { in: "123", out: 123 },
+        { in: 123, out: 123 },
+        { in: "1.23", out: 1.23 },
+        { in: 1.23, out: 1.23 },
+        { in: true, out: NaN },
+        { in: "true", out: NaN },
+        { in: false, out: NaN },
+        { in: "false", out: NaN },
+        { in: "", out: NaN },
+      ]);
+    });
+
+    test("booleans", async () => {
+      await _test("boolean", [
+        { in: "abc", out: false },
+        { in: "123", out: false },
+        { in: 123, out: false },
+        { in: "1.23", out: false },
+        { in: 1.23, out: false },
+        { in: true, out: true },
+        { in: "true", out: true },
+        { in: false, out: false },
+        { in: "false", out: false },
+        { in: "", out: false },
+      ]);
+    });
+
+    test("special case booleans", async () => {
+      await _test("boolean", [
+        { in: true, out: true },
+        { in: false, out: false },
+        { in: "1", out: true },
+        { in: "0", out: false },
+        { in: "true", out: true },
+        { in: "false", out: false },
+      ]);
+    });
+  });
+
+  describe("optionHelper", () => {
+    let app: App;
+    beforeAll(async () => {
+      app = await helper.factories.app();
+    });
+
+    test("number option types are maintained", async () => {
+      const opts = { fileId: "abc" };
+      await OptionHelper.setOptions(app, opts);
+      expect(await OptionHelper.getOptions(app)).toEqual(opts);
+    });
+
+    test("number option types are maintained", async () => {
+      const opts = { fileId: 123.4 };
+      await OptionHelper.setOptions(app, opts);
+      expect(await OptionHelper.getOptions(app)).toEqual(opts);
+    });
+
+    test("number option types are maintained", async () => {
+      const opts = { fileId: true };
+      await OptionHelper.setOptions(app, opts);
+      expect(await OptionHelper.getOptions(app)).toEqual(opts);
+    });
+
+    describe("options from environment variables", () => {
+      beforeAll(() => {
+        process.env.GROUPAROO_OPTION__APP__TEST_OPTION = "abc123";
+      });
+      afterAll(() => {
+        process.env.GROUPAROO_OPTION__APP__TEST_OPTION = undefined;
+      });
+
+      test("options can be set from an environment variable but not stored in the database", async () => {
+        await OptionHelper.setOptions(app, { fileId: "TEST_OPTION" });
+        const options = await app.getOptions();
+        expect(options.fileId).toBe("abc123");
+      });
+    });
+  });
+});

--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -527,10 +527,7 @@ describe("models/property", () => {
                   profile
                 );
 
-                if (
-                  propertyOptions.column &&
-                  propertyOptions.column.match(/throw/)
-                ) {
+                if (propertyOptions.column?.toString().match(/throw/)) {
                   throw new Error(`throw`);
                 }
                 queryCounter++;

--- a/core/__tests__/models/run/run.ts
+++ b/core/__tests__/models/run/run.ts
@@ -569,7 +569,7 @@ describe("models/run", () => {
             methods: {
               profileProperty: async ({ propertyOptions }) => {
                 if (propertyOptions.column) {
-                  throw new Error(propertyOptions.column);
+                  throw new Error(propertyOptions.column.toString());
                 } else {
                   return ["ok"];
                 }

--- a/core/src/initializers/events.ts
+++ b/core/src/initializers/events.ts
@@ -259,7 +259,9 @@ const eventProfileProperty: ProfilePropertyPluginMethod = async ({
   if (!propertyOptions["column"]) return;
   if (!propertyOptions["aggregationMethod"]) return;
 
-  const dataKey = propertyOptions["column"].replace(/^\[data\]-/, "");
+  const dataKey = propertyOptions["column"]
+    .toString()
+    .replace(/^\[data\]-/, "");
   const aggregationMethod = propertyOptions["aggregationMethod"];
 
   if (aggregationMethod === "all values") {
@@ -322,7 +324,7 @@ const eventProfileProperty: ProfilePropertyPluginMethod = async ({
       limit: 1,
     });
   } else {
-    if (!propertyOptions["column"].match(/^\[data\]-/)) {
+    if (!propertyOptions["column"].toString().match(/^\[data\]-/)) {
       throw new Error(
         "aggregation method not available outside of event data properties"
       );
@@ -379,7 +381,7 @@ const eventProfileProperty: ProfilePropertyPluginMethod = async ({
   if (!events) {
     return null;
   } else {
-    if (propertyOptions["column"].match(/^\[data\]-/)) {
+    if (propertyOptions["column"].toString().match(/^\[data\]-/)) {
       const eventData = await Promise.all(events.map((e) => e.getData()));
       return eventData
         .map((eventData) => eventData[dataKey])
@@ -394,7 +396,7 @@ const eventProfileProperty: ProfilePropertyPluginMethod = async ({
         })
         .flat();
     } else {
-      return events.map((event) => event[propertyOptions["column"]]);
+      return events.map((event) => event[propertyOptions["column"].toString()]);
     }
   }
 };

--- a/core/src/migrations/000060-addTypeToOption.ts
+++ b/core/src/migrations/000060-addTypeToOption.ts
@@ -1,0 +1,18 @@
+export default {
+  up: async function (migration, DataTypes) {
+    await migration.addColumn("options", "type", {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: "string",
+    });
+
+    await migration.changeColumn("options", "type", {
+      type: DataTypes.STRING,
+      allowNull: false,
+    });
+  },
+
+  down: async function (migration) {
+    await migration.removeColumn("options", "type");
+  },
+};

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -313,7 +313,7 @@ export class Destination extends LoggedModel<Destination> {
       const k = keys[i];
       parameterizedOptions[k] =
         typeof options[k] === "string"
-          ? await plugin.replaceTemplateRunVariables(options[k])
+          ? await plugin.replaceTemplateRunVariables(options[k].toString())
           : options[k];
     }
 

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -206,7 +206,7 @@ export class Property extends LoggedModel<Property> {
       options[
         i
       ] = await plugin.replaceTemplateProfilePropertyIdsWithProfilePropertyKeys(
-        options[i]
+        options[i].toString()
       );
     }
 
@@ -220,7 +220,7 @@ export class Property extends LoggedModel<Property> {
       options[
         i
       ] = await plugin.replaceTemplateProfilePropertyKeysWithProfilePropertyId(
-        options[i]
+        options[i].toString()
       );
     }
 

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -122,7 +122,7 @@ export class Source extends LoggedModel<Source> {
       const k = keys[i];
       parameterizedOptions[k] =
         typeof options[k] === "string"
-          ? await plugin.replaceTemplateRunVariables(options[k], run)
+          ? await plugin.replaceTemplateRunVariables(options[k].toString(), run)
           : options[k];
     }
 

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -21,7 +21,7 @@ function modelName(instance): string {
 
 export namespace OptionHelper {
   export interface SimpleOptions {
-    [key: string]: string;
+    [key: string]: string | number | boolean;
   }
 
   export async function getOptions(
@@ -38,7 +38,7 @@ export namespace OptionHelper {
     });
 
     options.forEach((option) => {
-      optionsObject[option.key] = option.value;
+      optionsObject[option.key] = option.typedValue();
     });
 
     if (sourceFromEnvironment) {
@@ -82,6 +82,7 @@ export namespace OptionHelper {
         ownerType: modelName(instance),
         key,
         value: options[key],
+        type: typeof options[key],
       });
     }
 
@@ -140,7 +141,7 @@ export namespace OptionHelper {
 
   export async function validateOptions(
     instance: Source | Destination | Schedule | Property | App,
-    options: { [key: string]: string },
+    options: SimpleOptions,
     allowEmpty = false
   ) {
     let requiredOptions: string[];
@@ -314,10 +315,10 @@ export namespace OptionHelper {
     );
 
     for (const k in options) {
-      if (envOptionKeys.includes(options[k]))
+      if (envOptionKeys.includes(options[k].toString()))
         options[k] = getEnvironmentVariableOption(
           modelName(instance),
-          options[k]
+          options[k].toString()
         );
     }
 

--- a/core/src/tasks/event/associateProfile.ts
+++ b/core/src/tasks/event/associateProfile.ts
@@ -40,7 +40,7 @@ export class EventAssociateProfile extends Task {
 
     try {
       await CLS.wrap(async () =>
-        event.associate(appOptions.identifyingPropertyId)
+        event.associate(appOptions.identifyingPropertyId.toString())
       );
     } catch (error) {
       log(`re-enqueuing association of event ${eventId}`);

--- a/plugins/@grouparoo/app-templates/src/source/query/profileProperty.ts
+++ b/plugins/@grouparoo/app-templates/src/source/query/profileProperty.ts
@@ -32,7 +32,10 @@ export const getProfileProperty: GetProfilePropertyMethod = ({
     let query;
 
     try {
-      query = await plugin.replaceTemplateProfileVariables(ruleQuery, profile);
+      query = await plugin.replaceTemplateProfileVariables(
+        ruleQuery?.toString(),
+        profile
+      );
     } catch (error) {
       // if we don't have the right properties to build the query, bail
       return undefined;

--- a/plugins/@grouparoo/app-templates/src/source/table/profileProperties.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/profileProperties.ts
@@ -30,12 +30,12 @@ export const getProfileProperties: GetProfilePropertiesMethod = ({
     propertyOptions,
     propertyFilters,
   }) => {
-    const tableName = sourceOptions[tableNameKey];
-    const columnName = propertyOptions[columnNameKey];
+    const tableName = sourceOptions[tableNameKey]?.toString();
+    const columnName = propertyOptions[columnNameKey]?.toString();
     const aggregationMethod = <AggregationMethod>(
       propertyOptions[aggregationMethodKey]
     );
-    const sortColumn = propertyOptions[sortColumnKey];
+    const sortColumn = propertyOptions[sortColumnKey]?.toString();
 
     if (!aggregationMethod || !columnName) {
       return undefined;

--- a/plugins/@grouparoo/app-templates/src/source/table/profileProperty.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/profileProperty.ts
@@ -30,14 +30,14 @@ export const getProfileProperty: GetProfilePropertyMethod = ({
     propertyOptions,
     propertyFilters,
   }) => {
-    const tableName = sourceOptions[tableNameKey];
+    const tableName = sourceOptions[tableNameKey]?.toString();
     const matchName = Object.keys(sourceMapping)[0]; // tableCol
     const profilePropertyMatch = Object.values(sourceMapping)[0];
-    const columnName = propertyOptions[columnNameKey];
+    const columnName = propertyOptions[columnNameKey]?.toString();
     const aggregationMethod = <AggregationMethod>(
       propertyOptions[aggregationMethodKey]
     );
-    const sortColumn = propertyOptions[sortColumnKey];
+    const sortColumn = propertyOptions[sortColumnKey]?.toString();
 
     if (!aggregationMethod || !columnName) {
       return undefined;

--- a/plugins/@grouparoo/app-templates/src/source/table/profiles.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/profiles.ts
@@ -37,7 +37,9 @@ export const getProfiles: GetProfilesMethod = ({ getChangedRows }) => {
       highWaterMark,
     });
     sourceOffset = parseInt(sourceOffset.toString()); // we use integers
-    const highWaterMarkAndSortColumnASC = scheduleOptions[columnNameKey];
+    const highWaterMarkAndSortColumnASC = scheduleOptions[
+      columnNameKey
+    ]?.toString();
     const secondarySortColumnASC = Object.keys(sourceMapping)[0];
 
     let importsCount = 0;
@@ -113,7 +115,7 @@ export const getChangeVariables: GetChangeVariablesMethod = async ({
   highWaterMark,
 }) => {
   const runOptions = await source.parameterizedOptions(run);
-  const tableName = runOptions[tableNameKey];
+  const tableName = runOptions[tableNameKey]?.toString();
 
   const hasHighWaterMark = Object.keys(highWaterMark).length === 1;
   let highWaterMarkCondition: MatchCondition = null;

--- a/plugins/@grouparoo/app-templates/src/source/table/propertyOptions.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/propertyOptions.ts
@@ -44,7 +44,7 @@ export const getPropertyOptions: GetPropertyOptionsMethod = ({
       description: "where the data comes from",
       type: "typeahead",
       options: async ({ connection, appOptions, appId, sourceOptions }) => {
-        const tableName = sourceOptions[tableNameKey];
+        const tableName = sourceOptions[tableNameKey]?.toString();
         return getColumnExamples({
           connection,
           appOptions,
@@ -77,7 +77,7 @@ export const getPropertyOptions: GetPropertyOptionsMethod = ({
         "which column to sort by for most and least recent properties",
       type: "typeahead",
       options: async ({ connection, appOptions, appId, sourceOptions }) => {
-        const tableName = sourceOptions[tableNameKey];
+        const tableName = sourceOptions[tableNameKey]?.toString();
         return getColumnExamples({
           connection,
           appOptions,

--- a/plugins/@grouparoo/app-templates/src/source/table/scheduleOptions.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/scheduleOptions.ts
@@ -25,7 +25,7 @@ export const getScheduleOptions: GetScheduleOptionsMethod = ({
       description: "which column to scan for changes",
       type: "list",
       options: async ({ connection, appOptions, appId, sourceOptions }) => {
-        const tableName = sourceOptions[tableNameKey];
+        const tableName = sourceOptions[tableNameKey]?.toString();
         return getSortableColumnExamples({
           connection,
           appOptions,

--- a/plugins/@grouparoo/app-templates/src/source/table/sourceFilters.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/sourceFilters.ts
@@ -19,7 +19,7 @@ export const getSourceFilters: GetSourceFiltersMethod = ({ getColumns }) => {
     appId,
     sourceOptions,
   }) => {
-    const tableName = sourceOptions[tableNameKey];
+    const tableName = sourceOptions[tableNameKey]?.toString();
     const map: ColumnDefinitionMap = await getColumns({
       connection,
       appOptions,

--- a/plugins/@grouparoo/app-templates/src/source/table/sourcePreview.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/sourcePreview.ts
@@ -23,7 +23,7 @@ export const getSourcePreview: GetSourcePreviewMethod = ({
     appId,
     sourceOptions,
   }) => {
-    const tableName = sourceOptions[tableNameKey];
+    const tableName = sourceOptions[tableNameKey]?.toString();
     return getExampleRows({
       connection,
       appOptions,

--- a/plugins/@grouparoo/bigquery/__tests__/integration/cli.ts
+++ b/plugins/@grouparoo/bigquery/__tests__/integration/cli.ts
@@ -100,7 +100,9 @@ describe("bigquery cli tests", () => {
         )
         .replace(
           `private_key: "-----BEGIN PRIVATE KEY-----\\n..."`,
-          `private_key: "${appOptions.private_key.replace(/\n/g, "\\n")}"`
+          `private_key: "${appOptions.private_key
+            ?.toString()
+            .replace(/\n/g, "\\n")}"`
         )
     );
   });

--- a/plugins/@grouparoo/bigquery/src/lib/connect.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/connect.ts
@@ -2,10 +2,12 @@ import { BigQuery } from "@google-cloud/bigquery";
 import { ConnectPluginAppMethod } from "@grouparoo/core";
 
 export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
-  const projectId = appOptions.project_id || "";
-  const dataset = appOptions.dataset || "";
-  const client_email = appOptions.client_email || "";
-  const private_key = (appOptions.private_key || "").replace(/\\n/g, "\n");
+  const projectId = appOptions.project_id?.toString() || "";
+  const dataset = appOptions.dataset?.toString() || "";
+  const client_email = appOptions.client_email?.toString() || "";
+  const private_key = (appOptions.private_key || "")
+    .toString()
+    .replace(/\\n/g, "\n");
   const client = new BigQuery({
     projectId,
     credentials: { client_email, private_key },

--- a/plugins/@grouparoo/csv/src/lib/file-import/profiles.ts
+++ b/plugins/@grouparoo/csv/src/lib/file-import/profiles.ts
@@ -23,12 +23,13 @@ export const profiles: ProfilesPluginMethod = async ({
     const propertyOptions = await property.getOptions();
     const propertyMapping = {};
     if (propertyOptions.column) {
-      propertyMapping[propertyOptions.column] = property.key;
+      propertyMapping[propertyOptions.column?.toString()] = property.key;
       combinedMapping = Object.assign(combinedMapping, propertyMapping);
     }
   }
 
-  const localPath = await plugin.getLocalFilePath(sourceOptions.fileId);
+  const fileId = sourceOptions.fileId?.toString();
+  const localPath = await plugin.getLocalFilePath(fileId);
   const stream = fs.createReadStream(localPath);
   const parser = stream.pipe(csvParser());
 

--- a/plugins/@grouparoo/csv/src/lib/file-import/sourceRunPercentComplete.ts
+++ b/plugins/@grouparoo/csv/src/lib/file-import/sourceRunPercentComplete.ts
@@ -5,7 +5,8 @@ export const sourceRunPercentComplete: SourceRunPercentCompleteMethod = async ({
   run,
   sourceOptions,
 }) => {
-  const localPath = await plugin.getLocalFilePath(sourceOptions.fileId);
+  const fileId = sourceOptions.fileId?.toString();
+  const localPath = await plugin.getLocalFilePath(fileId);
 
   const total: number = await new Promise((resolve, reject) => {
     let i: number;

--- a/plugins/@grouparoo/demo/src/bin/grouparoo/demo/eventStream.ts
+++ b/plugins/@grouparoo/demo/src/bin/grouparoo/demo/eventStream.ts
@@ -39,7 +39,7 @@ export class Console extends CLI {
     const appOptions = await eventApp.getOptions();
     const id = appOptions.identifyingPropertyId;
     if (!id) throw new Error("no identifyingPropertyId on the events app");
-    return id;
+    return id.toString();
   }
 
   makeSession(i) {

--- a/plugins/@grouparoo/facebook/src/lib/connect.ts
+++ b/plugins/@grouparoo/facebook/src/lib/connect.ts
@@ -13,7 +13,7 @@ export class Client {
 
   constructor(appOptions: SimpleAppOptions) {
     const { accessToken, adAccountId } = appOptions;
-    this.accessToken = accessToken;
+    this.accessToken = accessToken?.toString();
     this.adAccountId = `act_${adAccountId}`;
     this.sdk = bizSdk;
   }

--- a/plugins/@grouparoo/google-sheets/src/lib/sheet-import/profiles.ts
+++ b/plugins/@grouparoo/google-sheets/src/lib/sheet-import/profiles.ts
@@ -16,14 +16,17 @@ export const profiles: ProfilesPluginMethod = async ({
     const ruleOptions = await rule.getOptions();
     const ruleMapping = {};
     if (ruleOptions.column) {
-      ruleMapping[ruleOptions.column] = rule.key;
+      ruleMapping[ruleOptions.column?.toString()] = rule.key;
       combinedMapping = Object.assign(combinedMapping, ruleMapping);
     }
   }
 
   const offset = sourceOffset ? parseInt(sourceOffset.toString()) : 0;
   let importsCount = 0;
-  const sheet = new Spreadsheet(appOptions, sourceOptions.sheet_url);
+  const sheet = new Spreadsheet(
+    appOptions,
+    sourceOptions.sheet_url?.toString()
+  );
   const rows = await sheet.read({ limit, offset });
 
   for (const row of rows) {

--- a/plugins/@grouparoo/google-sheets/src/lib/sheet-import/spreadsheet.ts
+++ b/plugins/@grouparoo/google-sheets/src/lib/sheet-import/spreadsheet.ts
@@ -55,7 +55,9 @@ export default class Spreadsheet {
       return;
     }
     const client_email = this.credentials.client_email;
-    const private_key = this.credentials.private_key.replace(/\\n/g, "\n");
+    const private_key = this.credentials.private_key
+      ?.toString()
+      .replace(/\\n/g, "\n");
     await this.doc.useServiceAccountAuth({ client_email, private_key });
     this.connected = true;
   }

--- a/plugins/@grouparoo/hubspot/src/lib/client.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/client.ts
@@ -8,7 +8,7 @@ class HubspotClient {
 
   constructor(appOptions: SimpleAppOptions) {
     this.client = new Client(appOptions);
-    this.hapikey = appOptions["hapikey"];
+    this.hapikey = appOptions.hapikey?.toString();
   }
 
   async getLists(): Promise<any> {

--- a/plugins/@grouparoo/logger/src/lib/export/exportProfiles.ts
+++ b/plugins/@grouparoo/logger/src/lib/export/exportProfiles.ts
@@ -7,7 +7,7 @@ export const exportProfiles: ExportProfilesPluginMethod = async ({
   appOptions,
   exports,
 }) => {
-  const filePath = getFilePath(appOptions.filename);
+  const filePath = getFilePath(appOptions.filename?.toString());
   let lines = [];
 
   exports.map((_export) => {

--- a/plugins/@grouparoo/logger/src/lib/test.ts
+++ b/plugins/@grouparoo/logger/src/lib/test.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import { getFilePath } from "./utils/getFilePath";
 
 export const test: TestPluginMethod = async ({ appOptions }) => {
-  const filePath = getFilePath(appOptions.filename);
+  const filePath = getFilePath(appOptions.filename?.toString());
 
   const now = new Date();
   try {

--- a/plugins/@grouparoo/mailchimp/src/lib/connect.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/connect.ts
@@ -2,6 +2,6 @@ import { SimpleAppOptions } from "@grouparoo/core";
 import Mailchimp from "mailchimp-api-v3";
 
 export async function connect(appOptions: SimpleAppOptions) {
-  const client = new Mailchimp(appOptions.apiKey);
+  const client = new Mailchimp(appOptions.apiKey?.toString());
   return client;
 }

--- a/plugins/@grouparoo/mailchimp/src/lib/export-id/exportProfile.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/export-id/exportProfile.ts
@@ -16,7 +16,7 @@ export const exportProfile: ExportProfilePluginMethod = async ({
     return { success: true };
   }
 
-  const { listId } = destinationOptions;
+  const listId = destinationOptions.listId?.toString();
 
   const mailchimpId = newProfileProperties["mailchimp_id"]; // this is a required key for mailchimp
   if (!mailchimpId) {

--- a/plugins/@grouparoo/mailchimp/src/lib/export/exportProfile.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/export/exportProfile.ts
@@ -21,7 +21,7 @@ export const exportProfile: ExportProfilePluginMethod = async ({
     return { success: true };
   }
 
-  const { listId } = destinationOptions;
+  const listId = destinationOptions.listId?.toString();
 
   const email_address = newProfileProperties["email_address"]; // this is a required key for mailchimp
   if (!email_address) {

--- a/plugins/@grouparoo/mailchimp/src/lib/import/profiles.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/import/profiles.ts
@@ -17,7 +17,7 @@ export const profiles: ProfilesPluginMethod = async ({
     const ruleOptions = await rule.getOptions();
     const ruleMapping = {};
     if (ruleOptions.field) {
-      ruleMapping[ruleOptions.field] = rule.key;
+      ruleMapping[ruleOptions.field?.toString()] = rule.key;
       combinedMapping = Object.assign(combinedMapping, ruleMapping);
     }
   }

--- a/plugins/@grouparoo/mailchimp/src/lib/shared/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/shared/destinationMappingOptions.ts
@@ -19,7 +19,7 @@ export const getDestinationMappingOptions: GetDestinationMappingOptionsMethod = 
     destinationOptions,
   }) => {
     const client = await connect(appOptions);
-    const { listId } = destinationOptions;
+    const listId = destinationOptions.listId?.toString();
     const mergeVars = await getMergeVars(client, listId);
     const properties = getProperties(mergeVars, mappingKey);
 

--- a/plugins/@grouparoo/mysql/src/lib/connect.ts
+++ b/plugins/@grouparoo/mysql/src/lib/connect.ts
@@ -10,7 +10,7 @@ export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
 
   const config = {
     host,
-    port: port ? parseInt(port) : null,
+    port: port ? parseInt(port?.toString()) : null,
     database,
     user,
     password,

--- a/plugins/@grouparoo/mysql/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/destinationMappingOptions.ts
@@ -36,7 +36,9 @@ export const destinationMappingOptions: DestinationMappingOptionsMethod = async 
       },
     },
     properties: {
-      required: [{ key: destinationOptions.primaryKey, type: "any" }],
+      required: [
+        { key: destinationOptions.primaryKey?.toString(), type: "any" },
+      ],
       known: columns,
       allowOptionalFromProperties: false,
     },

--- a/plugins/@grouparoo/mysql/src/lib/export/destinationOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/destinationOptions.ts
@@ -44,17 +44,19 @@ export const destinationOptions: DestinationOptionsMethod = async ({
 
   if (destinationOptions.table) {
     response.primaryKey.type = "typeahead";
-    response.primaryKey.options = await getColumns(destinationOptions.table);
+    response.primaryKey.options = await getColumns(
+      destinationOptions.table?.toString()
+    );
   }
 
   if (destinationOptions.groupsTable) {
     response.groupForeignKey.type = "typeahead";
     response.groupColumnName.type = "typeahead";
     response.groupForeignKey.options = await getColumns(
-      destinationOptions.groupsTable
+      destinationOptions.groupsTable?.toString()
     );
     response.groupColumnName.options = await getColumns(
-      destinationOptions.groupsTable
+      destinationOptions.groupsTable?.toString()
     );
   }
 

--- a/plugins/@grouparoo/mysql/src/lib/export/exportProfile.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/exportProfile.ts
@@ -8,13 +8,19 @@ export const exportProfile: ExportProfilePluginMethod = async ({
   let success = false;
   let error;
 
-  const {
+  let {
     table,
     primaryKey,
     groupsTable,
     groupForeignKey,
     groupColumnName,
   } = await destination.parameterizedOptions();
+
+  table = table?.toString();
+  primaryKey = primaryKey?.toString();
+  groupsTable = groupsTable?.toString();
+  groupForeignKey = groupForeignKey?.toString();
+  groupColumnName = groupColumnName?.toString();
 
   if (Object.keys(newProfileProperties).length === 0) {
     return { success: true };

--- a/plugins/@grouparoo/postgres/src/lib/connect.ts
+++ b/plugins/@grouparoo/postgres/src/lib/connect.ts
@@ -22,6 +22,7 @@ export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
   const sslOptions = ["ssl_cert", "ssl_key", "ssl_ca"];
   sslOptions.forEach((opt) => {
     if (formattedOptions[opt] !== null && formattedOptions[opt] !== undefined) {
+      if (!formattedOptions["ssl"]) formattedOptions["ssl"] = {};
       formattedOptions["ssl"][opt.replace("ssl_", "")] = formattedOptions[opt];
       delete formattedOptions[opt];
     }

--- a/plugins/@grouparoo/postgres/src/lib/connect.ts
+++ b/plugins/@grouparoo/postgres/src/lib/connect.ts
@@ -12,18 +12,16 @@ export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
       formattedOptions["ssl"].toString().toLowerCase() === "true";
   }
 
+  // convert SSL options to an object
+  if (formattedOptions["ssl"]) {
+    // for Grouparoo's use-case, we always want to trust self-signed SSL certs
+    formattedOptions["ssl"] = { rejectUnauthorized: false };
+  }
+
   // handle SSL options
   const sslOptions = ["ssl_cert", "ssl_key", "ssl_ca"];
   sslOptions.forEach((opt) => {
     if (formattedOptions[opt] !== null && formattedOptions[opt] !== undefined) {
-      if (
-        !formattedOptions["ssl"] ||
-        typeof formattedOptions["ssl"] === "boolean" ||
-        typeof formattedOptions["ssl"] === "string"
-      ) {
-        formattedOptions["ssl"] = { rejectUnauthorized: false };
-      }
-
       formattedOptions["ssl"][opt.replace("ssl_", "")] = formattedOptions[opt];
       delete formattedOptions[opt];
     }

--- a/plugins/@grouparoo/postgres/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/export/destinationMappingOptions.ts
@@ -41,7 +41,9 @@ export const destinationMappingOptions: DestinationMappingOptionsMethod = async 
       },
     },
     properties: {
-      required: [{ key: destinationOptions.primaryKey, type: "any" }],
+      required: [
+        { key: destinationOptions.primaryKey.toString(), type: "any" },
+      ],
       known: columns,
       allowOptionalFromProperties: false,
     },

--- a/plugins/@grouparoo/postgres/src/lib/export/destinationOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/export/destinationOptions.ts
@@ -52,17 +52,19 @@ export const destinationOptions: DestinationOptionsMethod = async ({
 
   if (destinationOptions.table) {
     response.primaryKey.type = "typeahead";
-    response.primaryKey.options = await getColumns(destinationOptions.table);
+    response.primaryKey.options = await getColumns(
+      destinationOptions.table.toString()
+    );
   }
 
   if (destinationOptions.groupsTable) {
     response.groupForeignKey.type = "typeahead";
     response.groupColumnName.type = "typeahead";
     response.groupForeignKey.options = await getColumns(
-      destinationOptions.groupsTable
+      destinationOptions.groupsTable.toString()
     );
     response.groupColumnName.options = await getColumns(
-      destinationOptions.groupsTable
+      destinationOptions.groupsTable.toString()
     );
   }
 

--- a/plugins/@grouparoo/postgres/src/lib/export/exportProfile.ts
+++ b/plugins/@grouparoo/postgres/src/lib/export/exportProfile.ts
@@ -7,16 +7,21 @@ export const exportProfile: ExportProfilePluginMethod = async ({
   destination,
   export: { newProfileProperties, oldProfileProperties, newGroups, toDelete },
 }) => {
-  let success = false;
   let error: Error;
 
-  const {
+  let {
     table,
     primaryKey,
     groupsTable,
     groupForeignKey,
     groupColumnName,
   } = await destination.parameterizedOptions();
+
+  table = table?.toString();
+  primaryKey = primaryKey?.toString();
+  groupsTable = groupsTable?.toString();
+  groupForeignKey = groupForeignKey?.toString();
+  groupColumnName = groupColumnName?.toString();
 
   if (Object.keys(newProfileProperties).length === 0) {
     return { success: true };
@@ -178,8 +183,6 @@ export const exportProfile: ExportProfilePluginMethod = async ({
         await connection.query(validateQuery(groupInsertQuery));
       }
     }
-
-    success = true;
   } catch (e) {
     error = e;
   } finally {

--- a/plugins/@grouparoo/salesforce/src/lib/export/options.ts
+++ b/plugins/@grouparoo/salesforce/src/lib/export/options.ts
@@ -98,7 +98,7 @@ async function getProfileOptions(
   const objects = await getObjectNames(conn, specialObjects, true);
   out.profileObject.options = objects;
 
-  const name = destinationOptions.profileObject;
+  const name = destinationOptions.profileObject?.toString();
   if (name && objects.includes(name)) {
     // look up its fields
     const supportedTypes = getSupportedSalesforceTypes();
@@ -144,7 +144,7 @@ async function getGroupOptions(
   const objects = await getObjectNames(conn, specialObjects, false);
   out.groupObject.options = objects;
 
-  const name = destinationOptions.groupObject;
+  const name = destinationOptions.groupObject?.toString();
   if (name && objects.includes(name)) {
     // look up its fields
     const supportedTypes = getSupportedSalesforceTypes(["string"]);
@@ -203,7 +203,7 @@ async function getMembershipOptions(
   const objects = await getObjectNames(conn, specialObjects, false);
   out.membershipObject.options = objects;
 
-  const name = destinationOptions.membershipObject;
+  const name = destinationOptions.membershipObject?.toString();
   if (name && objects.includes(name)) {
     // look up its fields
     const fields = await getObjectMatchNames(
@@ -243,10 +243,8 @@ async function getReferenceOptions(
     profileReferenceObject: { type: "pending", options: [] },
     profileReferenceMatchField: { type: "pending", options: [] },
   };
-  const { profileObject } = destinationOptions;
-  if (!profileObject) {
-    return out;
-  }
+  const profileObject = destinationOptions.profileObject?.toString();
+  if (!profileObject) return out;
 
   // for Account, other?
   const specialFields = ["AccountNumber", "Name"];
@@ -258,7 +256,7 @@ async function getReferenceOptions(
   out.profileReferenceField.type = "typeahead";
   out.profileReferenceField.options = Object.keys(nameMap);
 
-  const fieldName = destinationOptions.profileReferenceField;
+  const fieldName = destinationOptions.profileReferenceField?.toString();
   if (fieldName && nameMap[fieldName]) {
     const field = nameMap[fieldName];
     const relationshipObjects = field.referenceTo;
@@ -266,7 +264,7 @@ async function getReferenceOptions(
     out.profileReferenceObject.type = "typeahead";
     out.profileReferenceObject.options = relationshipObjects;
 
-    const refName = destinationOptions.profileReferenceObject;
+    const refName = destinationOptions.profileReferenceObject?.toString();
     if (refName && relationshipObjects.includes(refName)) {
       const supportedTypes = getSupportedSalesforceTypes();
       const refFields = await getObjectMatchNames(

--- a/plugins/@grouparoo/sendgrid/src/lib/connect.ts
+++ b/plugins/@grouparoo/sendgrid/src/lib/connect.ts
@@ -2,5 +2,5 @@ import { SimpleAppOptions } from "@grouparoo/core";
 import { SendgridClient } from "./client";
 
 export async function connect(appOptions: SimpleAppOptions) {
-  return new SendgridClient(appOptions.apiKey);
+  return new SendgridClient(appOptions.apiKey?.toString());
 }

--- a/plugins/@grouparoo/snowflake/src/lib/connect.ts
+++ b/plugins/@grouparoo/snowflake/src/lib/connect.ts
@@ -5,8 +5,12 @@ import { ConnectPluginAppMethod } from "@grouparoo/core";
 import { log } from "actionhero";
 
 export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
-  let { account, username, password, warehouse, database, schema } = appOptions;
-  schema = schema || "PUBLIC";
+  const account = appOptions.account?.toString();
+  const username = appOptions.username?.toString();
+  const password = appOptions.password?.toString();
+  const warehouse = appOptions.warehouse?.toString();
+  const database = appOptions.database?.toString();
+  const schema = appOptions.schema?.toString() || "PUBLIC";
 
   const logger = SnowflakeLogger.getInstance();
   SnowflakeLogger.setInstance(logToActionhero(logger));

--- a/ui/ui-enterprise/pages/app/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/app/[id]/edit.tsx
@@ -248,7 +248,9 @@ export default function Page(props) {
                                 <Form.Control
                                   as="select"
                                   required={opt.required}
-                                  defaultValue={app.options[opt.key] || ""}
+                                  defaultValue={
+                                    app.options[opt.key]?.toString() || ""
+                                  }
                                   disabled={loading}
                                   onChange={(e) => {
                                     updateOption(e.target.id, e.target.value);
@@ -289,7 +291,9 @@ export default function Page(props) {
                                   required={opt.required}
                                   type="text"
                                   disabled={loading}
-                                  defaultValue={app.options[opt.key]}
+                                  defaultValue={app.options[
+                                    opt.key
+                                  ]?.toString()}
                                   placeholder={opt.placeholder}
                                   onChange={(e) => {
                                     updateOption(e.target.id, e.target.value);

--- a/ui/ui-enterprise/pages/destination/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/destination/[id]/edit.tsx
@@ -255,7 +255,9 @@ export default function Page(props) {
                               as="select"
                               required={opt.required}
                               disabled={loading || loadingOptions}
-                              defaultValue={destination.options[opt.key] || ""}
+                              defaultValue={
+                                destination.options[opt.key]?.toString() || ""
+                              }
                               onChange={(e) =>
                                 updateOption(
                                   e.target.id.replace("_opt~", ""),
@@ -308,7 +310,9 @@ export default function Page(props) {
                               required={opt.required}
                               type="text"
                               disabled={loading || loadingOptions}
-                              defaultValue={destination.options[opt.key]}
+                              defaultValue={destination.options[
+                                opt.key
+                              ]?.toString()}
                               placeholder={opt.placeholder}
                               onChange={(e) =>
                                 updateOption(

--- a/ui/ui-enterprise/pages/property/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/property/[id]/edit.tsx
@@ -361,7 +361,7 @@ export default function Page(props) {
                           required
                           disabled={loading}
                           type="text"
-                          value={property.options[opt.key]}
+                          value={property.options[opt.key]?.toString()}
                           onChange={(e) =>
                             updateOption(opt.key, e.target.value)
                           }
@@ -385,7 +385,7 @@ export default function Page(props) {
                           as="textarea"
                           disabled={loading}
                           rows={5}
-                          value={property.options[opt.key]}
+                          value={property.options[opt.key]?.toString()}
                           onChange={(e) =>
                             updateOption(opt.key, e.target["value"])
                           }

--- a/ui/ui-enterprise/pages/source/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/source/[id]/edit.tsx
@@ -272,7 +272,9 @@ export default function Page(props) {
                               as="select"
                               required={opt.required}
                               disabled={loading || loadingOptions}
-                              defaultValue={source.options[opt.key] || ""}
+                              defaultValue={
+                                source.options[opt.key]?.toString() || ""
+                              }
                               onChange={(e) =>
                                 updateOption(
                                   e.target.id.replace("_opt~", ""),
@@ -325,7 +327,7 @@ export default function Page(props) {
                               required={opt.required}
                               type="text"
                               disabled={loading || loadingOptions}
-                              defaultValue={source.options[opt.key]}
+                              defaultValue={source.options[opt.key]?.toString()}
                               placeholder={opt.placeholder}
                               onChange={(e) =>
                                 updateOption(

--- a/ui/ui-enterprise/pages/source/[id]/schedule.tsx
+++ b/ui/ui-enterprise/pages/source/[id]/schedule.tsx
@@ -251,7 +251,9 @@ export default function Page(props) {
                         <Form.Control
                           as="select"
                           required={opt.required}
-                          defaultValue={schedule.options[opt.key] || ""}
+                          defaultValue={
+                            schedule.options[opt.key]?.toString() || ""
+                          }
                           disabled={schedule.state !== "draft"}
                           onChange={(e) => {
                             updateOption(opt.key, e.target.value);
@@ -283,7 +285,7 @@ export default function Page(props) {
                           required
                           type="text"
                           disabled={schedule.state !== "draft"}
-                          value={schedule.options[opt.key]}
+                          value={schedule.options[opt.key]?.toString()}
                           onChange={(e) =>
                             updateOption(opt.key, e.target.value)
                           }
@@ -301,7 +303,7 @@ export default function Page(props) {
                           required
                           as="textarea"
                           rows={5}
-                          value={schedule.options[opt.key]}
+                          value={schedule.options[opt.key]?.toString()}
                           disabled={schedule.state !== "draft"}
                           onChange={(e) =>
                             updateOption(opt.key, e.target["value"])


### PR DESCRIPTION
This PR maintains the `type` of options as they are saved to the database (string, number, boolean). Prior to this PR, Options were always stored as strings.   This was specifically a problem when using SQLite with boolean options - as `true` would be serialized to `"1"` rather than `"true"`.

For Example:

``` 
options {
  port: 5432,
  ssl: true
}
```

would previously have been converted into this by SQLite: 
```
saved options {
  port: '5432',
  ssl: '1'
}
```

This PR also always allows for connection to Postgres SSL servers with self-signed SSL certificates (ie: Heroku)