### PR TITLE
`export:send` tasks should not rollback transaction if there's a returned error

### DIFF
--- a/core/__tests__/models/destination/plugins/exportProfile.ts
+++ b/core/__tests__/models/destination/plugins/exportProfile.ts
@@ -638,7 +638,7 @@ describe("models/destination", () => {
       expect(foundSendTasks[1].timestamp).toBeGreaterThan(new Date().getTime());
 
       await _export.reload();
-      expect(_export.completedAt).toBeFalsy();
+      expect(_export.startedAt).not.toBeFalsy();
       expect(_export.errorMessage).toMatch(/oh no!/);
       expect(_export.errorLevel).toBe("error");
       expect(_export.completedAt).toBeFalsy();

--- a/core/__tests__/tasks/export/send.ts
+++ b/core/__tests__/tasks/export/send.ts
@@ -1,6 +1,14 @@
 import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
 import { api, task, specHelper } from "actionhero";
-import { Profile, Group, Destination, Export, Run } from "../../../src";
+import {
+  Profile,
+  Group,
+  Destination,
+  Export,
+  Run,
+  App,
+  plugin,
+} from "../../../src";
 
 describe("tasks/export:send", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -106,6 +114,184 @@ describe("tasks/export:send", () => {
       expect(_exports.length).toBe(1);
       expect(_exports[0].startedAt).toBeTruthy();
       expect(_exports[0].completedAt).toBeTruthy();
+    });
+
+    describe("with custom destination", () => {
+      let app: App;
+      let destination: Destination;
+
+      let exportProfileResponse = {
+        success: true,
+        error: undefined,
+        retryDelay: undefined,
+      };
+
+      beforeAll(async () => {
+        plugin.registerPlugin({
+          name: "test-export-plugin",
+          apps: [
+            {
+              name: "test-template-app",
+              options: [{ key: "test_key", required: true }],
+              methods: {
+                test: async () => {
+                  return { success: true };
+                },
+              },
+            },
+          ],
+          connections: [
+            {
+              name: "export-from-test-app",
+              description: "a test app connection",
+              app: "test-template-app",
+              direction: "export",
+              options: [],
+              methods: {
+                destinationMappingOptions: async () => {
+                  return {
+                    labels: {
+                      group: {
+                        singular: "list",
+                        plural: "lists",
+                      },
+                      property: {
+                        singular: "var",
+                        plural: "vars",
+                      },
+                    },
+                    properties: {
+                      required: [],
+                      known: [],
+                      allowOptionalFromProperties: true,
+                    },
+                  };
+                },
+                exportArrayProperties: async () => [],
+                exportProfile: async () => {
+                  return exportProfileResponse;
+                },
+              },
+            },
+          ],
+        });
+
+        app = await App.create({
+          name: "test with real methods",
+          type: "test-template-app",
+        });
+        await app.setOptions({ test_key: "abc" });
+        await app.update({ state: "ready" });
+
+        destination = await Destination.create({
+          name: "test plugin destination",
+          type: "export-from-test-app",
+          appId: app.id,
+        });
+        await destination.update({ state: "ready" });
+        await destination.trackGroup(group);
+      });
+
+      beforeEach(async () => {
+        await Export.truncate();
+        await api.resque.queue.connection.redis.flushdb();
+      });
+
+      test("if the export succeeds, the task will not be enqueued and the export will be marked as complete", async () => {
+        // this export will succeed
+        exportProfileResponse = {
+          success: true,
+          error: null,
+          retryDelay: null,
+        };
+
+        await destination.exportProfile(profile);
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
+
+        await specHelper.runTask("export:enqueue", {});
+        let foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundSendTasks.length).toBe(1);
+
+        await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
+
+        // the task should not be re-enqueued
+        foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundSendTasks.length).toBe(1); // the original one
+
+        // the export should be complete
+        await _export.reload();
+        expect(_export.startedAt).not.toBeFalsy();
+        expect(_export.errorMessage).toBeNull();
+        expect(_export.errorLevel).toBeNull();
+        expect(_export.completedAt).not.toBeFalsy();
+      });
+
+      test("if the export fails with a retryDelay, the task will be re-enqueued and the export will have the error message appended", async () => {
+        // this export will fail
+        exportProfileResponse = {
+          success: false,
+          error: new Error("oh no!"),
+          retryDelay: 1000 * 5,
+        };
+
+        await destination.exportProfile(profile);
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
+
+        await specHelper.runTask("export:enqueue", {});
+        let foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundSendTasks.length).toBe(1);
+
+        await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
+
+        // the task should be re-enqueued
+        foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundSendTasks.length).toBe(1 + 1);
+        expect(foundSendTasks[1].timestamp).toBeGreaterThan(
+          new Date().getTime()
+        );
+
+        // the export should be marked with the error
+        await _export.reload();
+        expect(_export.startedAt).not.toBeFalsy();
+        expect(_export.errorMessage).toMatch(/oh no!/);
+        expect(_export.errorLevel).toBe("error");
+        expect(_export.completedAt).toBeFalsy();
+      });
+
+      test("if the export fails without a retryDelay, the task will be re-enqueued and the export will have the error message appended", async () => {
+        // this export will fail
+        exportProfileResponse = {
+          success: false,
+          error: new Error("oh no!"),
+          retryDelay: null,
+        };
+
+        await destination.exportProfile(profile);
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
+
+        await specHelper.runTask("export:enqueue", {});
+        let foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundSendTasks.length).toBe(1);
+
+        await expect(
+          specHelper.runFullTask("export:send", foundSendTasks[0].args[0])
+        ).rejects.toThrow(
+          /error exporting 1 profiles to destination test plugin destination/
+        ); // throw === retry in real system
+
+        // the export should be marked with the error
+        await _export.reload();
+        expect(_export.startedAt).not.toBeFalsy();
+        expect(_export.errorMessage).toMatch(/oh no!/);
+        expect(_export.errorLevel).toBe("error");
+        expect(_export.completedAt).toBeFalsy();
+      });
     });
   });
 });

