### PR TITLE
Remove `[ run ] starting...` log messages

### DIFF
--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -171,10 +171,7 @@ export class Schedule extends LoggedModel<Schedule> {
       state: "running",
     });
 
-    log(
-      `[ run ] starting run ${run.id} for schedule ${this.name} (${this.id})`,
-      "notice"
-    );
+
 
     await CLS.enqueueTask(
       "schedule:run",

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -171,8 +171,6 @@ export class Schedule extends LoggedModel<Schedule> {
       state: "running",
     });
 
-
-
     await CLS.enqueueTask(
       "schedule:run",
       { scheduleId: this.id, runId: run.id },

--- a/core/src/modules/internalRun.ts
+++ b/core/src/modules/internalRun.ts
@@ -25,12 +25,5 @@ export async function internalRun(creatorType: string, creatorId: string) {
     groupMethod: "internalRun",
   });
 
-  log(
-    `[ run ] starting run ${
-      run.id
-    } for ${creatorType} ${await run.getCreatorName()} (${creatorId})`,
-    "notice"
-  );
-
   return run;
 }

--- a/core/src/modules/ops/group.ts
+++ b/core/src/modules/ops/group.ts
@@ -29,11 +29,6 @@ export namespace GroupOps {
       force,
     });
 
-    log(
-      `[ run ] starting run ${run.id} for group ${group.name} (${group.id})`,
-      "notice"
-    );
-
     return run;
   }
 

--- a/core/src/tasks/group/destroy.ts
+++ b/core/src/tasks/group/destroy.ts
@@ -72,10 +72,6 @@ export class GroupDestroy extends CLSTask {
         limit,
       });
     } else {
-      log(
-        `[ run ] completed run ${run.id} for group ${group.name} (${group.id})`,
-        "notice"
-      );
       await run.afterBatch("complete");
       await group.destroy();
     }

--- a/core/src/tasks/group/destroy.ts
+++ b/core/src/tasks/group/destroy.ts
@@ -45,11 +45,6 @@ export class GroupDestroy extends CLSTask {
         state: "running",
       });
       await group.update({ state: "deleted" });
-
-      log(
-        `[ run ] starting run ${run.id} for group ${group.name} (${group.id})`,
-        "notice"
-      );
     }
 
     if (run.state === "stopped") return;

--- a/core/src/tasks/schedule/updateSchedules.ts
+++ b/core/src/tasks/schedule/updateSchedules.ts
@@ -64,11 +64,6 @@ export class UpdateSchedules extends CLSTask {
           creatorType: "schedule",
           state: "running",
         });
-
-        log(
-          `[ run ] starting run ${run.id} for schedule ${schedule.name} (${schedule.id})`,
-          "notice"
-        );
       }
     }
   }


### PR DESCRIPTION
These are annoying, and we have other, better ways in the UI and CLI to see what runs are running. 