### PR TITLE
Perform migrations within transactions

### DIFF
--- a/core/src/migrations/000001-createApps.ts
+++ b/core/src/migrations/000001-createApps.ts
@@ -1,48 +1,52 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("apps", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("apps", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      name: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        name: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      type: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        type: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      state: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
-    });
+        state: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("apps", ["name"], {
-      unique: true,
-      fields: ["name"],
-    });
+      await migration.addIndex("apps", ["name"], {
+        unique: true,
+        fields: ["name"],
+      });
 
-    await migration.addIndex("apps", ["state"], {
-      fields: ["state"],
+      await migration.addIndex("apps", ["state"], {
+        fields: ["state"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("apps");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("apps");
+    });
   },
 };

--- a/core/src/migrations/000002-createDestinationGroups.ts
+++ b/core/src/migrations/000002-createDestinationGroups.ts
@@ -1,43 +1,47 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("destinationGroups", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("destinationGroups", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      destinationGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        destinationGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      groupGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        groupGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
+      });
+
+      await migration.addIndex(
+        "destinationGroups",
+        ["destinationGuid", "groupGuid"],
+        {
+          unique: true,
+          fields: ["destinationGuid", "groupGuid"],
+        }
+      );
     });
-
-    await migration.addIndex(
-      "destinationGroups",
-      ["destinationGuid", "groupGuid"],
-      {
-        unique: true,
-        fields: ["destinationGuid", "groupGuid"],
-      }
-    );
   },
 
   down: async function (migration) {
-    await migration.dropTable("destinationGroups");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("destinationGroups");
+    });
   },
 };

--- a/core/src/migrations/000003-createDestinations.ts
+++ b/core/src/migrations/000003-createDestinations.ts
@@ -1,62 +1,66 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("destinations", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("destinations", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      appGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        appGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      name: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        name: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      type: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        type: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      state: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        state: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      trackAllGroups: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
-    });
+        trackAllGroups: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("destinations", ["name"], {
-      unique: true,
-      fields: ["name"],
-    });
+      await migration.addIndex("destinations", ["name"], {
+        unique: true,
+        fields: ["name"],
+      });
 
-    await migration.addIndex("destinations", ["appGuid"], {
-      fields: ["appGuid"],
-    });
+      await migration.addIndex("destinations", ["appGuid"], {
+        fields: ["appGuid"],
+      });
 
-    await migration.addIndex("destinations", ["state"], {
-      fields: ["state"],
+      await migration.addIndex("destinations", ["state"], {
+        fields: ["state"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("destinations");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("destinations");
+    });
   },
 };

--- a/core/src/migrations/000004-createExportImports.ts
+++ b/core/src/migrations/000004-createExportImports.ts
@@ -1,39 +1,43 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("exportImports", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("exportImports", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      importGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        importGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      exportGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
-    });
+        exportGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("exportImports", ["importGuid", "exportGuid"], {
-      unique: true,
-      fields: ["importGuid", "exportGuid"],
+      await migration.addIndex("exportImports", ["importGuid", "exportGuid"], {
+        unique: true,
+        fields: ["importGuid", "exportGuid"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("exportImports");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("exportImports");
+    });
   },
 };

--- a/core/src/migrations/000005-createExports.ts
+++ b/core/src/migrations/000005-createExports.ts
@@ -1,87 +1,91 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("exports", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("exports", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      profileGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        profileGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      destinationGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        destinationGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      oldProfileProperties: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        oldProfileProperties: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      newProfileProperties: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        newProfileProperties: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      oldGroups: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        oldGroups: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      newGroups: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        newGroups: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      errorMessage: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        errorMessage: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      toDelete: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
+        toDelete: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
 
-      mostRecent: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
+        mostRecent: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
 
-      startedAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-      },
+        startedAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
 
-      completedAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-      },
-    });
+        completedAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
+      });
 
-    await migration.addIndex("exports", ["profileGuid"], {
-      fields: ["profileGuid"],
-    });
+      await migration.addIndex("exports", ["profileGuid"], {
+        fields: ["profileGuid"],
+      });
 
-    await migration.addIndex("exports", ["destinationGuid"], {
-      fields: ["destinationGuid"],
+      await migration.addIndex("exports", ["destinationGuid"], {
+        fields: ["destinationGuid"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("exports");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("exports");
+    });
   },
 };

--- a/core/src/migrations/000006-createFiles.ts
+++ b/core/src/migrations/000006-createFiles.ts
@@ -1,63 +1,67 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("files", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("files", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      transport: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        transport: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      type: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        type: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      bucket: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        bucket: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      path: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        path: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      extension: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        extension: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      mime: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        mime: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      sizeBytes: {
-        type: DataTypes.BIGINT,
-        allowNull: false,
-      },
-    });
+        sizeBytes: {
+          type: DataTypes.BIGINT,
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("files", ["type"], {
-      fields: ["type"],
+      await migration.addIndex("files", ["type"], {
+        fields: ["type"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("files");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("files");
+    });
   },
 };

--- a/core/src/migrations/000007-createGroupMembers.ts
+++ b/core/src/migrations/000007-createGroupMembers.ts
@@ -1,52 +1,56 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("groupMembers", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("groupMembers", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      profileGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        profileGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      groupGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        groupGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      removedAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-      },
-    });
+        removedAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
+      });
 
-    await migration.addIndex("groupMembers", ["profileGuid", "groupGuid"], {
-      unique: true,
-      fields: ["profileGuid", "groupGuid"],
-    });
+      await migration.addIndex("groupMembers", ["profileGuid", "groupGuid"], {
+        unique: true,
+        fields: ["profileGuid", "groupGuid"],
+      });
 
-    await migration.addIndex("groupMembers", ["profileGuid"], {
-      fields: ["profileGuid"],
-    });
+      await migration.addIndex("groupMembers", ["profileGuid"], {
+        fields: ["profileGuid"],
+      });
 
-    await migration.addIndex("groupMembers", ["groupGuid"], {
-      fields: ["groupGuid"],
+      await migration.addIndex("groupMembers", ["groupGuid"], {
+        fields: ["groupGuid"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("groupMembers");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("groupMembers");
+    });
   },
 };

--- a/core/src/migrations/000008-createGroupRules.ts
+++ b/core/src/migrations/000008-createGroupRules.ts
@@ -1,68 +1,72 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("groupRules", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("groupRules", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      groupGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        groupGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      profilePropertyRuleGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        profilePropertyRuleGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      position: {
-        type: DataTypes.BIGINT,
-        allowNull: false,
-      },
+        position: {
+          type: DataTypes.BIGINT,
+          allowNull: false,
+        },
 
-      match: {
-        type: DataTypes.STRING(191),
-        allowNull: true,
-      },
+        match: {
+          type: DataTypes.STRING(191),
+          allowNull: true,
+        },
 
-      op: {
-        type: DataTypes.STRING(191),
-        allowNull: true,
-      },
+        op: {
+          type: DataTypes.STRING(191),
+          allowNull: true,
+        },
 
-      relativeMatchNumber: {
-        type: DataTypes.BIGINT,
-        allowNull: true,
-      },
+        relativeMatchNumber: {
+          type: DataTypes.BIGINT,
+          allowNull: true,
+        },
 
-      relativeMatchUnit: {
-        type: DataTypes.STRING(191),
-        allowNull: true,
-      },
+        relativeMatchUnit: {
+          type: DataTypes.STRING(191),
+          allowNull: true,
+        },
 
-      relativeMatchDirection: {
-        type: DataTypes.STRING(191),
-        allowNull: true,
-      },
-    });
+        relativeMatchDirection: {
+          type: DataTypes.STRING(191),
+          allowNull: true,
+        },
+      });
 
-    await migration.addIndex("groupRules", ["groupGuid"], {
-      fields: ["groupGuid"],
+      await migration.addIndex("groupRules", ["groupGuid"], {
+        fields: ["groupGuid"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("groupRules");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("groupRules");
+    });
   },
 };

--- a/core/src/migrations/000009-createGroups.ts
+++ b/core/src/migrations/000009-createGroups.ts
@@ -1,58 +1,62 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("groups", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("groups", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      name: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        name: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      type: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        type: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      state: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        state: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      matchType: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        matchType: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      calculatedAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-      },
-    });
+        calculatedAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
+      });
 
-    await migration.addIndex("groups", ["name"], {
-      unique: true,
-      fields: ["name"],
-    });
+      await migration.addIndex("groups", ["name"], {
+        unique: true,
+        fields: ["name"],
+      });
 
-    await migration.addIndex("groups", ["state"], {
-      fields: ["state"],
+      await migration.addIndex("groups", ["state"], {
+        fields: ["state"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("groups");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("groups");
+    });
   },
 };

--- a/core/src/migrations/000010-createImports.ts
+++ b/core/src/migrations/000010-createImports.ts
@@ -1,111 +1,115 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("imports", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("imports", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      creatorType: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        creatorType: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      creatorGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        creatorGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      profileGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: true,
-      },
+        profileGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: true,
+        },
 
-      data: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        data: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      rawData: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        rawData: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      oldProfileProperties: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        oldProfileProperties: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      newProfileProperties: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        newProfileProperties: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      oldGroupGuids: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        oldGroupGuids: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      newGroupGuids: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        newGroupGuids: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      profileAssociatedAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-      },
+        profileAssociatedAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
 
-      profileUpdatedAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-      },
+        profileUpdatedAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
 
-      groupsUpdatedAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-      },
+        groupsUpdatedAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
 
-      exportedAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-      },
+        exportedAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
 
-      errorMessage: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        errorMessage: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      errorMetadata: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
-    });
+        errorMetadata: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
+      });
 
-    await migration.addIndex("imports", ["creatorGuid"], {
-      fields: ["creatorGuid"],
-    });
+      await migration.addIndex("imports", ["creatorGuid"], {
+        fields: ["creatorGuid"],
+      });
 
