### PR TITLE
Fix transaction error when running `grouparoo validate`

### DIFF
--- a/core/src/bin/validate.ts
+++ b/core/src/bin/validate.ts
@@ -78,7 +78,9 @@ export class Validate extends CLI {
         throw new Error("validate-rollback");
       });
     } catch (error) {
-      if (error.message !== "validate-rollback") throw error;
+      if (error.message !== "validate-rollback") {
+        GrouparooCLI.logger.fatal(`Validation failed - ${error.message}`);
+      }
     }
 
     return true;

--- a/core/src/config/errors.ts
+++ b/core/src/config/errors.ts
@@ -148,7 +148,7 @@ export const DEFAULT = {
   },
 };
 
-function GrouparooErrorSerializer(error) {
+export function GrouparooErrorSerializer(error) {
   let message = "";
   let code = error.code || undefined;
   let fields = [];

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -8,6 +8,7 @@ import {
   validateConfigObjects,
   IdsByClass,
 } from "../../classes/codeConfig";
+import { GrouparooErrorSerializer } from "../../config/errors";
 import { loadApp, deleteApps } from "./app";
 import { loadSource, deleteSources } from "./source";
 import { loadProperty, deleteProperties } from "./property";
@@ -206,9 +207,11 @@ export async function processConfigObjects(
           throw new Error(`unknown config object class: ${configObject.class}`);
       }
     } catch (error) {
+      const { message } = GrouparooErrorSerializer(error);
+
       const errorMessage = `[ config ] error with ${configObject?.class} \`${
         configObject.key || configObject.name
-      }\` (${configObject.id}): ${error}`;
+      }\` (${configObject.id}): ${message}`;
       errors.push(errorMessage);
       log(errorMessage, "warning");
       continue;


### PR DESCRIPTION
Steps to reproduce:

1. Load up staging-community with `demo-data-purchases`.
2. Add some config files that includes a property with an `id` value of `email`.
3. Run `grouparoo validate`.

You should see an unhelpful error for `email`:

```
warning: [ config ] error with Property `email` (email): SequelizeUniqueConstraintError: Validation error
```

All subsequent config objects will throw a transaction error:

```
...
warning: [ config ] error with Property `first name` (first_name): SequelizeDatabaseError: current transaction is aborted, commands ignored until end of transaction block
warning: [ config ] error with Property `last name` (last_name): SequelizeDatabaseError: current transaction is aborted, commands ignored until end of transaction block
warning: [ config ] error with Property `LTV` (ltv): SequelizeDatabaseError: current transaction is aborted, commands ignored until end of transaction block
warning: [ config ] error with Group `People with Email Addresses` (email_group): SequelizeDatabaseError: current transaction is aborted, commands ignored until end of transaction block
warning: [ config ] error with Group `A Small Group` (small_group): SequelizeDatabaseError: current transaction is aborted, commands ignored until end of transaction block
warning: [ config ] error with Group `High Value Customers` (high_value_group): SequelizeDatabaseError: current transaction is aborted, commands ignored until end of transaction block
warning: [ config ] error with apiKey `web-api-key` (website_api_key): SequelizeDatabaseError: current transaction is aborted, commands ignored until end of transaction block
warning: [ config ] error with team `Admin Team` (admin_team): SequelizeDatabaseError: current transaction is aborted, commands ignored until end of transaction block
warning: [ config ] error with teamMember `undefined` (demo): SequelizeDatabaseError: current transaction is aborted, commands ignored until end of transaction block
warning: [ config ] error with team `Marketing Team` (marketing_team): SequelizeDatabaseError: current transaction is aborted, commands ignored until end of transaction block
warning: [ config ] error with teamMember `undefined` (person): SequelizeDatabaseError: current transaction is aborted, commands ignored until end of transaction block

❌ Validation failed - 12 validation errors
```

## Testing Notes

Take the same approach as above. The result should still be invalid, but you should see a more helpful output. And the validate process should exit after hitting the email:

```
...
error: [ config ] error with Property `email` (email): id must be unique
❌ Validation failed - Cannot validate additional objects.
```