### PR TITLE
Ignore 1-char Redis usernames

### DIFF
--- a/core/src/config/redis.ts
+++ b/core/src/config/redis.ts
@@ -29,7 +29,9 @@ function RealRedisConfig() {
   const commonArgs = {
     port,
     host,
-    username: username?.length > 1 ? username : undefined, // For older redis servers, we cannot supply a username.  This is normally triggered by a 1 or 0 char username in REDIS_URL
+    // For older redis servers, we cannot supply a username.  This is normally triggered by a 1 or 0 char username in REDIS_URL
+    username:
+      username?.length > 1 || process.env.REDIS_USER ? username : undefined,
     password,
     db: parseInt(db),
     // you can learn more about retryStrategy @ https://github.com/luin/ioredis#auto-reconnect

--- a/core/src/config/redis.ts
+++ b/core/src/config/redis.ts
@@ -29,7 +29,7 @@ function RealRedisConfig() {
   const commonArgs = {
     port,
     host,
-    username,
+    username: username?.length > 1 ? username : undefined, // For older redis servers, we cannot supply a username.  This is normally triggered by a 1 or 0 char username in REDIS_URL
     password,
     db: parseInt(db),
     // you can learn more about retryStrategy @ https://github.com/luin/ioredis#auto-reconnect


### PR DESCRIPTION
This PR solves bugs like this, which were introduced by https://github.com/grouparoo/grouparoo/pull/1522:

```
[ERROR] The server returned "wrong number of arguments for 'auth' command". You are probably passing both username and password to Redis version 5 or below. You should only pass the 'password' option for Redis version 5 and under.
alert: Redis connection `client` error NOAUTH Authentication required. command=[object Object] stack=ReplyError: NOAUTH Authentication required.
```

For PaaS providers like Heroku, we can guess that a 1-char redis username is placeholder, and meant to be ignored. 
