### PR TITLE
Add sort indexes on tables displayed as lists in the UI

### DIFF
--- a/core/src/migrations/000064-addSortIndicies.ts
+++ b/core/src/migrations/000064-addSortIndicies.ts
@@ -1,0 +1,39 @@
+export default {
+  up: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.addIndex("profiles", ["createdAt"], {
+        fields: ["createdAt"],
+      });
+
+      await migration.addIndex("runs", ["updatedAt"], {
+        fields: ["updatedAt"],
+      });
+
+      await migration.addIndex("imports", ["createdAt"], {
+        fields: ["createdAt"],
+      });
+
+      await migration.addIndex("exports", ["createdAt"], {
+        fields: ["createdAt"],
+      });
+    });
+  },
+
+  down: async function (migration) {
+    await migration.removeIndex("profiles", ["createdAt"], {
+      fields: ["createdAt"],
+    });
+
+    await migration.removeIndex("runs", ["updatedAt"], {
+      fields: ["updatedAt"],
+    });
+
+    await migration.removeIndex("imports", ["createdAt"], {
+      fields: ["createdAt"],
+    });
+
+    await migration.removeIndex("exports", ["createdAt"], {
+      fields: ["createdAt"],
+    });
+  },
+};


### PR DESCRIPTION
This will speed up performance when viewing Profiles, Imports, Exports, and Runs with the default sorts. 