### PR TITLE
Respond to HEAD requests for status actions

### DIFF
--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -2,6 +2,10 @@ export const DEFAULT = {
   routes: (api) => {
     // prettier-ignore
     return {
+      head: [
+        { path: "/v:apiVersion/status/:route", action: "status:public", matchTrailingPathParts: true },
+      ],
+
       get: [
         { path: "/v:apiVersion/status/public", action: "status:public" },
         { path: "/v:apiVersion/status/private", action: "status:private" },

--- a/plugins/@grouparoo/sentry/src/initializers/sentry.ts
+++ b/plugins/@grouparoo/sentry/src/initializers/sentry.ts
@@ -25,6 +25,9 @@ export class SentryInitializer extends Initializer {
       // skip reporting some types of errors
       if (error?.code === "AUTHENTICATION_ERROR") return null;
       if (error?.code === "AUTHORIZATION_ERROR") return null;
+      if (error?.toString().includes("unknown action or invalid apiVersion")) {
+        return null;
+      }
 
       return event;
     }

--- a/plugins/@grouparoo/sentry/src/initializers/sentry.ts
+++ b/plugins/@grouparoo/sentry/src/initializers/sentry.ts
@@ -25,9 +25,6 @@ export class SentryInitializer extends Initializer {
       // skip reporting some types of errors
       if (error?.code === "AUTHENTICATION_ERROR") return null;
       if (error?.code === "AUTHORIZATION_ERROR") return null;
-      if (error?.toString().includes("unknown action or invalid apiVersion")) {
-        return null;
-      }
 
       return event;
     }


### PR DESCRIPTION
This will reduce the occurrence of errors like `unknown action or invalid apiVersion `:

```
2021-05-12T22:21:36.239Z - error: [ action @ web ] to=xxx.xxx.xxx.xxx params={"action":null,"apiVersion":null} duration=0 error=Error: unknown action or invalid apiVersion stack=Error: unknown action or invalid apiVersion
    at ActionProcessor.completeAction (/workspace/node_modules/actionhero/dist/classes/actionProcessor.js:70:21)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5) 
```