### PR TITLE
Do not fail tasks if primary objects cannot be found

### DIFF
--- a/core/__tests__/models/profile/profile.ts
+++ b/core/__tests__/models/profile/profile.ts
@@ -984,7 +984,7 @@ describe("models/profile", () => {
         "profile:destroyEvents"
       );
       expect(foundTasks.length).toBe(1);
-      expect(foundTasks[0].args[0].id).toBe(profile.id);
+      expect(foundTasks[0].args[0].profileId).toBe(profile.id);
     });
   });
 

--- a/core/__tests__/tasks/event/associateProfile.ts
+++ b/core/__tests__/tasks/event/associateProfile.ts
@@ -27,6 +27,12 @@ describe("tasks/event:associateProfile", () => {
       expect(foundTasks.length).toEqual(1);
     });
 
+    test("does not throw if the event cannot be found", async () => {
+      await specHelper.runTask("event:associateProfile", {
+        eventId: "missing",
+      });
+    });
+
     test("it will create a new profile from provided event data", async () => {
       const event = await helper.factories.event({
         anonymousId: "abc123",

--- a/core/__tests__/tasks/export/send.ts
+++ b/core/__tests__/tasks/export/send.ts
@@ -15,6 +15,21 @@ describe("tasks/export:send", () => {
     expect(found.length).toEqual(1);
   });
 
+  test("does not throw if the destination or export cannot be found", async () => {
+    await specHelper.runTask("export:send", {
+      destinationId: "missing",
+      exportId: "missing",
+    });
+
+    const destination = await helper.factories.destination();
+    await specHelper.runTask("export:send", {
+      destinationId: destination.id,
+      exportId: "missing",
+    });
+
+    await destination.destroy();
+  });
+
   describe("within an export workflow", () => {
     let destination: Destination, group: Group, profile: Profile, run: Run;
 

--- a/core/__tests__/tasks/export/sendBatch.ts
+++ b/core/__tests__/tasks/export/sendBatch.ts
@@ -15,6 +15,21 @@ describe("tasks/export:sendBatch", () => {
     expect(found.length).toEqual(1);
   });
 
+  test("does not throw if the destination or export cannot be found", async () => {
+    await specHelper.runTask("export:sendBatch", {
+      destinationId: "missing",
+      exportIds: ["missing"],
+    });
+
+    const destination = await helper.factories.destination();
+    await specHelper.runTask("export:send", {
+      destinationId: destination.id,
+      exportId: ["missing"],
+    });
+
+    await destination.destroy();
+  });
+
   describe("within an export workflow", () => {
     let destination: Destination, group: Group, profile: Profile, run: Run;
 

--- a/core/__tests__/tasks/group/run.ts
+++ b/core/__tests__/tasks/group/run.ts
@@ -67,6 +67,12 @@ describe("tasks/group:run", () => {
       await task.enqueue("group:run", { runId: "abc123" }); // does not throw
     });
 
+    test("does not throw if the run cannot be found", async () => {
+      await specHelper.runTask("group:run", {
+        runId: "missing",
+      });
+    });
+
     it("can create imports for profiles which should be added", async () => {
       let imports = [];
       await group.setRules([

--- a/core/__tests__/tasks/import/associateProfile.ts
+++ b/core/__tests__/tasks/import/associateProfile.ts
@@ -17,6 +17,12 @@ describe("tasks/import:associateProfile", () => {
       expect(found[0].timestamp).toBeNull();
     });
 
+    test("does not throw if the import cannot be found", async () => {
+      await specHelper.runTask("import:associateProfile", {
+        importId: "missing",
+      });
+    });
+
     test("it will create a new profile from provided import data and update the run if present", async () => {
       const run = await helper.factories.run();
 

--- a/core/__tests__/tasks/profile/destroyEvents.ts
+++ b/core/__tests__/tasks/profile/destroyEvents.ts
@@ -8,7 +8,7 @@ describe("tasks/profile:destroyEvents", () => {
 
   describe("profile:destroyEvents", () => {
     test("can be enqueued", async () => {
-      await task.enqueue("profile:destroyEvents", { id: "abc123" });
+      await task.enqueue("profile:destroyEvents", { profileId: "abc123" });
       const found = await specHelper.findEnqueuedTasks("profile:destroyEvents");
       expect(found.length).toEqual(1);
     });
@@ -22,7 +22,9 @@ describe("tasks/profile:destroyEvents", () => {
       let count = await Event.count();
       expect(count).toBe(2);
 
-      await specHelper.runTask("profile:destroyEvents", { id: profile.id });
+      await specHelper.runTask("profile:destroyEvents", {
+        profileId: profile.id,
+      });
 
       count = await Event.count();
       expect(count).toBe(1);

--- a/core/__tests__/tasks/profile/destroyEvents.ts
+++ b/core/__tests__/tasks/profile/destroyEvents.ts
@@ -13,6 +13,12 @@ describe("tasks/profile:destroyEvents", () => {
       expect(found.length).toEqual(1);
     });
 
+    test("does not throw if the profile cannot be found", async () => {
+      await specHelper.runTask("profile:destroyEvents", {
+        profileId: "missing",
+      });
+    });
+
     test("it will destroy the profile's events", async () => {
       const profile = await helper.factories.profile();
       const event = await helper.factories.event();

--- a/core/__tests__/tasks/profile/export.ts
+++ b/core/__tests__/tasks/profile/export.ts
@@ -22,6 +22,12 @@ describe("tasks/profile:export", () => {
       expect(found.length).toEqual(1);
     });
 
+    test("does not throw if the profile cannot be found", async () => {
+      await specHelper.runTask("profile:export", {
+        profileId: "missing",
+      });
+    });
+
     test("enqueuing more than one tasks for the same profile will de-duplicate", async () => {
       await task.enqueue("profile:export", { profileId: "abc123" });
       await task.enqueue("profile:export", { profileId: "abc123" });

--- a/core/__tests__/tasks/profileProperty/importProfileProperties.ts
+++ b/core/__tests__/tasks/profileProperty/importProfileProperties.ts
@@ -65,6 +65,28 @@ describe("tasks/profileProperty:importProfileProperties", () => {
       expect(found.length).toEqual(1);
     });
 
+    test("does not throw if the profile or property cannot be found", async () => {
+      const property = await Property.findOne();
+      const profile = await helper.factories.profile();
+
+      await specHelper.runTask("import:associateProfiles", {
+        profileIds: ["missing"],
+        propertyId: "missing",
+      });
+
+      await specHelper.runTask("import:associateProfiles", {
+        profileIds: [profile.id],
+        propertyId: "missing",
+      });
+
+      await specHelper.runTask("import:associateProfiles", {
+        profileIds: ["missing"],
+        propertyId: property.id,
+      });
+
+      await profile.destroy();
+    });
+
     test("will import profile properties that have no dependencies", async () => {
       const profile = await helper.factories.profile();
       await profile.addOrUpdateProperties({

--- a/core/__tests__/tasks/profileProperty/importProfileProperties.ts
+++ b/core/__tests__/tasks/profileProperty/importProfileProperties.ts
@@ -69,17 +69,17 @@ describe("tasks/profileProperty:importProfileProperties", () => {
       const property = await Property.findOne();
       const profile = await helper.factories.profile();
 
-      await specHelper.runTask("import:associateProfiles", {
+      await specHelper.runTask("profileProperty:importProfileProperties", {
         profileIds: ["missing"],
         propertyId: "missing",
       });
 
-      await specHelper.runTask("import:associateProfiles", {
+      await specHelper.runTask("profileProperty:importProfileProperties", {
         profileIds: [profile.id],
         propertyId: "missing",
       });
 
-      await specHelper.runTask("import:associateProfiles", {
+      await specHelper.runTask("profileProperty:importProfileProperties", {
         profileIds: ["missing"],
         propertyId: property.id,
       });

--- a/core/__tests__/tasks/profileProperty/importProfileProperty.ts
+++ b/core/__tests__/tasks/profileProperty/importProfileProperty.ts
@@ -23,17 +23,17 @@ describe("tasks/profileProperty:importProfileProperty", () => {
       const property = await Property.findOne();
       const profile = await helper.factories.profile();
 
-      await specHelper.runTask("import:associateProfiles", {
+      await specHelper.runTask("profileProperty:importProfileProperty", {
         profileId: "missing",
         propertyId: "missing",
       });
 
-      await specHelper.runTask("import:associateProfiles", {
+      await specHelper.runTask("profileProperty:importProfileProperty", {
         profileId: profile.id,
         propertyId: "missing",
       });
 
-      await specHelper.runTask("import:associateProfiles", {
+      await specHelper.runTask("profileProperty:importProfileProperty", {
         profileId: "missing",
         propertyId: property.id,
       });

--- a/core/__tests__/tasks/profileProperty/importProfileProperty.ts
+++ b/core/__tests__/tasks/profileProperty/importProfileProperty.ts
@@ -19,6 +19,28 @@ describe("tasks/profileProperty:importProfileProperty", () => {
       expect(found.length).toEqual(1);
     });
 
+    test("does not throw if the profile or property cannot be found", async () => {
+      const property = await Property.findOne();
+      const profile = await helper.factories.profile();
+
+      await specHelper.runTask("import:associateProfiles", {
+        profileId: "missing",
+        propertyId: "missing",
+      });
+
+      await specHelper.runTask("import:associateProfiles", {
+        profileId: profile.id,
+        propertyId: "missing",
+      });
+
+      await specHelper.runTask("import:associateProfiles", {
+        profileId: "missing",
+        propertyId: property.id,
+      });
+
+      await profile.destroy();
+    });
+
     test("will import profile properties that have no dependencies", async () => {
       const profile = await helper.factories.profile();
       await profile.addOrUpdateProperties({

--- a/core/__tests__/tasks/schedule/run.ts
+++ b/core/__tests__/tasks/schedule/run.ts
@@ -25,6 +25,12 @@ describe("tasks/schedule:run", () => {
       await task.enqueue("schedule:run", { runId: "12345" }); // does not throw
     });
 
+    test("does not throw if the run cannot be found", async () => {
+      await specHelper.runTask("schedule:run", {
+        runId: "missing",
+      });
+    });
+
     test("throws without a runId", async () => {
       await expect(
         task.enqueue("schedule:run", {

--- a/core/src/models/Profile.ts
+++ b/core/src/models/Profile.ts
@@ -247,7 +247,7 @@ export class Profile extends LoggedModel<Profile> {
   @AfterDestroy
   static async destroyEvents(instance: Profile) {
     await CLS.enqueueTask("profile:destroyEvents", {
-      id: instance.id,
+      profileId: instance.id,
     });
   }
 

--- a/core/src/tasks/event/associateProfile.ts
+++ b/core/src/tasks/event/associateProfile.ts
@@ -37,7 +37,8 @@ export class EventAssociateProfile extends Task {
     try {
       await CLS.wrap(
         async () => {
-          event = await Event.findById(eventId);
+          event = await Event.findOne({ where: { id: eventId } });
+          if (!event) return;
 
           const app = await App.findOne({ where: { type: "events" } });
           if (!app) return;

--- a/core/src/tasks/event/associateProfile.ts
+++ b/core/src/tasks/event/associateProfile.ts
@@ -37,7 +37,7 @@ export class EventAssociateProfile extends Task {
     try {
       await CLS.wrap(
         async () => {
-          event = await Event.findOne({ where: { id: eventId } });
+          event = await Event.scope(null).findOne({ where: { id: eventId } });
           if (!event) return;
 
           const app = await App.findOne({ where: { type: "events" } });

--- a/core/src/tasks/export/send.ts
+++ b/core/src/tasks/export/send.ts
@@ -17,12 +17,13 @@ export class ExportSend extends RetryableTask {
   }
 
   async runWithinTransaction(params) {
-    const destination = await Destination.findById(params.destinationId);
-    const _export = await Export.findById(params.exportId);
-    if (_export.completedAt) {
-      // be sure not to export twice
-      return;
-    }
+    const destination = await Destination.findOne({
+      where: { id: params.destinationId },
+    });
+    if (!destination) return;
+    const _export = await Export.findOne({ where: { id: params.exportId } });
+    if (!_export) return; // the export was deleted
+    if (_export.completedAt) return; // be sure not to export twice
 
     const { success, retryDelay, error } = await destination.sendExport(
       _export

--- a/core/src/tasks/export/send.ts
+++ b/core/src/tasks/export/send.ts
@@ -17,7 +17,7 @@ export class ExportSend extends RetryableTask {
   }
 
   async runWithinTransaction(params) {
-    const destination = await Destination.findOne({
+    const destination = await Destination.scope(null).findOne({
       where: { id: params.destinationId },
     });
     if (!destination) return;

--- a/core/src/tasks/export/sendBatch.ts
+++ b/core/src/tasks/export/sendBatch.ts
@@ -20,7 +20,7 @@ export class ExportSendBatches extends RetryableTask {
   async runWithinTransaction(params) {
     const destinationId: string = params.destinationId;
     const exportIds: string[] = params.exportIds;
-    const destination = await Destination.findOne({
+    const destination = await Destination.scope(null).findOne({
       where: { id: destinationId },
     });
     if (!destination) return;

--- a/core/src/tasks/export/sendBatch.ts
+++ b/core/src/tasks/export/sendBatch.ts
@@ -20,7 +20,10 @@ export class ExportSendBatches extends RetryableTask {
   async runWithinTransaction(params) {
     const destinationId: string = params.destinationId;
     const exportIds: string[] = params.exportIds;
-    const destination = await Destination.findById(params.destinationId);
+    const destination = await Destination.findOne({
+      where: { id: destinationId },
+    });
+    if (!destination) return;
 
     const _exports = await Export.findAll({
       where: {
@@ -30,9 +33,7 @@ export class ExportSendBatches extends RetryableTask {
       },
     });
 
-    if (_exports.length === 0) {
-      return;
-    }
+    if (_exports.length === 0) return;
 
     const {
       success,

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -25,10 +25,12 @@ export class RunGroup extends CLSTask {
     //    > Create imports for those profiles whose last update is older than the run's start time to remove them
     // 4. Delete any group members still hanging around from a pervious run that this run may have canceled
 
-    const run = await Run.findOne({ where: { id: params.runId } });
+    const run = await Run.scope(null).findOne({ where: { id: params.runId } });
     if (!run) return;
     if (run.state === "stopped") return;
-    const group = await Group.findOne({ where: { id: run.creatorId } });
+    const group = await Group.scope(null).findOne({
+      where: { id: run.creatorId },
+    });
     if (!group) return;
 
     const force = run.force || false;

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -25,9 +25,11 @@ export class RunGroup extends CLSTask {
     //    > Create imports for those profiles whose last update is older than the run's start time to remove them
     // 4. Delete any group members still hanging around from a pervious run that this run may have canceled
 
-    const run = await Run.findById(params.runId);
+    const run = await Run.findOne({ where: { id: params.runId } });
+    if (!run) return;
     if (run.state === "stopped") return;
-    const group = await Group.findById(run.creatorId);
+    const group = await Group.findOne({ where: { id: run.creatorId } });
+    if (!group) return;
 
     const force = run.force || false;
     const destinationId = run.destinationId;

--- a/core/src/tasks/import/associateProfile.ts
+++ b/core/src/tasks/import/associateProfile.ts
@@ -46,7 +46,7 @@ export class ImportAssociateProfile extends Task {
       );
     } catch (error) {
       if (env !== "test") log(`[ASSOCIATE PROFILE ERROR] ${error}`, "alert");
-      await _import.setError(error, this.name);
+      if (_import) await _import.setError(error, this.name);
     }
   }
 }

--- a/core/src/tasks/profile/destroyEvents.ts
+++ b/core/src/tasks/profile/destroyEvents.ts
@@ -9,19 +9,18 @@ export class ProfileDestroyEvents extends CLSTask {
     this.frequency = 0;
     this.queue = "events";
     this.inputs = {
-      id: { required: true },
+      profileId: { required: true },
     };
   }
 
   async runWithinTransaction(params) {
-    const { id } = params;
     const limit = 1000;
     let offset = 0;
     let events: Event[] = [];
 
     while (events.length > 0 || offset === 0) {
       events = await Event.findAll({
-        where: { profileId: id },
+        where: { profileId: params.profileId },
         limit,
         offset,
       });

--- a/core/src/tasks/profile/export.ts
+++ b/core/src/tasks/profile/export.ts
@@ -25,8 +25,7 @@ export class ProfileExport extends RetryableTask {
       where: { id: params.profileId },
     });
 
-    // the profile may have been deleted or merged by the time this task ran
-    if (!profile) return;
+    if (!profile) return; // the profile may have been deleted or merged by the time this task ran
     if (profile.state !== "ready") return;
 
     const imports = await Import.findAll({

--- a/core/src/tasks/schedule/run.ts
+++ b/core/src/tasks/schedule/run.ts
@@ -15,7 +15,8 @@ export class ScheduleRun extends RetryableTask {
   }
 
   async runWithinTransaction(params) {
-    const run = await Run.findById(params.runId);
+    const run = await Run.findOne({ where: { id: params.runId } });
+    if (!run) return;
 
     const schedule = await Schedule.findOne({
       where: { id: run.creatorId },

--- a/core/src/tasks/schedule/run.ts
+++ b/core/src/tasks/schedule/run.ts
@@ -15,7 +15,7 @@ export class ScheduleRun extends RetryableTask {
   }
 
   async runWithinTransaction(params) {
-    const run = await Run.findOne({ where: { id: params.runId } });
+    const run = await Run.scope(null).findOne({ where: { id: params.runId } });
     if (!run) return;
 
     const schedule = await Schedule.findOne({


### PR DESCRIPTION
This PR relaxes many of Grouparoo's tasks so that if the primary object the task is operating on cannot be found, the task exits gracefully.  For example, before this PR if `export:send` was passed an export that was no longer present (because the destination was deleted) the task would fail and present as a failure within the resque dashboard.