-    await migration.addIndex("imports", ["profileGuid"], {
-      fields: ["profileGuid"],
-    });
+      await migration.addIndex("imports", ["profileGuid"], {
+        fields: ["profileGuid"],
+      });
 
-    await migration.addIndex("imports", ["profileUpdatedAt"], {
-      fields: ["profileUpdatedAt"],
+      await migration.addIndex("imports", ["profileUpdatedAt"], {
+        fields: ["profileUpdatedAt"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("imports");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("imports");
+    });
   },
 };

--- a/core/src/migrations/000011-createLogs.ts
+++ b/core/src/migrations/000011-createLogs.ts
@@ -1,66 +1,70 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("logs", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("logs", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      ownerGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        ownerGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      topic: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        topic: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      verb: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        verb: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      who: {
-        type: DataTypes.STRING(191),
-        allowNull: true,
-      },
+        who: {
+          type: DataTypes.STRING(191),
+          allowNull: true,
+        },
 
-      message: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        message: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      data: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
-    });
+        data: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("logs", ["topic"], {
-      fields: ["topic"],
-    });
+      await migration.addIndex("logs", ["topic"], {
+        fields: ["topic"],
+      });
 
-    await migration.addIndex("logs", ["ownerGuid"], {
-      fields: ["ownerGuid"],
-    });
+      await migration.addIndex("logs", ["ownerGuid"], {
+        fields: ["ownerGuid"],
+      });
 
-    await migration.addIndex("logs", ["createdAt"], {
-      fields: ["createdAt"],
+      await migration.addIndex("logs", ["createdAt"], {
+        fields: ["createdAt"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("logs");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("logs");
+    });
   },
 };

--- a/core/src/migrations/000012-createMappings.ts
+++ b/core/src/migrations/000012-createMappings.ts
@@ -1,62 +1,66 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("mappings", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("mappings", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      ownerGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        ownerGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      ownerType: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        ownerType: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      profilePropertyRuleGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        profilePropertyRuleGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      remoteKey: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
-    });
+        remoteKey: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex(
-      "mappings",
-      ["ownerGuid", "profilePropertyRuleGuid"],
-      {
+      await migration.addIndex(
+        "mappings",
+        ["ownerGuid", "profilePropertyRuleGuid"],
+        {
+          unique: true,
+          fields: ["ownerGuid", "profilePropertyRuleGuid"],
+        }
+      );
+
+      await migration.addIndex("mappings", ["ownerGuid", "remoteKey"], {
         unique: true,
-        fields: ["ownerGuid", "profilePropertyRuleGuid"],
-      }
-    );
+        fields: ["ownerGuid", "remoteKey"],
+      });
 
-    await migration.addIndex("mappings", ["ownerGuid", "remoteKey"], {
-      unique: true,
-      fields: ["ownerGuid", "remoteKey"],
-    });
-
-    await migration.addIndex("mappings", ["ownerGuid"], {
-      fields: ["ownerGuid"],
+      await migration.addIndex("mappings", ["ownerGuid"], {
+        fields: ["ownerGuid"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("mappings");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("mappings");
+    });
   },
 };

--- a/core/src/migrations/000013-createOptions.ts
+++ b/core/src/migrations/000013-createOptions.ts
@@ -1,53 +1,57 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("options", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("options", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      ownerGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        ownerGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      ownerType: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        ownerType: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      key: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        key: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      value: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
-    });
+        value: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("options", ["ownerGuid", "key"], {
-      unique: true,
-      fields: ["ownerGuid", "key"],
-    });
+      await migration.addIndex("options", ["ownerGuid", "key"], {
+        unique: true,
+        fields: ["ownerGuid", "key"],
+      });
 
-    await migration.addIndex("options", ["ownerGuid"], {
-      fields: ["ownerGuid"],
+      await migration.addIndex("options", ["ownerGuid"], {
+        fields: ["ownerGuid"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("options");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("options");
+    });
   },
 };

--- a/core/src/migrations/000014-createProfileProperties.ts
+++ b/core/src/migrations/000014-createProfileProperties.ts
@@ -1,52 +1,56 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("profileProperties", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("profileProperties", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      profileGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        profileGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      rawValue: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        rawValue: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      profilePropertyRuleGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
-    });
+        profilePropertyRuleGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex(
-      "profileProperties",
-      ["profileGuid", "profilePropertyRuleGuid"],
-      {
-        unique: true,
-        fields: ["profileGuid", "profilePropertyRuleGuid"],
-      }
-    );
+      await migration.addIndex(
+        "profileProperties",
+        ["profileGuid", "profilePropertyRuleGuid"],
+        {
+          unique: true,
+          fields: ["profileGuid", "profilePropertyRuleGuid"],
+        }
+      );
 
-    await migration.addIndex("profileProperties", ["profileGuid"], {
-      fields: ["profileGuid"],
+      await migration.addIndex("profileProperties", ["profileGuid"], {
+        fields: ["profileGuid"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("profileProperties");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("profileProperties");
+    });
   },
 };

--- a/core/src/migrations/000015-createProfilePropertyRules.ts
+++ b/core/src/migrations/000015-createProfilePropertyRules.ts
@@ -1,58 +1,62 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("profilePropertyRules", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("profilePropertyRules", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      key: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        key: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      type: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        type: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      unique: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
+        unique: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
 
-      sourceGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        sourceGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      state: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
-    });
+        state: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("profilePropertyRules", ["key"], {
-      fields: ["key"],
-      unique: true,
-    });
+      await migration.addIndex("profilePropertyRules", ["key"], {
+        fields: ["key"],
+        unique: true,
+      });
 
-    await migration.addIndex("profilePropertyRules", ["state"], {
-      fields: ["state"],
+      await migration.addIndex("profilePropertyRules", ["state"], {
+        fields: ["state"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("profilePropertyRules");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("profilePropertyRules");
+    });
   },
 };

--- a/core/src/migrations/000016-createProfiles.ts
+++ b/core/src/migrations/000016-createProfiles.ts
@@ -1,24 +1,28 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("profiles", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("profiles", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("profiles");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("profiles");
+    });
   },
 };

--- a/core/src/migrations/000017-createRuns.ts
+++ b/core/src/migrations/000017-createRuns.ts
@@ -1,87 +1,91 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("runs", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("runs", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      creatorGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        creatorGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      creatorType: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        creatorType: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      state: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        state: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      importsCreated: {
-        type: DataTypes.BIGINT,
-        allowNull: false,
-      },
+        importsCreated: {
+          type: DataTypes.BIGINT,
+          allowNull: false,
+        },
 
-      profilesCreated: {
-        type: DataTypes.BIGINT,
-        allowNull: false,
-      },
+        profilesCreated: {
+          type: DataTypes.BIGINT,
+          allowNull: false,
+        },
 
-      profilesImported: {
-        type: DataTypes.BIGINT,
-        allowNull: false,
-      },
+        profilesImported: {
+          type: DataTypes.BIGINT,
+          allowNull: false,
+        },
 
-      profilesExported: {
-        type: DataTypes.BIGINT,
-        allowNull: false,
-      },
+        profilesExported: {
+          type: DataTypes.BIGINT,
+          allowNull: false,
+        },
 
-      completedAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-      },
+        completedAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
 
-      highWaterMark: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        highWaterMark: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      filter: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        filter: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      error: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
-    });
+        error: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
+      });
 
-    await migration.addIndex("runs", ["creatorGuid"], {
-      fields: ["creatorGuid"],
-    });
+      await migration.addIndex("runs", ["creatorGuid"], {
+        fields: ["creatorGuid"],
+      });
 
-    await migration.addIndex("runs", ["state"], {
-      fields: ["state"],
+      await migration.addIndex("runs", ["state"], {
+        fields: ["state"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("runs");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("runs");
+    });
   },
 };

--- a/core/src/migrations/000018-createSchedules.ts
+++ b/core/src/migrations/000018-createSchedules.ts
@@ -1,62 +1,66 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("schedules", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("schedules", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      sourceGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        sourceGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      name: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        name: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      state: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        state: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      recurring: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
+        recurring: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
 
-      recurringFrequency: {
-        type: DataTypes.BIGINT,
-        allowNull: true,
-      },
-    });
+        recurringFrequency: {
+          type: DataTypes.BIGINT,
+          allowNull: true,
+        },
+      });
 
-    await migration.addIndex("schedules", ["name"], {
-      unique: true,
-      fields: ["name"],
-    });
+      await migration.addIndex("schedules", ["name"], {
+        unique: true,
+        fields: ["name"],
+      });
 
-    await migration.addIndex("schedules", ["sourceGuid"], {
-      fields: ["sourceGuid"],
-    });
+      await migration.addIndex("schedules", ["sourceGuid"], {
+        fields: ["sourceGuid"],
+      });
 
-    await migration.addIndex("schedules", ["state"], {
-      fields: ["state"],
+      await migration.addIndex("schedules", ["state"], {
+        fields: ["state"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("schedules");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("schedules");
+    });
   },
 };

--- a/core/src/migrations/000019-createSettings.ts
+++ b/core/src/migrations/000019-createSettings.ts
@@ -1,58 +1,62 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("settings", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("settings", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      pluginName: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        pluginName: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      key: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        key: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      value: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        value: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      defaultValue: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        defaultValue: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      description: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
-    });
+        description: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
+      });
 
-    await migration.addIndex("settings", ["pluginName", "key"], {
-      unique: true,
-      fields: ["pluginName", "key"],
-    });
+      await migration.addIndex("settings", ["pluginName", "key"], {
+        unique: true,
+        fields: ["pluginName", "key"],
+      });
 
