### PR TITLE
Don't allow `--high-water-mark` to be used without a column name

### DIFF
--- a/plugins/@grouparoo/app-templates/src/source/table/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/templates.ts
@@ -81,6 +81,12 @@ export class TableSourceTemplate extends ConfigTemplateWithGetters {
     params["__pluginName"] = this.name.split(":")[0];
     params["schedule_id"] = this.extendId("schedule");
 
+    if (typeof params.highWaterMark === "boolean") {
+      throw new Error(
+        "You must pass a column name with the --high-water-mark option."
+      );
+    }
+
     let columnsMap: ConfigTemplateColumn[] = await loadTablesAndColumns(
       this,
       params


### PR DESCRIPTION
Took a guess here that this should be done in the app-templates plugin and not the primary generate command. I was a little tripped up that the main generate command even mentions hwm as an input.