### PR TITLE
Refactor `sortConfigObjectsWithIds` to use topological sort algorithm

### DIFF
--- a/core/__tests__/classes/codeConfig.ts
+++ b/core/__tests__/classes/codeConfig.ts
@@ -1,34 +1,93 @@
 import path from "path";
 import { loadConfigObjects } from "../../src/modules/configLoaders";
-import { getParentIds } from "../../src/classes/codeConfig";
+import {
+  getParentIds,
+  getConfigObjectsWithIds,
+  sortConfigObjectsWithIds,
+  ConfigurationObject,
+} from "../../src/classes/codeConfig";
 
 describe("classes/codeConfig", () => {
+  let configObjects: ConfigurationObject[];
+
+  beforeAll(async () => {
+    const dir = path.join(__dirname, "..", "fixtures", "codeConfig", "initial");
+    configObjects = await loadConfigObjects(dir);
+  });
+
   describe("#getParentIds", () => {
-    let configObjects;
-
-    beforeAll(async () => {
-      const dir = path.join(
-        __dirname,
-        "..",
-        "fixtures",
-        "codeConfig",
-        "initial"
-      );
-
-      configObjects = await loadConfigObjects(dir);
-    });
-
     test("includes its id as a provided id", async () => {
-      const parent = configObjects.find(({ id }) => id === "test_destination");
-      const { providedIds } = getParentIds(parent);
+      const destination = configObjects.find(
+        ({ id }) => id === "test_destination"
+      );
+      const { providedIds } = getParentIds(destination);
       expect(providedIds).toEqual(["test_destination"]);
     });
 
     test("includes the values of mappings", async () => {
-      const parent = configObjects.find(({ id }) => id === "test_destination");
-      const { prerequisiteIds } = getParentIds(parent);
+      const destination = configObjects.find(
+        ({ id }) => id === "test_destination"
+      );
+      const { prerequisiteIds } = getParentIds(destination);
       expect(prerequisiteIds).toContain("user_id");
       expect(prerequisiteIds).toContain("email");
+    });
+  });
+
+  describe("#getConfigObjectsWithIds", () => {
+    test("it applies prerequisiteIds", async () => {
+      const objectsWithId = getConfigObjectsWithIds(configObjects);
+      const destination = objectsWithId.find(
+        ({ configObject }) => configObject.id === "test_destination"
+      );
+      expect(destination.prerequisiteIds.sort()).toEqual([
+        "data_warehouse",
+        "email",
+        "email_group",
+        "user_id",
+      ]);
+      expect(destination.providedIds.sort()).toEqual(["test_destination"]);
+    });
+  });
+
+  describe("#sortConfigObjectsWithIds", () => {
+    it("works", async () => {
+      const objectsWithId = getConfigObjectsWithIds(configObjects);
+      const sortedObjects = sortConfigObjectsWithIds(objectsWithId);
+
+      const teamPosition = sortedObjects.findIndex(
+        (o) => o.configObject.id === "admin_team"
+      );
+      const teamMemberPosition = sortedObjects.findIndex(
+        (o) => o.configObject.id === "demo"
+      );
+      const appPosition = sortedObjects.findIndex(
+        (o) => o.configObject.id === "data_warehouse"
+      );
+      const sourcePosition = sortedObjects.findIndex(
+        (o) => o.configObject.id === "users_table"
+      );
+      const schedulePosition = sortedObjects.findIndex(
+        (o) => o.configObject.id === "users_table_schedule"
+      );
+      const propertyPosition = sortedObjects.findIndex(
+        (o) => o.configObject.id === "email"
+      );
+      const groupPosition = sortedObjects.findIndex(
+        (o) => o.configObject.id === "email_group"
+      );
+      const destinationPosition = sortedObjects.findIndex(
+        (o) => o.configObject.id === "test_destination"
+      );
+
+      expect(teamPosition).toBeLessThan(teamMemberPosition);
+      expect(appPosition).toBeLessThan(sourcePosition);
+      expect(sourcePosition).toBeLessThan(schedulePosition);
+      expect(sourcePosition).toBeLessThan(propertyPosition);
+      expect(sourcePosition).toBeLessThan(groupPosition);
+      expect(sourcePosition).toBeLessThan(destinationPosition);
+      expect(groupPosition).toBeLessThan(destinationPosition);
+      expect(propertyPosition).toBeLessThan(destinationPosition);
     });
   });
 });

