### PR TITLE
`export:enqueue` should not re-attempt to send complete exports

### DIFF
--- a/core/__tests__/tasks/export/enqueue.ts
+++ b/core/__tests__/tasks/export/enqueue.ts
@@ -18,8 +18,10 @@ describe("tasks/export:enqueue", () => {
       pendingExportB: Export,
       recentStartedExport: Export,
       stuckStartedExport: Export,
-      completeExport: Export,
-      errorExport: Export,
+      newCompleteExport: Export,
+      oldCompleteExport: Export,
+      newErrorExport: Export,
+      oldErrorExport: Export,
       infoExport: Export;
 
     beforeEach(async () => {
@@ -67,7 +69,7 @@ describe("tasks/export:enqueue", () => {
         startedAt: new Date(0),
       });
 
-      completeExport = await Export.create({
+      newCompleteExport = await Export.create({
         profileId: profile.id,
         destinationId: destination.id,
         oldProfileProperties: {},
@@ -78,7 +80,18 @@ describe("tasks/export:enqueue", () => {
         completedAt: new Date(),
       });
 
-      errorExport = await Export.create({
+      oldCompleteExport = await Export.create({
+        profileId: profile.id,
+        destinationId: destination.id,
+        oldProfileProperties: {},
+        newProfileProperties: {},
+        newGroups: [],
+        oldGroups: [],
+        startedAt: new Date(0),
+        completedAt: new Date(1),
+      });
+
+      newErrorExport = await Export.create({
         profileId: profile.id,
         destinationId: destination.id,
         oldProfileProperties: {},
@@ -86,6 +99,18 @@ describe("tasks/export:enqueue", () => {
         newGroups: [],
         oldGroups: [],
         startedAt: new Date(),
+        errorMessage: "Oh No!",
+        errorLevel: "error",
+      });
+
+      oldErrorExport = await Export.create({
+        profileId: profile.id,
+        destinationId: destination.id,
+        oldProfileProperties: {},
+        newProfileProperties: {},
+        newGroups: [],
+        oldGroups: [],
+        startedAt: new Date(0),
         errorMessage: "Oh No!",
         errorLevel: "error",
       });
@@ -128,8 +153,14 @@ describe("tasks/export:enqueue", () => {
       expect(foundTasks[0].args[0].exportIds).not.toContain(
         recentStartedExport.id
       );
-      expect(foundTasks[0].args[0].exportIds).not.toContain(completeExport.id);
-      expect(foundTasks[0].args[0].exportIds).not.toContain(errorExport.id);
+      expect(foundTasks[0].args[0].exportIds).not.toContain(
+        newCompleteExport.id
+      );
+      expect(foundTasks[0].args[0].exportIds).not.toContain(
+        oldCompleteExport.id
+      );
+      expect(foundTasks[0].args[0].exportIds).not.toContain(newErrorExport.id);
+      expect(foundTasks[0].args[0].exportIds).not.toContain(oldErrorExport.id);
       expect(foundTasks[0].args[0].exportIds).not.toContain(infoExport.id);
     });
 

--- a/core/__tests__/tasks/export/enqueue.ts
+++ b/core/__tests__/tasks/export/enqueue.ts
@@ -146,22 +146,18 @@ describe("tasks/export:enqueue", () => {
 
       const foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
       expect(foundTasks.length).toBe(1);
-      expect(foundTasks[0].args[0].exportIds.length).toBe(3);
-      expect(foundTasks[0].args[0].exportIds).toContain(pendingExportA.id);
-      expect(foundTasks[0].args[0].exportIds).toContain(pendingExportB.id);
-      expect(foundTasks[0].args[0].exportIds).toContain(stuckStartedExport.id);
-      expect(foundTasks[0].args[0].exportIds).not.toContain(
-        recentStartedExport.id
-      );
-      expect(foundTasks[0].args[0].exportIds).not.toContain(
-        newCompleteExport.id
-      );
-      expect(foundTasks[0].args[0].exportIds).not.toContain(
-        oldCompleteExport.id
-      );
-      expect(foundTasks[0].args[0].exportIds).not.toContain(newErrorExport.id);
-      expect(foundTasks[0].args[0].exportIds).not.toContain(oldErrorExport.id);
-      expect(foundTasks[0].args[0].exportIds).not.toContain(infoExport.id);
+      const exportIds = foundTasks[0].args[0].exportIds;
+
+      expect(exportIds.length).toBe(3);
+      expect(exportIds).toContain(pendingExportA.id);
+      expect(exportIds).toContain(pendingExportB.id);
+      expect(exportIds).toContain(stuckStartedExport.id);
+      expect(exportIds).not.toContain(recentStartedExport.id);
+      expect(exportIds).not.toContain(newCompleteExport.id);
+      expect(exportIds).not.toContain(oldCompleteExport.id);
+      expect(exportIds).not.toContain(newErrorExport.id);
+      expect(exportIds).not.toContain(oldErrorExport.id);
+      expect(exportIds).not.toContain(infoExport.id);
     });
 
     test("checking again will find no results as the exports should have a startedAt", async () => {

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -507,11 +507,10 @@ export namespace DestinationOps {
     for (const _export of givenExports) {
       // TODO: maybe should recalcuate hasChanges and from current mostRecent
       if (!_export.hasChanges) {
-        // do not include exports with hasChanges=false
-        await _export.completeAndMarkMostRecent();
-        continue;
+        await _export.completeAndMarkMostRecent(); // do not include exports with hasChanges=false
+      } else {
+        _exports.push(_export);
       }
-      _exports.push(_export);
     }
 
     const exportProfiles: ExportProfilesPluginMethod = await getBatchFunction(
@@ -527,9 +526,7 @@ export namespace DestinationOps {
     const parallelismOk = await app.checkAndUpdateParallelism("incr");
     if (!parallelismOk) {
       const error = new Error(`parallelism limit reached for ${app.type}`);
-      if (synchronous) {
-        throw error;
-      }
+      if (synchronous) throw error;
       return {
         success: false,
         error,

--- a/core/src/modules/ops/export.ts
+++ b/core/src/modules/ops/export.ts
@@ -106,6 +106,8 @@ export namespace ExportOps {
 
     _exports = await Export.findAll({
       where: {
+        completedAt: null,
+        errorMessage: null,
         startedAt: {
           [Op.or]: [null, { [Op.lt]: new Date().getTime() - delayMs }],
         },


### PR DESCRIPTION
This PR prevents a bug in which old, already-sent exports were constantly being re-considered to be sent by the `export:enqueue` task.   The effect of this was an ever-changing `export.startedAt` timestamps for all complete exports.