### PR TITLE
Grouparoo Init can run on Windows

### DIFF
--- a/cli/src/utils/npm.ts
+++ b/cli/src/utils/npm.ts
@@ -3,6 +3,8 @@ import { spawnPromise } from "./spawnPromise";
 import Chalk from "chalk";
 
 export namespace NPM {
+  const NPM = /^win/.test(process.platform) ? "npm.cmd" : "npm";
+
   export async function install(
     logger: any,
     workDir: string,
@@ -12,7 +14,7 @@ export namespace NPM {
   ) {
     const args = ["install"];
 
-    const npmCheck = await spawnPromise("npm", ["--version"]);
+    const npmCheck = await spawnPromise(NPM, ["--version"]);
     const npmVersion = npmCheck.stdout.trim();
     const majorNPMVersion = parseInt(npmVersion.split(".")[0]);
     if (majorNPMVersion === 7) args.push("--legacy-peer-deps");
@@ -23,7 +25,7 @@ export namespace NPM {
     logger.start("Installing...");
 
     const { exitCode, stdout, stderr } = await spawnPromise(
-      "npm",
+      NPM,
       args,
       workDir,
       { npm_config_loglevel },
@@ -51,7 +53,7 @@ export namespace NPM {
     logger.start("Uninstalling...");
 
     const { exitCode, stdout, stderr } = await spawnPromise(
-      "npm",
+      NPM,
       args,
       workDir,
       { npm_config_loglevel },


### PR DESCRIPTION
Related to https://github.com/grouparoo/grouparoo/discussions/1491

Grouparoo is still not supported on on windows natively.   However, you can use the WSL system to run Ubuntu on Windows to then run Grouparoo.

<img width="1819" alt="Screen Shot 2021-03-18 at 2 51 21 PM" src="https://user-images.githubusercontent.com/303226/111702690-e4ca4600-87f9-11eb-9c9c-752ba89d860e.png">


- [x] Use `npm.cmd` not `npm` when sub-shelling out to NPM for `grouparoo init` and `grouparoo install`
