### PR TITLE
Check that recurring tasks are enqueued every hour

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,6 +357,50 @@ jobs:
       - run:
           name: test
           command: cd core && ./node_modules/.bin/jest __tests__/classes --ci --maxWorkers 2
+  test-core-initializers:
+    docker:
+      - image: circleci/node:14
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: redis:latest
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: circleci/postgres:9
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+        environment:
+          POSTGRES_PASSWORD: password
+    steps:
+      - checkout
+      - restore_cache:
+          <<: *module-other-cache-options
+      - restore_cache:
+          <<: *plugin-1-cache-options
+      - restore_cache:
+          <<: *plugin-2-cache-options
+      - restore_cache:
+          <<: *plugin-3-cache-options
+      - restore_cache:
+          <<: *plugin-4-cache-options
+      - restore_cache:
+          <<: *dist-cache-options
+      - restore_cache:
+          <<: *core-cache-options
+      - run:
+          name: install postgresql client
+          command: sudo apt install -y postgresql-client
+      - run:
+          name: Wait for DB
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run:
+          name: create test databases
+          command: cd core && ./bin/create_test_databases
+      - run:
+          name: test
+          command: cd core && ./node_modules/.bin/jest __tests__/initializers --ci --maxWorkers 2
   test-core-integration:
     docker:
       - image: circleci/node:14
@@ -2511,6 +2555,11 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
+      - test-core-initializers:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
       - test-core-integration:
           filters:
             <<: *ignored-branches
@@ -2756,6 +2805,7 @@ workflows:
             - test-core-actions
             - test-core-bin
             - test-core-classes
+            - test-core-initializers
             - test-core-integration
             - test-core-models
             - test-core-modules
@@ -2854,6 +2904,11 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
+      - test-core-initializers:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
       - test-core-integration:
           filters:
             <<: *ignored-branches
@@ -3099,6 +3154,7 @@ workflows:
             - test-core-actions
             - test-core-bin
             - test-core-classes
+            - test-core-initializers
             - test-core-integration
             - test-core-models
             - test-core-modules

--- a/core/__tests__/initializers/resque.ts
+++ b/core/__tests__/initializers/resque.ts
@@ -1,0 +1,63 @@
+import { helper } from "@grouparoo/spec-helper";
+import { specHelper, api } from "actionhero";
+import { ResqueInitializer } from "../../src/initializers/resque";
+
+jest.mock("../../src/config/tasks.ts", () => ({
+  __esModule: true,
+  test: {
+    tasks: () => {
+      return {
+        scheduler: true,
+        queues: ["*"],
+        workerLogging: {},
+        schedulerLogging: {},
+        timeout: 100,
+        checkTimeout: 50,
+        minTaskProcessors: 1,
+        maxTaskProcessors: 1,
+        maxEventLoopDelay: 5,
+        stuckWorkerTimeout: 1000 * 60 * 60,
+        connectionOptions: {
+          tasks: {},
+        },
+      };
+    },
+  },
+}));
+
+describe("initializers/resque", () => {
+  helper.grouparooTestServer({ truncate: true });
+
+  beforeAll(async () => {
+    await api.resque.queue.connection.redis.flushdb();
+  });
+
+  test("it will check for missing periodic tasks if the resque leader", async () => {
+    console.log(api.resque);
+    api.resque.scheduler.leader = true;
+
+    await api.resque.queue.connection.redis.flushdb();
+    let found = await specHelper.findEnqueuedTasks("status");
+    expect(found.length).toBe(0);
+
+    const instance = new ResqueInitializer();
+    await instance.recheckPeriodicTasks();
+
+    found = await specHelper.findEnqueuedTasks("status");
+    expect(found.length).toBe(1);
+  });
+
+  test("it will not check for missing periodic tasks if not the resque leader", async () => {
+    api.resque.scheduler.leader = false;
+
+    await api.resque.queue.connection.redis.flushdb();
+    let found = await specHelper.findEnqueuedTasks("status");
+    expect(found.length).toBe(0);
+
+    const instance = new ResqueInitializer();
+    await instance.recheckPeriodicTasks();
+
+    found = await specHelper.findEnqueuedTasks("status");
+    expect(found.length).toBe(0);
+  });
+});

--- a/core/src/initializers/resque.ts
+++ b/core/src/initializers/resque.ts
@@ -2,7 +2,7 @@ import { Initializer, route, task, api, log } from "actionhero";
 
 let taskRecheckInterval: NodeJS.Timeout;
 
-export class Plugins extends Initializer {
+export class ResqueInitializer extends Initializer {
   constructor() {
     super();
     this.name = `@grouparoo/resque`;

--- a/core/src/initializers/resque.ts
+++ b/core/src/initializers/resque.ts
@@ -100,8 +100,14 @@ export class Plugins extends Initializer {
 
   async recheckPeriodicTasks() {
     if (api?.resque?.scheduler?.leader) {
-      log("ensuring periodic tasks are enqueued");
-      task.enqueueAllRecurrentTasks();
+      const taskNames = await task.enqueueAllRecurrentTasks();
+      log(
+        `Ensuring periodic tasks are enqueued.  ${
+          taskNames.length > 0
+            ? `Added missing: ${taskNames.join(", ")}.`
+            : "None missing."
+        }`
+      );
     }
   }
 }


### PR DESCRIPTION
This PR will re-check that all expected recurring tasks are enqueued every hour.  This already happens as each instance in the cluster boots.  This will make us more resilient to redis errors. 