### PR TITLE
Remove waitForReady on `grouparoo run`

### DIFF
--- a/core/__tests__/bin/run.ts
+++ b/core/__tests__/bin/run.ts
@@ -35,10 +35,6 @@ describe("bin/run", () => {
       instance = new RunCLI();
     });
 
-    test("we can tell if the app has booted", async () => {
-      await instance.waitForReady(); // does not time out
-    });
-
     test("paused tasks can be run", async () => {
       await instance.runPausedTasks({}); // does not throw
     });

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -4,8 +4,6 @@ import { Schedule, Run } from "..";
 import { CLS } from "../modules/cls";
 import { Reset } from "../modules/reset";
 
-const CHECK_TIMEOUT = 1000 * 10;
-
 export class RunCLI extends CLI {
   constructor() {
     super();
@@ -67,7 +65,6 @@ export class RunCLI extends CLI {
 
     await import("../grouparoo"); // run the server
 
-    await this.waitForReady();
     await this.runPausedTasks(params);
 
     if (params.runAllSchedules) await this.runNonRecurringSchedules();
@@ -80,17 +77,6 @@ export class RunCLI extends CLI {
       throw new Error(`The Task Scheduler is not enabled`);
     if (config.tasks.minTaskProcessors < 1)
       throw new Error(`No Task Workers are enabled`);
-  }
-
-  async waitForReady() {
-    return new Promise(async (resolve) => {
-      async function check() {
-        if (api.process.started) return resolve(null);
-        setTimeout(() => check(), CHECK_TIMEOUT / 2);
-      }
-
-      await check();
-    });
   }
 
   async runPausedTasks(params) {


### PR DESCRIPTION
This method is no longer needed now that logging is handled by the `status` task.