### PR TITLE
Fix customer.io app template generation

### DIFF
--- a/plugins/@grouparoo/customerio/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/customerio/src/initializers/plugin.ts
@@ -36,7 +36,7 @@ export class Plugins extends Initializer {
       ],
       apps: [
         {
-          name: "customer.io",
+          name: "customerio",
           options: [
             {
               key: "siteId",
@@ -59,7 +59,7 @@ export class Plugins extends Initializer {
           name: "customerio-export",
           direction: "export",
           description: "Export profiles to customer.io as Customers",
-          app: "customer.io",
+          app: "customerio",
           options: [],
           methods: {
             exportProfile,

--- a/plugins/@grouparoo/customerio/src/migrations/000001-plugin-customerio-renameApp.ts
+++ b/plugins/@grouparoo/customerio/src/migrations/000001-plugin-customerio-renameApp.ts
@@ -1,0 +1,29 @@
+export default {
+  up: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.bulkUpdate(
+        "apps",
+        {
+          type: "customerio",
+        },
+        {
+          type: "customer.io",
+        }
+      );
+    });
+  },
+
+  down: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.bulkUpdate(
+        "apps",
+        {
+          type: "customer.io",
+        },
+        {
+          type: "customerio",
+        }
+      );
+    });
+  },
+};


### PR DESCRIPTION
Currently, trying to generate a customer.io app through `grouparoo generate customerio:app cioapp` causes an error on startup:
```
[ config ] error with app `cioapp` (cioapp): Cannot find a "customerio" plugin.  Did you install it? 
```

This is because the app name is actually `customer.io` instead of `customerio` (note the `.`). 

There are two main options here:
1. Rename the app to `customerio` so that it matches the plugin name and other templates. I believe this would be the right thing to do from the start, but this likely means we would need to add a migration so existing apps aren't affected.
2. Update the template so it uses `customer.io` as app type. Doing it this way is slightly inconsistent, but would not constitute a breaking change / require migrations.