### PR TITLE
Always display enough of the progress bar to see the label

### DIFF
--- a/ui/ui-components/components/visualizations/homepageWidgets.tsx
+++ b/ui/ui-components/components/visualizations/homepageWidgets.tsx
@@ -226,7 +226,7 @@ export function RunningRuns({ execApi }) {
                       variant="info"
                       style={{ minWidth: 300 }}
                       animated={run.percentComplete > 0 ? true : false}
-                      now={run.percentComplete}
+                      now={run.percentComplete < 5 ? 5 : run.percentComplete} // Always display enough of the progress bar to see the label
                       label={`${run.percentComplete}%`}
                     />
                   </td>


### PR DESCRIPTION
This PR will always show at least 5% of the ProgressBar on the dashboard.  This leaves enough space to show the label.

<img width="1355" alt="Screen Shot 2021-03-23 at 5 17 54 PM" src="https://user-images.githubusercontent.com/303226/112235468-f184da80-8bfb-11eb-96d9-f1223263dcb1.png">
