### PR TITLE
Default option values

### DIFF
--- a/core/__tests__/models/app/app.ts
+++ b/core/__tests__/models/app/app.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { plugin, App, Option, Log, Destination } from "../../../src";
+import { plugin, App, Option, Log } from "../../../src";
 import { api, redis, utils } from "actionhero";
 
 describe("models/app", () => {

--- a/core/__tests__/models/app/app.ts
+++ b/core/__tests__/models/app/app.ts
@@ -285,14 +285,7 @@ describe("models/app", () => {
         apps: [
           {
             name: "test-template-app",
-            options: [
-              { key: "test_key", required: true },
-              {
-                key: "test_default_key",
-                defaultValue: "default value",
-                required: false,
-              },
-            ],
+            options: [{ key: "test_key", required: true }],
             methods: {
               test: async () => {
                 testCounter++;
@@ -313,15 +306,8 @@ describe("models/app", () => {
             description: "a test app connection",
             app: "test-template-app",
             direction: "import" as "import",
-            options: [
-              {
-                key: "test_default_key",
-                defaultValue: "default value",
-                required: false,
-              },
-            ],
+            options: [],
             methods: {
-              exportProfile: async () => ({ success: true }),
               profiles: async () => {
                 return {
                   importsCount: 0,
@@ -362,53 +348,6 @@ describe("models/app", () => {
       expect(error).toBeUndefined();
       expect(success).toBe(true);
       expect(testCounter).toBe(1);
-    });
-
-    describe("default option values", () => {
-      test("it returns default values for app options that are not set", async () => {
-        const options = await app.getOptions();
-        expect(options.test_default_key).toEqual("default value");
-      });
-
-      test("it returns saved values for app options that are not set", async () => {
-        await app.setOptions({
-          test_default_key: "Some custom value",
-          test_key: true,
-        });
-
-        const options = await app.getOptions();
-        expect(options.test_default_key).toEqual("Some custom value");
-      });
-
-      describe("in app connection", () => {
-        let connection: Destination;
-        beforeAll(async () => {
-          await app.update({ state: "ready" });
-          connection = await Destination.create({
-            name: "incoming destination - default option values",
-            type: "import-from-test-template-app",
-            appId: app.id,
-          });
-        });
-
-        afterAll(async () => {
-          await connection.destroy();
-        });
-
-        test("it returns default values for connection options that are not set", async () => {
-          const options = await connection.getOptions();
-          expect(options.test_default_key).toEqual("default value");
-        });
-
-        test("it returns saved values for connection options that are not set", async () => {
-          await connection.setOptions({
-            test_default_key: "Some custom value",
-          });
-
-          const options = await connection.getOptions();
-          expect(options.test_default_key).toEqual("Some custom value");
-        });
-      });
     });
 
     test("apps can return their parallelism", async () => {

--- a/core/__tests__/models/app/app.ts
+++ b/core/__tests__/models/app/app.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { plugin, App, Option, Log } from "../../../src";
+import { plugin, App, Option, Log, Destination } from "../../../src";
 import { api, redis, utils } from "actionhero";
 
 describe("models/app", () => {
@@ -285,7 +285,14 @@ describe("models/app", () => {
         apps: [
           {
             name: "test-template-app",
-            options: [{ key: "test_key", required: true }],
+            options: [
+              { key: "test_key", required: true },
+              {
+                key: "test_default_key",
+                defaultValue: "default value",
+                required: false,
+              },
+            ],
             methods: {
               test: async () => {
                 testCounter++;
@@ -306,8 +313,15 @@ describe("models/app", () => {
             description: "a test app connection",
             app: "test-template-app",
             direction: "import" as "import",
-            options: [],
+            options: [
+              {
+                key: "test_default_key",
+                defaultValue: "default value",
+                required: false,
+              },
+            ],
             methods: {
+              exportProfile: async () => ({ success: true }),
               profiles: async () => {
                 return {
                   importsCount: 0,
@@ -348,6 +362,53 @@ describe("models/app", () => {
       expect(error).toBeUndefined();
       expect(success).toBe(true);
       expect(testCounter).toBe(1);
+    });
+
+    describe("default option values", () => {
+      test("it returns default values for app options that are not set", async () => {
+        const options = await app.getOptions();
+        expect(options.test_default_key).toEqual("default value");
+      });
+
+      test("it returns saved values for app options that are not set", async () => {
+        await app.setOptions({
+          test_default_key: "Some custom value",
+          test_key: true,
+        });
+
+        const options = await app.getOptions();
+        expect(options.test_default_key).toEqual("Some custom value");
+      });
+
+      describe("in app connection", () => {
+        let connection: Destination;
+        beforeAll(async () => {
+          await app.update({ state: "ready" });
+          connection = await Destination.create({
+            name: "incoming destination - default option values",
+            type: "import-from-test-template-app",
+            appId: app.id,
+          });
+        });
+
+        afterAll(async () => {
+          await connection.destroy();
+        });
+
+        test("it returns default values for connection options that are not set", async () => {
+          const options = await connection.getOptions();
+          expect(options.test_default_key).toEqual("default value");
+        });
+
+        test("it returns saved values for connection options that are not set", async () => {
+          await connection.setOptions({
+            test_default_key: "Some custom value",
+          });
+
+          const options = await connection.getOptions();
+          expect(options.test_default_key).toEqual("Some custom value");
+        });
+      });
     });
 
     test("apps can return their parallelism", async () => {

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -30,6 +30,7 @@ export interface AppOption {
   required: boolean;
   description?: string;
   placeholder?: string;
+  defaultValue?: string | number | boolean;
 }
 
 export interface SimpleAppOptions extends OptionHelper.SimpleOptions {}

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -331,10 +331,13 @@ export namespace OptionHelper {
     const plugin = await getPlugin(instance);
 
     let options: AppOption[] = [];
-    if (instance instanceof App) {
-      options = plugin.pluginApp?.options;
-    } else if (instance instanceof Source || instance instanceof Destination) {
-      options = plugin.pluginConnection?.options;
+    if (instance instanceof App && plugin.pluginApp) {
+      options = plugin.pluginApp.options;
+    } else if (
+      (instance instanceof Source || instance instanceof Destination) &&
+      plugin.pluginConnection
+    ) {
+      options = plugin.pluginConnection.options;
     }
 
     const defaultOptions: SimpleOptions = {};

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -32,7 +32,7 @@ export namespace OptionHelper {
       sourceFromEnvironment = true;
     }
 
-    let optionsObject: SimpleOptions = await getDefaultOptionValues(instance);
+    let optionsObject = await getDefaultOptionValues(instance);
     const options = await Option.findAll({
       where: { ownerId: instance.id },
     });
@@ -327,7 +327,7 @@ export namespace OptionHelper {
 
   async function getDefaultOptionValues(
     instance: Source | Destination | Schedule | Property | App
-  ): Promise<SimpleOptions> {
+  ) {
     const plugin = await getPlugin(instance);
 
     let options: AppOption[] = [];

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -9,7 +9,7 @@ import { Source } from "./../models/Source";
 import { Destination } from "./../models/Destination";
 import { Schedule } from "./../models/Schedule";
 import { Property } from "../models/Property";
-import { App } from "./../models/App";
+import { App, AppOption } from "./../models/App";
 import { LoggedModel } from "../classes/loggedModel";
 import { LockableHelper } from "./lockableHelper";
 
@@ -32,7 +32,7 @@ export namespace OptionHelper {
       sourceFromEnvironment = true;
     }
 
-    let optionsObject: SimpleOptions = {};
+    let optionsObject: SimpleOptions = await getDefaultOptionValues(instance);
     const options = await Option.findAll({
       where: { ownerId: instance.id },
     });
@@ -323,5 +323,27 @@ export namespace OptionHelper {
     }
 
     return options;
+  }
+
+  async function getDefaultOptionValues(
+    instance: Source | Destination | Schedule | Property | App
+  ): Promise<SimpleOptions> {
+    const plugin = await getPlugin(instance);
+
+    let options: AppOption[] = [];
+    if (instance instanceof App) {
+      options = plugin.pluginApp?.options;
+    } else if (instance instanceof Source || instance instanceof Destination) {
+      options = plugin.pluginConnection?.options;
+    }
+
+    const defaultOptions: Record<string, string | number | boolean> = {};
+    for (const opt of options) {
+      if (opt.defaultValue !== undefined) {
+        defaultOptions[opt.key] = opt.defaultValue;
+      }
+    }
+
+    return defaultOptions;
   }
 }

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -337,7 +337,7 @@ export namespace OptionHelper {
       options = plugin.pluginConnection?.options;
     }
 
-    const defaultOptions: Record<string, string | number | boolean> = {};
+    const defaultOptions: SimpleOptions = {};
     for (const opt of options) {
       if (opt.defaultValue !== undefined) {
         defaultOptions[opt.key] = opt.defaultValue;

--- a/plugins/@grouparoo/mysql/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mysql/src/initializers/plugin.ts
@@ -69,7 +69,7 @@ export class Plugins extends Initializer {
               displayName: "Port",
               required: false,
               description: "The MySQL port.",
-              placeholder: "3306",
+              defaultValue: 3306,
             },
             {
               key: "database",

--- a/plugins/@grouparoo/pardot/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/pardot/src/initializers/plugin.ts
@@ -69,11 +69,13 @@ export class Plugins extends Initializer {
             {
               key: "salesforceDomain",
               displayName: "Salesforce Domain",
+              defaultValue: "https://login.salesforce.com",
               required: false,
             },
             {
               key: "pardotDomain",
               displayName: "Pardot Domain",
+              defaultValue: "https://pi.pardot.com",
               required: false,
             },
           ],

--- a/plugins/@grouparoo/postgres/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/postgres/src/initializers/plugin.ts
@@ -69,7 +69,7 @@ export class Plugins extends Initializer {
               displayName: "Port",
               required: false,
               description: "The Postgres port.",
-              placeholder: "5432",
+              defaultValue: 5432,
             },
             {
               key: "database",
@@ -82,7 +82,7 @@ export class Plugins extends Initializer {
               displayName: "Schema",
               required: false,
               description: "The Postgres schema (default: public).",
-              placeholder: "public",
+              defaultValue: "public",
             },
             {
               key: "user",

--- a/plugins/@grouparoo/redshift/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/redshift/src/initializers/plugin.ts
@@ -68,6 +68,7 @@ export class Plugins extends Initializer {
               displayName: "Port",
               required: false,
               description: "The Redshift port.",
+              defaultValue: 5439,
             },
             {
               key: "database",
@@ -80,6 +81,7 @@ export class Plugins extends Initializer {
               displayName: "Schema",
               required: false,
               description: "The Redshift schema (default: public).",
+              defaultValue: "public",
             },
             {
               key: "user",

--- a/plugins/@grouparoo/snowflake/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/snowflake/src/initializers/plugin.ts
@@ -87,6 +87,7 @@ export class Plugins extends Initializer {
               displayName: "Schema",
               required: false,
               description: "The Snowflake schema (default: PUBLIC)",
+              defaultValue: "PUBLIC",
             },
           ],
           methods: { test, connect, disconnect },


### PR DESCRIPTION
This allows setting a `defaultValue` when configuring app and destination options. This happens in the `OptionHelper` so that default values are applied both in the enterprise UI and when working with options in plugins (e.g. the received options on the `connection` method)