### PR TITLE
fix: set options before updating property when loading from codeConfig

### DIFF
--- a/core/__tests__/fixtures/codeConfig/changes/config.js
+++ b/core/__tests__/fixtures/codeConfig/changes/config.js
@@ -92,7 +92,7 @@ module.exports = async function getConfig() {
       isArray: false,
       sourceId: "users_table", // sourceId -> `users_table`
       options: {
-        column: "first_name",
+        column: "other_first_name", // CHANGED!
       },
       filters: [],
     },

--- a/core/src/modules/configLoaders/property.ts
+++ b/core/src/modules/configLoaders/property.ts
@@ -34,14 +34,14 @@ export async function loadProperty(
     });
   }
 
+  await property.setOptions(extractNonNullParts(configObject, "options"), null);
+
   await property.update({
     type: configObject.type,
     key: configObject.key || configObject.name,
     unique: configObject.unique,
     isArray: configObject.isArray,
   });
-
-  await property.setOptions(extractNonNullParts(configObject, "options"), null);
 
   if (configObject.filters) {
     await property.setFilters(configObject.filters, externallyValidate);


### PR DESCRIPTION
If a property was somehow initially created without a required option, it's impossible to validate afterwards.
This happened because of a bug with the old method of bootstrapping properties (fixed by #1726), which did not set the options on the property. When we create the bootstrapped property, the hook that causes this validation does not run, so it was able to be created in an invalid state. Because of the previous fix, this now works on a brand new database, but we still have an issue if you use the existing db with the invalid property (see pivotal #178013312) and switch over to the new auto bootstrapped property.
This errors because when we try to update the existing, invalid property, it runs validation before setting the new options on the property. The PR fixes this by setting options before updating.
