### PR TITLE
Add a delay for pub/sub commands to break mock redis callback chains

### DIFF
--- a/core/src/initializers/rpc.ts
+++ b/core/src/initializers/rpc.ts
@@ -1,10 +1,14 @@
-import { Initializer, api } from "actionhero";
+import { Initializer, api, utils } from "actionhero";
 import { App } from "../models/App";
 
 export class GrouparooRPC extends Initializer {
   constructor() {
     super();
     this.name = "grouparooRPC";
+  }
+
+  async sleep(delay = 100) {
+    await utils.sleep(delay);
   }
 
   async initialize() {
@@ -17,8 +21,10 @@ export class GrouparooRPC extends Initializer {
 
     /**
      * Signal that all Apps in the cluster should disconnect form persistent connections.
+     * All handlers need start with a sleep() to decouple from mock redis' callback/transaction chain (there's no delay)
      */
     api.rpc.app.disconnect = async () => {
+      await this.sleep();
       await App.disconnect();
     };
   }


### PR DESCRIPTION
It looks like pub/sub handlers in `ioredos-mock` are implemented synchronously.  This, when coupled with transactions can make for messy behavior - a side-effect which expects not to be in the originating transaction might be.  To circumvent this, this PR makes our pub/sub handlers first start with a sleep (`setTimeout`) to bust out of the transaction/callback chain they might otherwise be within.