### PR TITLE
Log pacote/npm errors at `info` log level

### DIFF
--- a/core/src/modules/pluginVersions.ts
+++ b/core/src/modules/pluginVersions.ts
@@ -40,7 +40,7 @@ export async function pluginVersions() {
         const manifest = await getLatestNPMVersion(plugin);
         latestVersion = manifest.version;
       } catch (error) {
-        log(error.toString(), "error");
+        log(error.toString(), "info");
       }
 
       return {


### PR DESCRIPTION
This PR changes the error logging level from `error` to `info` if we cannot get information about a published plugin from NPM.  This happens 100% of the time with private packages like `@grouparoo/ui-enterprise`.  This PR makes those log messages less scary.  

Our code is resilient to not getting this info from NPM, but cannot show if there's an updated version or not. 

Related to https://github.com/npm/pacote/issues/77.  