### PR TITLE
Remove Underscore from HTTP headers

### DIFF
--- a/core/__tests__/actions/sessions.ts
+++ b/core/__tests__/actions/sessions.ts
@@ -470,28 +470,28 @@ describe("session", () => {
         expect(response.teamMember).toBeFalsy();
       });
 
-      test("actions cannot be authenticated with the x-grouparoo-server_token header and without the cookie", async () => {
+      test("actions cannot be authenticated with the x-grouparoo-server-token header and without the cookie", async () => {
         await buildSessionAndCookie();
         const response = await fetch(`${url}/api/v1/account`, {
           method: "GET",
           credentials: "include",
           headers: {
             "Content-Type": "application/json",
-            "X-GROUPAROO-SERVER_TOKEN": config.general.serverToken,
+            "X-GROUPAROO-SERVER-TOKEN": config.general.serverToken,
           },
         }).then((r) => r.json());
         expect(response.error.code).toBe("AUTHENTICATION_ERROR");
         expect(response.teamMember).toBeFalsy();
       });
 
-      test("actions can be authenticated with the x-grouparoo-server_token header and the cookie", async () => {
+      test("actions can be authenticated with the x-grouparoo-server-token header and the cookie", async () => {
         const response = await fetch(`${url}/api/v1/account`, {
           method: "GET",
           credentials: "include",
           headers: {
             "Content-Type": "application/json",
             Cookie: cookie,
-            "X-GROUPAROO-SERVER_TOKEN": config.general.serverToken,
+            "X-GROUPAROO-SERVER-TOKEN": config.general.serverToken,
           },
         }).then((r) => r.json());
         expect(response.teamMember.id).toBeTruthy();

--- a/core/src/modules/middleware/authentication.ts
+++ b/core/src/modules/middleware/authentication.ts
@@ -90,7 +90,7 @@ async function authenticateTeamMember(
     (data.params.csrfToken && data.params.csrfToken !== session.id) ||
     (!data.params.csrfToken &&
       data.connection.rawConnection?.req?.headers[
-        "x-grouparoo-server_token"
+        "x-grouparoo-server-token"
       ] !== config.general.serverToken)
   ) {
     await api.session.destroy(data.connection);

--- a/ui/ui-components/client/client.ts
+++ b/ui/ui-components/client/client.ts
@@ -113,7 +113,7 @@ export class Client {
     };
 
     if (req?.headers?.cookie) {
-      headers["X-GROUPAROO-SERVER_TOKEN"] = this.serverToken;
+      headers["X-GROUPAROO-SERVER-TOKEN"] = this.serverToken;
       headers["cookie"] = req?.headers?.cookie;
       useCache = false; // do not ever responses on the server
     }


### PR DESCRIPTION
It's possible that `_` are not valid in HTTP headers, and AWS removes any header with an underscore 
* https://stackoverflow.com/questions/29986028/custom-headers-are-not-working-in-amazon-ec2-server
* https://stackoverflow.com/questions/22856136/why-do-http-servers-forbid-underscores-in-http-header-names