-    await migration.addIndex("settings", ["pluginName"], {
-      fields: ["pluginName"],
+      await migration.addIndex("settings", ["pluginName"], {
+        fields: ["pluginName"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("settings");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("settings");
+    });
   },
 };

--- a/core/src/migrations/000020-createSources.ts
+++ b/core/src/migrations/000020-createSources.ts
@@ -1,57 +1,61 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("sources", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("sources", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      appGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        appGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      type: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        type: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      name: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        name: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      state: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
-    });
+        state: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("sources", ["name"], {
-      unique: true,
-      fields: ["name"],
-    });
+      await migration.addIndex("sources", ["name"], {
+        unique: true,
+        fields: ["name"],
+      });
 
-    await migration.addIndex("sources", ["appGuid"], {
-      fields: ["appGuid"],
-    });
+      await migration.addIndex("sources", ["appGuid"], {
+        fields: ["appGuid"],
+      });
 
-    await migration.addIndex("sources", ["state"], {
-      fields: ["state"],
+      await migration.addIndex("sources", ["state"], {
+        fields: ["state"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("sources");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("sources");
+    });
   },
 };

--- a/core/src/migrations/000021-createTeamMembers.ts
+++ b/core/src/migrations/000021-createTeamMembers.ts
@@ -1,63 +1,67 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("teamMembers", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("teamMembers", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      teamGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        teamGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      firstName: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        firstName: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      lastName: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        lastName: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      email: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        email: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      passwordHash: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        passwordHash: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      lastLoginAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-      },
-    });
+        lastLoginAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
+      });
 
-    await migration.addIndex("teamMembers", ["email"], {
-      unique: true,
-      fields: ["email"],
-    });
+      await migration.addIndex("teamMembers", ["email"], {
+        unique: true,
+        fields: ["email"],
+      });
 
-    await migration.addIndex("teamMembers", ["teamGuid"], {
-      fields: ["teamGuid"],
+      await migration.addIndex("teamMembers", ["teamGuid"], {
+        fields: ["teamGuid"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("teamMembers");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("teamMembers");
+    });
   },
 };

--- a/core/src/migrations/000022-createTeams.ts
+++ b/core/src/migrations/000022-createTeams.ts
@@ -1,54 +1,58 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("teams", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("teams", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      name: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        name: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      read: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
+        read: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
 
-      write: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
+        write: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
 
-      administer: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
+        administer: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
 
-      deletable: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
-    });
+        deletable: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("teams", ["name"], {
-      unique: true,
-      fields: ["name"],
+      await migration.addIndex("teams", ["name"], {
+        unique: true,
+        fields: ["name"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("teams");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("teams");
+    });
   },
 };

--- a/core/src/migrations/000023-nonUniqueNames.ts
+++ b/core/src/migrations/000023-nonUniqueNames.ts
@@ -1,41 +1,45 @@
 export default {
   up: async function (migration, DataTypes) {
-    const TABLES = [
-      "apps",
-      "sources",
-      "groups",
-      "destinations",
-      "profilePropertyRules",
-      "schedules",
-    ];
+    await migration.sequelize.transaction(async () => {
+      const TABLES = [
+        "apps",
+        "sources",
+        "groups",
+        "destinations",
+        "profilePropertyRules",
+        "schedules",
+      ];
 
-    for (const i in TABLES) {
-      const table = TABLES[i];
-      const columns = table === "profilePropertyRules" ? ["key"] : ["name"];
-      await migration.removeIndex(table, columns, {
-        unique: true,
-        fields: columns,
-      });
-    }
+      for (const i in TABLES) {
+        const table = TABLES[i];
+        const columns = table === "profilePropertyRules" ? ["key"] : ["name"];
+        await migration.removeIndex(table, columns, {
+          unique: true,
+          fields: columns,
+        });
+      }
+    });
   },
 
   down: async function (migration) {
-    const TABLES = [
-      "apps",
-      "sources",
-      "groups",
-      "destinations",
-      "profilePropertyRules",
-      "schedules",
-    ];
+    await migration.sequelize.transaction(async () => {
+      const TABLES = [
+        "apps",
+        "sources",
+        "groups",
+        "destinations",
+        "profilePropertyRules",
+        "schedules",
+      ];
 
-    for (const i in TABLES) {
-      const table = TABLES[i];
-      const columns = table === "profilePropertyRules" ? ["key"] : ["name"];
-      await migration.addIndex(table, columns, {
-        unique: true,
-        fields: columns,
-      });
-    }
+      for (const i in TABLES) {
+        const table = TABLES[i];
+        const columns = table === "profilePropertyRules" ? ["key"] : ["name"];
+        await migration.addIndex(table, columns, {
+          unique: true,
+          fields: columns,
+        });
+      }
+    });
   },
 };

--- a/core/src/migrations/000024-createProfilePropertyRuleFilters.ts
+++ b/core/src/migrations/000024-createProfilePropertyRuleFilters.ts
@@ -1,72 +1,76 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("profilePropertyRuleFilters", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("profilePropertyRuleFilters", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      profilePropertyRuleGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        profilePropertyRuleGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      key: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        key: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      position: {
-        type: DataTypes.BIGINT,
-        allowNull: false,
-      },
+        position: {
+          type: DataTypes.BIGINT,
+          allowNull: false,
+        },
 
-      match: {
-        type: DataTypes.STRING(191),
-        allowNull: true,
-      },
+        match: {
+          type: DataTypes.STRING(191),
+          allowNull: true,
+        },
 
-      op: {
-        type: DataTypes.STRING(191),
-        allowNull: true,
-      },
+        op: {
+          type: DataTypes.STRING(191),
+          allowNull: true,
+        },
 
-      relativeMatchNumber: {
-        type: DataTypes.BIGINT,
-        allowNull: true,
-      },
+        relativeMatchNumber: {
+          type: DataTypes.BIGINT,
+          allowNull: true,
+        },
 
-      relativeMatchUnit: {
-        type: DataTypes.STRING(191),
-        allowNull: true,
-      },
+        relativeMatchUnit: {
+          type: DataTypes.STRING(191),
+          allowNull: true,
+        },
 
-      relativeMatchDirection: {
-        type: DataTypes.STRING(191),
-        allowNull: true,
-      },
+        relativeMatchDirection: {
+          type: DataTypes.STRING(191),
+          allowNull: true,
+        },
+      });
+
+      await migration.addIndex(
+        "profilePropertyRuleFilters",
+        ["profilePropertyRuleGuid"],
+        {
+          fields: ["profilePropertyRuleGuid"],
+        }
+      );
     });
-
-    await migration.addIndex(
-      "profilePropertyRuleFilters",
-      ["profilePropertyRuleGuid"],
-      {
-        fields: ["profilePropertyRuleGuid"],
-      }
-    );
   },
 
   down: async function (migration) {
-    await migration.dropTable("profilePropertyRuleFilters");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("profilePropertyRuleFilters");
+    });
   },
 };

--- a/core/src/migrations/000025-createDestinationGroupMemberships.ts
+++ b/core/src/migrations/000025-createDestinationGroupMemberships.ts
@@ -1,57 +1,61 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("destinationGroupMemberships", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("destinationGroupMemberships", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      destinationGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        destinationGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      groupGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        groupGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      remoteKey: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        remoteKey: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
+      });
+
+      await migration.addIndex(
+        "destinationGroupMemberships",
+        ["destinationGuid", "groupGuid"],
+        {
+          unique: true,
+          fields: ["destinationGuid", "groupGuid"],
+        }
+      );
+
+      await migration.addIndex(
+        "destinationGroupMemberships",
+        ["destinationGuid", "remoteKey"],
+        {
+          unique: true,
+          fields: ["destinationGuid", "remoteKey"],
+        }
+      );
     });
-
-    await migration.addIndex(
-      "destinationGroupMemberships",
-      ["destinationGuid", "groupGuid"],
-      {
-        unique: true,
-        fields: ["destinationGuid", "groupGuid"],
-      }
-    );
-
-    await migration.addIndex(
-      "destinationGroupMemberships",
-      ["destinationGuid", "remoteKey"],
-      {
-        unique: true,
-        fields: ["destinationGuid", "remoteKey"],
-      }
-    );
   },
 
   down: async function (migration) {
-    await migration.dropTable("destinationGroupMemberships");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("destinationGroupMemberships");
+    });
   },
 };

--- a/core/src/migrations/000026-profileAnonymousId.ts
+++ b/core/src/migrations/000026-profileAnonymousId.ts
@@ -1,17 +1,21 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("profiles", "anonymousId", {
-      type: DataTypes.STRING(191),
-      allowNull: true,
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("profiles", "anonymousId", {
+        type: DataTypes.STRING(191),
+        allowNull: true,
+      });
 
-    await migration.addIndex("profiles", ["anonymousId"], {
-      fields: ["anonymousId"],
-      unique: true,
+      await migration.addIndex("profiles", ["anonymousId"], {
+        fields: ["anonymousId"],
+        unique: true,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("profiles", "anonymousId");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("profiles", "anonymousId");
+    });
   },
 };

--- a/core/src/migrations/000027-createApiKeysAndPermissions.ts
+++ b/core/src/migrations/000027-createApiKeysAndPermissions.ts
@@ -1,101 +1,105 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("apiKeys", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("apiKeys", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      apiKey: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        apiKey: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      name: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        name: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
+      });
+
+      await migration.addIndex("apiKeys", ["name"], {
+        unique: true,
+        fields: ["name"],
+      });
+
+      await migration.addIndex("apiKeys", ["apiKey"], {
+        unique: true,
+        fields: ["apiKey"],
+      });
+
+      await migration.createTable("permissions", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
+
+        ownerGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
+
+        ownerType: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
+
+        topic: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
+
+        read: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
+
+        write: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
+
+        locked: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
+
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
+
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
+      });
+
+      await migration.addIndex("permissions", ["ownerGuid", "topic"], {
+        unique: true,
+        fields: ["ownerGuid", "topic"],
+      });
+
+      await migration.removeColumn("teams", "read");
+      await migration.removeColumn("teams", "write");
+      await migration.removeColumn("teams", "administer");
     });
