### PR TITLE
fix: falsy check on formatVar could clear zeros

### DIFF
--- a/plugins/@grouparoo/marketo/src/lib/export/exportProfiles.ts
+++ b/plugins/@grouparoo/marketo/src/lib/export/exportProfiles.ts
@@ -164,7 +164,7 @@ function buildPayload(exportedProfile: BatchExport): any {
 }
 
 function formatVar(value) {
-  if (!value) {
+  if (value === undefined) {
     return null;
   }
   if (value instanceof Date) {

--- a/plugins/@grouparoo/sailthru/src/lib/export/exportProfile.ts
+++ b/plugins/@grouparoo/sailthru/src/lib/export/exportProfile.ts
@@ -90,7 +90,7 @@ export const exportProfile: ExportProfilePluginMethod = async ({
 };
 
 function formatVar(value) {
-  if (!value) {
+  if (value === undefined) {
     return null;
   }
   // TODO: how to format date, etc

--- a/plugins/@grouparoo/zendesk/src/lib/export/exportProfile.ts
+++ b/plugins/@grouparoo/zendesk/src/lib/export/exportProfile.ts
@@ -197,7 +197,7 @@ async function getRootFields(client) {
 }
 
 function formatVar(value) {
-  if (!value) {
+  if (value === undefined) {
     return null;
   }
   if (value instanceof Date) {


### PR DESCRIPTION
Changes various plugin's `formatVar` function on export to explicitly check for `undefined`/`null`, so `0` values are respected and not cleared.