### PR TITLE
Set all options when creating bootstrappedProperty

### DIFF
--- a/core/__tests__/models/source.ts
+++ b/core/__tests__/models/source.ts
@@ -454,6 +454,22 @@ describe("models/source", () => {
       expect(options).toEqual({ column: "__default_column" }); // from the plugin; see specHelper.ts
     });
 
+    test("provided property options will override defaults from uniquePropertyBootstrapOptions", async () => {
+      const property = await source.bootstrapUniqueProperty(
+        "uniqueId",
+        "integer",
+        "id",
+        undefined,
+        false,
+        { column: "my_column" }
+      );
+
+      const options = await property.getOptions();
+      expect(options).toEqual({ column: "my_column" });
+
+      await property.destroy();
+    });
+
     test("bootstrapUniqueProperty will fail if the property cannot be created", async () => {
       await expect(
         source.bootstrapUniqueProperty("userId", "integer", "id")

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -262,7 +262,8 @@ export class Source extends LoggedModel<Source> {
     type: string,
     mappedColumn: string,
     id?: string,
-    local = false
+    local = false,
+    options?: { [key: string]: any }
   ) {
     return SourceOps.bootstrapUniqueProperty(
       this,
@@ -270,7 +271,8 @@ export class Source extends LoggedModel<Source> {
       type,
       mappedColumn,
       id,
-      local
+      local,
+      options
     );
   }
 

--- a/core/src/modules/configLoaders/source.ts
+++ b/core/src/modules/configLoaders/source.ts
@@ -96,7 +96,8 @@ export async function loadSource(
         property.type,
         mappedColumn,
         property.id,
-        validate
+        validate,
+        property.options
       );
       await setMapping();
     } else {


### PR DESCRIPTION
This is mainly an issue for the old way of defining the `bootstrappedProperty`. If the plugin didn't define its own `uniquePropertyBootstrapOptions` method, no options would be set on the property. It also wasn't possible to override the defaults set by the plugin.

All options defined in the `bootstrappedProperty` section are now set on the property.