--- a/core/__tests__/tasks/export/sendBatch.ts
+++ b/core/__tests__/tasks/export/sendBatch.ts
@@ -1,6 +1,14 @@
 import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
 import { api, task, specHelper } from "actionhero";
-import { Profile, Group, Destination, Export, Run } from "../../../src";
+import {
+  Profile,
+  Group,
+  Destination,
+  Export,
+  Run,
+  App,
+  plugin,
+} from "../../../src";
 
 describe("tasks/export:sendBatch", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -22,9 +30,9 @@ describe("tasks/export:sendBatch", () => {
     });
 
     const destination = await helper.factories.destination();
-    await specHelper.runTask("export:send", {
+    await specHelper.runTask("export:sendBatch", {
       destinationId: destination.id,
-      exportId: ["missing"],
+      exportIds: ["missing"],
     });
 
     await destination.destroy();
@@ -117,6 +125,194 @@ describe("tasks/export:sendBatch", () => {
       expect(_exports.length).toBe(1);
       expect(_exports[0].startedAt).toBeTruthy();
       expect(_exports[0].completedAt).toBeTruthy();
+    });
+
+    describe("with custom destination", () => {
+      let app: App;
+      let destination: Destination;
+
+      let exportProfilesResponse = {
+        success: true,
+        errors: undefined,
+        retryDelay: undefined,
+      };
+
+      beforeAll(async () => {
+        plugin.registerPlugin({
+          name: "test-export-plugin",
+          apps: [
+            {
+              name: "test-template-app",
+              options: [{ key: "test_key", required: true }],
+              methods: {
+                test: async () => {
+                  return { success: true };
+                },
+              },
+            },
+          ],
+          connections: [
+            {
+              name: "export-from-test-app",
+              description: "a test app connection",
+              app: "test-template-app",
+              direction: "export",
+              options: [],
+              methods: {
+                destinationMappingOptions: async () => {
+                  return {
+                    labels: {
+                      group: {
+                        singular: "list",
+                        plural: "lists",
+                      },
+                      property: {
+                        singular: "var",
+                        plural: "vars",
+                      },
+                    },
+                    properties: {
+                      required: [],
+                      known: [],
+                      allowOptionalFromProperties: true,
+                    },
+                  };
+                },
+                exportArrayProperties: async () => [],
+                exportProfiles: async () => {
+                  return exportProfilesResponse;
+                },
+              },
+            },
+          ],
+        });
+
+        app = await App.create({
+          name: "test with real methods",
+          type: "test-template-app",
+        });
+        await app.setOptions({ test_key: "abc" });
+        await app.update({ state: "ready" });
+
+        destination = await Destination.create({
+          name: "test plugin destination",
+          type: "export-from-test-app",
+          appId: app.id,
+        });
+        await destination.update({ state: "ready" });
+        await destination.trackGroup(group);
+      });
+
+      beforeEach(async () => {
+        await Export.truncate();
+        await api.resque.queue.connection.redis.flushdb();
+      });
+
+      test("if the export succeeds, the task will not be enqueued and the export will be marked as complete", async () => {
+        // this export will succeed
+        exportProfilesResponse = {
+          success: true,
+          errors: null,
+          retryDelay: null,
+        };
+
+        await destination.exportProfile(profile);
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
+
+        await specHelper.runTask("export:enqueue", {});
+        let foundSendTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+        expect(foundSendTasks.length).toBe(1);
+
+        await specHelper.runTask("export:sendBatch", foundSendTasks[0].args[0]);
+
+        // the task should not be re-enqueued
+        foundSendTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
+        expect(foundSendTasks.length).toBe(1); // the original one
+
+        // the export should be complete
+        await _export.reload();
+        expect(_export.startedAt).not.toBeFalsy();
+        expect(_export.errorMessage).toBeNull();
+        expect(_export.errorLevel).toBeNull();
+        expect(_export.completedAt).not.toBeFalsy();
+      });
+
+      test("if the export fails with a retryDelay, the task will be re-enqueued and the export will have the error message appended", async () => {
+        // this export will fail
+        const error = new Error("oh no!");
+        error["profileId"] = profile.id;
+        exportProfilesResponse = {
+          success: false,
+          errors: [error],
+          retryDelay: 1000 * 5,
+        };
+
+        await destination.exportProfile(profile);
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
+
+        await specHelper.runTask("export:enqueue", {});
+        let foundSendTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+        expect(foundSendTasks.length).toBe(1);
+
+        await specHelper.runTask("export:sendBatch", foundSendTasks[0].args[0]);
+
+        // the task should be re-enqueued
+        foundSendTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
+        expect(foundSendTasks.length).toBe(1 + 1);
+        expect(foundSendTasks[1].timestamp).toBeGreaterThan(
+          new Date().getTime()
+        );
+
+        // the export should be marked with the error
+        await _export.reload();
+        expect(_export.startedAt).not.toBeFalsy();
+        expect(_export.errorMessage).toMatch(/oh no!/);
+        expect(_export.errorLevel).toBe("error");
+        expect(_export.completedAt).toBeFalsy();
+      });
+
+      test("if the export fails without a retryDelay, the task will be re-enqueued and the export will have the error message appended", async () => {
+        // this export will fail
+        const error = new Error("oh no!");
+        error["profileId"] = profile.id;
+        exportProfilesResponse = {
+          success: false,
+          errors: [error],
+          retryDelay: null,
+        };
+
+        await destination.exportProfile(profile);
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
+
+        await specHelper.runTask("export:enqueue", {});
+        let foundSendTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+        expect(foundSendTasks.length).toBe(1);
+
+        await expect(
+          specHelper.runFullTask("export:sendBatch", foundSendTasks[0].args[0])
+        ).rejects.toThrow(
+          /error exporting 1 profiles to destination test plugin destination/
+        ); // throw === retry in real system
+
+        // the export should be marked with the error
+        await _export.reload();
+        expect(_export.startedAt).not.toBeFalsy();
+        expect(_export.errorMessage).toMatch(/oh no!/);
+        expect(_export.errorLevel).toBe("error");
+        expect(_export.completedAt).toBeFalsy();
+      });
     });
   });
 });

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -153,9 +153,7 @@ export class Export extends Model {
 
   async setError(error: Error) {
     this.errorMessage = error.message || error.toString();
-    if (error["errorLevel"]) {
-      this.errorLevel = error["errorLevel"];
-    }
+    if (error["errorLevel"]) this.errorLevel = error["errorLevel"];
     await this.save();
   }
 

--- a/core/src/tasks/export/send.ts
+++ b/core/src/tasks/export/send.ts
@@ -1,9 +1,12 @@
-import { RetryableTask } from "../../classes/tasks/retryableTask";
+import { Task } from "actionhero";
 import { Destination } from "../../models/Destination";
 import { Export } from "../../models/Export";
+import { App } from "../../models/App";
+import { DestinationOps } from "../../modules/ops/destination";
 import { CLS } from "../../modules/cls";
+import { AsyncReturnType } from "type-fest";
 
-export class ExportSend extends RetryableTask {
+export class ExportSend extends Task {
   constructor() {
     super();
     this.name = "export:send";
@@ -16,31 +19,35 @@ export class ExportSend extends RetryableTask {
     };
   }
 
-  async runWithinTransaction(params) {
-    const destination = await Destination.scope(null).findOne({
-      where: { id: params.destinationId },
+  async run(params) {
+    let response: AsyncReturnType<typeof DestinationOps["sendExport"]>;
+    let app: App;
+
+    await CLS.wrap(async () => {
+      const destination = await Destination.scope(null).findOne({
+        where: { id: params.destinationId },
+      });
+      if (!destination) return;
+      app = await destination.$get("app");
+      const _export = await Export.findOne({
+        where: { id: params.exportId },
+      });
+      if (!_export) return; // the export was deleted
+      if (_export.completedAt) return; // be sure not to export twice
+
+      response = await destination.sendExport(_export);
     });
-    if (!destination) return;
-    const _export = await Export.findOne({ where: { id: params.exportId } });
-    if (!_export) return; // the export was deleted
-    if (_export.completedAt) return; // be sure not to export twice
 
-    const { success, retryDelay, error } = await destination.sendExport(
-      _export
-    );
-
-    if (!success) {
-      if (retryDelay) {
-        const app = await destination.$get("app");
+    if (!response.success) {
+      if (response.retryDelay) {
         return CLS.enqueueTaskIn(
-          retryDelay,
+          response.retryDelay,
           "export:send",
           params,
           `exports:${app.type}`
         );
       } else {
-        // auto retry
-        throw error;
+        throw response.error; // auto retry
       }
     }
   }

--- a/core/src/tasks/export/send.ts
+++ b/core/src/tasks/export/send.ts
@@ -38,6 +38,8 @@ export class ExportSend extends Task {
       response = await destination.sendExport(_export);
     });
 
+    if (!response) return; // we exited early
+
     if (!response.success) {
       if (response.retryDelay) {
         return CLS.enqueueTaskIn(

--- a/core/src/tasks/export/sendBatch.ts
+++ b/core/src/tasks/export/sendBatch.ts
@@ -1,10 +1,13 @@
-import { RetryableTask } from "../../classes/tasks/retryableTask";
+import { Task } from "actionhero";
 import { Destination } from "../../models/Destination";
 import { Export } from "../../models/Export";
+import { App } from "../../models/App";
 import { Op } from "sequelize";
+import { DestinationOps } from "../../modules/ops/destination";
 import { CLS } from "../../modules/cls";
+import { AsyncReturnType } from "type-fest";
 
-export class ExportSendBatches extends RetryableTask {
+export class ExportSendBatches extends Task {
   constructor() {
     super();
     this.name = "export:sendBatch";
@@ -17,57 +20,57 @@ export class ExportSendBatches extends RetryableTask {
     };
   }
 
-  async runWithinTransaction(params) {
+  async run(params) {
     const destinationId: string = params.destinationId;
     const exportIds: string[] = params.exportIds;
-    const destination = await Destination.scope(null).findOne({
-      where: { id: destinationId },
+    let _exports: Export[] = [];
+    let response: AsyncReturnType<typeof DestinationOps["sendExports"]>;
+    let app: App;
+
+    await CLS.wrap(async () => {
+      const destination = await Destination.scope(null).findOne({
+        where: { id: destinationId },
+      });
+      if (!destination) return;
+      app = await destination.$get("app");
+
+      _exports = await Export.findAll({
+        where: {
+          destinationId,
+          completedAt: null, // be sure not to export twice
+          id: { [Op.in]: exportIds },
+        },
+      });
+
+      if (_exports.length === 0) return;
+
+      response = await destination.sendExports(_exports);
     });
-    if (!destination) return;
 
-    const _exports = await Export.findAll({
-      where: {
-        destinationId,
-        completedAt: null, // be sure not to export twice
-        id: { [Op.in]: exportIds },
-      },
-    });
-
-    if (_exports.length === 0) return;
-
-    const {
-      success,
-      error,
-      retryDelay,
-      retryexportIds,
-    } = await destination.sendExports(_exports);
-
-    if (!success) {
-      const app = await destination.$get("app");
-      if (retryexportIds.length === _exports.length) {
+    if (!response.success) {
+      if (response.retryexportIds.length === _exports.length) {
         // all failed!
-        if (retryDelay) {
+        if (response.retryDelay) {
           return CLS.enqueueTaskIn(
-            retryDelay,
+            response.retryDelay,
             "export:sendBatch",
             params,
             `exports:${app.type}`
           );
         } else {
-          // auto retry
           // RESILIENCE: maybe we should split this in half or something, down to 1
-          throw error;
+          throw response.error; // auto retry
         }
       } else {
         // some of them succeeded
         // RESILIENCE: maybe we should split this in half or something, down to 1
         const newParams = {
           destinationId: params.destinationId,
-          exportIds: retryexportIds,
+          exportIds: response.retryexportIds,
         };
         const strategy = this.pluginOptions?.Retry?.backoffStrategy;
         const backoff = strategy ? strategy[0] : undefined;
-        const when = retryDelay || backoff || 1000;
+        const when = response.retryDelay || backoff || 1000;
         return CLS.enqueueTaskIn(
           when,
           "export:sendBatch",

--- a/core/src/tasks/export/sendBatch.ts
+++ b/core/src/tasks/export/sendBatch.ts
@@ -47,6 +47,8 @@ export class ExportSendBatches extends Task {
       response = await destination.sendExports(_exports);
     });
 
+    if (!response) return; // we exited early
+
     if (!response.success) {
       if (response.retryexportIds.length === _exports.length) {
         // all failed!

--- a/plugins/@grouparoo/iterable/src/lib/export/exportProfile.ts
+++ b/plugins/@grouparoo/iterable/src/lib/export/exportProfile.ts
@@ -17,7 +17,6 @@ export const exportProfile: ExportProfilePluginMethod = async (args) => {
 export const sendProfile: ExportProfilePluginMethod = async ({
   appId,
   appOptions,
-  destinationOptions,
   export: {
     toDelete,
     newProfileProperties,
@@ -29,6 +28,7 @@ export const sendProfile: ExportProfilePluginMethod = async ({
   if (Object.keys(newProfileProperties).length === 0) {
     return { success: true };
   }
+
   const client = await connect(appOptions);
   const email = newProfileProperties["email"]; // this is how we will identify profiles
   const currentEmail = oldProfileProperties["email"];
@@ -116,12 +116,4 @@ function formatVar(value) {
   } else {
     return value;
   }
-}
-
-async function getUser(client, email): Promise<any> {
-  const userResponse = await client.users.get({ email });
-  if ("user" in userResponse) {
-    return userResponse.user;
-  }
-  return null;
 }


### PR DESCRIPTION
The two tasks that send the exports to destinations, `export:send` and `exports:sendBatch` previously were wrapped entirely in a transaction, and would eventually `throw` any error we got back from the destination to retry the task. 
However, with our new transaction safety, that `throw` would rollback any changes that occurred in the task - most specifically the error messages would not be appended to the Export! 

This had the negative side-effect of exports which should be marked as failed being retried over and over again as they were found again by `export:enqueue` after N minutes (introduced in https://github.com/grouparoo/grouparoo/pull/1529). 