### PR TITLE
Clearer error messages when a plugin isn't installed or typo'd

### DIFF
--- a/core/__tests__/models/app/app.ts
+++ b/core/__tests__/models/app/app.ts
@@ -194,7 +194,7 @@ describe("models/app", () => {
       });
 
       await expect(app.save()).rejects.toThrow(
-        /Cannot find a \"oh no\" plugin/
+        /Cannot find a \"oh no\" app available within the installed plugins. Current apps installed are:/
       );
     });
 

--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -273,6 +273,18 @@ describe("models/destination", () => {
     });
 
     describe("validations", () => {
+      test("a destination requires a plugin connection", async () => {
+        await expect(
+          Destination.create({
+            type: "missing-destination",
+            name: "test destination",
+            appId: app.id,
+          })
+        ).rejects.toThrow(
+          /Cannot find a \"missing-destination\" connection available within the installed plugins. Current connections installed are:/
+        );
+      });
+
       test("options must match the app options (extra options needed by connection)", async () => {
         destination = new Destination({
           name: "incoming destination - too many options",

--- a/core/__tests__/models/source.ts
+++ b/core/__tests__/models/source.ts
@@ -80,7 +80,9 @@ describe("models/source", () => {
           name: "test source",
           appId: app.id,
         })
-      ).rejects.toThrow(/Cannot find a \"missing-source\" plugin./);
+      ).rejects.toThrow(
+        /Cannot find a \"missing-source\" connection available within the installed plugins. Current connections installed are:/
+      );
     });
 
     test("a new source will have a '' name", async () => {

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -521,7 +521,9 @@ describe("modules/codeConfig", () => {
             "error-not-installed"
           )
         );
-        expect(errors[0]).toMatch(/Cannot find a "missing-plugin" plugin/);
+        expect(errors[0]).toMatch(
+          /Cannot find a \"missing-plugin\" connection available within the installed plugins. Current connections installed are:/
+        );
       });
     });
 
@@ -669,7 +671,9 @@ describe("modules/codeConfig", () => {
       );
 
       expect(errors.length).toBe(1);
-      expect(errors[0]).toMatch(/Cannot find a "foo" plugin/);
+      expect(errors[0]).toMatch(
+        /Cannot find a \"foo\" app available within the installed plugins. Current apps installed are/
+      );
     });
 
     test("changing an app's type (valid) causes an error", async () => {

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -126,8 +126,8 @@ export namespace OptionHelper {
   }
 
   export function getPluginByType(type: string) {
-    const foundApps: Set<string> = new Set([]);
-    const foundConnections: Set<string> = new Set([]);
+    const foundApps: string[] = [];
+    const foundConnections: string[] = [];
     let match: {
       plugin: GrouparooPlugin;
       pluginConnection: PluginConnection;
@@ -137,7 +137,7 @@ export namespace OptionHelper {
     api.plugins.plugins.forEach((plugin: GrouparooPlugin) => {
       if (plugin.apps) {
         plugin.apps.forEach((pluginApp) => {
-          foundApps.add(pluginApp.name);
+          foundApps.push(pluginApp.name);
           if (pluginApp.name === type) {
             match.plugin = plugin;
             match.pluginApp = pluginApp;
@@ -147,7 +147,7 @@ export namespace OptionHelper {
 
       if (plugin.connections) {
         plugin.connections.forEach((pluginConnection) => {
-          foundConnections.add(pluginConnection.name);
+          foundConnections.push(pluginConnection.name);
           if (pluginConnection.name === type) {
             match.plugin = plugin;
             match.pluginConnection = pluginConnection;

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -12,6 +12,7 @@ import { Property } from "../models/Property";
 import { App, AppOption } from "./../models/App";
 import { LoggedModel } from "../classes/loggedModel";
 import { LockableHelper } from "./lockableHelper";
+import { plural } from "pluralize";
 
 export const ObfuscatedPasswordString = "__ObfuscatedPassword";
 
@@ -125,6 +126,8 @@ export namespace OptionHelper {
   }
 
   export function getPluginByType(type: string) {
+    const foundApps: Set<string> = new Set([]);
+    const foundConnections: Set<string> = new Set([]);
     let match: {
       plugin: GrouparooPlugin;
       pluginConnection: PluginConnection;
@@ -134,6 +137,7 @@ export namespace OptionHelper {
     api.plugins.plugins.forEach((plugin: GrouparooPlugin) => {
       if (plugin.apps) {
         plugin.apps.forEach((pluginApp) => {
+          foundApps.add(pluginApp.name);
           if (pluginApp.name === type) {
             match.plugin = plugin;
             match.pluginApp = pluginApp;
@@ -143,6 +147,7 @@ export namespace OptionHelper {
 
       if (plugin.connections) {
         plugin.connections.forEach((pluginConnection) => {
+          foundConnections.add(pluginConnection.name);
           if (pluginConnection.name === type) {
             match.plugin = plugin;
             match.pluginConnection = pluginConnection;
@@ -152,7 +157,18 @@ export namespace OptionHelper {
     });
 
     if (!match.plugin) {
-      throw new Error(`Cannot find a "${type}" plugin.  Did you install it?`);
+      const missingType =
+        type.includes("-") || type.includes(":") ? "connection" : "app";
+      const collection = missingType === "app" ? foundApps : foundConnections;
+      throw new Error(
+        `Cannot find a "${type}" ${missingType} available within the installed plugins. Current ${plural(
+          missingType
+        )} installed are: ${[...collection]
+          .sort()
+          .join(
+            ", "
+          )}. Use \`grouparoo install\` to add new plugins if necessary.`
+      );
     }
 
     return match;


### PR DESCRIPTION
Say that you are trying to create a `hubsport` app.  Now `grouparoo validate` will show an error message like this:

```
🦘 Grouparoo: validate

Validating 20 objects...
info: [ config ] validated App `Data Warehouse` (data_warehouse)
info: [ config ] validated Source `Users Table` (users_table)
info: [ config ] validated Property `User Id` (user_id)
info: [ config ] validated App `Grouparoo Events` (events)
warning: [ config ] error with App `Hubspot` (hubspot): Cannot find a "hubsport" app available within the installed plugins. Current apps installed are: bigquery, csv, events, hubspot, manual. Use `grouparoo install` to add new plugins if necessary.
...
```