### PR TITLE
Do not try to re-associate imports that have an error

### DIFF
--- a/core/src/tasks/import/associateProfiles.ts
+++ b/core/src/tasks/import/associateProfiles.ts
@@ -22,7 +22,7 @@ export class ImportAssociateProfiles extends CLSTask {
     );
 
     const imports = await Import.findAll({
-      where: { profileId: null },
+      where: { profileId: null, errorMessage: null },
       limit,
       order: [["createdAt", "asc"]],
     });


### PR DESCRIPTION
The `import:associateProfiles` task checks for imports that have not yet been associated to any profile.  Before this PR, the task could keep retrying a profile which had an error in a previous attempt to associate to a profile, e.g.: There were no unique properties provided in the input data. 

This PR tells `import:associateProfiles` to ignore imports with an `errorMessage`