### PR TITLE
Error message when table source generator can't find specified columns

### DIFF
--- a/plugins/@grouparoo/app-templates/src/source/table/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/templates.ts
@@ -239,6 +239,12 @@ async function loadTablesAndColumns(
           });
         }
       }
+
+      if (params.with && map.length === 0) {
+        throw new Error(
+          'Could not find any listed columns in source. If using * make sure you used quotes ("*")?'
+        );
+      }
     }
   } finally {
     await app.disconnect();

--- a/plugins/@grouparoo/app-templates/src/source/table/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/templates.ts
@@ -240,7 +240,7 @@ async function loadTablesAndColumns(
         }
       }
 
-      if (params.with && map.length === 0) {
+      if (params.with.replace(/['"]+/g, "") && map.length === 0) {
         throw new Error(
           'Could not find any listed columns in source. If using * make sure you used quotes ("*")?'
         );


### PR DESCRIPTION
I ran into an issue because I didn't quote the asterisk when looking for column names:

    $ grouparoo generate [thing]:table:source sourceId --from appId --with * ...

Now the generator looks for a column match if the `with` command is used and if it doesn't find any columns it will send a message that is hopefully helpful.