### PR TITLE
fix: update tracked group when going back to previously tracked group

### DIFF
--- a/core/__tests__/actions/destinations.ts
+++ b/core/__tests__/actions/destinations.ts
@@ -301,22 +301,14 @@ describe("actions/destinations", () => {
         connection.params = {
           csrfToken,
           id,
-          groupId: group.id,
+          trackedGroupId: group.id,
         };
-        const { error } = await specHelper.runAction(
-          "destination:trackGroup",
-          connection
-        );
-        expect(error).toBeUndefined();
 
-        connection.params = {
-          csrfToken,
-          id,
-        };
-        const { destination } = await specHelper.runAction(
-          "destination:view",
+        const { destination, error } = await specHelper.runAction(
+          "destination:edit",
           connection
         );
+        expect(error).toBeFalsy();
         expect(destination.destinationGroup.id).toBe(group.id);
       });
 
@@ -334,6 +326,7 @@ describe("actions/destinations", () => {
           connection
         );
         expect(error).toBeFalsy();
+        expect(destination.destinationGroup.id).toBe(group.id);
         expect(destination.destinationGroupMemberships).toEqual([
           {
             groupId: group.id,
@@ -472,17 +465,23 @@ describe("actions/destinations", () => {
         connection.params = {
           csrfToken,
           id,
-          groupId: destination.destinationGroup.id,
+          trackedGroupId: null,
         };
-        const { error } = await specHelper.runAction(
-          "destination:unTrackGroup",
-          connection
-        );
-        expect(error).toBeUndefined();
+        const {
+          destination: updatedDestination,
+          error,
+        } = await specHelper.runAction("destination:edit", connection);
+        expect(error).toBeFalsy();
+        expect(updatedDestination.destinationGroup).toBe(null);
       });
 
       test("an administrator can export the members of a destination with a forced group run", async () => {
-        await specHelper.runAction("destination:trackGroup", connection);
+        connection.params = {
+          csrfToken,
+          id,
+          trackedGroupId: group.id,
+        };
+        await specHelper.runAction("destination:edit", connection);
 
         connection.params = {
           csrfToken,
@@ -514,7 +513,12 @@ describe("actions/destinations", () => {
           })
         );
 
-        await specHelper.runAction("destination:unTrackGroup", connection);
+        connection.params = {
+          csrfToken,
+          id,
+          trackedGroupId: "_none",
+        };
+        await specHelper.runAction("destination:edit", connection);
       });
     });
 

--- a/core/__tests__/actions/destinations.ts
+++ b/core/__tests__/actions/destinations.ts
@@ -481,7 +481,11 @@ describe("actions/destinations", () => {
           id,
           trackedGroupId: group.id,
         };
-        await specHelper.runAction("destination:edit", connection);
+        const { destination: _destination } = await specHelper.runAction(
+          "destination:edit",
+          connection
+        );
+        expect(_destination.destinationGroup.id).toBe(group.id);
 
         connection.params = {
           csrfToken,
@@ -518,7 +522,11 @@ describe("actions/destinations", () => {
           id,
           trackedGroupId: "_none",
         };
-        await specHelper.runAction("destination:edit", connection);
+        const { destination: __destination } = await specHelper.runAction(
+          "destination:edit",
+          connection
+        );
+        expect(__destination.destinationGroup).toBe(null);
       });
     });
 

--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -96,8 +96,6 @@ export const DEFAULT = {
         { path: "/v:apiVersion/schedule", action: "schedule:create" },
         { path: "/v:apiVersion/schedule/:id/run", action: "schedule:run" },
         { path: "/v:apiVersion/destination", action: "destination:create" },
-        { path: "/v:apiVersion/destination/:id/track", action: "destination:trackGroup" },
-        { path: "/v:apiVersion/destination/:id/unTrack", action: "destination:unTrackGroup" },
         { path: "/v:apiVersion/destination/:id/export", action: "destination:export" },
         { path: "/v:apiVersion/file", action: "file:create" },
         { path: "/v:apiVersion/import", action: "import:create" }

--- a/plugins/@grouparoo/hubspot/__tests__/integration/hubspot-export.ts
+++ b/plugins/@grouparoo/hubspot/__tests__/integration/hubspot-export.ts
@@ -232,16 +232,7 @@ describe("integration/runs/hubspot", () => {
     await group.update({ state: "ready" });
   });
 
-  test("track the test group with the destination", async () => {
-    session.params = {
-      csrfToken,
-      id: destination.id,
-      groupId: group.id,
-    };
-    await specHelper.runAction("destination:trackGroup", session);
-  });
-
-  test(`the destination group membership can be set`, async () => {
+  test(`the destination group membership can be set and test group can be tracked`, async () => {
     const destinationGroupMemberships = {};
     destinationGroupMemberships[group.id] = group.name;
 
@@ -249,12 +240,14 @@ describe("integration/runs/hubspot", () => {
       csrfToken,
       id: destination.id,
       destinationGroupMemberships,
+      trackedGroupId: group.id,
     };
     const { error, destination: _destination } = await specHelper.runAction(
       "destination:edit",
       session
     );
     expect(error).toBeUndefined();
+    expect(_destination.destinationGroup.id).toBe(group.id);
     expect(_destination.destinationGroupMemberships).toEqual([
       {
         groupId: group.id,

--- a/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-export-id.ts
+++ b/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-export-id.ts
@@ -266,16 +266,7 @@ describe("integration/runs/mailchimp-export-id", () => {
     await group.update({ state: "ready" });
   });
 
-  test("track the test group with the destination", async () => {
-    session.params = {
-      csrfToken,
-      id: destination.id,
-      groupId: group.id,
-    };
-    await specHelper.runAction("destination:trackGroup", session);
-  });
-
-  test(`the destination group membership can be set`, async () => {
+  test(`the destination group membership can be set and test group can be tracked`, async () => {
     const destinationGroupMemberships = {};
     destinationGroupMemberships[group.id] = group.name;
 
@@ -283,12 +274,14 @@ describe("integration/runs/mailchimp-export-id", () => {
       csrfToken,
       id: destination.id,
       destinationGroupMemberships,
+      trackedGroupId: group.id,
     };
     const { error, destination: _destination } = await specHelper.runAction(
       "destination:edit",
       session
     );
     expect(error).toBeUndefined();
+    expect(_destination.destinationGroup.id).toBe(group.id);
     expect(_destination.destinationGroupMemberships).toEqual([
       {
         groupId: group.id,

--- a/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-export.ts
+++ b/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-export.ts
@@ -246,16 +246,7 @@ describe("integration/runs/mailchimp-export", () => {
     await group.update({ state: "ready" });
   });
 
-  test("track the test group with the destination", async () => {
-    session.params = {
-      csrfToken,
-      id: destination.id,
-      groupId: group.id,
-    };
-    await specHelper.runAction("destination:trackGroup", session);
-  });
-
-  test(`the destination group membership can be set`, async () => {
+  test(`the destination group membership can be set and test group can be tracked`, async () => {
     const destinationGroupMemberships = {};
     destinationGroupMemberships[group.id] = group.name;
 
@@ -263,12 +254,14 @@ describe("integration/runs/mailchimp-export", () => {
       csrfToken,
       id: destination.id,
       destinationGroupMemberships,
+      trackedGroupId: group.id,
     };
     const { error, destination: _destination } = await specHelper.runAction(
       "destination:edit",
       session
     );
     expect(error).toBeUndefined();
+    expect(_destination.destinationGroup.id).toBe(group.id);
     expect(_destination.destinationGroupMemberships).toEqual([
       {
         groupId: group.id,

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -239,15 +239,6 @@ describe("integration/runs/mysql", () => {
     ]);
   });
 
-  test("track the test group with the destination", async () => {
-    session.params = {
-      csrfToken,
-      id: destination.id,
-      groupId: group.id,
-    };
-    await specHelper.runAction("destination:trackGroup", session);
-  });
-
   test("we can read the mysql mapping options", async () => {
     session.params = {
       csrfToken,
@@ -278,7 +269,7 @@ describe("integration/runs/mysql", () => {
     });
   });
 
-  test(`the destination group membership can be set`, async () => {
+  test(`the destination group membership can be set and test group can be tracked`, async () => {
     const destinationGroupMemberships = {};
     destinationGroupMemberships[group.id] = group.name;
 
@@ -286,12 +277,14 @@ describe("integration/runs/mysql", () => {
       csrfToken,
       id: destination.id,
       destinationGroupMemberships,
+      trackedGroupId: group.id,
     };
     const { error, destination: _destination } = await specHelper.runAction(
       "destination:edit",
       session
     );
     expect(error).toBeUndefined();
+    expect(_destination.destinationGroup.id).toBe(group.id);
     expect(_destination.destinationGroupMemberships).toEqual([
       {
         groupId: group.id,

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
@@ -233,15 +233,6 @@ describe("integration/runs/postgres", () => {
     ]);
   });
 
-  test("track the test group with the destination", async () => {
-    session.params = {
-      csrfToken,
-      id: destination.id,
-      groupId: group.id,
-    };
-    await specHelper.runAction("destination:trackGroup", session);
-  });
-
   test("we can read the postgres mapping options", async () => {
     session.params = {
       csrfToken,
@@ -272,7 +263,7 @@ describe("integration/runs/postgres", () => {
     });
   });
 
-  test(`the destination group membership can be set`, async () => {
+  test(`the destination group membership can be set and test group can be tracked`, async () => {
     const destinationGroupMemberships = {};
     destinationGroupMemberships[group.id] = group.name;
 
@@ -280,12 +271,14 @@ describe("integration/runs/postgres", () => {
       csrfToken,
       id: destination.id,
       destinationGroupMemberships,
+      trackedGroupId: group.id,
     };
     const { error, destination: _destination } = await specHelper.runAction(
       "destination:edit",
       session
     );
     expect(error).toBeUndefined();
+    expect(_destination.destinationGroup.id).toBe(group.id);
     expect(_destination.destinationGroupMemberships).toEqual([
       {
         groupId: group.id,

--- a/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-table-import.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-table-import.ts
@@ -238,15 +238,6 @@ describe("integration/runs/sqlite", () => {
     ]);
   });
 
-  test("track the test group with the destination", async () => {
-    session.params = {
-      csrfToken,
-      id: destination.id,
-      groupId: group.id,
-    };
-    await specHelper.runAction("destination:trackGroup", session);
-  });
-
   test("we can read the sqlite mapping options", async () => {
     session.params = {
       csrfToken,
@@ -277,7 +268,7 @@ describe("integration/runs/sqlite", () => {
     });
   });
 
-  test(`the destination group membership can be set`, async () => {
+  test(`the destination group membership can be set and test group can be tracked`, async () => {
     const destinationGroupMemberships = {};
     destinationGroupMemberships[group.id] = group.name;
 
@@ -285,12 +276,14 @@ describe("integration/runs/sqlite", () => {
       csrfToken,
       id: destination.id,
       destinationGroupMemberships,
+      trackedGroupId: group.id,
     };
     const { error, destination: _destination } = await specHelper.runAction(
       "destination:edit",
       session
     );
     expect(error).toBeUndefined();
+    expect(_destination.destinationGroup.id).toBe(group.id);
     expect(_destination.destinationGroupMemberships).toEqual([
       {
         groupId: group.id,

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -102,8 +102,6 @@ import {
   DestinationExportArrayProperties,
   DestinationMappingOptions,
   DestinationProfilePreview,
-  DestinationTrackGroup,
-  DestinationUnTrackGroup,
   DestinationView,
 } from "@grouparoo/core/src/actions/destinations";
 import {
@@ -342,12 +340,6 @@ export namespace Actions {
   >;
   export type DestinationProfilePreview = AsyncReturnType<
     typeof DestinationProfilePreview.prototype.runWithinTransaction
-  >;
-  export type DestinationTrackGroup = AsyncReturnType<
-    typeof DestinationTrackGroup.prototype.runWithinTransaction
-  >;
-  export type DestinationUnTrackGroup = AsyncReturnType<
-    typeof DestinationUnTrackGroup.prototype.runWithinTransaction
   >;
   export type DestinationView = AsyncReturnType<
     typeof DestinationView.prototype.runWithinTransaction

--- a/ui/ui-enterprise/pages/destination/[id]/data.tsx
+++ b/ui/ui-enterprise/pages/destination/[id]/data.tsx
@@ -784,11 +784,9 @@ export default function Page(props) {
                   >
                     Save Destination Data
                   </LoadingButton>
-
-                  <br />
-                  <br />
-
+                  &nbsp;
                   <LoadingButton
+                    style={{ marginTop: 5 }}
                     variant="outline-secondary"
                     size="sm"
                     disabled={loading}

--- a/ui/ui-enterprise/pages/destination/[id]/data.tsx
+++ b/ui/ui-enterprise/pages/destination/[id]/data.tsx
@@ -77,11 +77,20 @@ export default function Page(props) {
       destinationGroupMemberships: destinationGroupMembershipsObject,
     });
 
-    // TODO await execApi("post", `/destination/${id}/export`, { force: true });
+    setLoading(false);
+    successHandler.set({
+      message: "Destination updated",
+    });
+  };
+
+  const forceExport = async () => {
+    setLoading(true);
+
+    await execApi("post", `/destination/${id}/export`, { force: true });
 
     setLoading(false);
     successHandler.set({
-      message: "Destination Updated and Profiles Exporting...",
+      message: "Exporting Profiles...",
     });
   };
 
@@ -774,6 +783,18 @@ export default function Page(props) {
                     disabled={loading}
                   >
                     Save Destination Data
+                  </LoadingButton>
+
+                  <br />
+                  <br />
+
+                  <LoadingButton
+                    variant="outline-secondary"
+                    size="sm"
+                    disabled={loading}
+                    onClick={forceExport}
+                  >
+                    Force Export Group Members
                   </LoadingButton>
                 </Col>
               </Row>

--- a/ui/ui-enterprise/pages/destination/[id]/data.tsx
+++ b/ui/ui-enterprise/pages/destination/[id]/data.tsx
@@ -37,9 +37,6 @@ export default function Page(props) {
   const { execApi } = useApi(props, errorHandler);
   const router = useRouter();
   const [loading, setLoading] = useState(false);
-  const [currentlyTrackedGroupId, setCurrentlyTrackedGroupId] = useState(
-    props.trackedGroupId
-  );
   const [trackedGroupId, settrackedGroupId] = useState(
     props.trackedGroupId || "_none"
   );
@@ -73,32 +70,15 @@ export default function Page(props) {
     destination.destinationGroupMemberships.forEach(
       (dgm) => (destinationGroupMembershipsObject[dgm.groupId] = dgm.remoteKey)
     );
+
     await execApi("put", `/destination/${id}`, {
       mapping: filteredMapping,
+      trackedGroupId: trackedGroupId || "_none",
       destinationGroupMemberships: destinationGroupMembershipsObject,
     });
 
-    // update group being tracked after the edit
-    if (
-      trackedGroupId !== currentlyTrackedGroupId &&
-      trackedGroupId !== "_none" &&
-      trackedGroupId !== null &&
-      trackedGroupId !== ""
-    ) {
-      await execApi("post", `/destination/${id}/track`, {
-        groupId: trackedGroupId,
-      });
-    } else if (
-      trackedGroupId !== currentlyTrackedGroupId &&
-      trackedGroupId === "_none"
-    ) {
-      await execApi("post", `/destination/${id}/untrack`);
-    } else {
-      // trigger a full export
-      await execApi("post", `/destination/${id}/export`, { force: true });
-    }
+    // TODO await execApi("post", `/destination/${id}/export`, { force: true });
 
-    setCurrentlyTrackedGroupId(trackedGroupId);
     setLoading(false);
     successHandler.set({
       message: "Destination Updated and Profiles Exporting...",

--- a/ui/ui-enterprise/pages/destination/[id]/data.tsx
+++ b/ui/ui-enterprise/pages/destination/[id]/data.tsx
@@ -37,6 +37,9 @@ export default function Page(props) {
   const { execApi } = useApi(props, errorHandler);
   const router = useRouter();
   const [loading, setLoading] = useState(false);
+  const [currentlyTrackedGroupId, setCurrentlyTrackedGroupId] = useState(
+    props.trackedGroupId || "_none"
+  );
   const [trackedGroupId, settrackedGroupId] = useState(
     props.trackedGroupId || "_none"
   );
@@ -77,7 +80,7 @@ export default function Page(props) {
 
     // update group being tracked after the edit
     if (
-      trackedGroupId !== props.trackedGroupId &&
+      trackedGroupId !== currentlyTrackedGroupId &&
       trackedGroupId !== "_none" &&
       trackedGroupId !== null &&
       trackedGroupId !== ""
@@ -86,7 +89,7 @@ export default function Page(props) {
         groupId: trackedGroupId,
       });
     } else if (
-      trackedGroupId !== props.trackedGroupId &&
+      trackedGroupId !== currentlyTrackedGroupId &&
       trackedGroupId === "_none"
     ) {
       await execApi("post", `/destination/${id}/untrack`);
@@ -95,6 +98,7 @@ export default function Page(props) {
       await execApi("post", `/destination/${id}/export`, { force: true });
     }
 
+    setCurrentlyTrackedGroupId(trackedGroupId);
     setLoading(false);
     successHandler.set({
       message: "Destination Updated and Profiles Exporting...",

--- a/ui/ui-enterprise/pages/destination/[id]/data.tsx
+++ b/ui/ui-enterprise/pages/destination/[id]/data.tsx
@@ -38,7 +38,7 @@ export default function Page(props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [currentlyTrackedGroupId, setCurrentlyTrackedGroupId] = useState(
-    props.trackedGroupId || "_none"
+    props.trackedGroupId
   );
   const [trackedGroupId, settrackedGroupId] = useState(
     props.trackedGroupId || "_none"


### PR DESCRIPTION
Switching back to the group that was tracked when loading the page wouldn't cause any changes.