### PR TITLE
Allow logged models to have id values that are 191 characters in length

### DIFF
--- a/core/__tests__/classes/loggedModel.ts
+++ b/core/__tests__/classes/loggedModel.ts
@@ -30,7 +30,7 @@ describe("classes/loggedModel", () => {
         "foo-dash",
         "fooUpperLower",
         "foo-with-numb3r",
-        "foo-that-is-oh-so-much-longer-than-40-characters",
+        "a".repeat(191),
       ].forEach((id) => {
         const app = new App();
         app.id = id;
@@ -49,7 +49,7 @@ describe("classes/loggedModel", () => {
         "foo:stuff",
         "foo;stuff",
         "foo$stuff",
-        "foo-is-long-really-long-really-really-long-really-really-really-long-really-really-really-really-long-really-really-really-really-really-long-really-really-really-long-like-192-characters-long",
+        "a".repeat(192),
       ].forEach((id) => {
         const app = new App();
         app.id = id;

--- a/core/__tests__/classes/loggedModel.ts
+++ b/core/__tests__/classes/loggedModel.ts
@@ -30,6 +30,7 @@ describe("classes/loggedModel", () => {
         "foo-dash",
         "fooUpperLower",
         "foo-with-numb3r",
+        "foo-that-is-oh-so-much-longer-than-40-characters",
       ].forEach((id) => {
         const app = new App();
         app.id = id;
@@ -48,6 +49,7 @@ describe("classes/loggedModel", () => {
         "foo:stuff",
         "foo;stuff",
         "foo$stuff",
+        "foo-is-long-really-long-really-really-long-really-really-really-long-really-really-really-really-long-really-really-really-really-really-long-really-really-really-long-like-192-characters-long",
       ].forEach((id) => {
         const app = new App();
         app.id = id;

--- a/core/src/classes/loggedModel.ts
+++ b/core/src/classes/loggedModel.ts
@@ -26,7 +26,7 @@ export abstract class LoggedModel<T> extends Model {
    */
   abstract idPrefix(): string;
 
-  @Length({ min: 1, max: 40 })
+  @Length({ min: 1, max: 191 })
   @Column({ primaryKey: true })
   id: string;
 
@@ -41,12 +41,12 @@ export abstract class LoggedModel<T> extends Model {
   static validateId(instance) {
     const id: string = instance.id;
     let failing = false;
-    if (id.length > 40) failing = true;
+    if (id.length > 191) failing = true;
     if (!/^[A-Za-z0-9-_]+$/.test(id)) failing = true; // only allow letters, numbers, hyphen and underscore
 
     if (failing) {
       throw new Error(
-        `invalid id: \`${id}\` - ids must be less than 40 characters and not contain spaces or special characters`
+        `invalid id: \`${id}\` - ids must be less than 191 characters and not contain spaces or special characters`
       );
     }
   }

--- a/core/src/migrations/000065-lengthen-id-columns.ts
+++ b/core/src/migrations/000065-lengthen-id-columns.ts
@@ -1,0 +1,55 @@
+const columnChanges = {
+  apiKeys: ["apiKey", "id"],
+  apps: ["id"],
+  destinationGroupMemberships: ["id", "destinationId", "groupId"],
+  destinations: ["id", "appId", "groupId"],
+  eventData: ["id", "eventId"],
+  events: ["id", "producerId", "profileId"],
+  exports: ["id", "profileId", "destinationId"],
+  files: ["id"],
+  groupMembers: ["id", "profileId", "groupId"],
+  groupRules: ["id", "groupId", "propertyId"],
+  groups: ["id"],
+  imports: ["id", "creatorId", "profileId"],
+  logs: ["id", "ownerId"],
+  mappings: ["id", "ownerId", "propertyId"],
+  notifications: ["id"],
+  options: ["id", "ownerId"],
+  permissions: ["id", "ownerId"],
+  profileProperties: ["id", "profileId", "propertyId"],
+  profiles: ["id"],
+  properties: ["id", "sourceId"],
+  propertyFilters: ["id", "propertyId"],
+  runs: ["id", "creatorId", "destinationId"],
+  schedules: ["id", "sourceId"],
+  sessions: ["id"],
+  settings: ["id"],
+  setupSteps: ["id"],
+  sources: ["id", "appId"],
+  teamMembers: ["id", "teamId"],
+  teams: ["id"],
+};
+
+export default {
+  up: async function (migration, DataTypes) {
+    await migration.sequelize.transaction(async () => {
+      for (const [tableName, columnNames] of Object.entries(columnChanges)) {
+        for (const columnName of columnNames) {
+          await migration.changeColumn(tableName, columnName, {
+            type: DataTypes.STRING(191),
+          });
+        }
+      }
+    });
+  },
+
+  down: async function (migration, DataTypes) {
+    for (const [tableName, columnNames] of Object.entries(columnChanges)) {
+      for (const columnName of columnNames) {
+        await migration.changeColumn(tableName, columnName, {
+          type: DataTypes.STRING(40),
+        });
+      }
+    }
+  },
+};

--- a/core/src/migrations/000065-lengthen-id-columns.ts
+++ b/core/src/migrations/000065-lengthen-id-columns.ts
@@ -1,55 +1,105 @@
-const columnChanges = {
-  apiKeys: ["apiKey", "id"],
-  apps: ["id"],
-  destinationGroupMemberships: ["id", "destinationId", "groupId"],
-  destinations: ["id", "appId", "groupId"],
-  eventData: ["id", "eventId"],
-  events: ["id", "producerId", "profileId"],
-  exports: ["id", "profileId", "destinationId"],
-  files: ["id"],
-  groupMembers: ["id", "profileId", "groupId"],
-  groupRules: ["id", "groupId", "propertyId"],
-  groups: ["id"],
-  imports: ["id", "creatorId", "profileId"],
-  logs: ["id", "ownerId"],
-  mappings: ["id", "ownerId", "propertyId"],
-  notifications: ["id"],
-  options: ["id", "ownerId"],
-  permissions: ["id", "ownerId"],
-  profileProperties: ["id", "profileId", "propertyId"],
-  profiles: ["id"],
-  properties: ["id", "sourceId"],
-  propertyFilters: ["id", "propertyId"],
-  runs: ["id", "creatorId", "destinationId"],
-  schedules: ["id", "sourceId"],
-  sessions: ["id"],
-  settings: ["id"],
-  setupSteps: ["id"],
-  sources: ["id", "appId"],
-  teamMembers: ["id", "teamId"],
-  teams: ["id"],
+import { config } from "actionhero";
+
+const tables = {
+  apiKeys: ["apiKey"],
+  apps: [],
+  destinationGroupMemberships: ["destinationId", "groupId"],
+  destinations: ["appId", "groupId"],
+  eventData: ["eventId"],
+  events: ["producerId", "profileId"],
+  exports: ["profileId", "destinationId"],
+  files: [],
+  groupMembers: ["profileId", "groupId"],
+  groupRules: ["groupId", "propertyId"],
+  groups: [],
+  imports: ["creatorId", "profileId"],
+  logs: ["ownerId"],
+  mappings: ["ownerId", "propertyId"],
+  notifications: [],
+  options: ["ownerId"],
+  permissions: ["ownerId"],
+  profileProperties: ["profileId", "propertyId"],
+  profiles: [],
+  properties: ["sourceId"],
+  propertyFilters: ["propertyId"],
+  runs: ["creatorId", "destinationId"],
+  schedules: ["sourceId"],
+  sessions: [],
+  settings: [],
+  setupSteps: [],
+  sources: ["appId"],
+  teamMembers: ["teamId"],
+  teams: [],
+};
+
+let primaryKeyConstraints = {};
+
+let pKeyQuery = `
+SELECT
+  kcu.table_schema,
+  kcu.table_name,
+  tco.constraint_name,
+  kcu.ordinal_position AS position,
+  kcu.column_name AS key_column
+FROM
+  information_schema.table_constraints tco
+  JOIN information_schema.key_column_usage kcu ON kcu.constraint_name = tco.constraint_name
+    AND kcu.constraint_schema = tco.constraint_schema
+    AND kcu.constraint_name = tco.constraint_name
+WHERE
+  tco.constraint_type = 'PRIMARY KEY'
+  AND kcu.table_schema = 'public'
+ORDER BY
+  kcu.table_schema,
+  kcu.table_name,
+  position;
+`;
+
+const runMigration = async ({ maxIdLength, migration, DataTypes }) => {
+  await migration.sequelize.transaction(async () => {
+    if (config.sequelize.dialect === "postgres") {
+      const [rows] = await migration.sequelize.query(pKeyQuery);
+      primaryKeyConstraints = Object.fromEntries(
+        rows.map((row) => [row.table_name, row.constraint_name])
+      );
+    }
+
+    for (const [tableName, columnNames] of Object.entries(tables)) {
+      if (config.sequelize.dialect === "postgres") {
+        await migration.removeConstraint(
+          tableName,
+          primaryKeyConstraints[tableName]
+        );
+      }
+
+      await migration.changeColumn(tableName, "id", {
+        type: DataTypes.STRING(maxIdLength),
+        primaryKey: true,
+      });
+
+      if (config.sequelize.dialect === "postgres") {
+        await migration.addConstraint(tableName, {
+          fields: ["id"],
+          type: "primary key",
+          name: primaryKeyConstraints[tableName],
+        });
+      }
+
+      for (const columnName of columnNames) {
+        await migration.changeColumn(tableName, columnName, {
+          type: DataTypes.STRING(maxIdLength),
+        });
+      }
+    }
+  });
 };
 
 export default {
   up: async function (migration, DataTypes) {
-    await migration.sequelize.transaction(async () => {
-      for (const [tableName, columnNames] of Object.entries(columnChanges)) {
-        for (const columnName of columnNames) {
-          await migration.changeColumn(tableName, columnName, {
-            type: DataTypes.STRING(191),
-          });
-        }
-      }
-    });
+    await runMigration({ maxIdLength: 191, migration, DataTypes });
   },
 
   down: async function (migration, DataTypes) {
-    for (const [tableName, columnNames] of Object.entries(columnChanges)) {
-      for (const columnName of columnNames) {
-        await migration.changeColumn(tableName, columnName, {
-          type: DataTypes.STRING(40),
-        });
-      }
-    }
+    await runMigration({ maxIdLength: 40, migration, DataTypes });
   },
 };


### PR DESCRIPTION
Does the following:

- Adds a migration to change all `id`-like columns that were 40 characters to have a max length of `191`. This includes `apiKeys.apiKey`, but I was unsure if that was a relevant change.
- Adjusts Logged Model to validate against the new `191` max length. There are a couple tests for the pass and fail varieties of this new max length.

I also checked the UI. From what I could tell, we seem to be using name/title values in most places and are only really surfacing the `id` in the route. That leads to some potentially goofy routes (see screenshot below). But, otherwise, things looked find. Of course, I may not be looking in the right places.

![Screen Shot 2021-05-05 at 4 04 59 PM](https://user-images.githubusercontent.com/5245089/117316905-0b4e4a00-ae57-11eb-9054-29bfef49400d.png)
