### PR TITLE
throw error if bootstrapped property is an array or not unique

### DIFF
--- a/core/__tests__/classes/codeConfig.ts
+++ b/core/__tests__/classes/codeConfig.ts
@@ -7,6 +7,7 @@ import {
   sortConfigObjectsWithIds,
   ConfigurationObject,
   getDirectParentId,
+  getAutoBootstrappedProperty,
 } from "../../src/classes/codeConfig";
 
 describe("classes/codeConfig", () => {
@@ -216,6 +217,66 @@ describe("classes/codeConfig", () => {
     for (let i = 0; i < 10; i++) {
       testSortConfigObjectsWithIds(i);
     }
+  });
+
+  describe("#getAutoBootstrappedProperty", () => {
+    test("it can automatically determine which property to bootstrap", () => {
+      const source = configObjects.find((o) => o.id === "users_table");
+      const bootstrappedProperty = getAutoBootstrappedProperty(
+        source,
+        configObjects
+      );
+      expect(bootstrappedProperty.id).toBe("user_id");
+    });
+
+    test("it returns null if the source's mapping should not be bootstrapped", async () => {
+      const dir = path.join(
+        __dirname,
+        "..",
+        "fixtures",
+        "codeConfig",
+        "multiple-sources"
+      );
+      const _configObjects = await loadConfigObjects(dir);
+      const source = _configObjects.find((o) => o.id === "purchases_table");
+      const bootstrappedProperty = getAutoBootstrappedProperty(
+        source,
+        _configObjects
+      );
+      expect(bootstrappedProperty).toBeNull();
+    });
+
+    test("it throws an error if the bootstrapped property is not unique", async () => {
+      const dir = path.join(
+        __dirname,
+        "..",
+        "fixtures",
+        "codeConfig",
+        "error-bootstrap-not-unique"
+      );
+      const _configObjects = await loadConfigObjects(dir);
+      const source = _configObjects.find((o) => o.id === "users_table");
+
+      expect(() => {
+        getAutoBootstrappedProperty(source, _configObjects);
+      }).toThrow(/"user_id" needs to be set as "unique: true"/);
+    });
+
+    test("it throws an error if the bootstrapped property is an array", async () => {
+      const dir = path.join(
+        __dirname,
+        "..",
+        "fixtures",
+        "codeConfig",
+        "error-bootstrap-is-array"
+      );
+      const _configObjects = await loadConfigObjects(dir);
+      const source = _configObjects.find((o) => o.id === "users_table");
+
+      expect(() => {
+        getAutoBootstrappedProperty(source, _configObjects);
+      }).toThrow(/"user_id" cannot be an array/);
+    });
   });
 });
 

--- a/core/__tests__/fixtures/codeConfig/error-bootstrap-is-array/config.js
+++ b/core/__tests__/fixtures/codeConfig/error-bootstrap-is-array/config.js
@@ -1,0 +1,56 @@
+module.exports = async function getConfig() {
+  return [
+    {
+      id: "data_warehouse", // id -> `data_warehouse`
+      name: "Data Warehouse",
+      class: "App",
+      type: "test-plugin-app",
+      options: {
+        fileId: "test-file-path.db",
+      },
+    },
+
+    {
+      id: "users_table", // id -> `data_warehouse`
+      name: "Users Table",
+      class: "Source",
+      type: "test-plugin-import",
+      appId: "data_warehouse", // appId -> `data_warehouse`
+      options: {
+        table: "users",
+      },
+      mapping: {
+        id: "user_id",
+      },
+    },
+
+    {
+      id: "user_id", // id -> `user_id`
+      name: "userId",
+      class: "Property",
+      type: "integer",
+      unique: true,
+      isArray: true, // IT IS AN ARRAY!!!
+      identifying: true,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "id",
+      },
+      filters: [],
+    },
+
+    {
+      id: "email", // id -> `email`
+      name: "email",
+      class: "Property",
+      type: "email",
+      unique: true,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "email",
+      },
+      filters: [],
+    },
+  ];
+};

