### PR TITLE
Wrap CLI commands and Initializers in transactions

### DIFF
--- a/core/__tests__/bin/reset.ts
+++ b/core/__tests__/bin/reset.ts
@@ -50,6 +50,15 @@ describe("bin/reset", () => {
     expect(output).not.toContain("Success!");
   });
 
+  test("requires valid mode argument", async () => {
+    const command = new ResetCLI();
+    await command.run({ params: { confirm: true, mode: "foo" } });
+    const output = messages.join(" ");
+
+    expect(output).toContain("mode not found");
+    expect(output).not.toContain("Success!");
+  });
+
   test("requires mode argument", async () => {
     const command = new ResetCLI();
     await command.run({ params: { confirm: true } });

--- a/core/__tests__/bin/run.ts
+++ b/core/__tests__/bin/run.ts
@@ -1,6 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
 import { RunCLI } from "../../src/bin/run";
-import { Run } from "../../src";
 
 describe("bin/run", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -42,45 +41,6 @@ describe("bin/run", () => {
 
     test("paused tasks can be run", async () => {
       await instance.runPausedTasks({}); // does not throw
-    });
-
-    test("will be complete with no pending items", async () => {
-      await Run.truncate(); // there will be pending runs from `factories.properties()`
-
-      const complete = await instance.checkForComplete();
-      expect(complete).toBe(true);
-    });
-
-    test("will not be complete with a pending profile", async () => {
-      const profile = await helper.factories.profile();
-      await profile.update({ state: "pending" });
-      expect(await instance.checkForComplete()).toBe(false);
-      await profile.destroy();
-    });
-
-    test("will not be complete with a pending import", async () => {
-      const profile = await helper.factories.profile();
-      await profile.update({ state: "ready" });
-      await helper.factories.import(null, { profileId: profile.id });
-
-      expect(await instance.checkForComplete()).toBe(false);
-      await profile.destroy();
-    });
-
-    test("will not be complete with a pending export", async () => {
-      const profile = await helper.factories.profile();
-      await profile.update({ state: "ready" });
-      await helper.factories.export(profile);
-
-      expect(await instance.checkForComplete()).toBe(false);
-      await profile.destroy();
-    });
-
-    test("will not be complete with a pending export", async () => {
-      const run = await helper.factories.run(null, { state: "running" });
-
-      expect(await instance.checkForComplete()).toBe(false);
-      await run.destroy();
     });
   });
 });

--- a/core/__tests__/tasks/system/status.ts
+++ b/core/__tests__/tasks/system/status.ts
@@ -1,0 +1,87 @@
+import { helper } from "@grouparoo/spec-helper";
+import { Run, Log, Import, Export, plugin } from "../../../src";
+import { api, task, specHelper } from "actionhero";
+import { StatusTask } from "../../../src/tasks/system/status";
+
+describe("tasks/status", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  beforeAll(async () => await api.resque.queue.connection.redis.flushdb());
+
+  describe("status", () => {
+    beforeAll(async () => {
+      await helper.factories.properties();
+    });
+
+    beforeEach(() => {
+      process.env.GROUPAROO_RUN_MODE = "test";
+    });
+
+    test("it can be enqueued", async () => {
+      await task.enqueue("status", {});
+      const found = await specHelper.findEnqueuedTasks("status");
+      expect(found.length).toEqual(1);
+      expect(found[0].timestamp).toBeNull();
+    });
+
+    test("it will have no recurring frequency when the server is started", async () => {
+      const instance = new StatusTask();
+      expect(instance.frequency).toBe(0);
+    });
+
+    test("it will have a recurring frequency when the server is running", async () => {
+      process.env.GROUPAROO_RUN_MODE = "cli:run";
+      const instance = new StatusTask();
+      expect(instance.frequency).toBeGreaterThan(0);
+    });
+
+    test("will be complete with no pending items", async () => {
+      await Run.truncate(); // there will be pending runs from `factories.properties()`
+
+      process.env.GROUPAROO_RUN_MODE = "cli:run";
+      const instance = new StatusTask();
+      const complete = await instance.checkForComplete();
+      expect(complete).toBe(true);
+    });
+
+    test("will not be complete with a pending profile", async () => {
+      const profile = await helper.factories.profile();
+      await profile.update({ state: "pending" });
+
+      process.env.GROUPAROO_RUN_MODE = "cli:run";
+      const instance = new StatusTask();
+      expect(await instance.checkForComplete()).toBe(false);
+      await profile.destroy();
+    });
+
+    test("will not be complete with a pending import", async () => {
+      const profile = await helper.factories.profile();
+      await profile.update({ state: "ready" });
+      await helper.factories.import(null, { profileId: profile.id });
+
+      process.env.GROUPAROO_RUN_MODE = "cli:run";
+      const instance = new StatusTask();
+      expect(await instance.checkForComplete()).toBe(false);
+      await profile.destroy();
+    });
+
+    test("will not be complete with a pending export", async () => {
+      const profile = await helper.factories.profile();
+      await profile.update({ state: "ready" });
+      await helper.factories.export(profile);
+
+      process.env.GROUPAROO_RUN_MODE = "cli:run";
+      const instance = new StatusTask();
+      expect(await instance.checkForComplete()).toBe(false);
+      await profile.destroy();
+    });
+
+    test("will not be complete with a pending export", async () => {
+      const run = await helper.factories.run(null, { state: "running" });
+
+      process.env.GROUPAROO_RUN_MODE = "cli:run";
+      const instance = new StatusTask();
+      expect(await instance.checkForComplete()).toBe(false);
+      await run.destroy();
+    });
+  });
+});

