### PR TITLE
Do not try to sanitize missing headers

### DIFF
--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -160,6 +160,8 @@ function renderError(error: AxiosError) {
 }
 
 function sanitizeHeaders(headers: { [k: string]: any } = {}) {
+  if (!process.env.SERVER_TOKEN) return headers; // if the page is being initialized in the browser, the ENV won't be set
+
   const matcher = new RegExp(process.env.SERVER_TOKEN, "g");
   const replacement = "[REDACTED]";
 


### PR DESCRIPTION
Fixes a big introduced by https://github.com/grouparoo/grouparoo/pull/1742

If there is no `process.env.SERVER_TOKEN` (most common when the page is being hydrated in the browser from a pre-fetched page after the server has shut down), the regular expression would be matching `""` which would try to replace every char with `[redacted]`.