### PR TITLE
If GROUPAROO_ENV_CONFIG_FILE is provided, don't try to load a local .env file

### DIFF
--- a/core/src/config/environment.ts
+++ b/core/src/config/environment.ts
@@ -2,12 +2,15 @@ import fs from "fs";
 import path from "path";
 import { getParentPath } from "../utils/pluginDetails";
 
-const envFileAttempts = [path.resolve(path.join(getParentPath(), ".env"))];
+const envFileAttempts: string[] = [];
+
 if (process.env.GROUPAROO_ENV_CONFIG_FILE) {
   envFileAttempts.unshift(process.env.GROUPAROO_ENV_CONFIG_FILE);
   envFileAttempts.unshift(
     path.join(getParentPath(), process.env.GROUPAROO_ENV_CONFIG_FILE)
   );
+} else {
+  envFileAttempts.push(path.resolve(path.join(getParentPath(), ".env")));
 }
 
 let found = false;

--- a/plugins/@grouparoo/spec-helper/src/lib/integrationSpecHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/integrationSpecHelper.ts
@@ -96,6 +96,7 @@ export namespace IntegrationSpecHelper {
       JEST_WORKER_ID: jestId,
       SERVER_TOKEN: serverToken,
       GROUPAROO_CONFIG_DIR: disableCodeConfig ? "/not/a/real/dir" : undefined,
+      GROUPAROO_ENV_CONFIG_FILE: "/path/to/nothing",
     });
 
     const subProcess = spawn("node", ["dist/grouparoo.js"], {


### PR DESCRIPTION
This came up in https://github.com/grouparoo/grouparoo/pull/1530 and created a problem that my local `.env` was in use by the test running the `app/staging-enterprise`.  We want to be able to choose a different .env, or not use one at all.

Thanks @tealjulia again!