--- a/core/__tests__/classes/codeConfig.ts
+++ b/core/__tests__/classes/codeConfig.ts
@@ -48,46 +48,71 @@ describe("classes/codeConfig", () => {
       ]);
       expect(destination.providedIds.sort()).toEqual(["test_destination"]);
     });
+
+    test("options are not included", async () => {
+      const objectsWithId = getConfigObjectsWithIds(configObjects);
+      const app = objectsWithId.find(
+        ({ configObject }) => configObject.id === "data_warehouse"
+      );
+      expect(app.prerequisiteIds).toEqual([]);
+      expect(app.providedIds).toEqual(["data_warehouse"]);
+    });
   });
 
   describe("#sortConfigObjectsWithIds", () => {
-    it("works", async () => {
-      const objectsWithId = getConfigObjectsWithIds(configObjects);
-      const sortedObjects = sortConfigObjectsWithIds(objectsWithId);
+    // we are running this test a few times with the input array shuffled each time
+    function testSortConfigObjectsWithIds(idx: number) {
+      it(`works (attempt ${idx})`, async () => {
+        const shuffledConfigObjects = [...configObjects];
+        shuffleArray(shuffledConfigObjects);
+        const objectsWithId = getConfigObjectsWithIds(shuffledConfigObjects);
+        const sortedObjects = sortConfigObjectsWithIds(objectsWithId);
 
-      const teamPosition = sortedObjects.findIndex(
-        (o) => o.configObject.id === "admin_team"
-      );
-      const teamMemberPosition = sortedObjects.findIndex(
-        (o) => o.configObject.id === "demo"
-      );
-      const appPosition = sortedObjects.findIndex(
-        (o) => o.configObject.id === "data_warehouse"
-      );
-      const sourcePosition = sortedObjects.findIndex(
-        (o) => o.configObject.id === "users_table"
-      );
-      const schedulePosition = sortedObjects.findIndex(
-        (o) => o.configObject.id === "users_table_schedule"
-      );
-      const propertyPosition = sortedObjects.findIndex(
-        (o) => o.configObject.id === "email"
-      );
-      const groupPosition = sortedObjects.findIndex(
-        (o) => o.configObject.id === "email_group"
-      );
-      const destinationPosition = sortedObjects.findIndex(
-        (o) => o.configObject.id === "test_destination"
-      );
+        const teamPosition = sortedObjects.findIndex(
+          (o) => o.configObject.id === "admin_team"
+        );
+        const teamMemberPosition = sortedObjects.findIndex(
+          (o) => o.configObject.id === "demo"
+        );
+        const appPosition = sortedObjects.findIndex(
+          (o) => o.configObject.id === "data_warehouse"
+        );
+        const sourcePosition = sortedObjects.findIndex(
+          (o) => o.configObject.id === "users_table"
+        );
+        const schedulePosition = sortedObjects.findIndex(
+          (o) => o.configObject.id === "users_table_schedule"
+        );
+        const propertyPosition = sortedObjects.findIndex(
+          (o) => o.configObject.id === "email"
+        );
+        const groupPosition = sortedObjects.findIndex(
+          (o) => o.configObject.id === "email_group"
+        );
+        const destinationPosition = sortedObjects.findIndex(
+          (o) => o.configObject.id === "test_destination"
+        );
 
-      expect(teamPosition).toBeLessThan(teamMemberPosition);
-      expect(appPosition).toBeLessThan(sourcePosition);
-      expect(sourcePosition).toBeLessThan(schedulePosition);
-      expect(sourcePosition).toBeLessThan(propertyPosition);
-      expect(sourcePosition).toBeLessThan(groupPosition);
-      expect(sourcePosition).toBeLessThan(destinationPosition);
-      expect(groupPosition).toBeLessThan(destinationPosition);
-      expect(propertyPosition).toBeLessThan(destinationPosition);
-    });
+        expect(teamPosition).toBeLessThan(teamMemberPosition);
+        expect(appPosition).toBeLessThan(sourcePosition);
+        expect(sourcePosition).toBeLessThan(schedulePosition);
+        expect(sourcePosition).toBeLessThan(propertyPosition);
+        expect(sourcePosition).toBeLessThan(groupPosition);
+        expect(sourcePosition).toBeLessThan(destinationPosition);
+        expect(groupPosition).toBeLessThan(destinationPosition);
+        expect(propertyPosition).toBeLessThan(destinationPosition);
+      });
+    }
+
+    for (let i = 0; i < 10; i++) {
+      testSortConfigObjectsWithIds(i);
+    }
   });
 });
