### PR TITLE
Re-apply `type` when code-configuring

### DIFF
--- a/core/__tests__/fixtures/codeConfig/error-changed-type-duplicate/config.js
+++ b/core/__tests__/fixtures/codeConfig/error-changed-type-duplicate/config.js
@@ -1,0 +1,174 @@
+module.exports = async function getConfig() {
+  return [
+    {
+      id: "setting_cluster_name", // this is actually ignored
+      class: "Setting",
+      pluginName: "core",
+      key: "cluster-name",
+      value: "Test Cluster",
+    },
+
+    {
+      id: "data_warehouse", // id -> `data_warehouse`
+      name: "Data Warehouse",
+      class: "App",
+      type: "manual",
+      options: {},
+    },
+
+    {
+      id: "events", // id -> `events`
+      name: "Grouparoo Events",
+      class: "App",
+      type: "events",
+      options: {
+        identifyingPropertyId: "user_id",
+      },
+    },
+
+    {
+      id: "users_table", // id -> `data_warehouse`
+      name: "Users Table",
+      class: "Source",
+      type: "test-plugin-import",
+      appId: "data_warehouse", // appId -> `data_warehouse`
+      options: {
+        table: "users",
+      },
+      mapping: {
+        id: "user_id",
+      },
+      bootstrappedProperty: {
+        name: "userId",
+        type: "integer",
+        id: "user_id", // id -> `user_id`
+        options: {
+          column: "id",
+        },
+      },
+    },
+
+    {
+      id: "users_table_schedule", // id -> `sch_users_table_schedule`
+      name: "Users Table Schedule",
+      class: "Schedule",
+      sourceId: "users_table", // sourceId -> `users_table`
+      recurring: true,
+      recurringFrequency: 1000 * 60 * 15, // 15 minutes in ms
+      options: {
+        maxColumn: "updated_at",
+      },
+    },
+
+    {
+      id: "email", // id -> `email`
+      name: "email",
+      class: "Property",
+      type: "email",
+      unique: true,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "email",
+      },
+      filters: [],
+    },
+
+    {
+      id: "first_name", // id -> `first_name`
+      name: "first name",
+      class: "Property",
+      type: "string",
+      unique: false,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "first_name",
+      },
+      filters: [],
+    },
+
+    {
+      id: "last_name", // id -> `first_name`
+      name: "last name",
+      class: "Property",
+      type: "string",
+      unique: false,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "last_name",
+      },
+      filters: [],
+    },
+
+    {
+      id: "email_group", // id -> `marketing_team`
+      name: "People with Email Addresses",
+      class: "Group",
+      type: "calculated",
+      rules: [
+        {
+          propertyId: "user_id",
+          operation: { op: "exists" },
+        },
+        {
+          propertyId: "email",
+          operation: { op: "like" },
+          match: "%@%",
+        },
+      ],
+    },
+
+    {
+      id: "test_destination", // id -> `dst_hubspot_destination`
+      name: "Test Destination",
+      class: "destination",
+      type: "test-plugin-export",
+      appId: "data_warehouse", // id -> data_warehouse
+      groupId: "email_group", // id -> email_group
+      options: {
+        table: "output",
+      },
+      mapping: {
+        "primary-id": "user_id",
+        "secondary-id": "email",
+      },
+      destinationGroupMemberships: {
+        "Literally Everyone": "email_group",
+      },
+    },
+
+    {
+      id: "website_key", // id -> `website_key`
+      name: "web-api-key",
+      class: "apiKey",
+      options: {
+        permissionAllRead: true,
+        permissionAllWrite: true,
+      },
+    },
+
+    {
+      id: "admin_team", // id -> `admin_team`
+      name: "Admin Team",
+      class: "team",
+      options: {
+        permissionAllRead: true,
+        permissionAllWrite: true,
+      },
+    },
+
+    {
+      id: "demo", // id -> `person`
+      email: "demo@grouparoo.com",
+      teamId: "admin_team", // id -> `marketing_team`
+      class: "teamMember",
+      options: {
+        firstName: "Example",
+        lastName: "Person",
+        password: "password",
+      },
+    },
+  ];
+};