-
-    await migration.addIndex("apiKeys", ["name"], {
-      unique: true,
-      fields: ["name"],
-    });
-
-    await migration.addIndex("apiKeys", ["apiKey"], {
-      unique: true,
-      fields: ["apiKey"],
-    });
-
-    await migration.createTable("permissions", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
-
-      ownerGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
-
-      ownerType: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
-
-      topic: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
-
-      read: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
-
-      write: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
-
-      locked: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
-
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
-
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
-    });
-
-    await migration.addIndex("permissions", ["ownerGuid", "topic"], {
-      unique: true,
-      fields: ["ownerGuid", "topic"],
-    });
-
-    await migration.removeColumn("teams", "read");
-    await migration.removeColumn("teams", "write");
-    await migration.removeColumn("teams", "administer");
   },
 
   down: async function (migration) {
-    await migration.dropTable("apiKeys");
-    await migration.dropTable("permissions");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("apiKeys");
+      await migration.dropTable("permissions");
+    });
   },
 };

--- a/core/src/migrations/000028-teamLockedAndAllPermissions.ts
+++ b/core/src/migrations/000028-teamLockedAndAllPermissions.ts
@@ -1,31 +1,35 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.renameColumn("teams", "deletable", "locked");
+    await migration.sequelize.transaction(async () => {
+      await migration.renameColumn("teams", "deletable", "locked");
 
-    await migration.addColumn("teams", "permissionAllRead", {
-      type: DataTypes.BOOLEAN,
-      allowNull: true,
-    });
-    await migration.addColumn("teams", "permissionAllWrite", {
-      type: DataTypes.BOOLEAN,
-      allowNull: true,
-    });
+      await migration.addColumn("teams", "permissionAllRead", {
+        type: DataTypes.BOOLEAN,
+        allowNull: true,
+      });
+      await migration.addColumn("teams", "permissionAllWrite", {
+        type: DataTypes.BOOLEAN,
+        allowNull: true,
+      });
 
-    await migration.addColumn("apiKeys", "permissionAllRead", {
-      type: DataTypes.BOOLEAN,
-      allowNull: true,
-    });
-    await migration.addColumn("apiKeys", "permissionAllWrite", {
-      type: DataTypes.BOOLEAN,
-      allowNull: true,
+      await migration.addColumn("apiKeys", "permissionAllRead", {
+        type: DataTypes.BOOLEAN,
+        allowNull: true,
+      });
+      await migration.addColumn("apiKeys", "permissionAllWrite", {
+        type: DataTypes.BOOLEAN,
+        allowNull: true,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.renameColumn("teams", "locked", "deletable");
-    await migration.removeColumn("teams", "permissionAllRead");
-    await migration.removeColumn("teams", "permissionAllWrite");
-    await migration.removeColumn("apiKeys", "permissionAllRead");
-    await migration.removeColumn("apiKeys", "permissionAllWrite");
+    await migration.sequelize.transaction(async () => {
+      await migration.renameColumn("teams", "locked", "deletable");
+      await migration.removeColumn("teams", "permissionAllRead");
+      await migration.removeColumn("teams", "permissionAllWrite");
+      await migration.removeColumn("apiKeys", "permissionAllRead");
+      await migration.removeColumn("apiKeys", "permissionAllWrite");
+    });
   },
 };

--- a/core/src/migrations/000029-createEvents.ts
+++ b/core/src/migrations/000029-createEvents.ts
@@ -1,122 +1,126 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("events", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("events", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      producerGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        producerGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      profileGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: true,
-      },
+        profileGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: true,
+        },
 
-      type: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        type: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      userId: {
-        type: DataTypes.STRING(191),
-        allowNull: true,
-      },
+        userId: {
+          type: DataTypes.STRING(191),
+          allowNull: true,
+        },
 
-      anonymousId: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        anonymousId: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      ipAddress: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        ipAddress: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      occurredAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        occurredAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      profileAssociatedAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-      },
+        profileAssociatedAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
-    });
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("events", ["type"], {
-      unique: false,
-      fields: ["type"],
-    });
+      await migration.addIndex("events", ["type"], {
+        unique: false,
+        fields: ["type"],
+      });
 
-    await migration.addIndex("events", ["profileGuid"], {
-      unique: false,
-      fields: ["profileGuid"],
-    });
+      await migration.addIndex("events", ["profileGuid"], {
+        unique: false,
+        fields: ["profileGuid"],
+      });
 
-    await migration.addIndex("events", ["anonymousId"], {
-      unique: false,
-      fields: ["anonymousId"],
-    });
+      await migration.addIndex("events", ["anonymousId"], {
+        unique: false,
+        fields: ["anonymousId"],
+      });
 
-    await migration.addIndex("events", ["occurredAt"], {
-      unique: false,
-      fields: ["occurredAt"],
-    });
+      await migration.addIndex("events", ["occurredAt"], {
+        unique: false,
+        fields: ["occurredAt"],
+      });
 
-    await migration.createTable("eventData", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+      await migration.createTable("eventData", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      eventGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        eventGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      key: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        key: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      value: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        value: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
-    });
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("eventData", ["eventGuid"], {
-      unique: false,
-      fields: ["eventGuid"],
+      await migration.addIndex("eventData", ["eventGuid"], {
+        unique: false,
+        fields: ["eventGuid"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("events");
-    await migration.dropTable("eventData");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("events");
+      await migration.dropTable("eventData");
+    });
   },
 };

--- a/core/src/migrations/000030-exportRunGuids.ts
+++ b/core/src/migrations/000030-exportRunGuids.ts
@@ -1,19 +1,23 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("runs", "exportsCreated", {
-      type: DataTypes.BIGINT,
-      allowNull: false,
-      defaultValue: 0,
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("runs", "exportsCreated", {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        defaultValue: 0,
+      });
 
-    await migration.addColumn("exports", "runGuids", {
-      type: DataTypes.TEXT,
-      allowNull: true,
+      await migration.addColumn("exports", "runGuids", {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("runs", "exportsCreated");
-    await migration.removeColumn("exports", "runGuids");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("runs", "exportsCreated");
+      await migration.removeColumn("exports", "runGuids");
+    });
   },
 };

--- a/core/src/migrations/000031-runLimitOffsetMethod.ts
+++ b/core/src/migrations/000031-runLimitOffsetMethod.ts
@@ -1,26 +1,30 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("runs", "limit", {
-      type: DataTypes.BIGINT,
-      allowNull: false,
-      defaultValue: 0,
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("runs", "limit", {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        defaultValue: 0,
+      });
 
-    await migration.addColumn("runs", "offset", {
-      type: DataTypes.BIGINT,
-      allowNull: false,
-      defaultValue: 0,
-    });
+      await migration.addColumn("runs", "offset", {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        defaultValue: 0,
+      });
 
-    await migration.addColumn("runs", "method", {
-      type: DataTypes.TEXT,
-      allowNull: true,
+      await migration.addColumn("runs", "method", {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("runs", "limit");
-    await migration.removeColumn("runs", "offset");
-    await migration.removeColumn("runs", "method");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("runs", "limit");
+      await migration.removeColumn("runs", "offset");
+      await migration.removeColumn("runs", "method");
+    });
   },
 };

--- a/core/src/migrations/000032-runHighWaterMarkAndSourceOffest.ts
+++ b/core/src/migrations/000032-runHighWaterMarkAndSourceOffest.ts
@@ -1,29 +1,33 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.removeColumn("runs", "filter");
-    await migration.removeColumn("runs", "highWaterMark");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("runs", "filter");
+      await migration.removeColumn("runs", "highWaterMark");
 
-    await migration.addColumn("runs", "highWaterMark", {
-      type: DataTypes.TEXT,
-      allowNull: true,
+      await migration.addColumn("runs", "highWaterMark", {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      });
+
+      await migration.addColumn("runs", "sourceOffset", {
+        type: DataTypes.STRING(191),
+        allowNull: true,
+      });
+
+      await migration.renameColumn("runs", "limit", "groupMemberLimit");
+      await migration.renameColumn("runs", "offset", "groupMemberOffset");
+      await migration.renameColumn("runs", "method", "groupMethod");
     });
-
-    await migration.addColumn("runs", "sourceOffset", {
-      type: DataTypes.STRING(191),
-      allowNull: true,
-    });
-
-    await migration.renameColumn("runs", "limit", "groupMemberLimit");
-    await migration.renameColumn("runs", "offset", "groupMemberOffset");
-    await migration.renameColumn("runs", "method", "groupMethod");
   },
 
   down: async function (migration) {
-    await migration.removeColumn("runs", "highWaterMark");
-    await migration.removeColumn("runs", "sourceOffset");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("runs", "highWaterMark");
+      await migration.removeColumn("runs", "sourceOffset");
 
-    await migration.renameColumn("runs", "groupMemberLimit", "limit");
-    await migration.renameColumn("runs", "groupMemberOffset", "offset");
-    await migration.renameColumn("runs", "groupMethod", "method");
+      await migration.renameColumn("runs", "groupMemberLimit", "limit");
+      await migration.renameColumn("runs", "groupMemberOffset", "offset");
+      await migration.renameColumn("runs", "groupMethod", "method");
+    });
   },
 };

--- a/core/src/migrations/000033-profilePropertyArray.ts
+++ b/core/src/migrations/000033-profilePropertyArray.ts
@@ -1,53 +1,60 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("profileProperties", "position", {
-      type: DataTypes.BIGINT,
-      allowNull: false,
-      defaultValue: 0,
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("profileProperties", "position", {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        defaultValue: 0,
+      });
 
-    await migration.addColumn("profilePropertyRules", "isArray", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-    });
+      await migration.addColumn("profilePropertyRules", "isArray", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
 
-    await migration.removeIndex(
-      "profileProperties",
-      ["profileGuid", "profilePropertyRuleGuid"],
-      {
-        unique: true,
-        fields: ["profileGuid", "profilePropertyRuleGuid"],
-      }
-    );
-    await migration.addIndex(
-      "profileProperties",
-      ["profileGuid", "profilePropertyRuleGuid", "position"],
-      {
-        unique: true,
-        fields: ["profileGuid", "profilePropertyRuleGuid", "position"],
-      }
-    );
+      await migration.removeIndex(
+        "profileProperties",
+        ["profileGuid", "profilePropertyRuleGuid"],
+        {
+          unique: true,
+          fields: ["profileGuid", "profilePropertyRuleGuid"],
+        }
+      );
+
+      await migration.addIndex(
+        "profileProperties",
+        ["profileGuid", "profilePropertyRuleGuid", "position"],
+        {
+          unique: true,
+          fields: ["profileGuid", "profilePropertyRuleGuid", "position"],
+        }
+      );
+    });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("profileProperties", "position");
-    await migration.removeColumn("profilePropertyRules", "isArray");
-    await migration.removeIndex(
-      "profileProperties",
-      ["profileGuid", "profilePropertyRuleGuid", "position"],
-      {
-        unique: true,
-        fields: ["profileGuid", "profilePropertyRuleGuid", "position"],
-      }
-    );
-    await migration.addIndex(
-      "profileProperties",
-      ["profileGuid", "profilePropertyRuleGuid"],
-      {
-        unique: true,
-        fields: ["profileGuid", "profilePropertyRuleGuid"],
-      }
-    );
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("profileProperties", "position");
+      await migration.removeColumn("profilePropertyRules", "isArray");
+
+      await migration.removeIndex(
+        "profileProperties",
+        ["profileGuid", "profilePropertyRuleGuid", "position"],
+        {
+          unique: true,
+          fields: ["profileGuid", "profilePropertyRuleGuid", "position"],
+        }
+      );
+
+      await migration.addIndex(
+        "profileProperties",
+        ["profileGuid", "profilePropertyRuleGuid"],
+        {
+          unique: true,
+          fields: ["profileGuid", "profilePropertyRuleGuid"],
+        }
+      );
+    });
   },
 };

