### PR TITLE
Imports and Exports that aren't complete after a time will be retried

### DIFF
--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -1,6 +1,6 @@
 import { URL } from "url";
 import { join, isAbsolute } from "path";
-import { getParentPath, getCoreRootPath } from "../utils/pluginDetails";
+import { getParentPath } from "../utils/pluginDetails";
 
 // import {CLS} from '../modules/cls'
 import cls from "cls-hooked";

--- a/core/src/initializers/settings.ts
+++ b/core/src/initializers/settings.ts
@@ -85,6 +85,14 @@ export class Plugins extends Initializer {
         type: "number",
       },
       {
+        key: "imports-retry-delay-seconds",
+        title: "Imports Retry Delay Seconds",
+        defaultValue: 60 * 5, // 5 minutes
+        description:
+          "How long before Grouparoo considers a started but not-yet-complete Import to have stalled and try again?",
+        type: "number",
+      },
+      {
         key: "runs-previous-can-include-errors",
         title: "Runs: Previous Runs with Errors Considered",
         defaultValue: "false",
@@ -99,6 +107,14 @@ export class Plugins extends Initializer {
         defaultValue: 100,
         description:
           "How many Profiles should a Run try to send at once to Destinations which support batch exporting?",
+        type: "number",
+      },
+      {
+        key: "exports-retry-delay-seconds",
+        title: "Exports Retry Delay Seconds",
+        defaultValue: 60 * 5, // 5 minutes
+        description:
+          "How long before Grouparoo considers a started but not-yet-complete Export to have stalled and try again?",
         type: "number",
       },
       {

--- a/core/src/migrations/000061-addImportStartedAt.ts
+++ b/core/src/migrations/000061-addImportStartedAt.ts
@@ -1,0 +1,12 @@
+export default {
+  up: async function (migration, DataTypes) {
+    await migration.addColumn("imports", "startedAt", {
+      type: DataTypes.DATE,
+      allowNull: true,
+    });
+  },
+
+  down: async function (migration) {
+    await migration.removeColumn("imports", "startedAt");
+  },
+};

--- a/core/src/models/Import.ts
+++ b/core/src/models/Import.ts
@@ -59,7 +59,7 @@ export class Import extends Model {
   // data: string;
   get data(): ImportData {
     //@ts-ignore
-    return JSON.parse(this.getDataValue("data"));
+    return JSON.parse(this.getDataValue("data") || "{}");
   }
   set data(value: ImportData) {
     //@ts-ignore
@@ -70,7 +70,7 @@ export class Import extends Model {
   // rawData: string;
   get rawData(): ImportData {
     //@ts-ignore
-    return JSON.parse(this.getDataValue("rawData"));
+    return JSON.parse(this.getDataValue("rawData") || "{}");
   }
   set rawData(value: ImportData) {
     //@ts-ignore
@@ -83,9 +83,6 @@ export class Import extends Model {
 
   @BelongsTo(() => Profile)
   profile: Profile;
-
-  @Column
-  profileAssociatedAt: Date;
 
   @AllowNull(false)
   @Default(false)
@@ -114,9 +111,6 @@ export class Import extends Model {
     this.setDataValue("newProfileProperties", JSON.stringify(value));
   }
 
-  @Column
-  profileUpdatedAt: Date;
-
   @Column(DataType.TEXT)
   // oldGroupIds: string;
   get oldGroupIds(): string[] {
@@ -138,6 +132,15 @@ export class Import extends Model {
     //@ts-ignore
     this.setDataValue("newGroupIds", JSON.stringify(value));
   }
+
+  @Column
+  startedAt: Date;
+
+  @Column
+  profileAssociatedAt: Date;
+
+  @Column
+  profileUpdatedAt: Date;
 
   @Column
   groupsUpdatedAt: Date;
@@ -174,6 +177,7 @@ export class Import extends Model {
 
       // lifecycle timestamps
       createdAt: APIData.formatDate(this.createdAt),
+      startedAt: APIData.formatDate(this.startedAt),
       profileAssociatedAt: APIData.formatDate(this.profileAssociatedAt),
       profileUpdatedAt: APIData.formatDate(this.profileUpdatedAt),
       groupsUpdatedAt: APIData.formatDate(this.groupsUpdatedAt),

--- a/core/src/modules/ops/export.ts
+++ b/core/src/modules/ops/export.ts
@@ -90,7 +90,8 @@ export namespace ExportOps {
 
   export async function processPendingExportsForDestination(
     destination: Destination,
-    limit = 100
+    limit = 100,
+    delayMs = 1000 * 60 * 5
   ) {
     const app = await destination.$get("app");
     const { pluginConnection } = await destination.getPlugin();
@@ -99,7 +100,9 @@ export namespace ExportOps {
 
     _exports = await Export.findAll({
       where: {
-        startedAt: null,
+        startedAt: {
+          [Op.or]: [null, { [Op.lt]: new Date().getTime() - delayMs }],
+        },
         destinationId: destination.id,
       },
       order: [["createdAt", "asc"]],

--- a/core/src/modules/ops/import.ts
+++ b/core/src/modules/ops/import.ts
@@ -1,7 +1,58 @@
 import { Import } from "../../models/Import";
+import { Run } from "../../models/Run";
 import { ProfileOps } from "./profile";
+import { CLS } from "../../modules/cls";
+import { Op } from "sequelize";
 
 export namespace ImportOps {
+  export async function processPendingImportsForAssociation(
+    limit = 100,
+    delayMs = 1000 * 60 * 5
+  ) {
+    const imports = await Import.findAll({
+      where: {
+        profileId: null,
+        errorMessage: null,
+        startedAt: {
+          [Op.or]: [null, { [Op.lt]: new Date().getTime() - delayMs }],
+        },
+      },
+      limit,
+      order: [["createdAt", "asc"]],
+    });
+
+    await Import.update(
+      { startedAt: new Date() },
+      {
+        where: { id: { [Op.in]: imports.map((i) => i.id) }, startedAt: null },
+      }
+    );
+
+    const runIds: string[] = [];
+    for (const i in imports) {
+      const _import = imports[i];
+      await CLS.enqueueTask("import:associateProfile", {
+        importId: _import.id,
+      });
+
+      if (
+        _import.creatorType === "run" &&
+        !runIds.includes(_import.creatorId)
+      ) {
+        runIds.push(_import.creatorId);
+      }
+    }
+
+    if (runIds.length > 0) {
+      await Run.update(
+        { state: "running", completedAt: null },
+        { where: { state: "complete", id: { [Op.in]: runIds } } }
+      );
+    }
+
+    return imports;
+  }
+
   export async function associateProfile(_import: Import) {
     const {
       profile,

--- a/core/src/tasks/event/associateProfiles.ts
+++ b/core/src/tasks/event/associateProfiles.ts
@@ -10,7 +10,7 @@ export class EventsAssociateProfiles extends CLSTask {
     this.name = "event:associateProfiles";
     this.description =
       "ensure that events are associated to profiles, even if they were created outside of the Grouparoo API";
-    this.frequency = 30 * 1000;
+    this.frequency = 60 * 1000;
     this.queue = "events";
     this.inputs = {};
   }

--- a/core/src/tasks/export/enqueue.ts
+++ b/core/src/tasks/export/enqueue.ts
@@ -24,13 +24,19 @@ export class EnqueueExports extends RetryableTask {
       (await plugin.readSetting("core", "exports-profile-batch-size")).value
     );
 
+    const delayMs =
+      parseInt(
+        (await plugin.readSetting("core", "exports-retry-delay-seconds")).value
+      ) * 1000;
+
     let totalEnqueued = 0;
     const destinations = await Destination.scope(null).findAll();
 
     for (const i in destinations) {
       const enqueuedExportsCount = await ExportOps.processPendingExportsForDestination(
         destinations[i],
-        limit
+        limit,
+        delayMs
       );
       totalEnqueued += enqueuedExportsCount;
       if (enqueuedExportsCount > 0) {

--- a/core/src/tasks/import/associateProfiles.ts
+++ b/core/src/tasks/import/associateProfiles.ts
@@ -1,17 +1,14 @@
 import { log } from "actionhero";
 import { plugin } from "../../modules/plugin";
-import { Import } from "../../models/Import";
-import { Run } from "../../models/Run";
 import { CLSTask } from "../../classes/tasks/clsTask";
-import { CLS } from "../../modules/cls";
-import { Op } from "sequelize";
+import { ImportOps } from "../../modules/ops/import";
 
 export class ImportAssociateProfiles extends CLSTask {
   constructor() {
     super();
     this.name = "import:associateProfiles";
     this.description = "ensure that imports are associated to profiles";
-    this.frequency = 30 * 1000;
+    this.frequency = 1000 * 10;
     this.queue = "imports";
     this.inputs = {};
   }
@@ -21,33 +18,15 @@ export class ImportAssociateProfiles extends CLSTask {
       (await plugin.readSetting("core", "runs-profile-batch-size")).value
     );
 
-    const imports = await Import.findAll({
-      where: { profileId: null, errorMessage: null },
+    const delayMs =
+      parseInt(
+        (await plugin.readSetting("core", "imports-retry-delay-seconds")).value
+      ) * 1000;
+
+    const imports = await ImportOps.processPendingImportsForAssociation(
       limit,
-      order: [["createdAt", "asc"]],
-    });
-
-    const runIds: string[] = [];
-    for (const i in imports) {
-      const _import = imports[i];
-      await CLS.enqueueTask("import:associateProfile", {
-        importId: _import.id,
-      });
-
-      if (
-        _import.creatorType === "run" &&
-        !runIds.includes(_import.creatorId)
-      ) {
-        runIds.push(_import.creatorId);
-      }
-    }
-
-    if (runIds.length > 0) {
-      await Run.update(
-        { state: "running", completedAt: null },
-        { where: { state: "complete", id: { [Op.in]: runIds } } }
-      );
-    }
+      delayMs
+    );
 
     if (imports.length > 0) {
       log(`enqueued ${imports.length} imports for association`);


### PR DESCRIPTION
This PR makes Import association and Export processing more resilient. 

Both Imports and Exports have been updated to follow this pattern:

- have a `startedAt` column  that will be set when the record is first enqueued to be processed
- when looking for records to process, consider those with a null `startedAt` or those with a `startedAt` that is far in the past & not yet complete
  - Imports: not yet complete = no profile Id
  - Exports: not yet complete = no completedAt
- add 2 new settings, `imports-retry-delay-seconds` and `exports-retry-delay-seconds` to know what "too far in the past" means; default to 5 minutes

<img width="846" alt="Screen Shot 2021-03-24 at 3 14 39 PM" src="https://user-images.githubusercontent.com/303226/112390511-ad551100-8cb3-11eb-8426-3cc02bf0474d.png">
<img width="824" alt="Screen Shot 2021-03-24 at 3 14 43 PM" src="https://user-images.githubusercontent.com/303226/112390515-ae863e00-8cb3-11eb-96f4-c974a7d8f289.png">
