### PR TITLE
Set jest maxWorkers to 50%

### DIFF
--- a/clients/@grouparoo/web/jest.config.js
+++ b/clients/@grouparoo/web/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   testEnvironment: "node",
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/core/jest.config.js
+++ b/core/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/core/package.json
+++ b/core/package.json
@@ -26,7 +26,7 @@
     "prepare": "./bin/build",
     "dev": "./bin/dev",
     "pretest": "npm run lint && npm run prepare",
-    "test": "jest --maxWorkers 5",
+    "test": "jest",
     "lint": "prettier --check src __tests__",
     "docs": "typedoc --out docs --theme default src/index.ts",
     "import": "./api/bin/import",

--- a/plugins/@grouparoo/app-templates/jest.config.js
+++ b/plugins/@grouparoo/app-templates/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/bigquery/jest.config.js
+++ b/plugins/@grouparoo/bigquery/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/csv/jest.config.js
+++ b/plugins/@grouparoo/csv/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/customerio/jest.config.js
+++ b/plugins/@grouparoo/customerio/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   testEnvironment: "node",
   testTimeout: 240000,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/dbt/jest.config.js
+++ b/plugins/@grouparoo/dbt/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/demo/jest.config.js
+++ b/plugins/@grouparoo/demo/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/facebook/jest.config.js
+++ b/plugins/@grouparoo/facebook/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/google-sheets/jest.config.js
+++ b/plugins/@grouparoo/google-sheets/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/hubspot/jest.config.js
+++ b/plugins/@grouparoo/hubspot/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/intercom/jest.config.js
+++ b/plugins/@grouparoo/intercom/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/iterable/jest.config.js
+++ b/plugins/@grouparoo/iterable/jest.config.js
@@ -1,6 +1,9 @@
+const { helper } = require("@grouparoo/spec-helper");
+
 module.exports = {
   testEnvironment: "node",
-  testTimeout: 10000,
+  testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/logger/jest.config.js
+++ b/plugins/@grouparoo/logger/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/mailchimp/jest.config.js
+++ b/plugins/@grouparoo/mailchimp/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/marketo/jest.config.js
+++ b/plugins/@grouparoo/marketo/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/mongo/jest.config.js
+++ b/plugins/@grouparoo/mongo/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/mysql/jest.config.js
+++ b/plugins/@grouparoo/mysql/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/newrelic/jest.config.js
+++ b/plugins/@grouparoo/newrelic/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/onesignal/jest.config.js
+++ b/plugins/@grouparoo/onesignal/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   testEnvironment: "node",
   testTimeout: 240000,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/pardot/jest.config.js
+++ b/plugins/@grouparoo/pardot/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   testEnvironment: "node",
   testTimeout: 240000,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/pipedrive/jest.config.js
+++ b/plugins/@grouparoo/pipedrive/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.longTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/postgres/jest.config.js
+++ b/plugins/@grouparoo/postgres/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/redshift/jest.config.js
+++ b/plugins/@grouparoo/redshift/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/sailthru/jest.config.js
+++ b/plugins/@grouparoo/sailthru/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/salesforce/jest.config.js
+++ b/plugins/@grouparoo/salesforce/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/sendgrid/jest.config.js
+++ b/plugins/@grouparoo/sendgrid/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   testEnvironment: "node",
   testTimeout: 240000,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/sentry/jest.config.js
+++ b/plugins/@grouparoo/sentry/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/snowflake/jest.config.js
+++ b/plugins/@grouparoo/snowflake/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/spec-helper/jest.config.js
+++ b/plugins/@grouparoo/spec-helper/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("./dist/index");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/sqlite/jest.config.js
+++ b/plugins/@grouparoo/sqlite/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/plugins/@grouparoo/zendesk/jest.config.js
+++ b/plugins/@grouparoo/zendesk/jest.config.js
@@ -3,6 +3,7 @@ const { helper } = require("@grouparoo/spec-helper");
 module.exports = {
   testEnvironment: "node",
   testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
     "^.+\\.ts?$": "ts-jest",

--- a/ui/ui-community/jest.config.js
+++ b/ui/ui-community/jest.config.js
@@ -1,8 +1,6 @@
-const { helper } = require("@grouparoo/spec-helper");
-
 module.exports = {
   setupFiles: ["<rootDir>/jest.setup.js"],
-  testTimeout: helper.defaultTime,
+  testTimeout: 1000 * 10,
   maxWorkers: "50%",
   testPathIgnorePatterns: [
     "<rootDir>/.next/",

--- a/ui/ui-community/jest.config.js
+++ b/ui/ui-community/jest.config.js
@@ -1,6 +1,9 @@
+const { helper } = require("@grouparoo/spec-helper");
+
 module.exports = {
   setupFiles: ["<rootDir>/jest.setup.js"],
-  testTimeout: 10000,
+  testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   testPathIgnorePatterns: [
     "<rootDir>/.next/",
     "<rootDir>/__tests__/utils",

--- a/ui/ui-components/jest.config.js
+++ b/ui/ui-components/jest.config.js
@@ -1,6 +1,9 @@
+const { helper } = require("@grouparoo/spec-helper");
+
 module.exports = {
   setupFiles: ["<rootDir>/jest.setup.js"],
-  testTimeout: 10000,
+  testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   testPathIgnorePatterns: [
     "<rootDir>/.next/",
     "<rootDir>/__tests__/__utils__",

--- a/ui/ui-components/jest.config.js
+++ b/ui/ui-components/jest.config.js
@@ -1,8 +1,6 @@
-const { helper } = require("@grouparoo/spec-helper");
-
 module.exports = {
   setupFiles: ["<rootDir>/jest.setup.js"],
-  testTimeout: helper.defaultTime,
+  testTimeout: 1000 * 10,
   maxWorkers: "50%",
   testPathIgnorePatterns: [
     "<rootDir>/.next/",

--- a/ui/ui-enterprise/jest.config.js
+++ b/ui/ui-enterprise/jest.config.js
@@ -1,8 +1,6 @@
-const { helper } = require("@grouparoo/spec-helper");
-
 module.exports = {
   setupFiles: ["<rootDir>/jest.setup.js"],
-  testTimeout: helper.defaultTime,
+  testTimeout: 1000 * 10,
   maxWorkers: "50%",
   testPathIgnorePatterns: [
     "<rootDir>/.next/",

--- a/ui/ui-enterprise/jest.config.js
+++ b/ui/ui-enterprise/jest.config.js
@@ -1,6 +1,9 @@
+const { helper } = require("@grouparoo/spec-helper");
+
 module.exports = {
   setupFiles: ["<rootDir>/jest.setup.js"],
-  testTimeout: 10000,
+  testTimeout: helper.defaultTime,
+  maxWorkers: "50%",
   testPathIgnorePatterns: [
     "<rootDir>/.next/",
     "<rootDir>/__tests__/utils",


### PR DESCRIPTION
This PR sets the default `--maxWorkers` to 50% for all jest runs.  This means "50% of your CPUs" - so on my 8-core machines, there will be 4 parallel test runs.  This in practice is often faster than the default behavior of "100%", because we need to reserve some power for Postgres and Redis... and not run out of memory. 

This does not change the behavior on CI which is overwritten to be `--maxWorkers=2`

Inspired by https://ivantanev.com/make-jest-faster/