### PR TITLE
CodeConfig to consider properties in mustache queries when sorting objects

### DIFF
--- a/core/__tests__/modules/mustacheUtils.ts
+++ b/core/__tests__/modules/mustacheUtils.ts
@@ -1,0 +1,84 @@
+import { helper } from "@grouparoo/spec-helper";
+import { Property } from "../../src";
+import { ConfigurationObject } from "../../src/classes/codeConfig";
+import { MustacheUtils } from "../../src/modules/mustacheUtils";
+
+describe("modules/mustacheUtils", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
+  beforeAll(async () => {
+    await helper.factories.properties();
+  });
+
+  describe("#strictlyRender", () => {
+    test("works with a valid string and data", () => {
+      const result = MustacheUtils.strictlyRender("hello {{value}}", {
+        value: "world",
+      });
+      expect(result).toEqual("hello world");
+    });
+
+    test("throws a good error message if data is missing", () => {
+      expect(() =>
+        MustacheUtils.strictlyRender("hello {{value}}", {
+          foo: "world",
+        })
+      ).toThrow(/missing mustache key "value"/);
+    });
+
+    test("null values can be OK", () => {
+      expect(() =>
+        MustacheUtils.strictlyRender(
+          "hello {{value}}",
+          {
+            value: null,
+          },
+          null,
+          false
+        )
+      ).toThrow('null "value"');
+
+      const result = MustacheUtils.strictlyRender(
+        "hello {{value}}",
+        {
+          value: null,
+        },
+        null,
+        true
+      );
+      expect(result).toEqual("hello ");
+    });
+  });
+
+  describe("#getMustacheVariables", () => {
+    test("the names of the mustache variables can be extracted", () => {
+      const keys = MustacheUtils.getMustacheVariables(
+        "I need a {{foo}}, a {{{ bar }}} and one more {{    thing}}"
+      );
+      expect(keys).toEqual(["foo", "bar", "thing"]);
+    });
+  });
+
+  describe("#getMustacheVariablesAsPropertyIds", () => {
+    test("it works with existing properties", async () => {
+      const property = await Property.findOne({ where: { key: "userId" } });
+      const string = "SELECT email from users where id = {{ userId }}";
+      const ids = await MustacheUtils.getMustacheVariablesAsPropertyIds(string);
+      expect(ids).toEqual([property.id]);
+    });
+
+    test("it works with additional codeConfig objects", async () => {
+      const property = await Property.findOne({ where: { key: "userId" } });
+      const string =
+        "SELECT email from users where id = {{ userId }} and {{ subscribed }} = true";
+      const configObjects: ConfigurationObject[] = [
+        { class: "property", id: "subscribed_id", name: "subscribed" },
+      ];
+      const ids = await MustacheUtils.getMustacheVariablesAsPropertyIds(
+        string,
+        configObjects
+      );
+      expect(ids).toEqual([property.id, "subscribed_id"]);
+    });
+  });
+});

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -229,22 +229,22 @@ export async function getParentIds(
   // special cases
   // - Bootstrapped property
   if (
-    configObject.class.toLowerCase() === "source" &&
+    configObject.class?.toLowerCase() === "source" &&
     configObject?.bootstrappedProperty?.id
   ) {
     providedIds.push(configObject.bootstrappedProperty.id);
   }
+
   // - query property with mustache dependency
   if (
-    configObject.class.toLowerCase() === "property" &&
+    configObject.class?.toLowerCase() === "property" &&
     configObject?.options?.query
   ) {
-    prerequisiteIds.push(
-      ...(await MustacheUtils.getMustacheVariablesAsPropertyIds(
-        configObject?.options?.query,
-        otherConfigObjects
-      ))
+    const mustachePrerequisiteIds = await MustacheUtils.getMustacheVariablesAsPropertyIds(
+      configObject?.options?.query,
+      otherConfigObjects
     );
+    prerequisiteIds.push(...mustachePrerequisiteIds);
   }
 
   // prerequisites

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -121,12 +121,14 @@ export async function processConfigObjects(
       const extraSortingConfigObjectIds = extraSortingConfigObjects.map(
         (o) => o.id
       );
-      configObjects = sortConfigurationObjects(
-        [].concat(extraSortingConfigObjects, configObjects)
+      configObjects = (
+        await sortConfigurationObjects(
+          [].concat(extraSortingConfigObjects, configObjects)
+        )
       ).filter((o) => !extraSortingConfigObjectIds.includes(o.id));
     } else {
       // A normal collection of config objects
-      configObjects = sortConfigurationObjects(configObjects);
+      configObjects = await sortConfigurationObjects(configObjects);
     }
   } catch (error) {
     // If something we wrong while sorting, log the messages and return. We

--- a/core/src/modules/configLoaders/syncTable.ts
+++ b/core/src/modules/configLoaders/syncTable.ts
@@ -8,7 +8,7 @@ import { OptionHelper } from "../optionHelper";
 
 // TODO:
 // because this is so dynamic the "providedIds" in getParentIds isn't right for properties, bootstrap, source, destination, schedule, etc
-// equilavent of validateConfigObjectKeys(Source, configObject); for this whole thing to freak out if not applicable. is this important?
+// equivalent of validateConfigObjectKeys(Source, configObject); for this whole thing to freak out if not applicable. is this important?
 // Error: only one property can be identifying
 
 interface columnTypes {

--- a/core/src/modules/mustacheUtils.ts
+++ b/core/src/modules/mustacheUtils.ts
@@ -1,4 +1,6 @@
 import Mustache from "mustache";
+import { ConfigurationObject } from "../classes/codeConfig";
+import { Property } from "../models/Property";
 
 export namespace MustacheUtils {
   export interface MustacheArgs {
@@ -25,14 +27,50 @@ export namespace MustacheUtils {
     errorPrefix = "missing mustache key",
     allowNull = false
   ) {
-    Mustache.parse(string)
+    getMustacheVariables(string).map((key) => {
+      const value = key.split(".").reduce((o, i) => o[i], data);
+      if (value === undefined || (allowNull === false && value === null)) {
+        throw new Error(`${errorPrefix} ${JSON.stringify(key)}`);
+      }
+    });
+  }
+
+  export function getMustacheVariables(string: string) {
+    return Mustache.parse(string)
       .filter((chunk) => chunk[0] === "name" || chunk[0] === "&")
-      .map((chunk) => chunk[1])
-      .map((key) => {
-        const value = key.split(".").reduce((o, i) => o[i], data);
-        if (value === undefined || (allowNull === false && value === null)) {
-          throw new Error(`${errorPrefix} ${JSON.stringify(key)}`);
-        }
-      });
+      .map((chunk) => chunk[1]) as string[];
+  }
+
+  export async function getMustacheVariablesAsPropertyIds(
+    string: string,
+    configObjects: ConfigurationObject[] = []
+  ) {
+    const keys = getMustacheVariables(string);
+    const properties = await Property.findAll();
+    const searchItems: Array<{ id: string; key: string }> = [].concat(
+      properties.map((p) => {
+        return { id: p.id, key: p.key };
+      }),
+      configObjects
+        .filter((c) => c.class.toLowerCase() === "property")
+        .map((c) => {
+          return { id: c.id, key: c.key || c.name };
+        }),
+      configObjects
+        .filter((c) => c.class.toLowerCase() === "source")
+        .filter((c) => c.bootstrappedProperty?.id)
+        .map((c) => {
+          return {
+            id: c.bootstrappedProperty.id,
+            key: c.bootstrappedProperty.key || c.bootstrappedProperty.name,
+          };
+        })
+    );
+
+    return keys.map((k) => {
+      const item = searchItems.find((p) => p.key === k);
+      if (!item) throw new Error(`no property with key ${k}`);
+      return item.id;
+    });
   }
 }

--- a/core/src/modules/mustacheUtils.ts
+++ b/core/src/modules/mustacheUtils.ts
@@ -1,6 +1,7 @@
 import Mustache from "mustache";
+// import { Property } from "../models/Property"; // TODO: importing this causes a circular dependency loop; we'll use api.sequelize.models for now
 import { ConfigurationObject } from "../classes/codeConfig";
-import { Property } from "../models/Property";
+import { api } from "actionhero";
 
 export namespace MustacheUtils {
   export interface MustacheArgs {
@@ -46,7 +47,7 @@ export namespace MustacheUtils {
     configObjects: ConfigurationObject[] = []
   ) {
     const keys = getMustacheVariables(string);
-    const properties = await Property.findAll();
+    const properties = await api.sequelize.models.Property.findAll();
     const searchItems: Array<{ id: string; key: string }> = [].concat(
       properties.map((p) => {
         return { id: p.id, key: p.key };

--- a/core/src/modules/ops/property.ts
+++ b/core/src/modules/ops/property.ts
@@ -4,7 +4,6 @@ import { GroupRule } from "../../models/GroupRule";
 import { App } from "../../models/App";
 import { internalRun } from "../internalRun";
 import { Op } from "sequelize";
-import { api } from "actionhero";
 import Mustache from "mustache";
 
 export namespace PropertyOps {

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -256,7 +256,7 @@ export namespace helper {
         {
           name: "test-plugin-import",
           direction: "import",
-          description: "import or update profiles from an uploaded file",
+          description: "import or update profiles from a table",
           app: "test-plugin-app",
           options: [
             { key: "table", required: true },


### PR DESCRIPTION
Prior to this PR, query-mode properties which had queries like `SELECT email from users where id = {{ userId }}` were not being considered properly in the topological sort when applying code-config to the sever.  This PR now considers both Properties which are already stored in the server's database and not-yet-applied but in the same code-config batch.