### PR TITLE
fix: don't crash on `null` option for bootstrapped property

### DIFF
--- a/core/__tests__/fixtures/codeConfig/initial/config.js
+++ b/core/__tests__/fixtures/codeConfig/initial/config.js
@@ -65,6 +65,7 @@ module.exports = async function getConfig() {
       sourceId: "users_table", // sourceId -> `users_table`
       options: {
         column: "id",
+        sortColumn: null,
       },
       filters: [],
     },
@@ -93,6 +94,7 @@ module.exports = async function getConfig() {
       sourceId: "users_table", // sourceId -> `users_table`
       options: {
         column: "first_name",
+        sortColumn: null,
       },
       filters: [],
     },

--- a/core/src/modules/configLoaders/source.ts
+++ b/core/src/modules/configLoaders/source.ts
@@ -98,7 +98,7 @@ export async function loadSource(
         mappedColumn,
         property.id,
         validate,
-        property.options
+        extractNonNullParts(property, "options")
       );
       await setMapping();
     } else {


### PR DESCRIPTION
Fixes pivotal-178152658