### PR TITLE
fix property names in default mapping for pipedrive template

### DIFF
--- a/plugins/@grouparoo/pipedrive/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/pipedrive/public/templates/destination/{{{id}}}.js.template
@@ -14,8 +14,8 @@ exports.default = async function buildConfig() {
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       mapping: {
-        email: "email",
-        name: "name",
+        Email: "email",
+        Name: "name",
       },
 
       // You can export group memberships.


### PR DESCRIPTION
The names are actually capitalized