--- a/core/src/migrations/000034-runPercentComplete.ts
+++ b/core/src/migrations/000034-runPercentComplete.ts
@@ -1,13 +1,17 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("runs", "percentComplete", {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      defaultValue: 100,
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("runs", "percentComplete", {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        defaultValue: 100,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("runs", "percentComplete");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("runs", "percentComplete");
+    });
   },
 };

--- a/core/src/migrations/000035-identifyingProfilePropertyRule.ts
+++ b/core/src/migrations/000035-identifyingProfilePropertyRule.ts
@@ -1,24 +1,29 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("profilePropertyRules", "identifying", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("profilePropertyRules", "identifying", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
 
-    // we need to pick one of the existing rules to be identifying - prefer the oldest unique rule.
-    const [results] = await migration.sequelize.query(
-      'select * from "profilePropertyRules" order by "unique" desc, "createdAt" desc limit 1'
-    );
-    if (results.length === 1) {
-      const rule = results[0];
-      await migration.sequelize.query(
-        `update "profilePropertyRules" set identifying=true where guid='${rule.guid}'`
+      // we need to pick one of the existing rules to be identifying - prefer the oldest unique rule.
+      const [results] = await migration.sequelize.query(
+        'select * from "profilePropertyRules" order by "unique" desc, "createdAt" desc limit 1'
       );
-    }
+
+      if (results.length === 1) {
+        const rule = results[0];
+        await migration.sequelize.query(
+          `update "profilePropertyRules" set identifying=true where guid='${rule.guid}'`
+        );
+      }
+    });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("profilePropertyRules", "identifying");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("profilePropertyRules", "identifying");
+    });
   },
 };

--- a/core/src/migrations/000036-createExportRuns.ts
+++ b/core/src/migrations/000036-createExportRuns.ts
@@ -1,46 +1,50 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("exportRuns", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("exportRuns", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      exportGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        exportGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      runGuid: {
-        type: DataTypes.STRING(40),
-        allowNull: false,
-      },
+        runGuid: {
+          type: DataTypes.STRING(40),
+          allowNull: false,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
+      });
+
+      await migration.addIndex("exportRuns", ["exportGuid", "runGuid"], {
+        unique: true,
+        fields: ["exportGuid", "runGuid"],
+      });
+
+      await migration.removeColumn("exports", "runGuids");
     });
-
-    await migration.addIndex("exportRuns", ["exportGuid", "runGuid"], {
-      unique: true,
-      fields: ["exportGuid", "runGuid"],
-    });
-
-    await migration.removeColumn("exports", "runGuids");
   },
 
   down: async function (migration, DataTypes) {
-    await migration.dropTable("exportRuns");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("exportRuns");
 
-    await migration.addColumn("exports", "runGuids", {
-      type: DataTypes.TEXT,
-      allowNull: true,
+      await migration.addColumn("exports", "runGuids", {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      });
     });
   },
 };

--- a/core/src/migrations/000037-exportHasChanges.ts
+++ b/core/src/migrations/000037-exportHasChanges.ts
@@ -1,20 +1,24 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("exports", "hasChanges", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: true,
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("exports", "hasChanges", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: true,
+      });
 
-    await migration.addColumn("runs", "force", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
+      await migration.addColumn("runs", "force", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("exports", "hasChanges");
-    await migration.removeColumn("runs", "force");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("exports", "hasChanges");
+      await migration.removeColumn("runs", "force");
+    });
   },
 };

--- a/core/src/migrations/000038-groupRuleProfileColumn.ts
+++ b/core/src/migrations/000038-groupRuleProfileColumn.ts
@@ -1,22 +1,26 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.changeColumn("groupRules", "profilePropertyRuleGuid", {
-      type: DataTypes.STRING(40),
-      allowNull: true,
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.changeColumn("groupRules", "profilePropertyRuleGuid", {
+        type: DataTypes.STRING(40),
+        allowNull: true,
+      });
 
-    await migration.addColumn("groupRules", "profileColumn", {
-      type: DataTypes.STRING(191),
-      allowNull: true,
+      await migration.addColumn("groupRules", "profileColumn", {
+        type: DataTypes.STRING(191),
+        allowNull: true,
+      });
     });
   },
 
   down: async function (migration, DataTypes) {
-    await migration.changeColumn("groupRules", "profilePropertyRuleGuid", {
-      type: DataTypes.STRING(40),
-      allowNull: false,
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.changeColumn("groupRules", "profilePropertyRuleGuid", {
+        type: DataTypes.STRING(40),
+        allowNull: false,
+      });
 
-    await migration.removeColumn("groupRules", "profileColumn");
+      await migration.removeColumn("groupRules", "profileColumn");
+    });
   },
 };

--- a/core/src/migrations/000039-removeDestinationTrackAllGroups.ts
+++ b/core/src/migrations/000039-removeDestinationTrackAllGroups.ts
@@ -1,45 +1,49 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("destinations", "groupGuid", {
-      type: DataTypes.STRING(40),
-      allowNull: true,
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("destinations", "groupGuid", {
+        type: DataTypes.STRING(40),
+        allowNull: true,
+      });
 
-    const [destinations] = await migration.sequelize.query(
-      'select * from "destinations"'
-    );
-    for (const i in destinations) {
-      const destination = destinations[i];
+      const [destinations] = await migration.sequelize.query(
+        'select * from "destinations"'
+      );
+      for (const i in destinations) {
+        const destination = destinations[i];
 
-      if (destinations.trackAllGroups) {
-        await migration.sequelize.query(
-          `delete from "destinationGroups" where "destinationGuid" = '${destinations.guid}'`
-        );
-      } else {
-        const destinationGroups = await migration.sequelize.query(
-          `select * from "destinationGroups" where "destinationGuid" = '${destination.guid}'`
-        );
-        if (destinationGroups.length === 1) {
+        if (destinations.trackAllGroups) {
           await migration.sequelize.query(
-            `update destinations set "groupGuid" = '${destinationGroups[0].groupGuid}'`
+            `delete from "destinationGroups" where "destinationGuid" = '${destinations.guid}'`
           );
+        } else {
+          const destinationGroups = await migration.sequelize.query(
+            `select * from "destinationGroups" where "destinationGuid" = '${destination.guid}'`
+          );
+          if (destinationGroups.length === 1) {
+            await migration.sequelize.query(
+              `update destinations set "groupGuid" = '${destinationGroups[0].groupGuid}'`
+            );
+          }
         }
       }
-    }
 
-    await migration.removeColumn("destinations", "trackAllGroups");
+      await migration.removeColumn("destinations", "trackAllGroups");
 
-    await migration.dropTable("destinationGroups");
+      await migration.dropTable("destinationGroups");
+    });
   },
 
   down: async function (migration, DataTypes) {
-    await migration.removeColumn("destinations", "groupGuid");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("destinations", "groupGuid");
 
-    await migration.addColumn("destinations", "trackAllGroups", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
+      await migration.addColumn("destinations", "trackAllGroups", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+      });
+
+      // not rebuilding the destinationGroups table
     });
-
-    // not rebuilding the destinationGroups table
   },
 };

--- a/core/src/migrations/000040-addExportForce.ts
+++ b/core/src/migrations/000040-addExportForce.ts
@@ -1,13 +1,17 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("exports", "force", {
-      type: DataTypes.BOOLEAN,
-      defaultValue: false,
-      allowNull: false,
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("exports", "force", {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("exports", "force");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("exports", "force");
+    });
   },
 };