--- a/core/__tests__/fixtures/codeConfig/error-changed-type-missing/config.js
+++ b/core/__tests__/fixtures/codeConfig/error-changed-type-missing/config.js
@@ -1,0 +1,176 @@
+module.exports = async function getConfig() {
+  return [
+    {
+      id: "setting_cluster_name", // this is actually ignored
+      class: "Setting",
+      pluginName: "core",
+      key: "cluster-name",
+      value: "Test Cluster",
+    },
+
+    {
+      id: "data_warehouse", // id -> `data_warehouse`
+      name: "Data Warehouse",
+      class: "App",
+      type: "foo",
+      options: {
+        fileId: "test-file-path.db",
+      },
+    },
+
+    {
+      id: "events", // id -> `events`
+      name: "Grouparoo Events",
+      class: "App",
+      type: "events",
+      options: {
+        identifyingPropertyId: "user_id",
+      },
+    },
+
+    {
+      id: "users_table", // id -> `data_warehouse`
+      name: "Users Table",
+      class: "Source",
+      type: "test-plugin-import",
+      appId: "data_warehouse", // appId -> `data_warehouse`
+      options: {
+        table: "users",
+      },
+      mapping: {
+        id: "user_id",
+      },
+      bootstrappedProperty: {
+        name: "userId",
+        type: "integer",
+        id: "user_id", // id -> `user_id`
+        options: {
+          column: "id",
+        },
+      },
+    },
+
+    {
+      id: "users_table_schedule", // id -> `sch_users_table_schedule`
+      name: "Users Table Schedule",
+      class: "Schedule",
+      sourceId: "users_table", // sourceId -> `users_table`
+      recurring: true,
+      recurringFrequency: 1000 * 60 * 15, // 15 minutes in ms
+      options: {
+        maxColumn: "updated_at",
+      },
+    },
+
+    {
+      id: "email", // id -> `email`
+      name: "email",
+      class: "Property",
+      type: "email",
+      unique: true,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "email",
+      },
+      filters: [],
+    },
+
+    {
+      id: "first_name", // id -> `first_name`
+      name: "first name",
+      class: "Property",
+      type: "string",
+      unique: false,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "first_name",
+      },
+      filters: [],
+    },
+
+    {
+      id: "last_name", // id -> `first_name`
+      name: "last name",
+      class: "Property",
+      type: "string",
+      unique: false,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "last_name",
+      },
+      filters: [],
+    },
+
+    {
+      id: "email_group", // id -> `marketing_team`
+      name: "People with Email Addresses",
+      class: "Group",
+      type: "calculated",
+      rules: [
+        {
+          propertyId: "user_id",
+          operation: { op: "exists" },
+        },
+        {
+          propertyId: "email",
+          operation: { op: "like" },
+          match: "%@%",
+        },
+      ],
+    },
+
+    {
+      id: "test_destination", // id -> `dst_hubspot_destination`
+      name: "Test Destination",
+      class: "destination",
+      type: "test-plugin-export",
+      appId: "data_warehouse", // id -> data_warehouse
+      groupId: "email_group", // id -> email_group
+      options: {
+        table: "output",
+      },
+      mapping: {
+        "primary-id": "user_id",
+        "secondary-id": "email",
+      },
+      destinationGroupMemberships: {
+        "Literally Everyone": "email_group",
+      },
+    },
+
+    {
+      id: "website_key", // id -> `website_key`
+      name: "web-api-key",
+      class: "apiKey",
+      options: {
+        permissionAllRead: true,
+        permissionAllWrite: true,
+      },
+    },
+
+    {
+      id: "admin_team", // id -> `admin_team`
+      name: "Admin Team",
+      class: "team",
+      options: {
+        permissionAllRead: true,
+        permissionAllWrite: true,
+      },
+    },
+
+    {
+      id: "demo", // id -> `person`
+      email: "demo@grouparoo.com",
+      teamId: "admin_team", // id -> `marketing_team`
+      class: "teamMember",
+      options: {
+        firstName: "Example",
+        lastName: "Person",
+        password: "password",
+      },
+    },
+  ];
+};

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -630,4 +630,54 @@ describe("modules/codeConfig", () => {
       });
     });
   });
