### PR TITLE
UI resilience if API has errors

### DIFF
--- a/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
+++ b/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
@@ -3,6 +3,7 @@ import { Models } from "../../utils/apiData";
 import { ProgressBar } from "react-bootstrap";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { Actions } from "../../utils/apiData";
 
 export default function SetupStepsNavProgressBar({
   execApi,
@@ -30,9 +31,15 @@ export default function SetupStepsNavProgressBar({
   }, []);
 
   async function getSetupSteps() {
-    const { setupSteps, toDisplay } = await execApi("get", `/setupSteps`);
-    setShouldDisplay(toDisplay);
-    setSteps(setupSteps);
+    const { setupSteps, toDisplay }: Actions.SetupStepsList = await execApi(
+      "get",
+      `/setupSteps`
+    );
+
+    if (setupSteps) {
+      setShouldDisplay(toDisplay);
+      setSteps(setupSteps);
+    }
   }
 
   const activeStep = steps.find((step) => !step.complete && !step.skipped);

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -231,6 +231,10 @@ import {
   sourceConnectionOptions,
   SourcePreview,
 } from "@grouparoo/core/src/actions/sources";
+import {
+  PublicStatus,
+  PrivateStatus,
+} from "@grouparoo/core/src/actions/status";
 import { Swagger } from "@grouparoo/core/src/actions/swagger";
 import {
   TeamMemberCreate,
@@ -662,6 +666,13 @@ export namespace Actions {
   >;
   export type SourcePreview = AsyncReturnType<
     typeof SourcePreview.prototype.runWithinTransaction
+  >;
+
+  export type PublicStatus = AsyncReturnType<
+    typeof PublicStatus.prototype.runWithinTransaction
+  >;
+  export type PrivateStatus = AsyncReturnType<
+    typeof PrivateStatus.prototype.runWithinTransaction
   >;
 
   export type Swagger = AsyncReturnType<typeof Swagger.prototype.run>;

--- a/ui/ui-components/utils/statusHandler.ts
+++ b/ui/ui-components/utils/statusHandler.ts
@@ -1,4 +1,5 @@
 import { EventDispatcher } from "./eventDispatcher";
+import { Actions } from "../utils/apiData";
 
 export class StatusHandler extends EventDispatcher {
   maxSamples: 50;
@@ -25,7 +26,11 @@ export class StatusHandler extends EventDispatcher {
   }
 
   async getSamples(execApi) {
-    const { metrics } = await execApi("get", `/status/private`);
+    const { metrics }: Actions.PrivateStatus = await execApi(
+      "get",
+      `/status/private`
+    );
+    if (!metrics) return;
     if (metrics.length === 0) return;
     const mostRecent = metrics.shift();
     this.samples.push(...metrics.reverse());


### PR DESCRIPTION
Adds some resilience to API calls that happen on every page (loading status & checking setup steps).  Do not try to update the UI if the API cannot be reached for some reason. 