--- a/core/__tests__/fixtures/codeConfig/error-bootstrap-not-unique/config.js
+++ b/core/__tests__/fixtures/codeConfig/error-bootstrap-not-unique/config.js
@@ -1,0 +1,56 @@
+module.exports = async function getConfig() {
+  return [
+    {
+      id: "data_warehouse", // id -> `data_warehouse`
+      name: "Data Warehouse",
+      class: "App",
+      type: "test-plugin-app",
+      options: {
+        fileId: "test-file-path.db",
+      },
+    },
+
+    {
+      id: "users_table", // id -> `data_warehouse`
+      name: "Users Table",
+      class: "Source",
+      type: "test-plugin-import",
+      appId: "data_warehouse", // appId -> `data_warehouse`
+      options: {
+        table: "users",
+      },
+      mapping: {
+        id: "user_id",
+      },
+    },
+
+    {
+      id: "user_id", // id -> `user_id`
+      name: "userId",
+      class: "Property",
+      type: "integer",
+      unique: false, // NOT UNIQUE!!!
+      isArray: false,
+      identifying: true,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "id",
+      },
+      filters: [],
+    },
+
+    {
+      id: "email", // id -> `email`
+      name: "email",
+      class: "Property",
+      type: "email",
+      unique: true,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "email",
+      },
+      filters: [],
+    },
+  ];
+};

