### PR TITLE
Add option to show a setup step on Community Edition

### DIFF
--- a/core/__tests__/actions/setupSteps.ts
+++ b/core/__tests__/actions/setupSteps.ts
@@ -64,6 +64,9 @@ describe("actions/setupSteps", () => {
       expect(setupSteps[0].helpLink).toBe(
         "https://www.grouparoo.com/docs/config/settings"
       );
+      expect(setupSteps[0].showCtaOnCommunity).toBe(true);
+      // showCtaOnCommunity is false when not defined.
+      expect(setupSteps[1].showCtaOnCommunity).toBe(false);
       expect(setupSteps[0].outcome).toBe(null);
       expect(setupSteps[0].skipped).toBe(false);
       expect(setupSteps[0].complete).toBe(false);

--- a/core/src/models/SetupStep.ts
+++ b/core/src/models/SetupStep.ts
@@ -41,6 +41,7 @@ export class SetupStep extends LoggedModel<SetupStep> {
     const href = this.getHref(ssd);
     const cta = this.getCta(ssd);
     const helpLink = this.getHelpLink(ssd);
+    const showCtaOnCommunity = this.getShowCtaOnCommunity(ssd);
     const outcome = await this.getOutcome(ssd);
 
     return {
@@ -52,6 +53,7 @@ export class SetupStep extends LoggedModel<SetupStep> {
       href,
       cta,
       helpLink,
+      showCtaOnCommunity,
       outcome,
       skipped: this.skipped,
       complete: this.complete,
@@ -83,6 +85,11 @@ export class SetupStep extends LoggedModel<SetupStep> {
   getHelpLink(ssd?: SetupStepOps.setupStepDescription) {
     if (!ssd) ssd = this.getSetupStepDescription();
     return ssd.helpLink;
+  }
+
+  getShowCtaOnCommunity(ssd?: SetupStepOps.setupStepDescription) {
+    if (!ssd) ssd = this.getSetupStepDescription();
+    return ssd.showCtaOnCommunity || false;
   }
 
   async performCheck(ssd?: SetupStepOps.setupStepDescription) {

--- a/core/src/modules/ops/setupSteps.ts
+++ b/core/src/modules/ops/setupSteps.ts
@@ -22,6 +22,7 @@ export namespace SetupStepOps {
     href: string;
     cta: string;
     helpLink: string;
+    showCtaOnCommunity?: boolean;
     check?: () => Promise<boolean>;
     outcome?: () => Promise<string>;
   };
@@ -34,6 +35,7 @@ export namespace SetupStepOps {
       description: "Give your Grouparoo cluster a name.",
       href: "/settings/core",
       cta: "Change your Grouparoo Cluster Name",
+      showCtaOnCommunity: true,
       helpLink: `${configURL}/settings`,
       check: async () => {
         const setting = await plugin.readSetting("core", "cluster-name");

--- a/ui/ui-components/components/setupSteps/setupStepCard.tsx
+++ b/ui/ui-components/components/setupSteps/setupStepCard.tsx
@@ -71,7 +71,8 @@ export default function SetupStepCard({
                       Learn More
                     </Button>
                     &nbsp;&nbsp;
-                    {process.env.GROUPAROO_UI_EDITION === "enterprise" ? (
+                    {process.env.GROUPAROO_UI_EDITION === "enterprise" ||
+                    step.showCtaOnCommunity ? (
                       <Button size="sm" href={step.href}>
                         {step.cta}
                       </Button>


### PR DESCRIPTION
This is an extension of #1436.

The adjustment to the workflow here is if I create a team using code config, then sign into the UI, I should see that Setup Step 1 is not completed, and there should be a button that takes me to the settings to rename the cluster.