### PR TITLE
Assume redis db=0 when undefined

### DIFF
--- a/core/src/config/redis.ts
+++ b/core/src/config/redis.ts
@@ -33,7 +33,8 @@ function RealRedisConfig() {
     username:
       username?.length > 1 || process.env.REDIS_USER ? username : undefined,
     password,
-    db: parseInt(db),
+    // If we have a REDIS_URL, but no database, assume we mean db=0
+    db: parseInt(db || "0"),
     // you can learn more about retryStrategy @ https://github.com/luin/ioredis#auto-reconnect
     retryStrategy: (times) => {
       if (times === 1) {


### PR DESCRIPTION
After https://github.com/grouparoo/grouparoo/pull/1698, we removed all of the implicit connection defaults for Grouparoo.  We've seen that some PaaS providers like Heroku provide a REDIS_URL, but not a database.  In these cases, we will default to assuming `db=0`.  This was the behavior prior to https://github.com/grouparoo/grouparoo/pull/1698, but it was implicit before.

e.g.: `REDIS_URL=redis://h:password@ec2-11-22-33-44.compute-1.amazonaws.com:1234`