--- a/core/src/migrations/000041-createSetupSteps.ts
+++ b/core/src/migrations/000041-createSetupSteps.ts
@@ -1,49 +1,53 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("setupSteps", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("setupSteps", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      position: {
-        type: DataTypes.BIGINT,
-        allowNull: false,
-      },
+        position: {
+          type: DataTypes.BIGINT,
+          allowNull: false,
+        },
 
-      key: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        key: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      skipped: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
+        skipped: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
 
-      complete: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-      },
+        complete: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
-    });
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("setupSteps", ["key"], {
-      unique: true,
-      fields: ["key"],
+      await migration.addIndex("setupSteps", ["key"], {
+        unique: true,
+        fields: ["key"],
+      });
     });
   },
 
   down: async function (migration, DataTypes) {
-    await migration.dropTable("setupSteps");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("setupSteps");
+    });
   },
 };

--- a/core/src/migrations/000042-addSettingType.ts
+++ b/core/src/migrations/000042-addSettingType.ts
@@ -1,28 +1,32 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("settings", "type", {
-      type: DataTypes.STRING(191),
-      defaultValue: "string",
-      allowNull: false,
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("settings", "type", {
+        type: DataTypes.STRING(191),
+        defaultValue: "string",
+        allowNull: false,
+      });
 
-    // If the defaultValue is a regexp number, we can assume a numeric field
-    // There were no boolean type settings before this migration
-    // https://stackoverflow.com/questions/175739/built-in-way-in-javascript-to-check-if-a-string-is-a-valid-number
-    const [settings] = await migration.sequelize.query(
-      `select * from "settings"`
-    );
-    for (const i in settings) {
-      const setting = settings[i];
-      if (!isNaN(setting.defaultValue)) {
-        await migration.sequelize.query(
-          `update "settings" set type='number' where guid='${setting.guid}'`
-        );
+      // If the defaultValue is a regexp number, we can assume a numeric field
+      // There were no boolean type settings before this migration
+      // https://stackoverflow.com/questions/175739/built-in-way-in-javascript-to-check-if-a-string-is-a-valid-number
+      const [settings] = await migration.sequelize.query(
+        `select * from "settings"`
+      );
+      for (const i in settings) {
+        const setting = settings[i];
+        if (!isNaN(setting.defaultValue)) {
+          await migration.sequelize.query(
+            `update "settings" set type='number' where guid='${setting.guid}'`
+          );
+        }
       }
-    }
+    });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("settings", "type");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("settings", "type");
+    });
   },
 };

--- a/core/src/migrations/000043-addRunGroupHighWaterMark.ts
+++ b/core/src/migrations/000043-addRunGroupHighWaterMark.ts
@@ -1,12 +1,16 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("runs", "groupHighWaterMark", {
-      type: DataTypes.BIGINT,
-      allowNull: true,
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("runs", "groupHighWaterMark", {
+        type: DataTypes.BIGINT,
+        allowNull: true,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("runs", "groupHighWaterMark");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("runs", "groupHighWaterMark");
+    });
   },
 };

