### PR TITLE
Plugins can choose to obfuscate passwords

### DIFF
--- a/core/__tests__/actions/apps.ts
+++ b/core/__tests__/actions/apps.ts
@@ -64,6 +64,7 @@ describe("actions/apps", () => {
       const pluginTestAppType = types.find((t) => t.name === "test-plugin-app");
       expect(pluginTestAppType.options).toEqual([
         { key: "fileId", required: true },
+        { key: "password", required: false },
       ]);
       expect(pluginTestAppType.plugin).toEqual({
         name: "@grouparoo/test-plugin",
@@ -118,6 +119,7 @@ describe("actions/apps", () => {
       expect(error).toBeUndefined();
       expect(options).toEqual({
         fileId: { options: ["a", "b"], type: "list" },
+        password: { type: "password" },
       });
     });
 
@@ -171,13 +173,15 @@ describe("actions/apps", () => {
         csrfToken,
         id,
         name: "new app name",
-        options: { fileId: "zzz" },
+        options: { fileId: "zzz", password: "SECRET" },
       };
       const { error, app } = await specHelper.runAction("app:edit", connection);
+
       expect(error).toBeUndefined();
       expect(app.id).toBeTruthy();
       expect(app.name).toBe("new app name");
       expect(app.options.fileId).toBe("zzz");
+      expect(app.options.password).toBe("******");
     });
 
     test("an administrator can view an app", async () => {
@@ -190,6 +194,7 @@ describe("actions/apps", () => {
       expect(app.id).toBeTruthy();
       expect(app.name).toBe("new app name");
       expect(app.options.fileId).toBe("zzz");
+      expect(app.options.password).toBe("******");
     });
 
     test("an administrator can destroy an app", async () => {

--- a/core/__tests__/models/app/app.ts
+++ b/core/__tests__/models/app/app.ts
@@ -285,14 +285,20 @@ describe("models/app", () => {
         apps: [
           {
             name: "test-template-app",
-            options: [{ key: "test_key", required: true }],
+            options: [
+              { key: "test_key", required: true },
+              { key: "password", required: false },
+            ],
             methods: {
               test: async () => {
                 testCounter++;
                 return { success: true };
               },
               appOptions: async () => {
-                return { fileId: { type: "list", options: ["a", "b"] } };
+                return {
+                  test_key: { type: "list", options: ["a", "b"] },
+                  password: { type: "password" },
+                };
               },
               parallelism: async () => {
                 return parallelism;
@@ -336,10 +342,21 @@ describe("models/app", () => {
       expect(apiData.icon).toBe("/path/to/icon.svg");
     });
 
+    test("apiData returns '*****' for any appOption of type 'password'", async () => {
+      await app.setOptions({ password: "SECRET", test_key: "something" });
+
+      const apiData = await app.apiData();
+      expect(apiData.options).toEqual({
+        test_key: "something",
+        password: "******",
+      });
+    });
+
     test("it can return the appOptions from the plugin", async () => {
       const options = await app.appOptions();
       expect(options).toEqual({
-        fileId: { type: "list", options: ["a", "b"] },
+        test_key: { type: "list", options: ["a", "b"] },
+        password: { type: "password" },
       });
     });
 

--- a/core/__tests__/models/option.ts
+++ b/core/__tests__/models/option.ts
@@ -1,6 +1,9 @@
 import { helper } from "@grouparoo/spec-helper";
 import { Option, App, Destination, plugin } from "../../src";
-import { OptionHelper } from "../../src/modules/optionHelper";
+import {
+  OptionHelper,
+  ObfuscatedPasswordString,
+} from "../../src/modules/optionHelper";
 
 describe("models/option", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -143,7 +146,19 @@ describe("models/option", () => {
       await OptionHelper.setOptions(app, opts);
       const options = await OptionHelper.getOptions(app, undefined, true);
       expect(options["fileId"]).toEqual(opts.fileId);
-      expect(options["password"]).toEqual("******");
+      expect(options["password"]).toEqual(ObfuscatedPasswordString);
+    });
+
+    test("If I try to set options with the ObfuscatedPasswordString, the previous value will be used", async () => {
+      const originalOpts = { fileId: "abc123", password: "SECRET" };
+      await OptionHelper.setOptions(app, originalOpts);
+
+      const opts = { fileId: "abc123", password: ObfuscatedPasswordString };
+      await OptionHelper.setOptions(app, opts);
+
+      const options = await OptionHelper.getOptions(app);
+      expect(options["fileId"]).toEqual(opts.fileId);
+      expect(options["password"]).toEqual("SECRET");
     });
 
     describe("options from environment variables", () => {

--- a/core/__tests__/models/option.ts
+++ b/core/__tests__/models/option.ts
@@ -114,7 +114,7 @@ describe("models/option", () => {
       app = await helper.factories.app();
     });
 
-    test("number option types are maintained", async () => {
+    test("string option types are maintained", async () => {
       const opts = { fileId: "abc" };
       await OptionHelper.setOptions(app, opts);
       expect(await OptionHelper.getOptions(app)).toEqual(opts);
@@ -126,10 +126,24 @@ describe("models/option", () => {
       expect(await OptionHelper.getOptions(app)).toEqual(opts);
     });
 
-    test("number option types are maintained", async () => {
+    test("boolean option types are maintained", async () => {
       const opts = { fileId: true };
       await OptionHelper.setOptions(app, opts);
       expect(await OptionHelper.getOptions(app)).toEqual(opts);
+    });
+
+    test("I will see passwords by default for Apps", async () => {
+      const opts = { fileId: "abc123", password: "SECRET" };
+      await OptionHelper.setOptions(app, opts);
+      expect(await OptionHelper.getOptions(app)).toEqual(opts);
+    });
+
+    test("I can choose to obfuscate passwords", async () => {
+      const opts = { fileId: "abc123", password: "SECRET" };
+      await OptionHelper.setOptions(app, opts);
+      const options = await OptionHelper.getOptions(app, undefined, true);
+      expect(options["fileId"]).toEqual(opts.fileId);
+      expect(options["password"]).toEqual("******");
     });
 
     describe("options from environment variables", () => {

--- a/core/src/classes/plugin.ts
+++ b/core/src/classes/plugin.ts
@@ -490,7 +490,12 @@ export interface ExportArrayPropertiesMethod {
 
 export type ExportArrayPropertiesMethodResponse = Array<string>;
 
-export type PluginOptionTypes = "string" | "list" | "typeahead" | "pending";
+export type PluginOptionTypes =
+  | "string"
+  | "list"
+  | "typeahead"
+  | "pending"
+  | "password";
 
 /** Template Utils */
 

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -84,8 +84,8 @@ export class App extends LoggedModel<App> {
     return pluginApp.methods.appOptions();
   }
 
-  async getOptions(sourceFromEnvironment = true) {
-    return OptionHelper.getOptions(this, sourceFromEnvironment);
+  async getOptions(sourceFromEnvironment = true, hidePasswords = false) {
+    return OptionHelper.getOptions(this, sourceFromEnvironment, hidePasswords);
   }
 
   async setOptions(options: SimpleAppOptions) {
@@ -160,7 +160,7 @@ export class App extends LoggedModel<App> {
   }
 
   async apiData() {
-    const options = await this.getOptions(false);
+    const options = await this.getOptions(false, true);
     const icon = await this._getIcon();
     const provides = this.provides();
 

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -84,8 +84,12 @@ export class App extends LoggedModel<App> {
     return pluginApp.methods.appOptions();
   }
 
-  async getOptions(sourceFromEnvironment = true, hidePasswords = false) {
-    return OptionHelper.getOptions(this, sourceFromEnvironment, hidePasswords);
+  async getOptions(sourceFromEnvironment = true, obfuscatePasswords = false) {
+    return OptionHelper.getOptions(
+      this,
+      sourceFromEnvironment,
+      obfuscatePasswords
+    );
   }
 
   async setOptions(options: SimpleAppOptions) {

--- a/core/src/modules/ops/app.ts
+++ b/core/src/modules/ops/app.ts
@@ -97,8 +97,14 @@ export namespace AppOps {
       throw new Error(`cannot find a pluginApp type of ${app.type}`);
     }
 
-    if (!options) options = await app.getOptions(true);
-    options = OptionHelper.sourceEnvironmentVariableOptions(app, options);
+    let sanitizedOptions = await OptionHelper.replaceObfuscatedPasswords(
+      app,
+      options
+    );
+    sanitizedOptions = OptionHelper.sourceEnvironmentVariableOptions(
+      app,
+      sanitizedOptions
+    );
 
     let connection;
     try {
@@ -106,14 +112,14 @@ export namespace AppOps {
         connection = await pluginApp.methods.connect({
           app,
           appId: app.id,
-          appOptions: options,
+          appOptions: sanitizedOptions,
         });
       }
 
       const result = await pluginApp.methods.test({
         app,
         appId: app.id,
-        appOptions: options,
+        appOptions: sanitizedOptions,
         connection,
       });
       message = result.message;
@@ -131,7 +137,7 @@ export namespace AppOps {
           connection,
           app,
           appId: app.id,
-          appOptions: options,
+          appOptions: sanitizedOptions,
         });
       }
     }

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -26,7 +26,8 @@ export namespace OptionHelper {
 
   export async function getOptions(
     instance: Source | Destination | Schedule | Property | App,
-    sourceFromEnvironment = true
+    sourceFromEnvironment = true,
+    hidePasswords = false
   ) {
     if (sourceFromEnvironment === null || sourceFromEnvironment === undefined) {
       sourceFromEnvironment = true;
@@ -37,8 +38,24 @@ export namespace OptionHelper {
       where: { ownerId: instance.id },
     });
 
+    const optionsToHide: string[] = [];
+    if (instance instanceof App) {
+      const appOptions = await instance.appOptions();
+      const appOptionKeys = Object.keys(appOptions);
+
+      appOptionKeys.forEach((appOptionKey) => {
+        if (appOptions[appOptionKey].type == "password" && hidePasswords) {
+          optionsToHide.push(appOptionKey);
+        }
+      });
+    }
+
     options.forEach((option) => {
-      optionsObject[option.key] = option.typedValue();
+      if (optionsToHide.includes(option.key)) {
+        optionsObject[option.key] = "******";
+      } else {
+        optionsObject[option.key] = option.typedValue();
+      }
     });
 
     if (sourceFromEnvironment) {

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -382,9 +382,11 @@ export namespace OptionHelper {
     options?: SimpleOptions
   ) {
     let sanitizedOptions: SimpleOptions = Object.assign({}, options);
-    const optionsFromDatabase = await app.getOptions(true);
+    const optionsFromDatabase = await app.getOptions(true, false);
 
-    if (!sanitizedOptions) sanitizedOptions = optionsFromDatabase;
+    if (Object.keys(sanitizedOptions).length === 0) {
+      sanitizedOptions = optionsFromDatabase;
+    }
 
     let optionsKeys = Object.keys(sanitizedOptions);
     optionsKeys.forEach((option) => {

--- a/plugins/@grouparoo/bigquery/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/bigquery/src/initializers/plugin.ts
@@ -5,6 +5,7 @@ import { plugin } from "@grouparoo/core";
 import { connect } from "./../lib/connect";
 import { disconnect } from "./../lib/disconnect";
 import { test } from "./../lib/test";
+import { appOptions } from "../lib/appOptions";
 
 import { getConnection as getTableConnection } from "../lib/table-import/connection";
 import { getConnection as getQueryConnection } from "../lib/query-import/connection";
@@ -78,7 +79,7 @@ export class Plugins extends Initializer {
               placeholder: "e.g. -----BEGIN PRIVATE KEY-----\nMII ...",
             },
           ],
-          methods: { test, connect, disconnect },
+          methods: { test, connect, disconnect, appOptions },
         },
       ],
       connections: [getTableConnection(), getQueryConnection()],

--- a/plugins/@grouparoo/bigquery/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    private_key: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/customerio/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/customerio/src/initializers/plugin.ts
@@ -3,6 +3,7 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
+import { appOptions } from "../lib/appOptions";
 
 import { exportProfile } from "../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
@@ -50,7 +51,7 @@ export class Plugins extends Initializer {
               description: "Customer.io Tracking API key",
             },
           ],
-          methods: { test },
+          methods: { test, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/customerio/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/customerio/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    apiKey: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/facebook/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/facebook/src/initializers/plugin.ts
@@ -2,6 +2,8 @@ import path from "path";
 import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 import { test } from "./../lib/test";
+import { appOptions } from "../lib/appOptions";
+
 import { buildConnection as buildCustomConnection } from "../lib/export-custom/connection";
 
 const packageJSON = require("./../../package.json");
@@ -46,7 +48,7 @@ export class Plugins extends Initializer {
               description: "Needs the ads_management permission",
             },
           ],
-          methods: { test },
+          methods: { test, appOptions },
         },
       ],
       connections: [buildCustomConnection()],

--- a/plugins/@grouparoo/facebook/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/facebook/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    accessToken: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/google-sheets/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/google-sheets/src/initializers/plugin.ts
@@ -2,6 +2,8 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "../lib/test";
+import { appOptions } from "../lib/appOptions";
+
 import { sourcePreview } from "../lib/sheet-import/sourcePreview";
 import { profiles } from "../lib/sheet-import/profiles";
 import { propertyOptions } from "../lib/sheet-import/propertyOptions";
@@ -50,7 +52,7 @@ export class Plugins extends Initializer {
               placeholder: "e.g. -----BEGIN PRIVATE KEY-----\nMII ...",
             },
           ],
-          methods: { test },
+          methods: { test, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/google-sheets/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/google-sheets/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    private_key: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/hubspot/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/hubspot/src/initializers/plugin.ts
@@ -3,6 +3,7 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
+import { appOptions } from "../lib/appOptions";
 
 import { exportProfile } from "../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
@@ -44,7 +45,7 @@ export class Plugins extends Initializer {
               description: "Hubspot hapikey (api) key.",
             },
           ],
-          methods: { test },
+          methods: { test, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/hubspot/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    hapikey: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/intercom/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/intercom/src/initializers/plugin.ts
@@ -3,6 +3,7 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
+import { appOptions } from "../lib/appOptions";
 
 import { exportProfile } from "../lib/export-contacts/exportProfile";
 import { destinationOptions } from "../lib/export-contacts/destinationOptions";
@@ -45,7 +46,7 @@ export class Plugins extends Initializer {
                 "Access token from your private app in the developer hub",
             },
           ],
-          methods: { test },
+          methods: { test, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/intercom/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/intercom/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    token: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/iterable/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/iterable/src/initializers/plugin.ts
@@ -3,6 +3,7 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
+import { appOptions } from "../lib/appOptions";
 
 import { exportProfile } from "../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
@@ -45,7 +46,7 @@ export class Plugins extends Initializer {
                 "Iterable api key. The api keys can be managed here: https://app.iterable.com/settings/apiKeys",
             },
           ],
-          methods: { test },
+          methods: { test, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/iterable/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/iterable/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    apiKey: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/mailchimp/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mailchimp/src/initializers/plugin.ts
@@ -4,6 +4,7 @@ import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
 import { parallelism } from "./../lib/parallelism";
+import { appOptions } from "../lib/appOptions";
 
 import emailDestination from "../lib/export/connection";
 import idDestination from "../lib/export-id/connection";
@@ -47,7 +48,7 @@ export class Plugins extends Initializer {
               description: "Mailchimp api key.",
             },
           ],
-          methods: { test, parallelism },
+          methods: { test, parallelism, appOptions },
         },
       ],
       connections: [importSource, emailDestination, idDestination],

--- a/plugins/@grouparoo/mailchimp/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    apiKey: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/marketo/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/marketo/src/initializers/plugin.ts
@@ -4,6 +4,7 @@ import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
 import { parallelism } from "./../lib/parallelism";
+import { appOptions } from "../lib/appOptions";
 
 import { exportProfiles } from "../lib/export/exportProfiles";
 import { destinationOptions } from "../lib/export/destinationOptions";
@@ -65,7 +66,7 @@ export class Plugins extends Initializer {
               description: "Found in LaunchPoint for an API user.",
             },
           ],
-          methods: { test, parallelism },
+          methods: { test, parallelism, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/marketo/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/marketo/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    clientSecret: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/mysql/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mysql/src/initializers/plugin.ts
@@ -7,6 +7,7 @@ import { connect } from "./../lib/connect";
 import { disconnect } from "./../lib/disconnect";
 import { exportProfile } from "./../lib/export/exportProfile";
 import { exportArrayProperties } from "./../lib/export/exportArrayProperties";
+import { appOptions } from "./../lib/appOptions";
 
 import { getConnection as getTableConnection } from "../lib/table-import/connection";
 import { getConnection as getQueryConnection } from "../lib/query-import/connection";
@@ -90,7 +91,7 @@ export class Plugins extends Initializer {
               description: "The MySQL user's password.",
             },
           ],
-          methods: { test, connect, disconnect },
+          methods: { test, connect, disconnect, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/mysql/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    password: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/onesignal/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/onesignal/src/initializers/plugin.ts
@@ -3,6 +3,7 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
+import { appOptions } from "../lib/appOptions";
 
 import { exportProfile } from "../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
@@ -52,7 +53,7 @@ export class Plugins extends Initializer {
                 "OneSignal REST API Key. Found in the app's Settings > Keys & IDs.",
             },
           ],
-          methods: { test },
+          methods: { test, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/onesignal/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/onesignal/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    apiKey: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/pardot/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/pardot/src/lib/appOptions.ts
@@ -12,5 +12,7 @@ export const appOptions: AppOptionsMethod = async () => {
       options: ["https://pi.pardot.com", "https://pi.demo.pardot.com"],
       descriptions: ["Production domain", "Demo domain"],
     },
+    password: { type: "password" },
+    securityToken: { type: "password" },
   };
 };

--- a/plugins/@grouparoo/pipedrive/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/pipedrive/src/initializers/plugin.ts
@@ -3,6 +3,7 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
+import { appOptions } from "../lib/appOptions";
 
 import { exportProfile } from "../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
@@ -44,7 +45,7 @@ export class Plugins extends Initializer {
               description: "Pipedrive API token",
             },
           ],
-          methods: { test },
+          methods: { test, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/pipedrive/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/pipedrive/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    apiToken: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/postgres/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/postgres/src/initializers/plugin.ts
@@ -5,6 +5,8 @@ import path from "path";
 import { test } from "./../lib/test";
 import { connect } from "./../lib/connect";
 import { disconnect } from "./../lib/disconnect";
+import { appOptions } from "../lib/appOptions";
+
 import { exportProfile } from "../lib/export/exportProfile";
 import { exportArrayProperties } from "../lib/export/exportArrayProperties";
 
@@ -122,7 +124,7 @@ export class Plugins extends Initializer {
               description: "The ssl certificate authority (CA).",
             },
           ],
-          methods: { test, connect, disconnect },
+          methods: { test, connect, disconnect, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/postgres/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    password: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/redshift/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/redshift/src/initializers/plugin.ts
@@ -5,6 +5,8 @@ import { plugin } from "@grouparoo/core";
 import { test } from "@grouparoo/postgres/dist/lib/test";
 import { connect } from "@grouparoo/postgres/dist/lib/connect";
 import { disconnect } from "@grouparoo/postgres/dist/lib/disconnect";
+import { appOptions } from "@grouparoo/postgres/dist/lib/appOptions";
+
 import { exportProfile } from "@grouparoo/postgres/dist/lib/export/exportProfile";
 import { exportArrayProperties } from "@grouparoo/postgres/dist/lib/export/exportArrayProperties";
 
@@ -96,7 +98,7 @@ export class Plugins extends Initializer {
               description: "The Redshift user's password.",
             },
           ],
-          methods: { test, connect, disconnect },
+          methods: { test, connect, disconnect, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/sailthru/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/sailthru/src/initializers/plugin.ts
@@ -3,6 +3,7 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
+import { appOptions } from "../lib/appOptions";
 
 import { exportProfile } from "../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
@@ -50,7 +51,7 @@ export class Plugins extends Initializer {
               description: "Sailthru apiKey secret.",
             },
           ],
-          methods: { test },
+          methods: { test, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/sailthru/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/sailthru/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    apiSecret: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/salesforce/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/salesforce/src/initializers/plugin.ts
@@ -4,6 +4,7 @@ import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
 import { parallelism } from "./../lib/parallelism";
+import { appOptions } from "../lib/appOptions";
 
 import { exportProfiles } from "../lib/export-objects/exportProfiles";
 import { destinationOptions } from "../lib/export-objects/destinationOptions";
@@ -58,7 +59,7 @@ export class Plugins extends Initializer {
                 "To get a new security token, click on 'Reset My Security Token' in `personal settings`",
             },
           ],
-          methods: { test, parallelism },
+          methods: { test, parallelism, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/salesforce/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/salesforce/src/lib/appOptions.ts
@@ -1,0 +1,12 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    password: {
+      type: "password",
+    },
+    securityToken: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/sendgrid/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/sendgrid/src/initializers/plugin.ts
@@ -3,6 +3,7 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
+import { appOptions } from "../lib/appOptions";
 
 import { exportProfile } from "../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
@@ -45,7 +46,7 @@ export class Plugins extends Initializer {
                 "Sendgrid api key. The api keys can be managed here: https://app.sendgrid.com/settings/api_keys",
             },
           ],
-          methods: { test },
+          methods: { test, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/sendgrid/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/sendgrid/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    apiKey: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/snowflake/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/snowflake/src/initializers/plugin.ts
@@ -5,6 +5,7 @@ import { plugin } from "@grouparoo/core";
 import { connect } from "./../lib/connect";
 import { disconnect } from "./../lib/disconnect";
 import { test } from "./../lib/test";
+import { appOptions } from "../lib/appOptions";
 
 import { getConnection as getTableConnection } from "../lib/table-import/connection";
 import { getConnection as getQueryConnection } from "../lib/query-import/connection";
@@ -90,7 +91,7 @@ export class Plugins extends Initializer {
               defaultValue: "PUBLIC",
             },
           ],
-          methods: { test, connect, disconnect },
+          methods: { test, connect, disconnect, appOptions },
         },
       ],
       connections: [getTableConnection(), getQueryConnection()],

--- a/plugins/@grouparoo/snowflake/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/snowflake/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    password: {
+      type: "password",
+    },
+  };
+};

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -234,13 +234,20 @@ export namespace helper {
               key: "fileId",
               required: true,
             },
+            {
+              key: "password",
+              required: false,
+            },
           ],
           methods: {
             test: async () => {
               return { success: true, message: "OK" };
             },
             appOptions: async () => {
-              return { fileId: { type: "list", options: ["a", "b"] } };
+              return {
+                fileId: { type: "list", options: ["a", "b"] },
+                password: { type: "password" },
+              };
             },
           },
         },

--- a/plugins/@grouparoo/zendesk/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/zendesk/src/initializers/plugin.ts
@@ -3,6 +3,7 @@ import { Initializer } from "actionhero";
 import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
+import { appOptions } from "../lib/appOptions";
 
 import { exportProfile } from "../lib/export/exportProfile";
 import { destinationOptions } from "../lib/export/destinationOptions";
@@ -57,7 +58,7 @@ export class Plugins extends Initializer {
               description: "Zendesk api token for the admin user.",
             },
           ],
-          methods: { test },
+          methods: { test, appOptions },
         },
       ],
       connections: [

--- a/plugins/@grouparoo/zendesk/src/lib/appOptions.ts
+++ b/plugins/@grouparoo/zendesk/src/lib/appOptions.ts
@@ -1,0 +1,9 @@
+import { AppOptionsMethod } from "@grouparoo/core";
+
+export const appOptions: AppOptionsMethod = async () => {
+  return {
+    token: {
+      type: "password",
+    },
+  };
+};

--- a/ui/ui-enterprise/pages/app/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/app/[id]/edit.tsx
@@ -289,7 +289,11 @@ export default function Page(props) {
                               <>
                                 <Form.Control
                                   required={opt.required}
-                                  type="text"
+                                  type={
+                                    optionOptions[opt.key]?.type === "password"
+                                      ? "password"
+                                      : "text"
+                                  }
                                   disabled={loading}
                                   defaultValue={app.options[
                                     opt.key

--- a/ui/ui-enterprise/pages/destination/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/destination/[id]/edit.tsx
@@ -308,7 +308,11 @@ export default function Page(props) {
                           <>
                             <Form.Control
                               required={opt.required}
-                              type="text"
+                              type={
+                                connectionOptions[opt.key]?.type === "password"
+                                  ? "password"
+                                  : "text"
+                              }
                               disabled={loading || loadingOptions}
                               defaultValue={destination.options[
                                 opt.key

--- a/ui/ui-enterprise/pages/source/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/source/[id]/edit.tsx
@@ -325,7 +325,11 @@ export default function Page(props) {
                           <>
                             <Form.Control
                               required={opt.required}
-                              type="text"
+                              type={
+                                connectionOptions[opt.key]?.type === "password"
+                                  ? "password"
+                                  : "text"
+                              }
                               disabled={loading || loadingOptions}
                               defaultValue={source.options[opt.key]?.toString()}
                               placeholder={opt.placeholder}


### PR DESCRIPTION
Plugins can now describe their AppOptions as type 'password', which will never be shown the UI or returned from the API. 

* You cannot save an obfuscated password option
* You can continue to test an app even when an obfuscated password option is locally displayed / ****'d out
* Many plugins now have obfuscated options (APIKeys, passwords, tokens, etc)

Thanks to @tealjulia for the help!