### PR TITLE
Build step on CI requires more RAM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ references:
 # Define Jobs to run
 jobs:
   build:
+    resource_class: "medium+"
     docker:
       - image: circleci/node:14
         auth:

--- a/tools/merger/data/ci/base.yml.template
+++ b/tools/merger/data/ci/base.yml.template
@@ -16,6 +16,7 @@ references:
 # Define Jobs to run
 jobs:
   build:
+    resource_class: "medium+"
     docker:
       - image: circleci/node:14
         auth:


### PR DESCRIPTION
Sometimes the `pnpm install` step fails, running out of RAM.  This moves just the build step to a larger server. 

Interestingly, there doesn't seem to be a way to tell `pnpm` not to do 4 installs at once