### PR TITLE
Log internal SQL statements at `debug` log level

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -67,7 +67,7 @@
     "pg-hstore": "2.3.3",
     "prettier": "2.2.1",
     "reflect-metadata": "0.1.13",
-    "sequelize": "6.6.1",
+    "sequelize": "6.6.2",
     "sequelize-typescript": "2.1.0",
     "sqlite3": "5.0.2",
     "ts-node": "9.1.1",

--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -1,6 +1,7 @@
 import { URL } from "url";
 import { join, isAbsolute } from "path";
 import { getParentPath } from "../utils/pluginDetails";
+import { log } from "actionhero";
 
 // import {CLS} from '../modules/cls'
 import cls from "cls-hooked";
@@ -88,9 +89,16 @@ export const DEFAULT = {
       }
     }
 
+    /** Query Logging */
+    function logging(message) {
+      if (typeof message !== "string") return;
+      log(message, "debug");
+    }
+
     return {
+      _toExpand: false,
+      logging,
       autoMigrate: true,
-      logging: false,
       dialect: dialect,
       port: parseInt(port),
       database: database,

--- a/plugins/@grouparoo/demo/package.json
+++ b/plugins/@grouparoo/demo/package.json
@@ -32,7 +32,7 @@
     "isomorphic-fetch": "3.0.0",
     "pg": "8.5.1",
     "prettier": "2.2.1",
-    "sequelize": "6.6.1",
+    "sequelize": "6.6.2",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/plugins/@grouparoo/spec-helper/package.json
+++ b/plugins/@grouparoo/spec-helper/package.json
@@ -32,7 +32,7 @@
     "axios": "0.21.1",
     "faker": "5.4.0",
     "nock": "13.0.11",
-    "sequelize": "6.6.1",
+    "sequelize": "6.6.2",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
       '@types/validator': 13.1.3
       actionhero: 25.0.8
       ah-next-plugin: 0.5.1_actionhero@25.0.8
-      ah-sequelize-plugin: 3.0.1_c05e9086cc214dc4917d47d312abe2a2
+      ah-sequelize-plugin: 3.0.1_6bca7e1438690bc81bcace543a6d79f6
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
       colors: 1.4.0
@@ -227,8 +227,8 @@ importers:
       pg-hstore: 2.3.3
       prettier: 2.2.1
       reflect-metadata: 0.1.13
-      sequelize: 6.6.1_2de4b17fccf4949c1d4891cd0897c67a
-      sequelize-typescript: 2.1.0_a40e1b037a0b8d5b0b3646abf2b13f33
+      sequelize: 6.6.2_2de4b17fccf4949c1d4891cd0897c67a
+      sequelize-typescript: 2.1.0_86bb3ec1fed1cccc1ddef652e9e65bed
       sqlite3: 5.0.2
       ts-node: 9.1.1_typescript@4.2.3
       umzug: 2.3.0
@@ -241,7 +241,7 @@ importers:
       '@types/faker': 5.1.7
       '@types/jest': 26.0.21
       csv-parse: 4.15.3
-      jest: 26.6.3
+      jest: 26.6.3_ts-node@9.1.1
       jest-fetch-mock: 3.0.3
       nock: 13.0.11
       ts-jest: 26.5.3_jest@26.6.3+typescript@4.2.3
@@ -288,7 +288,7 @@ importers:
       pg-hstore: 2.3.3
       prettier: 2.2.1
       reflect-metadata: 0.1.13
-      sequelize: 6.6.1
+      sequelize: 6.6.2
       sequelize-typescript: 2.1.0
       sqlite3: 5.0.2
       ts-jest: 26.5.3
@@ -455,7 +455,7 @@ importers:
       isomorphic-fetch: 3.0.0
       pg: 8.5.1
       prettier: 2.2.1
-      sequelize: 6.6.1_pg@8.5.1
+      sequelize: 6.6.2_pg@8.5.1
       uuid: 8.3.2
     devDependencies:
       '@grouparoo/core': link:../../../core
@@ -478,7 +478,7 @@ importers:
       jest: 26.6.3
       pg: 8.5.1
       prettier: 2.2.1
-      sequelize: 6.6.1
+      sequelize: 6.6.2
       ts-jest: 26.5.3
       typescript: 4.2.3
       uuid: 8.3.2
@@ -1154,7 +1154,7 @@ importers:
       axios: 0.21.1
       faker: 5.4.0
       nock: 13.0.11
-      sequelize: 6.6.1
+      sequelize: 6.6.2
       uuid: 8.3.2
     devDependencies:
       '@grouparoo/core': link:../../../core
@@ -1177,7 +1177,7 @@ importers:
       jest: 26.6.3
       nock: 13.0.11
       prettier: 2.2.1
-      sequelize: 6.6.1
+      sequelize: 6.6.2
       ts-jest: 26.5.3
       typescript: 4.2.3
       uuid: 8.3.2
@@ -2014,6 +2014,43 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
+  /@jest/core/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@jest/console': 26.6.2
+      '@jest/reporters': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/transform': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 14.14.35
+      ansi-escapes: 4.3.2
+      chalk: 4.1.0
+      exit: 0.1.2
+      graceful-fs: 4.2.6
+      jest-changed-files: 26.6.2
+      jest-config: 26.6.3_ts-node@9.1.1
+      jest-haste-map: 26.6.2
+      jest-message-util: 26.6.2
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.6.2
+      jest-resolve-dependencies: 26.6.3
+      jest-runner: 26.6.3_ts-node@9.1.1
+      jest-runtime: 26.6.3_ts-node@9.1.1
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      jest-watcher: 26.6.2
+      micromatch: 4.0.2
+      p-each-series: 2.2.0
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      ts-node: '*'
+    resolution:
+      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
   /@jest/environment/26.6.2:
     dependencies:
       '@jest/fake-timers': 26.6.2
@@ -2112,6 +2149,20 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
+    resolution:
+      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
+  /@jest/test-sequencer/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@jest/test-result': 26.6.2
+      graceful-fs: 4.2.6
+      jest-haste-map: 26.6.2
+      jest-runner: 26.6.3_ts-node@9.1.1
+      jest-runtime: 26.6.3_ts-node@9.1.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      ts-node: '*'
     resolution:
       integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
   /@jest/transform/26.6.2:
@@ -3912,11 +3963,11 @@ packages:
       react-dom: ^16.6.0 || ^17
     resolution:
       integrity: sha512-GxVj6i7M37fpp3KKBoGKwHIGCLRkbmeF/4Eru9oKyRF4UXDdY/KrNszllQjnNlCg/0kiv0M2BbBdfv7y15Rfvw==
-  /ah-sequelize-plugin/3.0.1_c05e9086cc214dc4917d47d312abe2a2:
+  /ah-sequelize-plugin/3.0.1_6bca7e1438690bc81bcace543a6d79f6:
     dependencies:
       actionhero: 25.0.8
-      sequelize: 6.6.1_2de4b17fccf4949c1d4891cd0897c67a
-      sequelize-typescript: 2.1.0_a40e1b037a0b8d5b0b3646abf2b13f33
+      sequelize: 6.6.2_2de4b17fccf4949c1d4891cd0897c67a
+      sequelize-typescript: 2.1.0_86bb3ec1fed1cccc1ddef652e9e65bed
       umzug: 3.0.0-beta.5
     dev: false
     engines:
@@ -8735,6 +8786,29 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
+  /jest-cli/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@jest/core': 26.6.3_ts-node@9.1.1
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      chalk: 4.1.0
+      exit: 0.1.2
+      graceful-fs: 4.2.6
+      import-local: 3.0.2
+      is-ci: 2.0.0
+      jest-config: 26.6.3_ts-node@9.1.1
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      prompts: 2.4.0
+      yargs: 15.4.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      ts-node: '*'
+    resolution:
+      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
   /jest-config/26.6.3:
     dependencies:
       '@babel/core': 7.13.10
@@ -8755,6 +8829,37 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.2
       pretty-format: 26.6.2
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+    resolution:
+      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
+  /jest-config/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@babel/core': 7.13.10
+      '@jest/test-sequencer': 26.6.3_ts-node@9.1.1
+      '@jest/types': 26.6.2
+      babel-jest: 26.6.3_@babel+core@7.13.10
+      chalk: 4.1.0
+      deepmerge: 4.2.2
+      glob: 7.1.6
+      graceful-fs: 4.2.6
+      jest-environment-jsdom: 26.6.2
+      jest-environment-node: 26.6.2
+      jest-get-type: 26.3.0
+      jest-jasmine2: 26.6.3_ts-node@9.1.1
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.6.2
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      micromatch: 4.0.2
+      pretty-format: 26.6.2
+      ts-node: 9.1.1_typescript@4.2.3
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -8902,6 +9007,33 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
+  /jest-jasmine2/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@babel/traverse': 7.13.0
+      '@jest/environment': 26.6.2
+      '@jest/source-map': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 14.14.35
+      chalk: 4.1.0
+      co: 4.6.0
+      expect: 26.6.2
+      is-generator-fn: 2.1.0
+      jest-each: 26.6.2
+      jest-matcher-utils: 26.6.2
+      jest-message-util: 26.6.2
+      jest-runtime: 26.6.3_ts-node@9.1.1
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      pretty-format: 26.6.2
+      throat: 5.0.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      ts-node: '*'
+    resolution:
+      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
   /jest-leak-detector/26.6.2:
     dependencies:
       jest-get-type: 26.3.0
@@ -9038,6 +9170,35 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
+  /jest-runner/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@jest/console': 26.6.2
+      '@jest/environment': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 14.14.35
+      chalk: 4.1.0
+      emittery: 0.7.2
+      exit: 0.1.2
+      graceful-fs: 4.2.6
+      jest-config: 26.6.3_ts-node@9.1.1
+      jest-docblock: 26.0.0
+      jest-haste-map: 26.6.2
+      jest-leak-detector: 26.6.2
+      jest-message-util: 26.6.2
+      jest-resolve: 26.6.2
+      jest-runtime: 26.6.3_ts-node@9.1.1
+      jest-util: 26.6.2
+      jest-worker: 26.6.2
+      source-map-support: 0.5.19
+      throat: 5.0.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      ts-node: '*'
+    resolution:
+      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
   /jest-runtime/26.6.3:
     dependencies:
       '@jest/console': 26.6.2
@@ -9071,6 +9232,43 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    resolution:
+      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
+  /jest-runtime/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@jest/console': 26.6.2
+      '@jest/environment': 26.6.2
+      '@jest/fake-timers': 26.6.2
+      '@jest/globals': 26.6.2
+      '@jest/source-map': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/transform': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/yargs': 15.0.13
+      chalk: 4.1.0
+      cjs-module-lexer: 0.6.0
+      collect-v8-coverage: 1.0.1
+      exit: 0.1.2
+      glob: 7.1.6
+      graceful-fs: 4.2.6
+      jest-config: 26.6.3_ts-node@9.1.1
+      jest-haste-map: 26.6.2
+      jest-message-util: 26.6.2
+      jest-mock: 26.6.2
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.6.2
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      jest-validate: 26.6.2
+      slash: 3.0.0
+      strip-bom: 4.0.0
+      yargs: 15.4.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      ts-node: '*'
     resolution:
       integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
   /jest-serializer/26.6.2:
@@ -9184,6 +9382,19 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    resolution:
+      integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
+  /jest/26.6.3_ts-node@9.1.1:
+    dependencies:
+      '@jest/core': 26.6.3_ts-node@9.1.1
+      import-local: 3.0.2
+      jest-cli: 26.6.3_ts-node@9.1.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      ts-node: '*'
     resolution:
       integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
   /jju/1.4.0:
@@ -13302,13 +13513,13 @@ packages:
       node: '>= 10.0.0'
     resolution:
       integrity: sha512-4YwEw3ZgK/tY/so+GfnSgXkdwIJJ1I32uZJztIEgZeAO6HMgj64OzySbWLgxj+tXhZCJnzRfkY9gINw8Ft8ZMg==
-  /sequelize-typescript/2.1.0_a40e1b037a0b8d5b0b3646abf2b13f33:
+  /sequelize-typescript/2.1.0_86bb3ec1fed1cccc1ddef652e9e65bed:
     dependencies:
       '@types/node': 14.14.35
       '@types/validator': 13.1.3
       glob: 7.1.6
       reflect-metadata: 0.1.13
-      sequelize: 6.6.1_2de4b17fccf4949c1d4891cd0897c67a
+      sequelize: 6.6.2_2de4b17fccf4949c1d4891cd0897c67a
     dev: false
     engines:
       node: '>=10.0.0'
@@ -13319,7 +13530,7 @@ packages:
       sequelize: '>=6.2.0'
     resolution:
       integrity: sha512-wwPxydBQ/wIZ92pFxDQEAhW8uRHqwFZGm6JkPmpsCjrODWrH8TANZiOCjwGouygFMgBwCNK91RNwLe5TYoy5pg==
-  /sequelize/6.6.1:
+  /sequelize/6.6.2:
     dependencies:
       debug: 4.3.1
       dottie: 2.0.2
@@ -13358,8 +13569,8 @@ packages:
       tedious:
         optional: true
     resolution:
-      integrity: sha512-dhu25X8L084YyQ9E7iTvleb+g7t9THeI13PV1tKERNCax1W0+sObtSQw0fphMiAr/BeAP2kELyY33s4Bh5tA4Q==
-  /sequelize/6.6.1_2de4b17fccf4949c1d4891cd0897c67a:
+      integrity: sha512-H/zrzmTK+tis9PJaSigkuXI57nKBvNCtPQol0yxCvau1iWLzSOuq8t3tMOVeQ+Ep8QH2HoD9/+FCCIAqzUr/BQ==
+  /sequelize/6.6.2_2de4b17fccf4949c1d4891cd0897c67a:
     dependencies:
       debug: 4.3.1
       dottie: 2.0.2
@@ -13401,8 +13612,8 @@ packages:
       tedious:
         optional: true
     resolution:
-      integrity: sha512-dhu25X8L084YyQ9E7iTvleb+g7t9THeI13PV1tKERNCax1W0+sObtSQw0fphMiAr/BeAP2kELyY33s4Bh5tA4Q==
-  /sequelize/6.6.1_pg@8.5.1:
+      integrity: sha512-H/zrzmTK+tis9PJaSigkuXI57nKBvNCtPQol0yxCvau1iWLzSOuq8t3tMOVeQ+Ep8QH2HoD9/+FCCIAqzUr/BQ==
+  /sequelize/6.6.2_pg@8.5.1:
     dependencies:
       debug: 4.3.1
       dottie: 2.0.2
@@ -13442,7 +13653,7 @@ packages:
       tedious:
         optional: true
     resolution:
-      integrity: sha512-dhu25X8L084YyQ9E7iTvleb+g7t9THeI13PV1tKERNCax1W0+sObtSQw0fphMiAr/BeAP2kELyY33s4Bh5tA4Q==
+      integrity: sha512-H/zrzmTK+tis9PJaSigkuXI57nKBvNCtPQol0yxCvau1iWLzSOuq8t3tMOVeQ+Ep8QH2HoD9/+FCCIAqzUr/BQ==
   /sequin/0.1.1:
     dev: false
     engines:


### PR DESCRIPTION
This PR adds Sequelize (the internal Grouparoo database; Postgres or SQLite) statements to the Actionhero logger at the debug level.  This means you can opt into seeing the SQL via: `GROUPAROO_LOG_LEVEL=debug gouparoo start` or `GROUPAROO_LOG_LEVEL=debug npm run dev`

![Screen Shot 2021-03-26 at 3 39 32 PM](https://user-images.githubusercontent.com/303226/112699997-5df51900-8e4a-11eb-9e52-519c526cb89e.png)

This PR also bumps the version of Sequelize