+
+  describe("errors in a second run", () => {
+    beforeEach(async () => {
+      helper.truncate();
+    });
+
+    test("changing an app's type (missing) causes an error", async () => {
+      // initial load
+      await loadConfigDirectory(
+        path.join(__dirname, "..", "..", "fixtures", "codeConfig", "initial")
+      );
+
+      // changes
+      const { errors } = await loadConfigDirectory(
+        path.join(
+          __dirname,
+          "..",
+          "..",
+          "fixtures",
+          "codeConfig",
+          "error-changed-type-missing"
+        )
+      );
+
+      expect(errors.length).toBe(1);
+      expect(errors[0]).toMatch(/Cannot find a "foo" plugin/);
+    });
+
+    test("changing an app's type (valid) causes an error", async () => {
+      // initial load
+      await loadConfigDirectory(
+        path.join(__dirname, "..", "..", "fixtures", "codeConfig", "initial")
+      );
+
+      // changes
+      const { errors } = await loadConfigDirectory(
+        path.join(
+          __dirname,
+          "..",
+          "..",
+          "fixtures",
+          "codeConfig",
+          "error-changed-type-duplicate"
+        )
+      );
+
+      expect(errors.length).toBe(1);
+      expect(errors[0]).toMatch(/fileId is not an option for a manual app/);
+    });
+  });
 });

--- a/core/src/modules/configLoaders/apiKey.ts
+++ b/core/src/modules/configLoaders/apiKey.ts
@@ -31,7 +31,7 @@ export async function loadApiKey(
     });
   }
 
-  await apiKey.update({ name: configObject.name }, {});
+  await apiKey.update({ type: configObject.type, name: configObject.name }, {});
 
   if (
     configObject.options?.permissionAllRead !== undefined &&

--- a/core/src/modules/configLoaders/app.ts
+++ b/core/src/modules/configLoaders/app.ts
@@ -32,7 +32,7 @@ export async function loadApp(
     });
   }
 
-  await app.update({ name: configObject.name });
+  await app.update({ type: configObject.type, name: configObject.name });
   await app.setOptions(extractNonNullParts(configObject, "options"));
 
   if (externallyValidate) {

--- a/core/src/modules/configLoaders/destination.ts
+++ b/core/src/modules/configLoaders/destination.ts
@@ -43,7 +43,10 @@ export async function loadDestination(
     group = await getParentByName(Group, configObject.groupId);
   }
 
-  await destination.update({ name: configObject.name });
+  await destination.update({
+    type: configObject.type,
+    name: configObject.name,
+  });
 
   await destination.setOptions(extractNonNullParts(configObject, "options"));
 

--- a/core/src/modules/configLoaders/group.ts
+++ b/core/src/modules/configLoaders/group.ts
@@ -33,7 +33,7 @@ export async function loadGroup(
     });
   }
 
-  await group.update({ name: configObject.name });
+  await group.update({ type: configObject.type, name: configObject.name });
 
   if (configObject.rules) {
     const rules = [...configObject.rules];

--- a/core/src/modules/configLoaders/property.ts
+++ b/core/src/modules/configLoaders/property.ts
@@ -37,6 +37,7 @@ export async function loadProperty(
   }
 
   await property.update({
+    type: configObject.type,
     key: configObject.key || configObject.name,
     unique: configObject.unique,
     isArray: configObject.isArray,

--- a/core/src/modules/configLoaders/schedule.ts
+++ b/core/src/modules/configLoaders/schedule.ts
@@ -34,6 +34,7 @@ export async function loadSchedule(
   }
 
   await schedule.update({
+    type: configObject.type,
     name: configObject.name,
     recurring: configObject.recurring,
     recurringFrequency: configObject.recurringFrequency,

--- a/core/src/modules/configLoaders/source.ts
+++ b/core/src/modules/configLoaders/source.ts
@@ -37,7 +37,7 @@ export async function loadSource(
     });
   }
 
-  await source.update({ name: configObject.name });
+  await source.update({ type: configObject.type, name: configObject.name });
 
   await source.setOptions(extractNonNullParts(configObject, "options"));
 


### PR DESCRIPTION
This PR will re-check the `type` provided in code-config objects.  In most cases, this will not produce any changed behavior.  However, if you do for some reason change the type of an object, you'll now get a reasonable error, for example:

```
`warning: [ config ] error with App `Data Warehouse` (data_warehouse): Cannot find a "foo" plugin.  Did you install it?
```