+
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}

--- a/core/__tests__/fixtures/codeConfig/duplicate-id/config.js
+++ b/core/__tests__/fixtures/codeConfig/duplicate-id/config.js
@@ -1,0 +1,23 @@
+module.exports = async function getConfig() {
+  return [
+    {
+      id: "data_warehouse_a",
+      name: "Data Warehouse A",
+      class: "App",
+      type: "test-plugin-app",
+      options: {
+        fileId: "test-file-path.db",
+      },
+    },
+
+    {
+      id: "data_warehouse_a", // duplicate ID
+      name: "Data Warehouse B",
+      class: "App",
+      type: "test-plugin-app",
+      options: {
+        fileId: "other-file-path.db",
+      },
+    },
+  ];
+};

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -475,6 +475,24 @@ describe("modules/codeConfig", () => {
     });
   });
 
+  describe("duplicate IDs", () => {
+    test("config with duplicate IDs will not be applied", async () => {
+      api.codeConfig.allowLockedModelChanges = true;
+      const { errors } = await loadConfigDirectory(
+        path.join(
+          __dirname,
+          "..",
+          "..",
+          "fixtures",
+          "codeConfig",
+          "duplicate-id"
+        )
+      );
+
+      expect(errors[0]).toEqual("Duplicate ID values found: data_warehouse_a");
+    });
+  });
+
   describe("errors", () => {
     describe("plugin not installed", () => {
       beforeAll(async () => {

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -36,10 +36,15 @@ describe("modules/codeConfig", () => {
       expect(errors).toEqual([]);
       expect(seenIds).toEqual({
         apikey: ["website_key"],
-        app: ["data_warehouse", "events"],
+        app: expect.arrayContaining(["data_warehouse", "events"]),
         destination: ["test_destination"],
         group: ["email_group"],
-        property: ["user_id", "last_name", "first_name", "email"],
+        property: expect.arrayContaining([
+          "user_id",
+          "email",
+          "last_name",
+          "first_name",
+        ]),
         schedule: ["users_table_schedule"],
         source: ["users_table"],
         team: ["admin_team"],
@@ -235,10 +240,15 @@ describe("modules/codeConfig", () => {
       expect(errors).toEqual([]);
       expect(seenIds).toEqual({
         apikey: ["website_key"],
-        app: ["data_warehouse", "events"],
+        app: expect.arrayContaining(["data_warehouse", "events"]),
         destination: [],
         group: ["email_group"],
-        property: ["user_id", "last_name", "first_name", "email"],
+        property: expect.arrayContaining([
+          "user_id",
+          "last_name",
+          "first_name",
+          "email",
+        ]),
         schedule: ["users_table_schedule"],
         source: ["users_table"],
         team: ["admin_team"],
@@ -390,7 +400,7 @@ describe("modules/codeConfig", () => {
         app: ["events"],
         destination: [],
         group: ["email_group"],
-        property: ["last_name", "first_name"],
+        property: expect.arrayContaining(["last_name", "first_name"]),
         schedule: ["users_table_schedule"],
         source: [],
         team: ["admin_team"],
@@ -499,7 +509,7 @@ describe("modules/codeConfig", () => {
         api.codeConfig.allowLockedModelChanges = true;
       });
 
-      test("errors will be thrown if the configuration is invalid", async () => {
+      test("missing plugin", async () => {
         const { errors } = await loadConfigDirectory(
           path.join(
             __dirname,
@@ -519,7 +529,7 @@ describe("modules/codeConfig", () => {
         api.codeConfig.allowLockedModelChanges = true;
       });
 
-      test("errors will be thrown if the configuration is invalid", async () => {
+      test("missing option", async () => {
         const { errors } = await loadConfigDirectory(
           path.join(
             __dirname,
@@ -541,7 +551,7 @@ describe("modules/codeConfig", () => {
         api.codeConfig.allowLockedModelChanges = true;
       });
 
-      test("errors will be thrown if the configuration is invalid", async () => {
+      test("broken source", async () => {
         const { errors } = await loadConfigDirectory(
           path.join(
             __dirname,
@@ -561,7 +571,7 @@ describe("modules/codeConfig", () => {
         api.codeConfig.allowLockedModelChanges = true;
       });
 
-      test("errors will be thrown if the configuration is invalid", async () => {
+      test("broken property", async () => {
         const { errors } = await loadConfigDirectory(
           path.join(
             __dirname,
@@ -581,7 +591,7 @@ describe("modules/codeConfig", () => {
         api.codeConfig.allowLockedModelChanges = true;
       });
 
-      test("errors will be thrown if the configuration is invalid", async () => {
+      test("broken group", async () => {
         const { errors } = await loadConfigDirectory(
           path.join(
             __dirname,
@@ -596,7 +606,7 @@ describe("modules/codeConfig", () => {
       });
     });
 
-    describe("team member", () => {
+    describe("broken team member", () => {
       beforeAll(async () => {
         api.codeConfig.allowLockedModelChanges = true;
       });

--- a/core/__tests__/modules/codeConfig/syncTable.ts
+++ b/core/__tests__/modules/codeConfig/syncTable.ts
@@ -69,17 +69,17 @@ describe("modules/codeConfig/syncTable", () => {
       expect(errors).toEqual([]);
       expect(seenIds).toEqual({
         apikey: [],
-        app: ["mailchimpapp", "data_warehouse"],
+        app: expect.arrayContaining(["mailchimpapp", "data_warehouse"]),
         destination: ["magic_table_destination"],
         group: ["magic_table_group"],
-        property: [
+        property: expect.arrayContaining([
           "magic_table_property_user_id", // bootstrapped
           "magic_table_property_fname",
           "magic_table_property_decimal_col",
           "magic_table_property_timestamp_col",
           "email_custom",
           "magic_table_membership",
-        ],
+        ]),
         schedule: ["magic_table_schedule"],
         source: ["magic_table_source"],
         team: [],

--- a/core/__tests__/modules/codeConfig/validate.ts
+++ b/core/__tests__/modules/codeConfig/validate.ts
@@ -75,10 +75,15 @@ describe("modules/codeConfig", () => {
           expect(errors).toEqual([]);
           expect(seenIds).toEqual({
             apikey: ["website_key"],
-            app: ["data_warehouse", "events"],
+            app: expect.arrayContaining(["data_warehouse", "events"]),
             destination: ["test_destination"],
             group: ["email_group"],
-            property: ["user_id", "last_name", "first_name", "email"],
+            property: expect.arrayContaining([
+              "user_id",
+              "last_name",
+              "first_name",
+              "email",
+            ]),
             schedule: ["users_table_schedule"],
             source: ["users_table"],
             team: ["admin_team"],

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -2,6 +2,7 @@ import { log } from "actionhero";
 import { PropertyFiltersWithKey } from "../models/Property";
 import { GroupRuleWithKey } from "../models/Group";
 import extractDuplicates from "../modules/validators/extractDuplicates";
+import { topologicalSort, Graph } from "../modules/topologicalSort";
 
 export interface IdsByClass {
   app?: string[];
@@ -54,7 +55,7 @@ export interface ConfigurationObject {
   highWaterColumn?: string;
 }
 
-interface orderedConfigObject {
+interface ConfigObjectWithReferenceIDs {
   configObject: ConfigurationObject;
   providedIds: string[];
   prerequisiteIds: string[];
@@ -192,7 +193,7 @@ export function validateConfigObjects(
 }
 
 export function getConfigObjectsWithIds(configObjects: ConfigurationObject[]) {
-  const configObjectsWithIds: orderedConfigObject[] = [];
+  const configObjectsWithIds: ConfigObjectWithReferenceIDs[] = [];
 
   for (const i in configObjects) {
     const configObject = configObjects[i];
@@ -228,16 +229,13 @@ export function getParentIds(configObject: ConfigurationObject) {
   }
 
   const objectContainers = ["options", "source", "destination"];
+  const validContainerKeys = ["identifyingPropertyId", "propertyId"];
   objectContainers.map((_container) => {
     if (configObject[_container]) {
       const containerKeys = Object.keys(configObject[_container]);
       for (const i in containerKeys) {
-        if (containerKeys[i].match(/.+Id$/)) {
+        if (validContainerKeys.includes(containerKeys[i])) {
           prerequisiteIds.push(configObject[_container][containerKeys[i]]);
-        } else if (containerKeys[i].match(/.+Id$/)) {
-          prerequisiteIds.push(
-            configObject[_container][containerKeys[i]].replace(/^.{3}_/, "")
-          );
         }
       }
     }
@@ -275,47 +273,32 @@ export function getParentIds(configObject: ConfigurationObject) {
 }
 
 export function sortConfigObjectsWithIds(
-  configObjectsWithIds: orderedConfigObject[]
+  configObjectsWithIds: ConfigObjectWithReferenceIDs[]
 ) {
-  const sortedConfigObjectsWithIds: orderedConfigObject[] = [];
+  const sortedConfigObjectsWithIds: ConfigObjectWithReferenceIDs[] = [];
+  const dependencyGraph: Graph = {};
 
-  configObjectsWithIds.forEach((c) => {
-    if (sortedConfigObjectsWithIds.length === 0) {
-      sortedConfigObjectsWithIds.push(c);
-    } else if (c.prerequisiteIds.length === 0) {
-      sortedConfigObjectsWithIds.unshift(c);
-    } else {
-      let indexOfLastDependency: number;
-      let indexOfFirstDependent: number;
-
-      sortedConfigObjectsWithIds.forEach((listedConfigObject, idx) => {
-        c.prerequisiteIds.forEach((id) => {
-          if (listedConfigObject.providedIds.includes(id)) {
-            indexOfLastDependency = idx;
-          }
-        });
-
-        c.providedIds.map((id) => {
-          if (
-            !indexOfFirstDependent &&
-            listedConfigObject.prerequisiteIds.includes(id)
-          ) {
-            indexOfFirstDependent = idx;
-          }
-        });
-      });
-
-      if (indexOfLastDependency) {
-        sortedConfigObjectsWithIds.splice(indexOfLastDependency + 1, 0, c);
-      } else if (indexOfFirstDependent) {
-        sortedConfigObjectsWithIds.splice(indexOfFirstDependent, 0, c);
-      } else {
-        sortedConfigObjectsWithIds.push(c);
-      }
-    }
+  configObjectsWithIds.forEach((o) => {
+    o.providedIds.forEach((providedId) => {
+      dependencyGraph[providedId] = o.prerequisiteIds.filter(
+        (preReq) => preReq !== providedId
+      );
+    });
   });
 
-  return sortedConfigObjectsWithIds;
+  const sortedKeys = topologicalSort(dependencyGraph);
+
+  sortedKeys.forEach((id) => {
+    sortedConfigObjectsWithIds.push(
+      configObjectsWithIds.find(
+        (o) =>
+          o.configObject.id === id ||
+          o.configObject?.bootstrappedProperty?.id === id
+      )
+    );
+  });
+
+  return sortedConfigObjectsWithIds.filter(uniqueArrayValues);
 }
 
 function uniqueArrayValues(value, index, self) {

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -104,8 +104,6 @@ export async function processConfigObjects(
   };
   const errors: string[] = [];
 
-  configObjects = sortConfigurationObjects(configObjects);
-
   const { errors: validationErrors } = validateConfigObjects(configObjects);
   validationErrors.map((err) =>
     log(`[ config ] ${err}`, env === "test" ? "info" : "error")
@@ -113,6 +111,8 @@ export async function processConfigObjects(
   errors.push(...validationErrors);
 
   if (errors.length > 0) return { seenIds, errors };
+
+  configObjects = sortConfigurationObjects(configObjects);
 
   for (const i in configObjects) {
     const configObject = configObjects[i];

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -112,7 +112,13 @@ export async function processConfigObjects(
 
   if (errors.length > 0) return { seenIds, errors };
 
-  configObjects = sortConfigurationObjects(configObjects);
+  let sortError: Error;
+  try {
+    configObjects = sortConfigurationObjects(configObjects);
+  } catch (error) {
+    // the config loaders below will produce better error messages
+    sortError = error;
+  }
 
   for (const i in configObjects) {
     const configObject = configObjects[i];
@@ -191,6 +197,8 @@ export async function processConfigObjects(
       seenIds[className].push(...newIds);
     }
   }
+
+  if (sortError && errors.length === 0) errors.push(sortError.message);
 
   return { seenIds, errors };
 }

--- a/core/src/modules/topologicalSort.ts
+++ b/core/src/modules/topologicalSort.ts
@@ -26,9 +26,9 @@ export type Graph = { [key: string]: string[] };
  * var vertices = topologicalSort(graph); // ['v3', 'v4', 'v1', 'v5', 'v2']
  */
 export function topologicalSort(graph: Graph) {
-  var result: string[] = [];
-  var visited = [];
-  var temp = [];
+  const result: string[] = [];
+  const visited = [];
+  const temp = [];
   for (var node in graph) {
     if (!visited[node] && !temp[node]) {
       topologicalSortHelper(node, visited, temp, graph, result);
@@ -46,9 +46,10 @@ function topologicalSortHelper(
   result: string[]
 ) {
   temp[node] = true;
-  var neighbors = graph[node];
-  for (var i = 0; i < neighbors.length; i += 1) {
-    var n = neighbors[i];
+  const neighbors = graph[node];
+  if (!neighbors) throw new Error(`Cannot find ${node}`);
+  for (let i = 0; i < neighbors.length; i += 1) {
+    const n = neighbors[i];
     if (temp[n]) throw new Error("The graph is not a DAG");
     if (!visited[n]) topologicalSortHelper(n, visited, temp, graph, result);
   }

--- a/core/src/modules/topologicalSort.ts
+++ b/core/src/modules/topologicalSort.ts
@@ -1,0 +1,58 @@
+// From https://jeremyckahn.github.io/javascript-algorithms/graphs_others_topological-sort.js.html (with modifications)
+// Learn more @ https://en.wikipedia.org/wiki/Topological_sorting
+
+export type Graph = { [key: string]: string[] };
+
+/**
+ * Topological sort algorithm of a directed acyclic graph.<br><br>
+ * Time complexity: O(|E| + |V|) where E is a number of edges
+ * and |V| is the number of nodes.
+ *
+ * @public
+ * @param {Array} Graph Adjacency list, which represents the graph.
+ * @returns {Array} Ordered vertices.
+ *
+ * @example
+ * var topsort =
+ *  require('path-to-algorithms/src/graphs/' +
+ * 'others/topological-sort').topologicalSort;
+ * var graph = {
+ *     v1: ['v2', 'v5'],
+ *     v2: [],
+ *     v3: ['v1', 'v2', 'v4', 'v5'],
+ *     v4: [],
+ *     v5: []
+ * };
+ * var vertices = topologicalSort(graph); // ['v3', 'v4', 'v1', 'v5', 'v2']
+ */
+export function topologicalSort(graph: Graph) {
+  var result: string[] = [];
+  var visited = [];
+  var temp = [];
+  for (var node in graph) {
+    if (!visited[node] && !temp[node]) {
+      topologicalSortHelper(node, visited, temp, graph, result);
+    }
+  }
+
+  return result;
+}
+
+function topologicalSortHelper(
+  node,
+  visited,
+  temp,
+  graph: Graph,
+  result: string[]
+) {
+  temp[node] = true;
+  var neighbors = graph[node];
+  for (var i = 0; i < neighbors.length; i += 1) {
+    var n = neighbors[i];
+    if (temp[n]) throw new Error("The graph is not a DAG");
+    if (!visited[n]) topologicalSortHelper(n, visited, temp, graph, result);
+  }
+  temp[node] = false;
+  visited[node] = true;
+  result.push(node);
+}


### PR DESCRIPTION
This PR improves the `sortConfigObjectsWithIds` method which is used to determine the order in which we should apply code config objects, based on dependencies and what they provide.  This PR uses a [topological sort algorithm](https://en.wikipedia.org/wiki/Topological_sorting) to _properly_ solve the DAG and crash if there's a loop.

Thanks to https://jeremyckahn.github.io/javascript-algorithms for doing the hard part.