### PR TITLE
Split lockfile update from ci_generate into different Github actions

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -1,7 +1,7 @@
-name: update-branch
+name: update-lockfile
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@master
         with:
           ref: ${{ github.head_ref }}
-      - name: Update merged files
+      - name: Update PNPM lockfile
         run: |
-          cd tools/merger && ./github_action
+          cd tools/merger && ./lockfile
       - uses: stefanzweifel/git-auto-commit-action@v4.1.2
         with:
           commit_message: Updating things automatically


### PR DESCRIPTION
* We want one action to, in pull requests, check that the CI suite is up-to-date and adds any new plugins
* We want another action to, on `main`, make sure the pnpm lockfile is up-to-date
  *  We don't want this to run in branches because it breaks dependabot.