### PR TITLE
`run` and `start` CLI commands await for process boot

### DIFF
--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -63,7 +63,8 @@ export class RunCLI extends CLI {
       params.export.toString().toLowerCase() !== "true"
     );
 
-    await import("../grouparoo"); // run the server
+    const { main } = await import("../grouparoo");
+    await main();
 
     await this.runPausedTasks(params);
 

--- a/core/src/bin/start.ts
+++ b/core/src/bin/start.ts
@@ -18,7 +18,9 @@ export class Start extends CLI {
   async run() {
     GrouparooCLI.logCLI(this.name, false);
 
-    await import("../grouparoo"); // run the server
+    const { main } = await import("../grouparoo");
+    await main();
+
     return false;
   }
 }

--- a/core/src/grouparoo.ts
+++ b/core/src/grouparoo.ts
@@ -1,6 +1,6 @@
 import { getCoreVersion, getNodeVersion } from "./utils/pluginDetails";
 
-async function main() {
+export async function main() {
   const { Process, log, api } = await import("actionhero");
 
   log(
@@ -21,4 +21,8 @@ async function main() {
   await app.start();
 }
 
-main();
+function isEntryPoint() {
+  return require.main === module;
+}
+
+if (isEntryPoint()) main();


### PR DESCRIPTION
A followup to https://github.com/grouparoo/grouparoo/pull/1746, the `grouparoo start` and `grouparoo run` commands can not properly `await` the actionhero initialization process without needing to poll.  