### PR TITLE
If a Profile Property's dependencies are not ready, update `startedAt` try again soon

### DIFF
--- a/core/__tests__/tasks/profileProperty/importProfileProperties.ts
+++ b/core/__tests__/tasks/profileProperty/importProfileProperties.ts
@@ -141,6 +141,14 @@ describe("tasks/profileProperty:importProfileProperties", () => {
       await profileProperty.reload();
       expect(profileProperty.state).toBe("pending");
       expect(profileProperty.rawValue).toBe(`old@example.com`);
+
+      // sendAt is slightly in the future from (now - 5 minutes) to try again soon
+      expect(profileProperty.startedAt.getTime()).toBeGreaterThan(
+        new Date().getTime() - 1000 * 60 * 5
+      );
+      expect(profileProperty.startedAt.getTime()).toBeLessThan(
+        new Date().getTime()
+      );
     });
 
     test("can be run for the same profile more than once without deadlock", async () => {

--- a/core/src/modules/ops/import.ts
+++ b/core/src/modules/ops/import.ts
@@ -3,9 +3,14 @@ import { Run } from "../../models/Run";
 import { ProfileOps } from "./profile";
 import { CLS } from "../../modules/cls";
 import { Op } from "sequelize";
+import { config } from "actionhero";
 
 export namespace ImportOps {
   const defaultImportProcessingDelay = 1000 * 60 * 5;
+
+  export function retrySendAt(delayMs = defaultImportProcessingDelay) {
+    return new Date(new Date().getTime() - delayMs + config.tasks.timeout * 2);
+  }
 
   export async function processPendingImportsForAssociation(
     limit = 100,

--- a/core/src/modules/ops/import.ts
+++ b/core/src/modules/ops/import.ts
@@ -8,7 +8,7 @@ import { config } from "actionhero";
 export namespace ImportOps {
   const defaultImportProcessingDelay = 1000 * 60 * 5;
 
-  export function retrySendAt(delayMs = defaultImportProcessingDelay) {
+  export function retryStartedAt(delayMs = defaultImportProcessingDelay) {
     return new Date(new Date().getTime() - delayMs + config.tasks.timeout * 2);
   }
 

--- a/core/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/src/tasks/profileProperty/importProfileProperties.ts
@@ -7,6 +7,7 @@ import { log } from "actionhero";
 import { CLS } from "../../modules/cls";
 import { ProfilePropertiesPluginMethodResponse } from "../../classes/plugin";
 import { PropertyOps } from "../../modules/ops/property";
+import { ImportOps } from "../../modules/ops/import";
 
 export class ImportProfileProperties extends RetryableTask {
   constructor() {
@@ -36,6 +37,7 @@ export class ImportProfileProperties extends RetryableTask {
     const source = await property.$get("source");
 
     const profilesToImport: Profile[] = [];
+    const profilesNotReady: Profile[] = [];
     const dependencies = await PropertyOps.dependencies(property);
 
     for (const profile of profiles) {
@@ -48,7 +50,26 @@ export class ImportProfileProperties extends RetryableTask {
         if (properties[dep.key].state !== "ready") ok = false;
       });
 
-      if (ok) profilesToImport.push(profile);
+      if (ok) {
+        profilesToImport.push(profile);
+      } else {
+        profilesNotReady.push(profile);
+      }
+    }
+
+    if (profilesNotReady.length > 0) {
+      await ProfileProperty.update(
+        { startedAt: ImportOps.retrySendAt() },
+        {
+          where: {
+            propertyId: property.id,
+            profileId: {
+              [Op.in]: profilesNotReady.map((p) => p.id),
+            },
+            state: "pending",
+          },
+        }
+      );
     }
 
     if (profilesToImport.length === 0) return;

--- a/core/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/src/tasks/profileProperty/importProfileProperties.ts
@@ -59,7 +59,7 @@ export class ImportProfileProperties extends RetryableTask {
 
     if (profilesNotReady.length > 0) {
       await ProfileProperty.update(
-        { startedAt: ImportOps.retrySendAt() },
+        { startedAt: ImportOps.retryStartedAt() },
         {
           where: {
             propertyId: property.id,

--- a/core/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/src/tasks/profileProperty/importProfileProperty.ts
@@ -1,9 +1,10 @@
 import { RetryableTask } from "../../classes/tasks/retryableTask";
 import { Profile } from "../../models/Profile";
 import { Property } from "../../models/Property";
-import { log } from "actionhero";
+import { config } from "actionhero";
 import { ProfileProperty } from "../../models/ProfileProperty";
 import { PropertyOps } from "../../modules/ops/property";
+import { ImportOps } from "../../modules/ops/import";
 
 export class ImportProfileProperty extends RetryableTask {
   constructor() {
@@ -46,7 +47,19 @@ export class ImportProfileProperty extends RetryableTask {
       if (properties[dep.key].state !== "ready") ok = false;
     });
 
-    if (!ok) return; // there's a dependency we don't have yet
+    if (!ok) {
+      // there's a dependency we don't have yet, sleep a little and will be retried later
+      return ProfileProperty.update(
+        { startedAt: ImportOps.retrySendAt() },
+        {
+          where: {
+            propertyId: property.id,
+            profileId: profile.id,
+            state: "pending",
+          },
+        }
+      );
+    }
 
     const propertyValues = await source.importProfileProperty(
       profile,

--- a/core/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/src/tasks/profileProperty/importProfileProperty.ts
@@ -50,7 +50,7 @@ export class ImportProfileProperty extends RetryableTask {
     if (!ok) {
       // there's a dependency we don't have yet, sleep a little and will be retried later
       return ProfileProperty.update(
-        { startedAt: ImportOps.retrySendAt() },
+        { startedAt: ImportOps.retryStartedAt() },
         {
           where: {
             propertyId: property.id,


### PR DESCRIPTION
This PR updates our retry logic when a Profile Property is to be imported, but it has a dependency that isn't ready yet.  For example in this chain: `user_id -> account_id -> account_name` if account_id is not yet ready and we are trying to import account_name.

Prior to this PR, account_name's `startedAt` would be untouched, so it would not be retried until (default) 5 minutes later.  This PR updates `startedAt` so that it can be retied again as soon as ~5 seconds later (as a function of `config.tasks.timeout`)