### PR TITLE
only auto-locally-validate direct dependencies, invalid id warning

### DIFF
--- a/core/__tests__/classes/codeConfig.ts
+++ b/core/__tests__/classes/codeConfig.ts
@@ -6,6 +6,7 @@ import {
   getConfigObjectsWithIds,
   sortConfigObjectsWithIds,
   ConfigurationObject,
+  getDirectParentId,
 } from "../../src/classes/codeConfig";
 
 describe("classes/codeConfig", () => {
@@ -103,6 +104,40 @@ describe("classes/codeConfig", () => {
         expect(prerequisiteIds).toEqual(["user_id", "query_source"]);
         expect(providedIds).toEqual(["ltv"]);
       });
+    });
+  });
+
+  describe("#getDirectParentId", () => {
+    test("gets correct parentId for destinations (appId)", async () => {
+      const destination = configObjects.find(
+        ({ id }) => id === "test_destination"
+      );
+      const parentId = await getDirectParentId(destination);
+      expect(parentId).toBe("data_warehouse");
+    });
+
+    test("gets correct parentId for sources (appId)", async () => {
+      const source = configObjects.find(({ id }) => id === "users_table");
+      const parentId = await getDirectParentId(source);
+      expect(parentId).toBe("data_warehouse");
+    });
+
+    test("gets correct parentId for properties (sourceId)", async () => {
+      const property = configObjects.find(({ id }) => id === "email");
+      const parentId = await getDirectParentId(property);
+      expect(parentId).toBe("users_table");
+    });
+
+    test("gets correct parentId for teamMembers (teamId)", async () => {
+      const teamMember = configObjects.find(({ id }) => id === "demo");
+      const parentId = await getDirectParentId(teamMember);
+      expect(parentId).toBe("admin_team");
+    });
+
+    test("returns null for objects without a parentId", async () => {
+      const team = configObjects.find(({ id }) => id === "admin_team");
+      const parentId = await getDirectParentId(team);
+      expect(parentId).toBeNull();
     });
   });
 

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -229,6 +229,24 @@ export async function getConfigObjectsWithIds(
   return configObjectsWithIds;
 }
 
+export async function getDirectParentId(configObject: ConfigurationObject) {
+  const parentKeys = {
+    destination: "appId",
+    source: "appId",
+    property: "sourceId",
+    teammember: "teamId",
+  };
+
+  const objectClass = configObject.class?.toLowerCase();
+  const parentKey = parentKeys[objectClass];
+  if (!parentKey) return null;
+
+  const parentId = configObject[parentKey];
+  if (!parentId) return null;
+
+  return parentId as string;
+}
+
 export async function getParentIds(
   configObject: ConfigurationObject,
   otherConfigObjects: Array<ConfigurationObject> = []

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -169,6 +169,16 @@ export async function processConfigObjects(
     return { seenIds: {}, errors };
   }
 
+  const configObjectIds = configObjects.map((o) => o.id);
+  locallyValidateIds.forEach(
+    (id) =>
+      !configObjectIds.includes(id) &&
+      log(
+        `[ config ] tried to locally validate \`${id}\`, but an object with that ID does not exist`,
+        "warning"
+      )
+  );
+
   for (const i in configObjects) {
     const configObject = configObjects[i];
     if (Object.keys(configObject).length === 0) continue;

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -7,7 +7,7 @@ import {
   sortConfigurationObjects,
   validateConfigObjects,
   IdsByClass,
-  getParentIds,
+  getDirectParentId,
 } from "../../classes/codeConfig";
 import { GrouparooErrorSerializer } from "../../config/errors";
 import { loadApp, deleteApps } from "./app";
@@ -91,21 +91,15 @@ async function loadConfigFile(file: string): Promise<ConfigurationObject> {
 export async function shouldExternallyValidate(
   canExternallyValidate: boolean,
   configObject: ConfigurationObject,
-  configObjects: ConfigurationObject[],
   locallyValidateIds: Set<string>
 ) {
   if (!canExternallyValidate) return false;
   if (!locallyValidateIds) return true;
 
-  const { prerequisiteIds: parentIds } = await getParentIds(
-    configObject,
-    configObjects
-  );
-
   const objectId = configObject.id;
 
-  const localParents = parentIds.filter((pId) => locallyValidateIds.has(pId));
-  if (localParents.length > 0) {
+  const parentId = await getDirectParentId(configObject);
+  if (parentId && locallyValidateIds.has(parentId)) {
     locallyValidateIds.add(objectId);
   }
 
@@ -184,7 +178,6 @@ export async function processConfigObjects(
     const externallyValidate = await shouldExternallyValidate(
       canExternallyValidate,
       configObject,
-      configObjects,
       locallyValidateIds
     );
 

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -169,15 +169,17 @@ export async function processConfigObjects(
     return { seenIds: {}, errors };
   }
 
-  const configObjectIds = configObjects.map((o) => o.id);
-  locallyValidateIds.forEach(
-    (id) =>
-      !configObjectIds.includes(id) &&
-      log(
-        `[ config ] tried to locally validate \`${id}\`, but an object with that ID does not exist`,
-        "warning"
-      )
-  );
+  if (locallyValidateIds) {
+    const configObjectIds = configObjects.map((o) => o.id);
+    locallyValidateIds.forEach(
+      (id) =>
+        !configObjectIds.includes(id) &&
+        log(
+          `[ config ] tried to locally validate \`${id}\`, but an object with that ID does not exist`,
+          "warning"
+        )
+    );
+  }
 
   for (const i in configObjects) {
     const configObject = configObjects[i];


### PR DESCRIPTION
- When using `roo validate --local id_here` or similar, only automatically apply local validation of direct dependents of `id_here`. Previous behavior would include any dependents down the tree. For example, locally validating a source would also do local validation of a destination that has a property from that source because the destination depended on the property which depended on the source
- Log warning when trying to locally validate unknown ids