### PR TITLE
Fix mysql CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1404,6 +1404,8 @@ jobs:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
+        environment:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1405,7 +1405,8 @@ jobs:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
         environment:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_USER: $DOCKERHUB_USERNAME
+          MYSQL_PASSWORD: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1431,8 +1431,6 @@ jobs:
       - run:
           name: create mysql databases
           command: mysql -e "create database grouparoo_test" -u root -h 127.0.0.1
-          environment:
-            MYSQL_ALLOW_EMPTY_PASSWORD: true
       - run:
           name: test
           command: cd plugins/@grouparoo/mysql && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1429,6 +1429,8 @@ jobs:
       - run:
           name: create mysql databases
           command: mysql -e "create database grouparoo_test" -u root -h 127.0.0.1
+          environment:
+            MYSQL_ALLOW_EMPTY_PASSWORD: true
       - run:
           name: test
           command: cd plugins/@grouparoo/mysql && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand

--- a/tools/merger/data/ci/plugin/mysql/docker.yml.template
+++ b/tools/merger/data/ci/plugin/mysql/docker.yml.template
@@ -3,4 +3,5 @@
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
         environment:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_USER: $DOCKERHUB_USERNAME
+          MYSQL_PASSWORD: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/plugin/mysql/docker.yml.template
+++ b/tools/merger/data/ci/plugin/mysql/docker.yml.template
@@ -2,3 +2,5 @@
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
+        environment:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true

--- a/tools/merger/data/ci/plugin/mysql/steps.yml.template
+++ b/tools/merger/data/ci/plugin/mysql/steps.yml.template
@@ -4,5 +4,3 @@
       - run:
           name: create mysql databases
           command: mysql -e "create database grouparoo_test" -u root -h 127.0.0.1
-          environment:
-            MYSQL_ALLOW_EMPTY_PASSWORD: true

--- a/tools/merger/data/ci/plugin/mysql/steps.yml.template
+++ b/tools/merger/data/ci/plugin/mysql/steps.yml.template
@@ -1,6 +1,8 @@
-      - run:
+- run:
           name: install mysql client
           command: sudo apt install -y mysql-client
       - run:
           name: create mysql databases
           command: mysql -e "create database grouparoo_test" -u root -h 127.0.0.1
+          environment:
+            MYSQL_ALLOW_EMPTY_PASSWORD: true

--- a/tools/merger/data/ci/plugin/mysql/steps.yml.template
+++ b/tools/merger/data/ci/plugin/mysql/steps.yml.template
@@ -1,4 +1,4 @@
-- run:
+      - run:
           name: install mysql client
           command: sudo apt install -y mysql-client
       - run:


### PR DESCRIPTION
[docker/mysql was updated last night](https://hub.docker.com/r/circleci/mysql/tags?page=1&ordering=last_updated) to 5.6.51. Builds are now failing with this message:

```
2021-03-18 09:49:35+00:00 [ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_PASSWORD cannot be used for the root user
    Use one of the following to control the root user password:
    - MYSQL_ROOT_PASSWORD
    - MYSQL_ALLOW_EMPTY_PASSWORD
    - MYSQL_RANDOM_ROOT_PASSWORD
```

This is me trying to find a fix without rewriting our Circle CI job-writing tool, since MySQL seems to be an exception among the plugins.

---

Another option is [to revert to the previous version](https://www.ninton.co.jp/archives/7661), but I'd rather solve for the future rather than being stuck on one specific patch.