### PR TITLE
Prevent deadlock for profileProperty:importProfileProperties

### DIFF
--- a/core/__tests__/models/profile/profile.ts
+++ b/core/__tests__/models/profile/profile.ts
@@ -565,54 +565,6 @@ describe("models/profile", () => {
         ]);
       });
 
-      test("adding a profile property touches the profile", async () => {
-        await profile.removeProperty("email");
-
-        await profile.reload();
-        const oldUpdatedAt = profile.updatedAt.getTime();
-        await helper.sleep(1);
-        await profile.addOrUpdateProperty({ email: ["luigi@example.com"] });
-        await profile.reload();
-        const newUpdatedAt = profile.updatedAt.getTime();
-        expect(newUpdatedAt).toBeGreaterThan(oldUpdatedAt);
-      });
-
-      test("editing a profile property touches the profile", async () => {
-        await profile.reload();
-        const oldUpdatedAt = profile.updatedAt.getTime();
-        await helper.sleep(1);
-        await profile.addOrUpdateProperty({
-          email: ["luigiAgain@example.com"],
-        });
-        await profile.reload();
-        const newUpdatedAt = profile.updatedAt.getTime();
-        expect(newUpdatedAt).toBeGreaterThan(oldUpdatedAt);
-      });
-
-      test("editing a profile property with a no-op will not touch the profile", async () => {
-        await profile.reload();
-        const oldUpdatedAt = profile.updatedAt.getTime();
-        await helper.sleep(1);
-        await profile.addOrUpdateProperty({
-          email: ["luigiAgain@example.com"],
-        });
-        await profile.reload();
-        const newUpdatedAt = profile.updatedAt.getTime();
-        expect(newUpdatedAt).toBe(oldUpdatedAt);
-      });
-
-      test("removing a profile property touches the profile", async () => {
-        await profile.reload();
-        const oldUpdatedAt = profile.updatedAt.getTime();
-        await helper.sleep(1);
-        await profile.removeProperty("email");
-        await profile.reload();
-        const newUpdatedAt = profile.updatedAt.getTime();
-        expect(newUpdatedAt).toBeGreaterThan(oldUpdatedAt);
-
-        await profile.addOrUpdateProperty({ email: ["luigi@example.com"] });
-      });
-
       test("orphan profile properties will be removed", async () => {
         await profile.reload();
 

--- a/core/__tests__/tasks/profileProperty/importProfileProperties.ts
+++ b/core/__tests__/tasks/profileProperty/importProfileProperties.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { api, task, specHelper, utils } from "actionhero";
+import { api, task, specHelper } from "actionhero";
 import { Op } from "sequelize";
 import {
   GrouparooPlugin,

--- a/core/src/models/Profile.ts
+++ b/core/src/models/Profile.ts
@@ -106,10 +106,13 @@ export class Profile extends LoggedModel<Profile> {
     return ProfileOps.addOrUpdateProperty(this, properties);
   }
 
-  async addOrUpdateProperties(properties: {
-    [key: string]: Array<string | number | boolean | Date>;
-  }) {
-    return ProfileOps.addOrUpdateProperties(this, properties);
+  async addOrUpdateProperties(
+    properties: {
+      [key: string]: Array<string | number | boolean | Date>;
+    },
+    toLock = true
+  ) {
+    return ProfileOps.addOrUpdateProperties(this, properties, toLock);
   }
 
   async removeProperty(key: string) {

--- a/core/src/models/ProfileProperty.ts
+++ b/core/src/models/ProfileProperty.ts
@@ -182,7 +182,7 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
   static async ensureOneProfilePropertyPerProfileProeprtyRule(
     instance: ProfileProperty
   ) {
-    const existing = await ProfileProperty.scope(null).findOne({
+    const count = await ProfileProperty.scope(null).count({
       where: {
         id: { [Op.ne]: instance.id },
         profileId: instance.profileId,
@@ -190,33 +190,10 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
         position: instance.position,
       },
     });
-    if (existing) {
+    if (count > 0) {
       throw new Error(
         `There is already a ProfileProperty for ${instance.profileId} and ${instance.propertyId} at position ${instance.position}`
       );
-    }
-  }
-
-  @AfterSave
-  static async updateProfileAfterSave(instance: ProfileProperty) {
-    const changed = instance.changed();
-    if (!changed) return;
-
-    const profile = await instance.$get("profile");
-    if (profile && changed.indexOf("rawValue") >= 0) {
-      profile.updatedAt = new Date();
-      profile.changed("updatedAt", true);
-      await profile.save();
-    }
-  }
-
-  @AfterDestroy
-  static async updateProfileAfterDestroy(instance: ProfileProperty) {
-    const profile = await instance.$get("profile");
-    if (profile) {
-      profile.updatedAt = new Date();
-      profile.changed("updatedAt", true);
-      await profile.save();
     }
   }
 }

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -234,7 +234,7 @@ export namespace ProfileOps {
     }
 
     try {
-      await profile.save();
+      if (profile.isNewRecord) await profile.save();
 
       const keys = Object.keys(properties);
       for (const i in keys) {


### PR DESCRIPTION
Enhancements:

- To not touch the Property every time a Profile Property is created/edited.  We no longer need this as the `profiles:checkReady` task will update the state of the profile, and the `updatedAt` once the profile goes "ready".
  - This was the main cause of the deadlock - many properties would update the profile at the same time, each with a slightly different `updatedAt`.
- Do not `profile.save()` all profiles in `ProfileOps.addOrUpdateProperties`.  Only do this if the profile is not yet persisted.  This could be causing deadlocks bumping the `updatedAt`
- Do not try to re-import a Profile Property that is in the ready state.  Another worker/transaction already updated it.