### PR TITLE
Protect SERVER_TOKEN in UI stack trace

### DIFF
--- a/core/__tests__/actions/navigation.ts
+++ b/core/__tests__/actions/navigation.ts
@@ -26,4 +26,40 @@ describe("actions/navigation", () => {
     const { clusterName } = await specHelper.runAction("navigation:list");
     expect(clusterName).toBe("My Grouparoo Cluster");
   });
+
+  describe("with session", () => {
+    beforeAll(async () => {
+      await specHelper.runAction("team:initialize", {
+        firstName: "Peach",
+        lastName: "Toadstool",
+        password: "P@ssw0rd!",
+        email: "peach@example.com",
+      });
+    });
+
+    test("the navigation action does not include the teamMember if not logged in", async () => {
+      const { teamMember } = await specHelper.runAction("navigation:list");
+      expect(teamMember).toBeUndefined();
+    });
+
+    test("the navigation action includes the teamMember if logged in", async () => {
+      const connection = await specHelper.buildConnection();
+      connection.params = {
+        email: "peach@example.com",
+        password: "P@ssw0rd!",
+      };
+      const sessionResponse = await specHelper.runAction(
+        "session:create",
+        connection
+      );
+      const csrfToken = sessionResponse.csrfToken;
+      connection.params = { csrfToken };
+
+      const { teamMember } = await specHelper.runAction(
+        "navigation:list",
+        connection
+      );
+      expect(teamMember.email).toBe("peach@example.com");
+    });
+  });
 });

--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -195,7 +195,7 @@ export class NavigationList extends OptionallyAuthenticatedAction {
     return {
       navigationMode,
       clusterName: clusterNameSetting?.value || "",
-      teamMember,
+      teamMember: teamMember ? await teamMember.apiData() : undefined,
       navigation: {
         navigationItems,
         platformItems,

--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -195,6 +195,7 @@ export class NavigationList extends OptionallyAuthenticatedAction {
     return {
       navigationMode,
       clusterName: clusterNameSetting?.value || "",
+      teamMember,
       navigation: {
         navigationItems,
         platformItems,

--- a/ui/ui-components/components/alerts/hydrationError.tsx
+++ b/ui/ui-components/components/alerts/hydrationError.tsx
@@ -20,7 +20,7 @@ export default function HydrationError({
   return (
     <>
       <Card border={"warning"}>
-        <Card.Header>There was an Error loading this Page</Card.Header>
+        <Card.Header>There was an error loading this Page</Card.Header>
         <Card.Body>
           <blockquote className="blockquote mb-0">
             <p>{error.message}</p>
@@ -28,22 +28,26 @@ export default function HydrationError({
           {errorData ? (
             <>
               <code>
-                {Object.keys(errorData).map((k) => {
-                  return (
-                    <Fragment key={`errorData-${k}`}>
-                      {k}:{" "}
-                      {typeof errorData[k] === "string"
-                        ? errorData[k]
-                        : JSON.stringify(errorData[k])}
-                      <br />
-                    </Fragment>
-                  );
-                })}
+                {Object.keys(errorData).map((k) =>
+                  errorDataDisplay(k, errorData[k])
+                )}
               </code>
             </>
           ) : null}
         </Card.Body>
       </Card>
     </>
+  );
+}
+
+function errorDataDisplay(name: string, content: string | Object) {
+  const stringContent =
+    typeof content === "string" ? content : JSON.stringify(content);
+
+  return (
+    <Fragment key={`errorData-${name}`}>
+      {name}: {stringContent}
+      <br />
+    </Fragment>
   );
 }


### PR DESCRIPTION
This PR also includes the session's TeamMember in the `get navigation` API request, so we can skip hydrating pages with `get session`.