### PR TITLE
Sort the data in GrouparooChart by x-axis

### DIFF
--- a/ui/ui-components/components/visualizations/grouparooChart.tsx
+++ b/ui/ui-components/components/visualizations/grouparooChart.tsx
@@ -41,7 +41,12 @@ export function GrouparooChart({
 
   let yMax = 1.25;
 
-  data.forEach((line, idx) => {
+  data.forEach((line) => {
+    // ensure the x-axis points are sorted
+    line = line.sort((a, b) => {
+      return a.x - b.x;
+    });
+
     line.forEach((point) => {
       if (point.y > yMax) yMax = point.y + point.y / 10; // add 10% more to show the rounded curve top
     });


### PR DESCRIPTION
Sometimes on the dashboard and resque pages we'll get responses out-of-order and chart them by the response time, not the request time.  This ensures that all the points in each line are sorted. 