--- a/core/src/migrations/000044-settingTitleAndVariant.ts
+++ b/core/src/migrations/000044-settingTitleAndVariant.ts
@@ -1,20 +1,24 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("settings", "title", {
-      type: DataTypes.STRING(191),
-      allowNull: false,
-      defaultValue: "",
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("settings", "title", {
+        type: DataTypes.STRING(191),
+        allowNull: false,
+        defaultValue: "",
+      });
 
-    await migration.addColumn("settings", "variant", {
-      type: DataTypes.STRING(191),
-      allowNull: false,
-      defaultValue: "",
+      await migration.addColumn("settings", "variant", {
+        type: DataTypes.STRING(191),
+        allowNull: false,
+        defaultValue: "",
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("settings", "title");
-    await migration.removeColumn("settings", "variant");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("settings", "title");
+      await migration.removeColumn("settings", "variant");
+    });
   },
 };

--- a/core/src/migrations/000045-createNotifications.ts
+++ b/core/src/migrations/000045-createNotifications.ts
@@ -1,54 +1,58 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("notifications", {
-      guid: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("notifications", {
+        guid: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      from: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        from: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      subject: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        subject: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      body: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        body: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      cta: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        cta: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      ctaLink: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
+        ctaLink: {
+          type: DataTypes.TEXT,
+          allowNull: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      readAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-      },
+        readAt: {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("notifications");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("notifications");
+    });
   },
 };

--- a/core/src/migrations/000046-addStateToProfilesAndProfileProperties.ts
+++ b/core/src/migrations/000046-addStateToProfilesAndProfileProperties.ts
@@ -1,36 +1,40 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("profiles", "state", {
-      type: DataTypes.STRING(191),
-      allowNull: false,
-      defaultValue: "ready",
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("profiles", "state", {
+        type: DataTypes.STRING(191),
+        allowNull: false,
+        defaultValue: "ready",
+      });
 
-    await migration.addColumn("profileProperties", "state", {
-      type: DataTypes.STRING(191),
-      allowNull: false,
-      defaultValue: "ready",
-    });
+      await migration.addColumn("profileProperties", "state", {
+        type: DataTypes.STRING(191),
+        allowNull: false,
+        defaultValue: "ready",
+      });
 
-    await migration.addColumn("profileProperties", "valueChangedAt", {
-      type: DataTypes.DATE,
-      allowNull: true,
-    });
-    await migration.addColumn("profileProperties", "stateChangedAt", {
-      type: DataTypes.DATE,
-      allowNull: true,
-    });
-    await migration.addColumn("profileProperties", "confirmedAt", {
-      type: DataTypes.DATE,
-      allowNull: true,
+      await migration.addColumn("profileProperties", "valueChangedAt", {
+        type: DataTypes.DATE,
+        allowNull: true,
+      });
+      await migration.addColumn("profileProperties", "stateChangedAt", {
+        type: DataTypes.DATE,
+        allowNull: true,
+      });
+      await migration.addColumn("profileProperties", "confirmedAt", {
+        type: DataTypes.DATE,
+        allowNull: true,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("profiles", "state");
-    await migration.removeColumn("profileProperties", "state");
-    await migration.removeColumn("profileProperties", "valueChangedAt");
-    await migration.removeColumn("profileProperties", "stateChangedAt");
-    await migration.removeColumn("profileProperties", "confirmedAt");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("profiles", "state");
+      await migration.removeColumn("profileProperties", "state");
+      await migration.removeColumn("profileProperties", "valueChangedAt");
+      await migration.removeColumn("profileProperties", "stateChangedAt");
+      await migration.removeColumn("profileProperties", "confirmedAt");
+    });
   },
 };

--- a/core/src/migrations/000047-removeExportRunsAndExportImports.ts
+++ b/core/src/migrations/000047-removeExportRunsAndExportImports.ts
@@ -1,13 +1,17 @@
 export default {
   up: async function (migration) {
-    await migration.dropTable("exportRuns");
-    await migration.dropTable("exportImports");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("exportRuns");
+      await migration.dropTable("exportImports");
 
-    await migration.removeColumn("runs", "exportsCreated");
-    await migration.removeColumn("runs", "profilesExported");
+      await migration.removeColumn("runs", "exportsCreated");
+      await migration.removeColumn("runs", "profilesExported");
+    });
   },
 
   down: async function (migration, DataTypes) {
-    throw new Error("cannot recover data for this migration");
+    await migration.sequelize.transaction(async () => {
+      throw new Error("cannot recover data for this migration");
+    });
   },
 };

--- a/core/src/migrations/000048-addImportCreatedProfile.ts
+++ b/core/src/migrations/000048-addImportCreatedProfile.ts
@@ -1,13 +1,17 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("imports", "createdProfile", {
-      type: DataTypes.BOOLEAN,
-      defaultValue: false,
-      allowNull: false,
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("imports", "createdProfile", {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("imports", "createdProfile");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("imports", "createdProfile");
+    });
   },
 };

--- a/core/src/migrations/000049-addStateIndxToProfiles.ts
+++ b/core/src/migrations/000049-addStateIndxToProfiles.ts
@@ -1,21 +1,25 @@
 export default {
   up: async function (migration) {
-    await migration.addIndex("profiles", ["state"], {
-      fields: ["state"],
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addIndex("profiles", ["state"], {
+        fields: ["state"],
+      });
 
-    await migration.addIndex("profileProperties", ["state"], {
-      fields: ["state"],
+      await migration.addIndex("profileProperties", ["state"], {
+        fields: ["state"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeIndex("profiles", ["state"], {
-      fields: ["state"],
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.removeIndex("profiles", ["state"], {
+        fields: ["state"],
+      });
 
-    await migration.removeIndex("profileProperties", ["state"], {
-      fields: ["state"],
+      await migration.removeIndex("profileProperties", ["state"], {
+        fields: ["state"],
+      });
     });
   },
 };

--- a/core/src/migrations/000050-addDirectlyMappedToRules.ts
+++ b/core/src/migrations/000050-addDirectlyMappedToRules.ts
@@ -1,13 +1,17 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("profilePropertyRules", "directlyMapped", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("profilePropertyRules", "directlyMapped", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("profilePropertyRules", "directlyMapped");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("profilePropertyRules", "directlyMapped");
+    });
   },
 };

--- a/core/src/migrations/000051-codeConfigModelSupport.ts
+++ b/core/src/migrations/000051-codeConfigModelSupport.ts
@@ -1,69 +1,73 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("apiKeys", "locked", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("apiKeys", "locked", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
 
-    await migration.addColumn("apps", "locked", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-    });
+      await migration.addColumn("apps", "locked", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
 
-    await migration.addColumn("destinations", "locked", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-    });
+      await migration.addColumn("destinations", "locked", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
 
-    await migration.addColumn("groups", "locked", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-    });
+      await migration.addColumn("groups", "locked", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
 
-    await migration.addColumn("profilePropertyRules", "locked", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-    });
+      await migration.addColumn("profilePropertyRules", "locked", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
 
-    await migration.addColumn("sources", "locked", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-    });
+      await migration.addColumn("sources", "locked", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
 
-    await migration.addColumn("schedules", "locked", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-    });
+      await migration.addColumn("schedules", "locked", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
 
-    await migration.addColumn("settings", "locked", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-    });
+      await migration.addColumn("settings", "locked", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
 
-    await migration.addColumn("teamMembers", "locked", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
+      await migration.addColumn("teamMembers", "locked", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("apiKeys", "locked");
-    await migration.removeColumn("apps", "locked");
-    await migration.removeColumn("destinations", "locked");
-    await migration.removeColumn("groups", "locked");
-    await migration.removeColumn("profilePropertyRules", "locked");
-    await migration.removeColumn("sources", "locked");
-    await migration.removeColumn("schedules", "locked");
-    await migration.removeColumn("settings", "locked");
-    await migration.removeColumn("teamMembers", "locked");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("apiKeys", "locked");
+      await migration.removeColumn("apps", "locked");
+      await migration.removeColumn("destinations", "locked");
+      await migration.removeColumn("groups", "locked");
+      await migration.removeColumn("profilePropertyRules", "locked");
+      await migration.removeColumn("sources", "locked");
+      await migration.removeColumn("schedules", "locked");
+      await migration.removeColumn("settings", "locked");
+      await migration.removeColumn("teamMembers", "locked");
+    });
   },
 };

--- a/core/src/migrations/000052-optionsDisplayName.ts
+++ b/core/src/migrations/000052-optionsDisplayName.ts
@@ -1,14 +1,16 @@
 export default {
   up: async function (migration, DataTypes) {
-    // "aggregation method" renamed to "aggregationMethod"
-    await migration.sequelize.query(
-      `UPDATE "options" SET key='aggregationMethod' WHERE key='aggregation method' AND "ownerType" = 'profilePropertyRule'`
-    );
+    await migration.sequelize.transaction(async () => {
+      // "aggregation method" renamed to "aggregationMethod"
+      await migration.sequelize.query(
+        `UPDATE "options" SET key='aggregationMethod' WHERE key='aggregation method' AND "ownerType" = 'profilePropertyRule'`
+      );
 
-    // "sort column" renamed to "sortColumn"
-    await migration.sequelize.query(
-      `UPDATE "options" SET key='sortColumn' WHERE key='sort column' AND "ownerType" = 'profilePropertyRule'`
-    );
+      // "sort column" renamed to "sortColumn"
+      await migration.sequelize.query(
+        `UPDATE "options" SET key='sortColumn' WHERE key='sort column' AND "ownerType" = 'profilePropertyRule'`
+      );
+    });
   },
 
   down: async function (migration) {

--- a/core/src/migrations/000053-removeCompoundindex.ts
+++ b/core/src/migrations/000053-removeCompoundindex.ts
@@ -2,72 +2,74 @@ import { config } from "actionhero";
 
 export default {
   up: async function (migration, DataTypes) {
-    if (config.sequelize.dialect === "sqlite") {
-      await migration.removeIndex(
-        "groupMembers",
-        ["profileGuid", "groupGuid"],
-        {
+    await migration.sequelize.transaction(async () => {
+      if (config.sequelize.dialect === "sqlite") {
+        await migration.removeIndex(
+          "groupMembers",
+          ["profileGuid", "groupGuid"],
+          {
+            unique: true,
+            fields: ["profileGuid", "groupGuid"],
+          }
+        );
+
+        await migration.removeIndex(
+          "mappings",
+          ["ownerGuid", "profilePropertyRuleGuid"],
+          {
+            unique: true,
+            fields: ["ownerGuid", "profilePropertyRuleGuid"],
+          }
+        );
+
+        await migration.removeIndex("mappings", ["ownerGuid", "remoteKey"], {
           unique: true,
-          fields: ["profileGuid", "groupGuid"],
-        }
-      );
+          fields: ["ownerGuid", "remoteKey"],
+        });
 
-      await migration.removeIndex(
-        "mappings",
-        ["ownerGuid", "profilePropertyRuleGuid"],
-        {
+        await migration.removeIndex("options", ["ownerGuid", "key"], {
           unique: true,
-          fields: ["ownerGuid", "profilePropertyRuleGuid"],
-        }
-      );
+          fields: ["ownerGuid", "key"],
+        });
 
-      await migration.removeIndex("mappings", ["ownerGuid", "remoteKey"], {
-        unique: true,
-        fields: ["ownerGuid", "remoteKey"],
-      });
+        await migration.removeIndex(
+          "profileProperties",
+          ["profileGuid", "profilePropertyRuleGuid", "position"],
+          {
+            unique: true,
+            fields: ["profileGuid", "profilePropertyRuleGuid", "position"],
+          }
+        );
 
-      await migration.removeIndex("options", ["ownerGuid", "key"], {
-        unique: true,
-        fields: ["ownerGuid", "key"],
-      });
-
-      await migration.removeIndex(
-        "profileProperties",
-        ["profileGuid", "profilePropertyRuleGuid", "position"],
-        {
+        await migration.removeIndex("settings", ["pluginName", "key"], {
           unique: true,
-          fields: ["profileGuid", "profilePropertyRuleGuid", "position"],
-        }
-      );
+          fields: ["pluginName", "key"],
+        });
 
-      await migration.removeIndex("settings", ["pluginName", "key"], {
-        unique: true,
-        fields: ["pluginName", "key"],
-      });
+        await migration.removeIndex(
+          "destinationGroupMemberships",
+          ["destinationGuid", "groupGuid"],
+          {
+            unique: true,
+            fields: ["destinationGuid", "groupGuid"],
+          }
+        );
 
-      await migration.removeIndex(
-        "destinationGroupMemberships",
-        ["destinationGuid", "groupGuid"],
-        {
+        await migration.removeIndex(
+          "destinationGroupMemberships",
+          ["destinationGuid", "remoteKey"],
+          {
+            unique: true,
+            fields: ["destinationGuid", "remoteKey"],
+          }
+        );
+
+        await migration.removeIndex("permissions", ["ownerGuid", "topic"], {
           unique: true,
-          fields: ["destinationGuid", "groupGuid"],
-        }
-      );
-
-      await migration.removeIndex(
-        "destinationGroupMemberships",
-        ["destinationGuid", "remoteKey"],
-        {
-          unique: true,
-          fields: ["destinationGuid", "remoteKey"],
-        }
-      );
-
-      await migration.removeIndex("permissions", ["ownerGuid", "topic"], {
-        unique: true,
-        fields: ["ownerGuid", "topic"],
-      });
-    }
+          fields: ["ownerGuid", "topic"],
+        });
+      }
+    });
   },
 
   down: async function () {

--- a/core/src/migrations/000054-lockedString.ts
+++ b/core/src/migrations/000054-lockedString.ts
@@ -14,38 +14,42 @@ const tables = [
 
 export default {
   up: async function (migration, DataTypes) {
-    for (const i in tables) {
-      const table = tables[i];
-      await migration.changeColumn(table, "locked", {
-        type: DataTypes.STRING(191),
-        allowNull: true,
-        defaultValue: null,
-      });
-      if (table !== "teams") {
+    await migration.sequelize.transaction(async () => {
+      for (const i in tables) {
+        const table = tables[i];
+        await migration.changeColumn(table, "locked", {
+          type: DataTypes.STRING(191),
+          allowNull: true,
+          defaultValue: null,
+        });
+        if (table !== "teams") {
+          await migration.sequelize.query(
+            `UPDATE "${table}" SET locked='config:code' WHERE (locked = '1' OR locked = 'true')`
+          );
+        } else {
+          await migration.sequelize.query(
+            `UPDATE "${table}" SET locked='team:initialize' WHERE (locked = '1' OR locked = 'true') AND name = 'Administrators' AND "permissionAllWrite" = true AND "permissionAllRead" = true`
+          );
+          await migration.sequelize.query(
+            `UPDATE "${table}" SET locked='config:code' WHERE (locked = '1' OR locked = 'true') AND name != 'Administrators'`
+          );
+        }
         await migration.sequelize.query(
-          `UPDATE "${table}" SET locked='config:code' WHERE (locked = '1' OR locked = 'true')`
-        );
-      } else {
-        await migration.sequelize.query(
-          `UPDATE "${table}" SET locked='team:initialize' WHERE (locked = '1' OR locked = 'true') AND name = 'Administrators' AND "permissionAllWrite" = true AND "permissionAllRead" = true`
-        );
-        await migration.sequelize.query(
-          `UPDATE "${table}" SET locked='config:code' WHERE (locked = '1' OR locked = 'true') AND name != 'Administrators'`
+          `UPDATE "${table}" SET locked=NULL WHERE (locked = '0' OR locked = 'false')`
         );
       }
-      await migration.sequelize.query(
-        `UPDATE "${table}" SET locked=NULL WHERE (locked = '0' OR locked = 'false')`
-      );
-    }
+    });
   },
 
   down: async function (migration, DataTypes) {
-    for (const i in tables) {
-      await migration.changeColumn(tables[i], "locked", {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-        defaultValue: false,
-      });
-    }
+    await migration.sequelize.transaction(async () => {
+      for (const i in tables) {
+        await migration.changeColumn(tables[i], "locked", {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+          defaultValue: false,
+        });
+      }
+    });
   },
 };

--- a/core/src/migrations/000055-errorLevelForExports.ts
+++ b/core/src/migrations/000055-errorLevelForExports.ts
@@ -1,17 +1,21 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("exports", "errorLevel", {
-      type: DataTypes.STRING(191),
-      allowNull: true,
-      defaultValue: null,
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("exports", "errorLevel", {
+        type: DataTypes.STRING(191),
+        allowNull: true,
+        defaultValue: null,
+      });
 
-    await migration.sequelize.query(
-      `UPDATE "exports" SET "errorLevel"='error' WHERE "errorMessage" IS NOT NULL`
-    );
+      await migration.sequelize.query(
+        `UPDATE "exports" SET "errorLevel"='error' WHERE "errorMessage" IS NOT NULL`
+      );
+    });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("exports", "errorLevel");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("exports", "errorLevel");
+    });
   },
 };

--- a/core/src/migrations/000056-propertiesModel.ts
+++ b/core/src/migrations/000056-propertiesModel.ts
@@ -1,59 +1,63 @@
 export default {
   up: async function (migration) {
-    await migration.renameColumn(
-      "groupRules",
-      "profilePropertyRuleGuid",
-      "propertyGuid"
-    );
-    await migration.renameColumn(
-      "mappings",
-      "profilePropertyRuleGuid",
-      "propertyGuid"
-    );
-    await migration.renameColumn(
-      "profileProperties",
-      "profilePropertyRuleGuid",
-      "propertyGuid"
-    );
-    await migration.renameColumn(
-      "profilePropertyRuleFilters",
-      "profilePropertyRuleGuid",
-      "propertyGuid"
-    );
+    await migration.sequelize.transaction(async () => {
+      await migration.renameColumn(
+        "groupRules",
+        "profilePropertyRuleGuid",
+        "propertyGuid"
+      );
+      await migration.renameColumn(
+        "mappings",
+        "profilePropertyRuleGuid",
+        "propertyGuid"
+      );
+      await migration.renameColumn(
+        "profileProperties",
+        "profilePropertyRuleGuid",
+        "propertyGuid"
+      );
+      await migration.renameColumn(
+        "profilePropertyRuleFilters",
+        "profilePropertyRuleGuid",
+        "propertyGuid"
+      );
 
-    await migration.renameTable("profilePropertyRules", "properties");
-    await migration.renameTable(
-      "profilePropertyRuleFilters",
-      "propertyFilters"
-    );
+      await migration.renameTable("profilePropertyRules", "properties");
+      await migration.renameTable(
+        "profilePropertyRuleFilters",
+        "propertyFilters"
+      );
+    });
   },
 
   down: async function (migration) {
-    await migration.renameTable("properties", "profilePropertyRules");
-    await migration.renameTable(
-      "propertyFilters",
-      "profilePropertyRuleFilters"
-    );
+    await migration.sequelize.transaction(async () => {
+      await migration.renameTable("properties", "profilePropertyRules");
+      await migration.renameTable(
+        "propertyFilters",
+        "profilePropertyRuleFilters"
+      );
 
-    await migration.renameColumn(
-      "groupRules",
-      "propertyGuid",
-      "profilePropertyRuleGuid"
-    );
-    await migration.renameColumn(
-      "mappings",
-      "propertyGuid",
-      "profilePropertyRuleGuid"
-    );
-    await migration.renameColumn(
-      "profileProperties",
-      "propertyGuid",
-      "profilePropertyRuleGuid"
-    );
-    await migration.renameColumn(
-      "profilePropertyRuleFilters",
-      "propertyGuid",
-      "profilePropertyRuleGuid"
-    );
+      await migration.renameColumn(
+        "groupRules",
+        "propertyGuid",
+        "profilePropertyRuleGuid"
+      );
+      await migration.renameColumn(
+        "mappings",
+        "propertyGuid",
+        "profilePropertyRuleGuid"
+      );
+      await migration.renameColumn(
+        "profileProperties",
+        "propertyGuid",
+        "profilePropertyRuleGuid"
+      );
+      await migration.renameColumn(
+        "profilePropertyRuleFilters",
+        "propertyGuid",
+        "profilePropertyRuleGuid"
+      );
+    });
   },
 };

--- a/core/src/migrations/000057-renameGuidsWithIDs.ts
+++ b/core/src/migrations/000057-renameGuidsWithIDs.ts
@@ -31,26 +31,30 @@ const tables = {
 
 export default {
   up: async function (migration) {
-    for (const table in tables) {
-      await migration.renameColumn(table, "guid", "id");
-      const cols = tables[table];
-      for (const j in cols) {
-        const oldName = cols[j];
-        const newName = oldName.replace("Guid", "Id");
-        await migration.renameColumn(table, oldName, newName);
+    await migration.sequelize.transaction(async () => {
+      for (const table in tables) {
+        await migration.renameColumn(table, "guid", "id");
+        const cols = tables[table];
+        for (const j in cols) {
+          const oldName = cols[j];
+          const newName = oldName.replace("Guid", "Id");
+          await migration.renameColumn(table, oldName, newName);
+        }
       }
-    }
+    });
   },
 
   down: async function (migration) {
-    for (const table in tables) {
-      await migration.renameColumn(table, "id", "guid");
-      const cols = tables[table];
-      for (const j in cols) {
-        const newName = cols[j];
-        const oldName = newName.replace("Guid", "Id");
-        await migration.renameColumn(table, oldName, newName);
+    await migration.sequelize.transaction(async () => {
+      for (const table in tables) {
+        await migration.renameColumn(table, "id", "guid");
+        const cols = tables[table];
+        for (const j in cols) {
+          const newName = cols[j];
+          const oldName = newName.replace("Guid", "Id");
+          await migration.renameColumn(table, oldName, newName);
+        }
       }
-    }
+    });
   },
 };

--- a/core/src/migrations/000058-runDestinationId.ts
+++ b/core/src/migrations/000058-runDestinationId.ts
@@ -1,13 +1,17 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("runs", "destinationId", {
-      type: DataTypes.STRING(40),
-      allowNull: true,
-      defaultValue: null,
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("runs", "destinationId", {
+        type: DataTypes.STRING(40),
+        allowNull: true,
+        defaultValue: null,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("runs", "destinationId");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("runs", "destinationId");
+    });
   },
 };

--- a/core/src/migrations/000059-createSessions.ts
+++ b/core/src/migrations/000059-createSessions.ts
@@ -1,44 +1,48 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.createTable("sessions", {
-      id: {
-        type: DataTypes.STRING(40),
-        primaryKey: true,
-      },
+    await migration.sequelize.transaction(async () => {
+      await migration.createTable("sessions", {
+        id: {
+          type: DataTypes.STRING(40),
+          primaryKey: true,
+        },
 
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        createdAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
+        updatedAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
 
-      teamMemberId: {
-        type: DataTypes.STRING(191),
-        allowNull: false,
-      },
+        teamMemberId: {
+          type: DataTypes.STRING(191),
+          allowNull: false,
+        },
 
-      fingerprint: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-      },
+        fingerprint: {
+          type: DataTypes.TEXT,
+          allowNull: false,
+        },
 
-      expiresAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-      },
-    });
+        expiresAt: {
+          type: DataTypes.DATE,
+          allowNull: false,
+        },
+      });
 
-    await migration.addIndex("sessions", ["fingerprint"], {
-      unique: true,
-      fields: ["fingerprint"],
+      await migration.addIndex("sessions", ["fingerprint"], {
+        unique: true,
+        fields: ["fingerprint"],
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.dropTable("sessions");
+    await migration.sequelize.transaction(async () => {
+      await migration.dropTable("sessions");
+    });
   },
 };

--- a/core/src/migrations/000060-addTypeToOption.ts
+++ b/core/src/migrations/000060-addTypeToOption.ts
@@ -1,18 +1,22 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("options", "type", {
-      type: DataTypes.STRING,
-      allowNull: true,
-      defaultValue: "string",
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("options", "type", {
+        type: DataTypes.STRING,
+        allowNull: true,
+        defaultValue: "string",
+      });
 
-    await migration.changeColumn("options", "type", {
-      type: DataTypes.STRING,
-      allowNull: false,
+      await migration.changeColumn("options", "type", {
+        type: DataTypes.STRING,
+        allowNull: false,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("options", "type");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("options", "type");
+    });
   },
 };

--- a/core/src/migrations/000061-addImportStartedAt.ts
+++ b/core/src/migrations/000061-addImportStartedAt.ts
@@ -1,12 +1,16 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("imports", "startedAt", {
-      type: DataTypes.DATE,
-      allowNull: true,
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("imports", "startedAt", {
+        type: DataTypes.DATE,
+        allowNull: true,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("imports", "startedAt");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("imports", "startedAt");
+    });
   },
 };

--- a/core/src/migrations/000062-addProfilePropertiesStartedAt.ts
+++ b/core/src/migrations/000062-addProfilePropertiesStartedAt.ts
@@ -1,12 +1,16 @@
 export default {
   up: async function (migration, DataTypes) {
-    await migration.addColumn("profileProperties", "startedAt", {
-      type: DataTypes.DATE,
-      allowNull: true,
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("profileProperties", "startedAt", {
+        type: DataTypes.DATE,
+        allowNull: true,
+      });
     });
   },
 
   down: async function (migration) {
-    await migration.removeColumn("profileProperties", "startedAt");
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("profileProperties", "startedAt");
+    });
   },
 };


### PR DESCRIPTION
Setting up good migration hygiene - All migrations should be wrapped within a transaction.   This means that the whole migration will be committed as a unit (or not if part of it has a problem). 

```ts
export default {
  up: async function (migration, DataTypes) {
    await migration.sequelize.transaction(async () => {
      await migration.addColumn("options", "type", {
        type: DataTypes.STRING,
        allowNull: true,
        defaultValue: "string",
      });

      await migration.changeColumn("options", "type", {
        type: DataTypes.STRING,
        allowNull: false,
      });
    });
  },

  down: async function (migration) {
    await migration.sequelize.transaction(async () => {
      await migration.removeColumn("options", "type");
    });
  },
};
```