### PR TITLE
Do not process Run if group is deleted

### DIFF
--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -32,6 +32,7 @@ export class RunGroup extends CLSTask {
       where: { id: run.creatorId },
     });
     if (!group) return;
+    if (group.state === "deleted") return;
 
     const force = run.force || false;
     const destinationId = run.destinationId;


### PR DESCRIPTION
The run will be processed by `group:destroy` instead