### PR TITLE
Inject APM instrumentation into CLSAction and CLSTask

### DIFF
--- a/core/src/classes/actions/clsAction.ts
+++ b/core/src/classes/actions/clsAction.ts
@@ -1,4 +1,5 @@
 import { Action } from "actionhero";
+import { APM } from "../../modules/apm";
 import { CLS } from "../../modules/cls";
 
 export interface ActionData {
@@ -23,17 +24,13 @@ export abstract class CLSAction extends Action {
   }
 
   async run(params: ActionData) {
-    if (typeof this.runWithinTransaction === "function") {
+    return APM.wrap(this.name, "action", params, async () => {
       const options = { write: this.isWriteTransaction(), priority: true };
       return CLS.wrap(
         async () => await this.runWithinTransaction(params),
         options
       );
-    } else {
-      throw new Error(
-        "No run or runWithinTransaction method for this task: " + this.name
-      );
-    }
+    });
   }
 
   abstract runWithinTransaction(params: ActionData): Promise<any>;

--- a/core/src/classes/tasks/clsTask.ts
+++ b/core/src/classes/tasks/clsTask.ts
@@ -1,5 +1,6 @@
 import { Task, log } from "actionhero";
 import { TaskInputs } from "actionhero/dist/classes/task";
+import { APM } from "../../modules/apm";
 import { CLS } from "../../modules/cls";
 
 export abstract class CLSTask extends Task {
@@ -8,7 +9,7 @@ export abstract class CLSTask extends Task {
   }
 
   async run(inputs: TaskInputs, worker: any) {
-    if (typeof this.runWithinTransaction === "function") {
+    return APM.wrap(this.name, "task", worker, async () => {
       try {
         return CLS.wrap(async () => this.runWithinTransaction(inputs, worker), {
           write: true,
@@ -20,11 +21,7 @@ export abstract class CLSTask extends Task {
           return CLS.enqueueTaskIn(30 * 1000, this.name, inputs, this.queue);
         }
       }
-    } else {
-      throw new Error(
-        "No run or runWithinTransaction method for this task: " + this.name
-      );
-    }
+    });
   }
 
   abstract runWithinTransaction(inputs: TaskInputs, worker: any): Promise<any>;

--- a/core/src/initializers/apm.ts
+++ b/core/src/initializers/apm.ts
@@ -1,0 +1,26 @@
+import { Initializer, api } from "actionhero";
+import { APMWrap } from "../modules/apm";
+
+declare module "actionhero" {
+  export interface Api {
+    apm: {
+      wrap: APMWrap;
+    };
+  }
+}
+
+export class APMInitializer extends Initializer {
+  constructor() {
+    super();
+    this.name = "apm";
+    this.loadPriority = 1;
+  }
+
+  async initialize() {
+    api.apm = {
+      wrap: async (name, type, data, run) => {
+        return run();
+      },
+    };
+  }
+}

--- a/core/src/modules/apm.ts
+++ b/core/src/modules/apm.ts
@@ -1,0 +1,19 @@
+import { api } from "actionhero";
+
+export type APMWrap = (
+  name: string,
+  type: "action" | "task",
+  data: any,
+  run: Function
+) => Promise<any>;
+
+export namespace APM {
+  export async function wrap(
+    name: string,
+    type: "action" | "task",
+    data: any,
+    run: Function
+  ): Promise<void> {
+    return api.apm.wrap(name, type, data, run);
+  }
+}

--- a/core/src/modules/plugin.ts
+++ b/core/src/modules/plugin.ts
@@ -2,6 +2,7 @@ import { api } from "actionhero";
 import { Op } from "sequelize";
 import { GrouparooPlugin } from "../classes/plugin";
 import { MustacheUtils } from "./mustacheUtils";
+import { APMWrap } from "./apm";
 
 import { App } from "../models/App";
 import { ApiKey } from "../models/ApiKey";
@@ -360,5 +361,9 @@ export namespace plugin {
     });
 
     return MustacheUtils.strictlyRender(string, data);
+  }
+
+  export function setApmWrap(f: APMWrap) {
+    api.apm.wrap = f;
   }
 }


### PR DESCRIPTION
In order to create the `domain` that Sentry requires to isolate transaction traces, we cannot use Actionhero's middleware approach.  This PR moves to a "wrapping" pattern which is part of CLSAction and CLSTask, if used.  

The downsides of this approach are that middleware execution will not be traced by APM.