--- a/core/__tests__/fixtures/codeConfig/multiple-sources/config.js
+++ b/core/__tests__/fixtures/codeConfig/multiple-sources/config.js
@@ -1,0 +1,226 @@
+module.exports = async function getConfig() {
+  return [
+    {
+      id: "setting_cluster_name", // this is actually ignored
+      class: "Setting",
+      pluginName: "core",
+      key: "cluster-name",
+      value: "Test Cluster",
+    },
+
+    {
+      id: "data_warehouse", // id -> `data_warehouse`
+      name: "Data Warehouse",
+      class: "App",
+      type: "test-plugin-app",
+      options: {
+        fileId: "test-file-path.db",
+      },
+    },
+
+    {
+      id: "events", // id -> `events`
+      name: "Grouparoo Events",
+      class: "App",
+      type: "events",
+      options: {
+        identifyingPropertyId: "user_id",
+      },
+    },
+
+    {
+      id: "users_table", // id -> `data_warehouse`
+      name: "Users Table",
+      class: "Source",
+      type: "test-plugin-import",
+      appId: "data_warehouse", // appId -> `data_warehouse`
+      options: {
+        table: "users",
+      },
+      mapping: {
+        id: "user_id",
+      },
+    },
+
+    {
+      id: "users_table_schedule", // id -> `sch_users_table_schedule`
+      name: "Users Table Schedule",
+      class: "Schedule",
+      sourceId: "users_table", // sourceId -> `users_table`
+      recurring: true,
+      recurringFrequency: 1000 * 60 * 15, // 15 minutes in ms
+      options: {
+        maxColumn: "updated_at",
+      },
+    },
+
+    {
+      id: "user_id", // id -> `user_id`
+      name: "userId",
+      class: "Property",
+      type: "integer",
+      unique: true,
+      isArray: false,
+      identifying: true,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "id",
+      },
+      filters: [],
+    },
+
+    {
+      id: "email", // id -> `email`
+      name: "email",
+      class: "Property",
+      type: "email",
+      unique: true,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "email",
+      },
+      filters: [],
+    },
+
+    {
+      id: "first_name", // id -> `first_name`
+      name: "first name",
+      class: "Property",
+      type: "string",
+      unique: false,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "first_name",
+      },
+      filters: [],
+    },
+
+    {
+      id: "last_name", // id -> `first_name`
+      name: "last name",
+      class: "Property",
+      type: "string",
+      unique: false,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "last_name",
+      },
+      filters: [],
+    },
+
+    {
+      id: "purchases_table", // id -> `purchases_table`
+      name: "Purchases Table",
+      class: "Source",
+      type: "test-plugin-import",
+      appId: "data_warehouse", // appId -> `data_warehouse`
+      options: {
+        table: "purchases",
+      },
+      mapping: {
+        user_id: "user_id",
+      },
+    },
+
+    {
+      id: "purchases_table_schedule", // id -> `sch_purchases_table_schedule`
+      name: "Purchases Table Schedule",
+      class: "Schedule",
+      sourceId: "purchases_table", // sourceId -> `purchases_table`
+      recurring: true,
+      recurringFrequency: 1000 * 60 * 15, // 15 minutes in ms
+      options: {
+        maxColumn: "updated_at",
+      },
+    },
+
+    {
+      id: "purchase_count",
+      name: "purchaseCount",
+      class: "Property",
+      type: "integer",
+      unique: false,
+      isArray: false,
+      sourceId: "purchases_table",
+      options: {
+        column: "id",
+        aggregationMethod: "count",
+        sortColumn: null,
+      },
+      filters: [{ key: "state", op: "equals", match: "successful" }],
+    },
+
+    {
+      id: "email_group", // id -> `marketing_team`
+      name: "People with Email Addresses",
+      class: "Group",
+      type: "calculated",
+      rules: [
+        {
+          propertyId: "user_id",
+          operation: { op: "exists" },
+        },
+        {
+          propertyId: "email",
+          operation: { op: "like" },
+          match: "%@%",
+        },
+      ],
+    },
+
+    {
+      id: "test_destination", // id -> `dst_hubspot_destination`
+      name: "Test Destination",
+      class: "destination",
+      type: "test-plugin-export",
+      appId: "data_warehouse", // id -> data_warehouse
+      groupId: "email_group", // id -> email_group
+      syncMode: "additive",
+      options: {
+        table: "output",
+      },
+      mapping: {
+        "primary-id": "user_id",
+        "secondary-id": "email",
+      },
+      destinationGroupMemberships: {
+        "Literally Everyone": "email_group",
+      },
+    },
+
+    {
+      id: "website_key", // id -> `website_key`
+      name: "web-api-key",
+      class: "apiKey",
+      options: {
+        permissionAllRead: true,
+        permissionAllWrite: true,
+      },
+    },
+
+    {
+      id: "admin_team", // id -> `admin_team`
+      name: "Admin Team",
+      class: "team",
+      options: {
+        permissionAllRead: true,
+        permissionAllWrite: true,
+      },
+    },
+
+    {
+      id: "demo", // id -> `person`
+      email: "demo@grouparoo.com",
+      teamId: "admin_team", // id -> `marketing_team`
+      class: "teamMember",
+      options: {
+        firstName: "Example",
+        lastName: "Person",
+        password: "password",
+      },
+    },
+  ];
+};

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -157,16 +157,26 @@ export function getAutoBootstrappedProperty(
   const mappingValues = Object.values(sourceConfigObject["mapping"]);
   for (const value of mappingValues) {
     // If this source id == its mapped property's sourceId, we should bootstrap the property
-    const autoBootstrappedProperty = otherConfigObjects.filter(
+    const autoBootstrappedProperty = otherConfigObjects.find(
       (o) =>
         o.class.toLowerCase() === "property" &&
         o.id === value &&
-        o.sourceId === sourceConfigObject.id &&
-        o.unique &&
-        !o.isArray
+        o.sourceId === sourceConfigObject.id
     );
-    if (autoBootstrappedProperty.length > 0) {
-      return autoBootstrappedProperty[0];
+    if (autoBootstrappedProperty) {
+      if (!autoBootstrappedProperty.unique) {
+        throw new Error(
+          `The property "${autoBootstrappedProperty.id}" needs to be set as "unique: true" to be used as the mapping for the source "${sourceConfigObject.id}"`
+        );
+      }
+
+      if (autoBootstrappedProperty.isArray) {
+        throw new Error(
+          `The property "${autoBootstrappedProperty.id}" cannot be an array to be used as the mapping for the source "${sourceConfigObject.id}"`
+        );
+      }
+
+      return autoBootstrappedProperty;
     }
   }
 


### PR DESCRIPTION
This prevents the ambiguous error of "Maximum call stack size exceeded" if the property was set as an array or is not unique.