### PR TITLE
Identifying should default to false

### DIFF
--- a/plugins/@grouparoo/app-templates/public/templates/table-property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/table-property/{{{id}}}.js.template
@@ -7,7 +7,7 @@ exports.default = async function buildConfig() {
       sourceId: {{{sourceId}}}, // The ID of the Source that this Property belongs to - e.g. `sourceId: "users_table"`
       type: {{#type}}{{{type}}}{{/type}}{{^type}}"string"{{/type}}, // The type of the Property.  Options are: {{{__typeOptions}}}
       unique: {{#unique}}{{{unique}}}{{/unique}}{{^unique}}false{{/unique}}, // Will Profiles have unique records for this Property?
-      identifying: true, // Should we consider this property Identifying in the UI? Only one Property can be identifying.
+      identifying: false, // Should we consider this property Identifying in the UI? Only one Property can be identifying.
       isArray: false, // Is this an Array Property?
       options: {
         column: {{#column}}{{{column}}}{{/column}}{{^column}}'...'{{/column}}, // The column to use for this Property - e.g. `column: "first_name"`


### PR DESCRIPTION
When generating a Property for a table source, the template should set `identifying: false` by default.