### PR TITLE
Reset Cluster removes all data in Redis

### DIFF
--- a/core/src/actions/cluster.ts
+++ b/core/src/actions/cluster.ts
@@ -1,29 +1,27 @@
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { cache, api, task, config } from "actionhero";
 
-import {
-  App,
-  Destination,
-  DestinationGroupMembership,
-  Export,
-  Event,
-  EventData,
-  Group,
-  GroupMember,
-  GroupRule,
-  Import,
-  Log,
-  Mapping,
-  Option,
-  Profile,
-  ProfileProperty,
-  Property,
-  PropertyFilter,
-  Run,
-  Schedule,
-  SetupStep,
-  Source,
-} from "..";
+import { App } from "../models/App";
+import { Destination } from "../models/Destination";
+import { DestinationGroupMembership } from "../models/DestinationGroupMembership";
+import { Export } from "../models/Export";
+import { Event } from "../models/Event";
+import { EventData } from "../models/EventData";
+import { Group } from "../models/Group";
+import { GroupMember } from "../models/GroupMember";
+import { GroupRule } from "../models/GroupRule";
+import { Import } from "../models/Import";
+import { Log } from "../models/Log";
+import { Mapping } from "../models/Mapping";
+import { Option } from "../models/Option";
+import { Profile } from "../models/Profile";
+import { ProfileProperty } from "../models/ProfileProperty";
+import { Property } from "../models/Property";
+import { PropertyFilter } from "../models/PropertyFilter";
+import { Run } from "../models/Run";
+import { Schedule } from "../models/Schedule";
+import { SetupStep } from "../models/SetupStep";
+import { Source } from "../models/Source";
 
 const models = [
   App,

--- a/core/src/actions/cluster.ts
+++ b/core/src/actions/cluster.ts
@@ -1,61 +1,50 @@
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { cache, api, task, config } from "actionhero";
 
-import { App } from "../models/App";
-// import { ApiKey } from "../models/ApiKey";
-import { Destination } from "../models/Destination";
-import { DestinationGroupMembership } from "../models/DestinationGroupMembership";
-// import { File } from "../models/File";
-import { Export } from "../models/Export";
-import { Event } from "../models/Event";
-import { EventData } from "../models/EventData";
-import { Group } from "../models/Group";
-import { GroupMember } from "../models/GroupMember";
-import { GroupRule } from "../models/GroupRule";
-import { Import } from "../models/Import";
-import { Log } from "../models/Log";
-import { Mapping } from "../models/Mapping";
-import { Option } from "../models/Option";
-// import { Permission } from "../models/Permission";
-import { Profile } from "../models/Profile";
-import { ProfileProperty } from "../models/ProfileProperty";
-import { Property } from "../models/Property";
-import { PropertyFilter } from "../models/PropertyFilter";
-import { Run } from "../models/Run";
-import { Schedule } from "../models/Schedule";
-// import { Setting } from "../models/Setting";
-import { SetupStep } from "../models/SetupStep";
-import { Source } from "../models/Source";
-// import { Team } from "../models/Team";
-// import { TeamMember } from "../models/TeamMember";
-
-const models = [
-  // ApiKey,
+import {
   App,
   Destination,
   DestinationGroupMembership,
+  Export,
   Event,
   EventData,
-  Export,
-  // File,
   Group,
   GroupMember,
   GroupRule,
   Import,
-  // Log,
+  Log,
   Mapping,
   Option,
-  // Permission,
   Profile,
   ProfileProperty,
   Property,
   PropertyFilter,
   Run,
   Schedule,
-  // Setting,
+  SetupStep,
   Source,
-  // Team,
-  // TeamMember,
+} from "../..";
+
+const models = [
+  App,
+  Destination,
+  DestinationGroupMembership,
+  Event,
+  EventData,
+  Export,
+  Group,
+  GroupMember,
+  GroupRule,
+  Import,
+  Mapping,
+  Option,
+  Profile,
+  ProfileProperty,
+  Property,
+  PropertyFilter,
+  Run,
+  Schedule,
+  Source,
 ];
 
 export class ClusterReset extends AuthenticatedAction {
@@ -90,14 +79,7 @@ export class ClusterReset extends AuthenticatedAction {
 
     await SetupStep.update({ complete: false }, { where: { complete: true } });
 
-    await cache.clear();
-
-    const redisStatKeys = await api.resque.queue.connection.redis.keys(
-      "*resque:stat:*"
-    );
-    await Promise.all(
-      redisStatKeys.map((k) => api.resque.queue.connection.redis.del(k))
-    );
+    await api.resque.queue.connection.redis.flushdb();
 
     await Log.create({
       topic: "cluster",

--- a/core/src/actions/cluster.ts
+++ b/core/src/actions/cluster.ts
@@ -23,7 +23,7 @@ import {
   Schedule,
   SetupStep,
   Source,
-} from "../..";
+} from "..";
 
 const models = [
   App,

--- a/ui/ui-components/components/settings/clearCache.tsx
+++ b/ui/ui-components/components/settings/clearCache.tsx
@@ -28,10 +28,11 @@ export default function ClearCache(props) {
       <Card.Body>
         <Card.Title>Clear Cache</Card.Title>
         <Card.Subtitle className="mb-2 text-muted">
-          Empty the Redis Cache for your Grouparoo Cluster.
+          Empty the Redis and Resque Cache for your Grouparoo Cluster.
           <br />
           <br />
           <small>
+            This will clear the redis cache and rest all resque stats and locks.
             This action should cause no data loss, but may result in slower
             responses for a short time.
           </small>

--- a/ui/ui-components/components/visualizations/grouparooChart.tsx
+++ b/ui/ui-components/components/visualizations/grouparooChart.tsx
@@ -43,7 +43,7 @@ export function GrouparooChart({
 
   data.forEach((line, idx) => {
     line.forEach((point) => {
-      if (point.y > yMax) yMax = point.y + 0.25;
+      if (point.y > yMax) yMax = point.y + point.y / 10; // add 10% more to show the rounded curve top
     });
 
     while (line.length < minPoints) {


### PR DESCRIPTION
Now that sessions have been moved to the database (https://github.com/grouparoo/grouparoo/pull/1369) and all runs can be recovered (https://github.com/grouparoo/grouparoo/pull/1353), there's no data that needs to persist in Redis.  We can safely erase all Redis data when reseting the cluster. 

This PR means that the `reset cluster` button will also clear up any problems with persisting resque locks. 