### PR TITLE
Migrator Fixes

### DIFF
--- a/core/bin/migrator
+++ b/core/bin/migrator
@@ -6,6 +6,7 @@
  */
 
 const path = require("path");
+const fs = require("fs");
 const { Sequelize } = require("sequelize-typescript");
 const { Umzug, SequelizeStorage } = require("umzug");
 
@@ -14,6 +15,20 @@ const direction = args[0];
 const migrationName = args[1];
 
 function validateInputs() {
+  if (!process.env.INIT_CWD) process.env.INIT_CWD = process.env.PWD;
+  const relativeCorePath = path.join(
+    process.env.INIT_CWD,
+    "node_modules",
+    "@grouparoo",
+    "core"
+  );
+  if (fs.existsSync(relativeCorePath)) {
+    console.info(`running migrator in ${process.env.INIT_CWD}\r\n`);
+    process.chdir(relativeCorePath);
+  } else {
+    console.info(`running migrator in core\r\n`);
+  }
+
   if (!direction) return completeProcess(`direction is required (up or down)`);
   if (!["up", "down"].includes(direction))
     return completeProcess(`invalid direction ${direction}`);

--- a/core/bin/migrator
+++ b/core/bin/migrator
@@ -1,8 +1,8 @@
-#!node_modules/.bin/ts-node-script
+#!/usr/bin/env node
 
 /**
  * Run me as if I were a bash program eg: `./bin/migrator up [name]` or `./bin/migrator down <name>}`
- * I need to be run from the working directory of `grouparoo/core` (not within bin), as I'm using a relative shebang for ts_node
+ * I run the **compiled** migrations (eg: dist).  You may want to `npm run watch` for changes as you run me.
  */
 
 const path = require("path");
@@ -13,20 +13,24 @@ const args = process.argv.slice(2);
 const direction = args[0];
 const migrationName = args[1];
 
-if (!direction) completeProcess(`direction is required (up or down)`);
-if (!["up", "down"].includes(direction))
-  completeProcess(`invalid direction ${direction}`);
-if (direction === "down" && !migrationName)
-  completeProcess(`migrationName is required`);
+function validateInputs() {
+  if (!direction) return completeProcess(`direction is required (up or down)`);
+  if (!["up", "down"].includes(direction))
+    return completeProcess(`invalid direction ${direction}`);
+  if (direction === "down" && !migrationName)
+    return completeProcess(`migrationName is required`);
+}
 
 async function main() {
+  validateInputs();
+
   const env = process.env.NODE_ENV || "development";
   const configFile = path.resolve(
     __dirname,
     "..",
-    "src",
+    "dist",
     "config",
-    "sequelize.ts"
+    "sequelize.js"
   );
   const CONFIG = Object.assign({}, require(configFile)[env], {
     autoMigrate: false,


### PR DESCRIPTION
This PR fixes the problems noted by @pedroslopez in https://github.com/grouparoo/grouparoo/pull/1631#issuecomment-817847115

1. The `migrator` command is a node command, not a `ts-node` command.  This will make it possible to run in any directory as we can use the system's already loaded `node` process and not have find the `ts-node` command (which may be relative or local).  The downside of this is that we are now going to run the compiled (`dist`) migrations from core.  That said, we were always running the plugins' `dist` migrations, so now everyone matches. 
2. The `migrator` command can now be run within the apps inside the monorepo.  We accomplish this by properly setting `process.env.INIT_CWD` to be the working directory the command is started from (emulating how `npm` does it).  This means the command should work like this:

```
# Navigate to the `staging-enterprise` repo

$ ../../core/bin/migrator up
running migrator in /Users/evan/workspace/grouparoo/grouparoo/apps/staging-enterprise

== 000062-addProfilePropertiesStartedAt: migrating =======
000062-addProfilePropertiesStartedAt migrating
Executing (f25d7b9a-7d45-49ce-a42b-8b1cadc50990): START TRANSACTION;
Executing (f25d7b9a-7d45-49ce-a42b-8b1cadc50990): ALTER TABLE "public"."profileProperties" ADD COLUMN "startedAt" TIMESTAMP WITH TIME ZONE;
Executing (f25d7b9a-7d45-49ce-a42b-8b1cadc50990): COMMIT;
== 000062-addProfilePropertiesStartedAt: migrated (0.010s)

000062-addProfilePropertiesStartedAt migrated
✅ Done
```