--- a/core/__tests__/tasks/system/sweeper.ts
+++ b/core/__tests__/tasks/system/sweeper.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { Run, Log, Import, Export, plugin } from "../../src";
+import { Run, Log, Import, Export, plugin } from "../../../src";
 import { api, task, specHelper } from "actionhero";
 
 describe("tasks/sweeper", () => {

--- a/core/__tests__/tasks/system/telemetry.ts
+++ b/core/__tests__/tasks/system/telemetry.ts
@@ -137,7 +137,7 @@ describe("tasks/telemetry", () => {
         expect(payload.metrics[0].aggregation).toBe("exact");
         expect(payload.metrics[0].value).toMatch("Error: OH NO");
         expect(payload.metrics[0].value).toMatch(
-          "core/__tests__/tasks/telemetry.ts"
+          "core/__tests__/tasks/system/telemetry.ts"
         );
       });
     });

--- a/core/__tests__/tasks/system/telemetry.ts
+++ b/core/__tests__/tasks/system/telemetry.ts
@@ -2,7 +2,7 @@ import fetch, { enableFetchMocks } from "jest-fetch-mock";
 enableFetchMocks();
 
 import { helper } from "@grouparoo/spec-helper";
-import { plugin, Log } from "../../src";
+import { plugin, Log } from "../../../src";
 import { api, specHelper, config } from "actionhero";
 
 describe("tasks/telemetry", () => {

--- a/core/src/bin/reset.ts
+++ b/core/src/bin/reset.ts
@@ -37,19 +37,17 @@ export class ResetCLI extends CLI {
       return GrouparooCLI.logger.fatal(`You need to --confirm this command`);
     }
 
-    await CLS.wrap(async () => {
-      const callerId = `cli:reset`;
-      if (params.mode === "cluster") {
-        await Reset.cluster(callerId);
-      } else if (params.mode === "data") {
-        await Reset.data(callerId);
-        await Reset.resetHighWatermarks();
-      } else if (params.mode === "cache") {
-        await Reset.cache(callerId);
-      } else {
-        return GrouparooCLI.logger.fatal("mode not found");
-      }
-    });
+    const callerId = `cli:reset`;
+    if (params.mode === "cluster") {
+      await CLS.wrap(async () => Reset.cluster(callerId));
+    } else if (params.mode === "data") {
+      await CLS.wrap(async () => Reset.data(callerId));
+      await CLS.wrap(async () => Reset.resetHighWatermarks());
+    } else if (params.mode === "cache") {
+      await CLS.wrap(async () => Reset.cache(callerId));
+    } else {
+      return GrouparooCLI.logger.fatal("mode not found");
+    }
 
     GrouparooCLI.logger.log(`✅ Success!`);
     return true;

--- a/core/src/bin/reset.ts
+++ b/core/src/bin/reset.ts
@@ -39,12 +39,12 @@ export class ResetCLI extends CLI {
 
     const callerId = `cli:reset`;
     if (params.mode === "cluster") {
-      await CLS.wrap(async () => Reset.cluster(callerId));
+      await CLS.wrap(async () => await Reset.cluster(callerId));
     } else if (params.mode === "data") {
-      await CLS.wrap(async () => Reset.data(callerId));
-      await CLS.wrap(async () => Reset.resetHighWatermarks());
+      await CLS.wrap(async () => await Reset.data(callerId));
+      await CLS.wrap(async () => await Reset.resetHighWatermarks());
     } else if (params.mode === "cache") {
-      await CLS.wrap(async () => Reset.cache(callerId));
+      await CLS.wrap(async () => await Reset.cache(callerId));
     } else {
       return GrouparooCLI.logger.fatal("mode not found");
     }

--- a/core/src/bin/reset.ts
+++ b/core/src/bin/reset.ts
@@ -1,6 +1,7 @@
 import { GrouparooCLI } from "../modules/cli";
 import { CLI } from "actionhero";
 import { Reset } from "../modules/reset";
+import { CLS } from "../modules/cls";
 
 export class ResetCLI extends CLI {
   constructor() {
@@ -36,17 +37,19 @@ export class ResetCLI extends CLI {
       return GrouparooCLI.logger.fatal(`You need to --confirm this command`);
     }
 
-    const callerId = `cli:reset`;
-    if (params.mode === "cluster") {
-      await Reset.cluster(callerId);
-    } else if (params.mode === "data") {
-      await Reset.data(callerId);
-      await Reset.resetHighWatermarks();
-    } else if (params.mode === "cache") {
-      await Reset.cache(callerId);
-    } else {
-      return GrouparooCLI.logger.fatal("mode not found");
-    }
+    await CLS.wrap(async () => {
+      const callerId = `cli:reset`;
+      if (params.mode === "cluster") {
+        await Reset.cluster(callerId);
+      } else if (params.mode === "data") {
+        await Reset.data(callerId);
+        await Reset.resetHighWatermarks();
+      } else if (params.mode === "cache") {
+        await Reset.cache(callerId);
+      } else {
+        return GrouparooCLI.logger.fatal("mode not found");
+      }
+    });
 
     GrouparooCLI.logger.log(`✅ Success!`);
     return true;

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -67,13 +67,7 @@ export class RunCLI extends CLI {
 
     await import("../grouparoo"); // run the server
 
-    const pendingStatus = await GrouparooCLI.getPendingStatus();
-    const runStatus = await GrouparooCLI.getRunsStatus();
-    GrouparooCLI.logger.status("Initial Status", [
-      { header: "Pending Items", status: pendingStatus },
-      { header: "Active Runs", status: runStatus },
-    ]);
-
+    await this.statusReport("Initial Status");
     await this.waitForReady();
     await this.runPausedTasks(params);
 
@@ -149,13 +143,7 @@ export class RunCLI extends CLI {
   }
 
   async checkForComplete() {
-    const pendingStatus = await GrouparooCLI.getPendingStatus();
-    const runStatus = await GrouparooCLI.getRunsStatus();
-    GrouparooCLI.logger.status("Status", [
-      { header: "Pending Items", status: pendingStatus },
-      { header: "Active Runs", status: runStatus },
-    ]);
-
+    const { pendingStatus } = await this.statusReport();
     let pendingItems = 0;
     for (const key in pendingStatus) {
       pendingItems += pendingStatus[key][0] as number;
@@ -172,5 +160,21 @@ export class RunCLI extends CLI {
       `All Grouparoo tasks complete - exiting with code 0`
     );
     process.exit(0);
+  }
+
+  async statusReport(title = "Status") {
+    let pendingStatus: GrouparooCLI.LogStatus;
+    let runStatus: GrouparooCLI.LogStatus;
+
+    await CLS.wrap(async () => {
+      pendingStatus = await GrouparooCLI.getPendingStatus();
+      runStatus = await GrouparooCLI.getRunsStatus();
+      GrouparooCLI.logger.status(title, [
+        { header: "Pending Items", status: pendingStatus },
+        { header: "Active Runs", status: runStatus },
+      ]);
+    });
+
+    return { pendingStatus, runStatus };
   }
 }

--- a/core/src/bin/status.ts
+++ b/core/src/bin/status.ts
@@ -4,6 +4,7 @@ import { Profile } from "../models/Profile";
 import { Group } from "../models/Group";
 import { GroupOps } from "../modules/ops/group";
 import { env, CLI } from "actionhero";
+import { CLS } from "../modules/cls";
 
 export class Status extends CLI {
   constructor() {
@@ -22,54 +23,56 @@ export class Status extends CLI {
   async run({ params }) {
     if (!params.json) GrouparooCLI.logCLI(this.name);
 
-    const { value: clusterName } = await plugin.readSetting(
-      "core",
-      "cluster-name"
-    );
+    await CLS.wrap(async () => {
+      const { value: clusterName } = await plugin.readSetting(
+        "core",
+        "cluster-name"
+      );
 
-    const totalProfiles = await Profile.count();
-    const totalGroups = await Group.count();
-    const { groups, newestMembersAdded } = await GroupOps.newestGroupMembers(
-      100
-    );
-    const groupsStatus = {};
-    for (const i in groups) {
-      const group = groups[i];
-      const additionTime = newestMembersAdded[group.id]
-        ? new Date(newestMembersAdded[group.id]).toISOString()
-        : "Never";
-      const groupMembersCount = await group.$count("groupMembers");
-      groupsStatus[group.name] = [
-        `${groupMembersCount} members`,
-        "newest member: " + additionTime,
+      const totalProfiles = await Profile.count();
+      const totalGroups = await Group.count();
+      const { groups, newestMembersAdded } = await GroupOps.newestGroupMembers(
+        100
+      );
+      const groupsStatus = {};
+      for (const i in groups) {
+        const group = groups[i];
+        const additionTime = newestMembersAdded[group.id]
+          ? new Date(newestMembersAdded[group.id]).toISOString()
+          : "Never";
+        const groupMembersCount = await group.$count("groupMembers");
+        groupsStatus[group.name] = [
+          `${groupMembersCount} members`,
+          "newest member: " + additionTime,
+        ];
+      }
+
+      const overview = {
+        ClusterName: [clusterName, env ? `${env}` : undefined],
+        TotalProfiles: [totalProfiles],
+        TotalGroups: [totalGroups],
+      };
+
+      const pendingStatus = await GrouparooCLI.getPendingStatus();
+      const runStatus = await GrouparooCLI.getRunsStatus();
+
+      const data = [
+        { header: "Overview", status: overview },
+        { header: "Groups", status: groupsStatus },
+        { header: "Active Runs", status: runStatus },
+        { header: "Pending Items", status: pendingStatus },
       ];
-    }
 
-    const overview = {
-      ClusterName: [clusterName, env ? `${env}` : undefined],
-      TotalProfiles: [totalProfiles],
-      TotalGroups: [totalGroups],
-    };
-
-    const pendingStatus = await GrouparooCLI.getPendingStatus();
-    const runStatus = await GrouparooCLI.getRunsStatus();
-
-    const data = [
-      { header: "Overview", status: overview },
-      { header: "Groups", status: groupsStatus },
-      { header: "Active Runs", status: runStatus },
-      { header: "Pending Items", status: pendingStatus },
-    ];
-
-    if (params.json) {
-      const jsonData = {};
-      data.map((collection) => {
-        jsonData[collection.header] = collection.status;
-      });
-      GrouparooCLI.logger.log(JSON.stringify(jsonData));
-    } else {
-      GrouparooCLI.logger.status("Cluster Status", data);
-    }
+      if (params.json) {
+        const jsonData = {};
+        data.map((collection) => {
+          jsonData[collection.header] = collection.status;
+        });
+        GrouparooCLI.logger.log(JSON.stringify(jsonData));
+      } else {
+        GrouparooCLI.logger.status("Cluster Status", data);
+      }
+    });
 
     return true;
   }

--- a/core/src/classes/initializers/clsInitializer.ts
+++ b/core/src/classes/initializers/clsInitializer.ts
@@ -1,0 +1,30 @@
+import { Initializer } from "actionhero";
+import { CLS } from "../../modules/cls";
+
+export abstract class CLSInitializer extends Initializer {
+  constructor() {
+    super();
+  }
+
+  async initialize() {
+    if (typeof this.initializeWithinTransaction === "function") {
+      return CLS.wrap(async () => await this.initializeWithinTransaction());
+    }
+  }
+
+  async start() {
+    if (typeof this.startWithinTransaction === "function") {
+      return CLS.wrap(async () => await this.startWithinTransaction());
+    }
+  }
+
+  async stop() {
+    if (typeof this.stopWithinTransaction === "function") {
+      return CLS.wrap(async () => await this.stopWithinTransaction());
+    }
+  }
+
+  abstract initializeWithinTransaction(): Promise<any>;
+  abstract startWithinTransaction(): Promise<any>;
+  abstract stopWithinTransaction(): Promise<any>;
+}

--- a/core/src/config/tasks.ts
+++ b/core/src/config/tasks.ts
@@ -11,7 +11,15 @@ export const DEFAULT = {
         const { api } = await import("actionhero"); // this needs to be async loaded as we are within the config system, to avoid circular dependencies
 
         return [].concat(
-          ["imports", "events", "runs", "schedules", "groups", "exports"],
+          [
+            "system",
+            "imports",
+            "events",
+            "runs",
+            "schedules",
+            "groups",
+            "exports",
+          ],
           api?.plugins?.plugins
             .filter((plugin) => plugin.apps?.length > 0)
             .map((plugin) => plugin.apps.map((app) => `exports:${app.name}`)),

--- a/core/src/initializers/codeConfig.ts
+++ b/core/src/initializers/codeConfig.ts
@@ -1,6 +1,6 @@
-import { api, Initializer } from "actionhero";
+import { api } from "actionhero";
 import { getConfigDir, loadConfigDirectory } from "../modules/configLoaders";
-import { CLS } from "../modules/cls";
+import { CLSInitializer } from "../classes/initializers/clsInitializer";
 
 declare module "actionhero" {
   export interface Api {
@@ -10,7 +10,7 @@ declare module "actionhero" {
   }
 }
 
-export class CodeConfig extends Initializer {
+export class CodeConfig extends CLSInitializer {
   constructor() {
     super();
     this.name = "codeConfig";
@@ -18,20 +18,20 @@ export class CodeConfig extends Initializer {
     this.startPriority = 1;
   }
 
-  async initialize() {
+  async initializeWithinTransaction() {
     api.codeConfig = {
       allowLockedModelChanges: true,
     };
   }
 
-  async start() {
+  async startWithinTransaction() {
     const configDir = getConfigDir();
-    await CLS.wrap(async () => {
-      const { errors } = await loadConfigDirectory(configDir);
-      if (errors.length > 0) throw new Error("code config error");
-    });
+    const { errors } = await loadConfigDirectory(configDir);
+    if (errors.length > 0) throw new Error("code config error");
 
     // after this point in the Actionhero boot lifecycle, locked models cannot be changed
     api.codeConfig.allowLockedModelChanges = false;
   }
+
+  async stopWithinTransaction() {}
 }

--- a/core/src/initializers/plugins.ts
+++ b/core/src/initializers/plugins.ts
@@ -4,7 +4,6 @@ import { plugin } from "../modules/plugin";
 import { App } from "../models/App";
 import { getPluginManifest } from "../utils/pluginDetails";
 import { ConfigTemplate } from "../classes/configTemplate";
-
 import {
   CalculatedGroupTemplate,
   ManualGroupTemplate,
@@ -18,6 +17,7 @@ import {
   ManualSourceTemplate,
   ManualPropertyTemplate,
 } from "../templates/manual";
+import { CLS } from "../modules/cls";
 
 declare module "actionhero" {
   export interface Api {
@@ -125,10 +125,12 @@ export class Plugins extends Initializer {
   }
 
   async stop() {
-    for (const id in api.plugins.persistentConnections) {
-      const app = await App.findById(id);
-      await app.disconnect();
-    }
+    await CLS.wrap(async () => {
+      for (const id in api.plugins.persistentConnections) {
+        const app = await App.findById(id);
+        await app.disconnect();
+      }
+    });
   }
 
   validatePlugin(plugin: GrouparooPlugin) {

--- a/core/src/initializers/rpc.ts
+++ b/core/src/initializers/rpc.ts
@@ -1,4 +1,4 @@
-import { Initializer, api, log, redis } from "actionhero";
+import { Initializer, api } from "actionhero";
 import { App } from "../models/App";
 
 export class GrouparooRPC extends Initializer {

--- a/core/src/initializers/session.ts
+++ b/core/src/initializers/session.ts
@@ -14,12 +14,6 @@ import {
   OptionallyAuthenticatedActionMiddleware,
 } from "../modules/middleware/authentication";
 
-interface SessionData {
-  id: string;
-  csrfToken: string;
-  createdAt: number;
-}
-
 declare module "actionhero" {
   export interface Api {
     session: {

--- a/core/src/initializers/settings.ts
+++ b/core/src/initializers/settings.ts
@@ -1,7 +1,6 @@
-import { Initializer } from "actionhero";
 import { plugin } from "../modules/plugin";
 import { settingTypes } from "../models/Setting";
-import { CLS } from "../modules/cls";
+import { CLSInitializer } from "../classes/initializers/clsInitializer";
 import * as UUID from "uuid";
 
 interface SettingsListItem {
@@ -12,7 +11,7 @@ interface SettingsListItem {
   type: typeof settingTypes[number];
   variant?: string;
 }
-export class Plugins extends Initializer {
+export class Plugins extends CLSInitializer {
   constructor() {
     super();
     this.name = "settings";
@@ -43,7 +42,7 @@ export class Plugins extends Initializer {
     }
   }
 
-  async initialize() {
+  async initializeWithinTransaction() {
     const coreSettings: SettingsListItem[] = [
       {
         key: "cluster-name",
@@ -178,12 +177,13 @@ export class Plugins extends Initializer {
       ...telemetrySettings,
     ].map(({ key }) => key);
 
-    await CLS.wrap(async () => {
-      await plugin.cleanSettings(settingKeys);
+    await plugin.cleanSettings(settingKeys);
 
-      await this.registerSettingsArray(coreSettings, "core");
-      await this.registerSettingsArray(interfaceSettings, "interface");
-      await this.registerSettingsArray(telemetrySettings, "telemetry");
-    });
+    await this.registerSettingsArray(coreSettings, "core");
+    await this.registerSettingsArray(interfaceSettings, "interface");
+    await this.registerSettingsArray(telemetrySettings, "telemetry");
   }
+
+  async startWithinTransaction() {}
+  async stopWithinTransaction() {}
 }

--- a/core/src/initializers/settings.ts
+++ b/core/src/initializers/settings.ts
@@ -1,6 +1,7 @@
 import { Initializer } from "actionhero";
 import { plugin } from "../modules/plugin";
 import { settingTypes } from "../models/Setting";
+import { CLS } from "../modules/cls";
 import * as UUID from "uuid";
 
 interface SettingsListItem {
@@ -177,10 +178,12 @@ export class Plugins extends Initializer {
       ...telemetrySettings,
     ].map(({ key }) => key);
 
-    await plugin.cleanSettings(settingKeys);
+    await CLS.wrap(async () => {
+      await plugin.cleanSettings(settingKeys);
 
-    await this.registerSettingsArray(coreSettings, "core");
-    await this.registerSettingsArray(interfaceSettings, "interface");
-    await this.registerSettingsArray(telemetrySettings, "telemetry");
+      await this.registerSettingsArray(coreSettings, "core");
+      await this.registerSettingsArray(interfaceSettings, "interface");
+      await this.registerSettingsArray(telemetrySettings, "telemetry");
+    });
   }
 }

--- a/core/src/initializers/setupSteps.ts
+++ b/core/src/initializers/setupSteps.ts
@@ -1,46 +1,45 @@
-import { Initializer } from "actionhero";
 import { Op } from "sequelize";
 import { SetupStep } from "../models/SetupStep";
 import { SetupStepOps } from "../modules/ops/setupSteps";
-import { CLS } from "../modules/cls";
+import { CLSInitializer } from "../classes/initializers/clsInitializer";
 
-export class OnboardingSteps extends Initializer {
+export class OnboardingSteps extends CLSInitializer {
   constructor() {
     super();
     this.name = "setupSteps";
   }
 
-  async start() {
-    await CLS.wrap(async () => {
-      // insert or update the setup steps we want
-      for (const i in SetupStepOps.setupStepDescriptions) {
-        const ssd = SetupStepOps.setupStepDescriptions[i];
-        const onboardingStep = await SetupStep.findOne({
-          where: { key: ssd.key },
-        });
+  async initializeWithinTransaction() {}
 
-        if (onboardingStep) {
-          if (onboardingStep.position !== ssd.position) {
-            await onboardingStep.update({ position: ssd.position });
-          }
-        } else {
-          await SetupStep.create({
-            position: ssd.position,
-            key: ssd.key,
-          });
-        }
-      }
-
-      // remove any old onboarding steps we no longer want
-      await SetupStep.destroy({
-        where: {
-          key: {
-            [Op.notIn]: SetupStepOps.setupStepDescriptions.map(
-              (ssd) => ssd.key
-            ),
-          },
-        },
+  async startWithinTransaction() {
+    // insert or update the setup steps we want
+    for (const i in SetupStepOps.setupStepDescriptions) {
+      const ssd = SetupStepOps.setupStepDescriptions[i];
+      const onboardingStep = await SetupStep.findOne({
+        where: { key: ssd.key },
       });
+
+      if (onboardingStep) {
+        if (onboardingStep.position !== ssd.position) {
+          await onboardingStep.update({ position: ssd.position });
+        }
+      } else {
+        await SetupStep.create({
+          position: ssd.position,
+          key: ssd.key,
+        });
+      }
+    }
+
+    // remove any old onboarding steps we no longer want
+    await SetupStep.destroy({
+      where: {
+        key: {
+          [Op.notIn]: SetupStepOps.setupStepDescriptions.map((ssd) => ssd.key),
+        },
+      },
     });
   }
+
+  async stopWithinTransaction() {}
 }

--- a/core/src/initializers/setupSteps.ts
+++ b/core/src/initializers/setupSteps.ts
@@ -2,40 +2,45 @@ import { Initializer } from "actionhero";
 import { Op } from "sequelize";
 import { SetupStep } from "../models/SetupStep";
 import { SetupStepOps } from "../modules/ops/setupSteps";
+import { CLS } from "../modules/cls";
 
 export class OnboardingSteps extends Initializer {
   constructor() {
     super();
-    this.name = "onboardingSteps";
+    this.name = "setupSteps";
   }
 
   async start() {
-    // insert or update the onboarding steps we want
-    for (const i in SetupStepOps.setupStepDescriptions) {
-      const ssd = SetupStepOps.setupStepDescriptions[i];
-      const onboardingStep = await SetupStep.findOne({
-        where: { key: ssd.key },
-      });
-
-      if (onboardingStep) {
-        if (onboardingStep.position !== ssd.position) {
-          await onboardingStep.update({ position: ssd.position });
-        }
-      } else {
-        await SetupStep.create({
-          position: ssd.position,
-          key: ssd.key,
+    await CLS.wrap(async () => {
+      // insert or update the setup steps we want
+      for (const i in SetupStepOps.setupStepDescriptions) {
+        const ssd = SetupStepOps.setupStepDescriptions[i];
+        const onboardingStep = await SetupStep.findOne({
+          where: { key: ssd.key },
         });
-      }
-    }
 
-    // remove any old onboarding steps we no longer want
-    await SetupStep.destroy({
-      where: {
-        key: {
-          [Op.notIn]: SetupStepOps.setupStepDescriptions.map((ssd) => ssd.key),
+        if (onboardingStep) {
+          if (onboardingStep.position !== ssd.position) {
+            await onboardingStep.update({ position: ssd.position });
+          }
+        } else {
+          await SetupStep.create({
+            position: ssd.position,
+            key: ssd.key,
+          });
+        }
+      }
+
+      // remove any old onboarding steps we no longer want
+      await SetupStep.destroy({
+        where: {
+          key: {
+            [Op.notIn]: SetupStepOps.setupStepDescriptions.map(
+              (ssd) => ssd.key
+            ),
+          },
         },
-      },
+      });
     });
   }
 }

--- a/core/src/initializers/teamPermissions.ts
+++ b/core/src/initializers/teamPermissions.ts
@@ -1,9 +1,9 @@
-import { Initializer, log } from "actionhero";
+import { log } from "actionhero";
 import { Team } from "../models/Team";
 import { waitForLock } from "../modules/locks";
-import { CLS } from "../modules/cls";
+import { CLSInitializer } from "../classes/initializers/clsInitializer";
 
-export class TeamPermissions extends Initializer {
+export class TeamPermissions extends CLSInitializer {
   constructor() {
     super();
     this.name = "teamPermissions";
@@ -30,12 +30,13 @@ export class TeamPermissions extends Initializer {
     }
   }
 
-  async initialize() {
-    await CLS.wrap(async () => {
-      const teams = await Team.findAll();
-      for (const i in teams) {
-        await this.updateTeamPermissions(teams[i]);
-      }
-    });
+  async initializeWithinTransaction() {
+    const teams = await Team.findAll();
+    for (const i in teams) {
+      await this.updateTeamPermissions(teams[i]);
+    }
   }
+
+  async startWithinTransaction() {}
+  async stopWithinTransaction() {}
 }

--- a/core/src/initializers/teamPermissions.ts
+++ b/core/src/initializers/teamPermissions.ts
@@ -1,6 +1,7 @@
 import { Initializer, log } from "actionhero";
 import { Team } from "../models/Team";
 import { waitForLock } from "../modules/locks";
+import { CLS } from "../modules/cls";
 
 export class TeamPermissions extends Initializer {
   constructor() {
@@ -30,9 +31,11 @@ export class TeamPermissions extends Initializer {
   }
 
   async initialize() {
-    const teams = await Team.findAll();
-    for (const i in teams) {
-      await this.updateTeamPermissions(teams[i]);
-    }
+    await CLS.wrap(async () => {
+      const teams = await Team.findAll();
+      for (const i in teams) {
+        await this.updateTeamPermissions(teams[i]);
+      }
+    });
   }
 }

--- a/core/src/modules/cls.ts
+++ b/core/src/modules/cls.ts
@@ -1,5 +1,6 @@
 import { api, task } from "actionhero";
 import cls from "cls-hooked";
+import { Transaction } from "sequelize";
 
 /**
  * This module is so you can delay the execution of side-effects within a transaction.
@@ -35,8 +36,8 @@ export namespace CLS {
       let runResponse: any;
       let afterCommitJobs: Array<Function> = [];
 
-      await api.sequelize.transaction(async () => {
-        runResponse = await f();
+      await api.sequelize.transaction(async (t: Transaction) => {
+        runResponse = await f(t);
         afterCommitJobs = getNamespace().get("afterCommitJobs");
       });
 

--- a/core/src/tasks/event/associateProfile.ts
+++ b/core/src/tasks/event/associateProfile.ts
@@ -42,7 +42,7 @@ export class EventAssociateProfile extends Task {
         if (!app) return;
         const appOptions = await app.getOptions();
 
-        event.associate(appOptions.identifyingPropertyId.toString());
+        await event.associate(appOptions.identifyingPropertyId.toString());
       });
     } catch (error) {
       log(`re-enqueuing association of event ${eventId}`);

--- a/core/src/tasks/event/associateProfile.ts
+++ b/core/src/tasks/event/associateProfile.ts
@@ -32,16 +32,18 @@ export class EventAssociateProfile extends Task {
 
   async run(params: { eventId: string; count: number }) {
     const { eventId } = params;
-    const event = await Event.findById(eventId);
-
-    const app = await App.findOne({ where: { type: "events" } });
-    if (!app) return;
-    const appOptions = await app.getOptions();
+    let event: Event;
 
     try {
-      await CLS.wrap(async () =>
-        event.associate(appOptions.identifyingPropertyId.toString())
-      );
+      await CLS.wrap(async () => {
+        event = await Event.findById(eventId);
+
+        const app = await App.findOne({ where: { type: "events" } });
+        if (!app) return;
+        const appOptions = await app.getOptions();
+
+        event.associate(appOptions.identifyingPropertyId.toString());
+      });
     } catch (error) {
       log(`re-enqueuing association of event ${eventId}`);
       throw new Error(`Error associating event ${event.id}: ${error.message}`);

--- a/core/src/tasks/import/associateProfile.ts
+++ b/core/src/tasks/import/associateProfile.ts
@@ -1,8 +1,10 @@
 import { log, env, Task } from "actionhero";
 import { Import } from "../../models/Import";
+import { CLS } from "../../modules/cls";
 
 export class ImportAssociateProfile extends Task {
   // This Task extends Task rather than CLSTask as we want to be able to view newly created profiles happening in parallel to this task/transaction
+  // We still want things to be in a transaction, so we wrap the run method custom
   // This Task has no side effects
   constructor() {
     super();
@@ -19,22 +21,26 @@ export class ImportAssociateProfile extends Task {
 
   async run(params) {
     const { importId } = params;
-    const _import = await Import.findById(importId);
-    if (_import.profileId) return;
+    let _import: Import;
 
     try {
-      const { profile, isNew } = await _import.associateProfile();
+      await CLS.wrap(async () => {
+        _import = await Import.findById(importId);
+        if (_import.profileId) return;
 
-      const oldProfileProperties = await profile.simplifiedProperties();
-      const oldGroups = await profile.$get("groups");
+        const { profile, isNew } = await _import.associateProfile();
 
-      await _import.update({
-        createdProfile: isNew,
-        oldProfileProperties,
-        oldGroupIds: oldGroups.map((g) => g.id),
+        const oldProfileProperties = await profile.simplifiedProperties();
+        const oldGroups = await profile.$get("groups");
+
+        await _import.update({
+          createdProfile: isNew,
+          oldProfileProperties,
+          oldGroupIds: oldGroups.map((g) => g.id),
+        });
+
+        await profile.markPending();
       });
-
-      await profile.markPending();
     } catch (error) {
       if (env !== "test") log(`[ASSOCIATE PROFILE ERROR] ${error}`, "alert");
       await _import.setError(error, this.name);

--- a/core/src/tasks/system/notifiers.ts
+++ b/core/src/tasks/system/notifiers.ts
@@ -1,5 +1,5 @@
 import { api } from "actionhero";
-import { CLSTask } from "../classes/tasks/clsTask";
+import { CLSTask } from "../../classes/tasks/clsTask";
 
 export class Notifier extends CLSTask {
   constructor() {
@@ -7,7 +7,7 @@ export class Notifier extends CLSTask {
     this.name = "notifier";
     this.description = "run all notifiers";
     this.frequency = 1000 * 60 * 60 * 6; // every 6 hours
-    this.queue = "default";
+    this.queue = "system";
   }
 
   async runWithinTransaction() {

--- a/core/src/tasks/system/status.ts
+++ b/core/src/tasks/system/status.ts
@@ -52,10 +52,13 @@ export class StatusTask extends Task {
     await CLS.wrap(async () => {
       pendingStatus = await GrouparooCLI.getPendingStatus();
       runStatus = await GrouparooCLI.getRunsStatus();
-      GrouparooCLI.logger.status(title, [
-        { header: "Pending Items", status: pendingStatus },
-        { header: "Active Runs", status: runStatus },
-      ]);
+
+      if (process.env.NODE_ENV !== "test") {
+        GrouparooCLI.logger.status(title, [
+          { header: "Pending Items", status: pendingStatus },
+          { header: "Active Runs", status: runStatus },
+        ]);
+      }
     });
 
     return { pendingStatus, runStatus };

--- a/core/src/tasks/system/status.ts
+++ b/core/src/tasks/system/status.ts
@@ -1,0 +1,63 @@
+import { Task, api } from "actionhero";
+import { GrouparooCLI } from "../../modules/cli";
+import { CLS } from "../../modules/cls";
+
+export class StatusTask extends Task {
+  constructor() {
+    super();
+    this.name = "status";
+    this.description = "log and display status";
+    this.frequency = 1000 * 10; // every 10 seconds
+    this.frequency =
+      process.env.GROUPAROO_RUN_MODE === "cli:run" ? 1000 * 10 : 0; // every 10 seconds
+    this.queue = "system";
+  }
+
+  async run() {
+    // double check...
+    if (process.env.GROUPAROO_RUN_MODE !== "cli:run") return;
+
+    const toStop = await this.checkForComplete();
+    if (toStop) await this.stopServer();
+  }
+
+  async checkForComplete() {
+    const { pendingStatus } = await this.statusReport();
+    let pendingItems = 0;
+    for (const key in pendingStatus) {
+      pendingItems += pendingStatus[key][0] as number;
+    }
+
+    if (pendingItems > 0) return false;
+    return true;
+  }
+
+  async stopServer() {
+    GrouparooCLI.logger.log("All Tasks Complete!");
+
+    // do not await so the task can end so the server can shut down
+    new Promise(async () => {
+      await api.process.stop();
+      GrouparooCLI.logger.log(
+        `All Grouparoo tasks complete - exiting with code 0`
+      );
+      process.nextTick(() => process.exit(0));
+    });
+  }
+
+  async statusReport(title = "Status") {
+    let pendingStatus: GrouparooCLI.LogStatus;
+    let runStatus: GrouparooCLI.LogStatus;
+
+    await CLS.wrap(async () => {
+      pendingStatus = await GrouparooCLI.getPendingStatus();
+      runStatus = await GrouparooCLI.getRunsStatus();
+      GrouparooCLI.logger.status(title, [
+        { header: "Pending Items", status: pendingStatus },
+        { header: "Active Runs", status: runStatus },
+      ]);
+    });
+
+    return { pendingStatus, runStatus };
+  }
+}

--- a/core/src/tasks/system/sweeper.ts
+++ b/core/src/tasks/system/sweeper.ts
@@ -1,10 +1,10 @@
 import { log } from "actionhero";
-import { Run } from "../models/Run";
-import { Import } from "../models/Import";
-import { Export } from "../models/Export";
-import { Log } from "../models/Log";
-import { Session } from "../models/Session";
-import { CLSTask } from "../classes/tasks/clsTask";
+import { Run } from "../../models/Run";
+import { Import } from "../../models/Import";
+import { Export } from "../../models/Export";
+import { Log } from "../../models/Log";
+import { Session } from "../../models/Session";
+import { CLSTask } from "../../classes/tasks/clsTask";
 
 export class Sweeper extends CLSTask {
   constructor() {
@@ -12,7 +12,7 @@ export class Sweeper extends CLSTask {
     this.name = "sweeper";
     this.description = "clear old database entries";
     this.frequency = 1000 * 60 * 30; // every half hour
-    this.queue = "default";
+    this.queue = "system";
   }
 
   log(model: string, count: number, days: number) {

--- a/core/src/tasks/system/telemetry.ts
+++ b/core/src/tasks/system/telemetry.ts
@@ -1,9 +1,9 @@
 import { api, config } from "actionhero";
 import "isomorphic-fetch";
-import { plugin } from "../modules/plugin";
+import { plugin } from "../../modules/plugin";
 import path from "path";
 import os from "os";
-import { CLSTask } from "../classes/tasks/clsTask";
+import { CLSTask } from "../../classes/tasks/clsTask";
 
 export class Telemetry extends CLSTask {
   constructor() {
@@ -11,7 +11,7 @@ export class Telemetry extends CLSTask {
     this.name = "telemetry";
     this.description = "send telemetry information about this cluster";
     this.frequency = 1000 * 60 * 60 * 24; // every 24 hours
-    this.queue = "default";
+    this.queue = "system";
   }
 
   async runWithinTransaction() {


### PR DESCRIPTION
* Adds `CLSInitializer` which when used will wrap initialize /start/stop methods in CLS transaction.  Note that not all initializers should use this, but it will be helpful for those more 'standard' types which create/modify records. 
* CLI commands which read/modify SQL objects should do so in transactions (most of the time)

This should help prevent SQLite Deadlocks