### PR TITLE
Do not run staging apps with `npm`

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web:    cd apps/$GROUPAROO_MONOREPO_APP && WEB_SERVER=true WORKERS=0 npm start
-worker: cd apps/$GROUPAROO_MONOREPO_APP && WEB_SERVER=false WORKERS=5 npm start
+web:    cd /app/apps/$GROUPAROO_MONOREPO_APP/node_modules/@grouparoo/core && INIT_CWD="/app/apps/$GROUPAROO_MONOREPO_APP" WEB_SERVER=true  WORKERS=0 ./bin/start
+worker: cd /app/apps/$GROUPAROO_MONOREPO_APP/node_modules/@grouparoo/core && INIT_CWD="/app/apps/$GROUPAROO_MONOREPO_APP" WEB_SERVER=false WORKERS=5 ./bin/start


### PR DESCRIPTION
The staging apps are not getting the shutdown signals because the NPM process is trapping them.  This PR updates the `Profile` to only use the grouparoo binary to start the process, thus getting the term/sig signals. 