### PR TITLE
Rescue stuck Groups who lost their runs

### DIFF
--- a/core/src/tasks/group/updateCalculatedGroups.ts
+++ b/core/src/tasks/group/updateCalculatedGroups.ts
@@ -1,6 +1,6 @@
 import { Group } from "../../models/Group";
+import { Run } from "../../models/Run";
 import { plugin } from "../../modules/plugin";
-import { Op } from "sequelize";
 import Moment from "moment";
 import { CLSTask } from "../../classes/tasks/clsTask";
 
@@ -21,21 +21,37 @@ export class GroupsUpdateCalculatedGroups extends CLSTask {
       "groups-calculation-delay-minutes"
     );
     const delayMinutes = parseInt(setting.value);
-    const lastCheckTime = Moment().subtract(delayMinutes, "minutes");
+    const lastCheckTime = Moment().subtract(delayMinutes, "minutes").toDate();
 
+    const groupsToRun: Group[] = [];
     const calculatedGroups = await Group.scope(null).findAll({
-      where: {
-        type: "calculated",
-        state: "ready",
-        calculatedAt: {
-          [Op.or]: {
-            [Op.eq]: null,
-            [Op.lt]: lastCheckTime,
-          },
-        },
-      },
+      where: { type: "calculated" },
     });
 
-    await Promise.all(calculatedGroups.map((group) => group.run()));
+    for (const group of calculatedGroups) {
+      if (group.state === "ready" && !group.calculatedAt) {
+        // the group has never been calculated
+        groupsToRun.push(group);
+      } else if (
+        // the group hasn't been calculated recently
+        group.state === "ready" &&
+        group.calculatedAt.getTime() < lastCheckTime.getTime()
+      ) {
+        groupsToRun.push(group);
+      } else if (
+        group.state === "updating" &&
+        group.calculatedAt.getTime() < lastCheckTime.getTime()
+      ) {
+        // the group is stuck in "updating" and has no run working it
+        const runningRun = await Run.findOne({
+          where: { creatorId: group.id, state: "running" },
+        });
+        if (!runningRun) groupsToRun.push(group);
+      } else {
+        // the group is up-to-date
+      }
+    }
+
+    await Promise.all(groupsToRun.map((group) => group.run()));
   }
 }


### PR DESCRIPTION
If a calculated Group was updating its members, it's possible for that calculation to never complete if the Run was stopped manually or had an error.   This PR will start a new calculation run for those Groups if they haven't been checked in some time and if there is not a running Run for them already. 