### PR TITLE
In-Memory `Property` cache

### DIFF
--- a/bin/timed_run
+++ b/bin/timed_run
@@ -14,6 +14,7 @@ ROO="$ROOT/cli/dist/grouparoo.js"
 PROJECT_DIR="$ROOT/apps/$APP"
 
 cd $PROJECT_DIR
+echo "Testing in: $PROJECT_DIR"
 
 echo "-----> RECOMPILING CORE"
 cd ../../core

--- a/core/__tests__/models/app/app.ts
+++ b/core/__tests__/models/app/app.ts
@@ -93,13 +93,12 @@ describe("models/app", () => {
   });
 
   test("the app options will not be logged", async () => {
-    await Log.truncate();
-
     const app = await App.create({
       name: "test log app",
       type: "test-plugin-app",
     });
 
+    await Log.truncate();
     await app.setOptions({ fileId: "abc123" });
 
     let log = await Log.findOne({
@@ -107,7 +106,7 @@ describe("models/app", () => {
     });
 
     expect(log.data.options).toBe("** filtered **");
-    expect(log.message).toMatch(/app "test log app" updated: updatedAt -> /);
+    expect(log.message).toMatch(/app "test log app" updated/);
 
     await app.destroy();
   });

--- a/core/__tests__/models/property/localCache.ts
+++ b/core/__tests__/models/property/localCache.ts
@@ -1,15 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { api, specHelper } from "actionhero";
-import {
-  plugin,
-  Property,
-  Log,
-  App,
-  Source,
-  Run,
-  Option,
-  PropertyFilter,
-} from "../../../src";
+import { Property, Source } from "../../../src";
 import { CachedProperties } from "../../../src/models/Property";
 
 describe("models/property", () => {

--- a/core/__tests__/models/property/localCache.ts
+++ b/core/__tests__/models/property/localCache.ts
@@ -1,0 +1,134 @@
+import { helper } from "@grouparoo/spec-helper";
+import { api, specHelper } from "actionhero";
+import {
+  plugin,
+  Property,
+  Log,
+  App,
+  Source,
+  Run,
+  Option,
+  PropertyFilter,
+} from "../../../src";
+import { CachedProperties } from "../../../src/models/Property";
+
+describe("models/property", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
+  let source: Source;
+  let originalPropertyCount: number;
+
+  beforeAll(async () => {
+    await helper.factories.properties();
+    originalPropertyCount = await Property.scope(null).count({
+      where: { state: "ready" },
+    });
+    source = await Source.findOne({ where: { state: "ready" } });
+  });
+
+  describe("#findAllWithCache", () => {
+    test("it returns all the instances", async () => {
+      const instances = await Property.findAllWithCache();
+      expect(instances.length).toBe(originalPropertyCount);
+    });
+
+    test("it only includes ready properties", async () => {
+      const property = await helper.factories.property(
+        source,
+        {},
+        { column: "foo" }
+      );
+      await property.update({ state: "deleted" });
+
+      const instances = await Property.findAllWithCache();
+      expect(instances.length).toBe(originalPropertyCount);
+
+      await property.destroy();
+    });
+
+    describe("rpc", () => {
+      let property: Property;
+
+      async function makeProperty() {
+        property = await helper.factories.property(
+          source,
+          {},
+          { column: "foo" }
+        );
+        await helper.sleep(100); // wait for delayed RPC calls
+      }
+
+      afterEach(async () => {
+        try {
+          await property.destroy();
+        } catch {}
+      });
+
+      test("creating a property signals RPC", async () => {
+        CachedProperties.expires = new Date().getTime();
+        await makeProperty();
+        await helper.sleep(10);
+        expect(CachedProperties.expires).toBe(0);
+      });
+
+      test("updating a property signals RPC", async () => {
+        await makeProperty();
+        CachedProperties.expires = new Date().getTime();
+        await property.update({ key: "new key" });
+        await helper.sleep(10);
+        expect(CachedProperties.expires).toBe(0);
+      });
+
+      test("calling setOptions signals RPC", async () => {
+        await makeProperty();
+        CachedProperties.expires = new Date().getTime();
+        await property.setOptions({ column: "test other column" });
+        await helper.sleep(10);
+        expect(CachedProperties.expires).toBe(0);
+      });
+
+      test("calling setFilter signals RPC", async () => {
+        await makeProperty();
+        CachedProperties.expires = new Date().getTime();
+        await property.setFilters([
+          { op: "greater than", match: 1, key: "id" },
+        ]);
+        await helper.sleep(10);
+        expect(CachedProperties.expires).toBe(0);
+      });
+
+      test("destroying a property signals RPC", async () => {
+        await makeProperty();
+        CachedProperties.expires = new Date().getTime();
+        await property.destroy();
+        await helper.sleep(10);
+        expect(CachedProperties.expires).toBe(0);
+      });
+    });
+  });
+
+  describe("#findOneWithCache", () => {
+    let emailProperty: Property;
+
+    beforeAll(async () => {
+      emailProperty = await Property.findOne({ where: { key: "email" } });
+    });
+
+    test("it will find by id by default", async () => {
+      const found = await Property.findOneWithCache(emailProperty.id);
+      expect(found.key).toBe("email");
+    });
+
+    test("it can find by other keys", async () => {
+      const found = await Property.findOneWithCache("email", "key");
+      expect(found.key).toBe("email");
+    });
+
+    test("a cache miss will invalidate the cache", async () => {
+      CachedProperties.expires = new Date().getTime();
+      const found = await Property.findOneWithCache("missing");
+      expect(found).toBeNull();
+      expect(CachedProperties.expires).toBe(0);
+    });
+  });
+});

--- a/core/src/classes/loggedModel.ts
+++ b/core/src/classes/loggedModel.ts
@@ -106,9 +106,11 @@ export abstract class LoggedModel<T> extends Model {
           });
         }
 
-        message = `${modelName(
-          this
-        )} "${primaryName}" updated: ${changedValueStrings.join(", ")}`;
+        message = `${modelName(this)} "${primaryName}" updated${
+          changedValueStrings.length > 0
+            ? ": " + changedValueStrings.join(", ")
+            : ""
+        }`;
         break;
       case "destroy":
         message = `${modelName(this)} "${primaryName}" destroyed`;

--- a/core/src/initializers/rpc.ts
+++ b/core/src/initializers/rpc.ts
@@ -18,8 +18,11 @@ export class GrouparooRPC extends Initializer {
     };
 
     /**
+     * All handlers need start with a sleep() to decouple from mock redis' callback/transaction chain (there's no delay), or have no side-effects
+     */
+
+    /**
      * Signal that all Apps in the cluster should disconnect form persistent connections.
-     * All handlers need start with a sleep() to decouple from mock redis' callback/transaction chain (there's no delay)
      */
     api.rpc.app.disconnect = async (appId: string) => {
       await utils.sleep(100);

--- a/core/src/initializers/rpc.ts
+++ b/core/src/initializers/rpc.ts
@@ -1,5 +1,6 @@
 import { Initializer, api, utils } from "actionhero";
 import { App } from "../models/App";
+import { Property } from "../models/Property";
 
 export class GrouparooRPC extends Initializer {
   constructor() {
@@ -13,6 +14,7 @@ export class GrouparooRPC extends Initializer {
      */
     api.rpc = {
       app: {},
+      property: {},
     };
 
     /**
@@ -22,6 +24,13 @@ export class GrouparooRPC extends Initializer {
     api.rpc.app.disconnect = async (appId: string) => {
       await utils.sleep(100);
       await App.disconnect(appId);
+    };
+
+    /**
+     * Clear the per-instance Property cache
+     */
+    api.rpc.property.invalidateCache = async () => {
+      Property.invalidateLocalCache();
     };
   }
 }

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -40,7 +40,7 @@ const STATE_TRANSITIONS = [
   {
     from: "draft",
     to: "ready",
-    checks: [(instance: App) => instance.validateOptions(null)],
+    checks: [(instance: App) => instance.validateOptions()],
   },
   { from: "draft", to: "deleted", checks: [] },
   { from: "ready", to: "deleted", checks: [] },

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -98,7 +98,7 @@ const STATE_TRANSITIONS = [
   {
     from: "draft",
     to: "ready",
-    checks: [(instance: Destination) => instance.validateOptions(null)],
+    checks: [(instance: Destination) => instance.validateOptions()],
   },
   { from: "draft", to: "deleted", checks: [] },
   { from: "ready", to: "deleted", checks: [] },
@@ -284,7 +284,7 @@ export class Destination extends LoggedModel<Destination> {
     return this.getDestinationGroupMemberships();
   }
 
-  async validateOptions(options: SimpleDestinationOptions) {
+  async validateOptions(options?: SimpleDestinationOptions) {
     if (!options) options = await this.getOptions(true);
     return OptionHelper.validateOptions(this, options, null);
   }

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -358,7 +358,7 @@ export class Destination extends LoggedModel<Destination> {
       false,
       saveCache
     );
-    const properties = await Property.findAll();
+    const properties = await Property.findAllWithCache();
     const exportArrayProperties = await this.getExportArrayProperties();
 
     // check for array properties

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -169,7 +169,7 @@ export class Group extends LoggedModel<Group> {
 
     for (const i in rules) {
       const rule: GroupRule = rules[i];
-      const property = await Property.findOneWithCache("id", rule.propertyId);
+      const property = await Property.findOneWithCache(rule.propertyId);
       const type = property
         ? property.type
         : TopLevelGroupRules.find((tlgr) => tlgr.key === rule.profileColumn)

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -169,7 +169,7 @@ export class Group extends LoggedModel<Group> {
 
     for (const i in rules) {
       const rule: GroupRule = rules[i];
-      const property = await Property.findOneWithCache('id', rule.propertyId)
+      const property = await Property.findOneWithCache("id", rule.propertyId);
       const type = property
         ? property.type
         : TopLevelGroupRules.find((tlgr) => tlgr.key === rule.profileColumn)

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -169,7 +169,7 @@ export class Group extends LoggedModel<Group> {
 
     for (const i in rules) {
       const rule: GroupRule = rules[i];
-      const property = await rule.$get("property");
+      const property = await Property.findOneWithCache('id', rule.propertyId)
       const type = property
         ? property.type
         : TopLevelGroupRules.find((tlgr) => tlgr.key === rule.profileColumn)

--- a/core/src/models/Profile.ts
+++ b/core/src/models/Profile.ts
@@ -87,12 +87,12 @@ export class Profile extends LoggedModel<Profile> {
     };
   }
 
-  async properties(preloadedProperties?: Property[]) {
-    return ProfileOps.properties(this, preloadedProperties);
+  async properties() {
+    return ProfileOps.properties(this);
   }
 
-  async simplifiedProperties(preloadedProperties?: Property[]) {
-    const properties = await this.properties(preloadedProperties);
+  async simplifiedProperties() {
+    const properties = await this.properties();
     const simpleProperties: {
       [key: string]: Array<string | boolean | number | Date>;
     } = {};
@@ -101,32 +101,19 @@ export class Profile extends LoggedModel<Profile> {
     return simpleProperties;
   }
 
-  async addOrUpdateProperty(
-    properties: {
-      [key: string]: Array<string | number | boolean | Date>;
-    },
-    preloadedProperties: Property[]
-  ) {
-    return ProfileOps.addOrUpdateProperty(
-      this,
-      properties,
-      preloadedProperties
-    );
+  async addOrUpdateProperty(properties: {
+    [key: string]: Array<string | number | boolean | Date>;
+  }) {
+    return ProfileOps.addOrUpdateProperty(this, properties);
   }
 
   async addOrUpdateProperties(
     properties: {
       [key: string]: Array<string | number | boolean | Date>;
     },
-    toLock = true,
-    preloadedProperties: Property[] = []
+    toLock = true
   ) {
-    return ProfileOps.addOrUpdateProperties(
-      this,
-      properties,
-      toLock,
-      preloadedProperties
-    );
+    return ProfileOps.addOrUpdateProperties(this, properties, toLock);
   }
 
   async removeProperty(key: string) {

--- a/core/src/models/ProfileProperty.ts
+++ b/core/src/models/ProfileProperty.ts
@@ -78,7 +78,7 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
   property: Property;
 
   async apiData() {
-    const property = await this.$get("property");
+    const property = await Property.findOneWithCache("id", this.propertyId);
 
     return {
       profileId: this.profileId,
@@ -109,7 +109,7 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
   }
 
   async ensureProperty() {
-    const property = await this.$get("property");
+    const property = await Property.findOneWithCache("id", this.propertyId);
     if (!property) {
       throw new Error(`property not found for propertyId ${this.propertyId}`);
     }

--- a/core/src/models/ProfileProperty.ts
+++ b/core/src/models/ProfileProperty.ts
@@ -78,7 +78,7 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
   property: Property;
 
   async apiData() {
-    const property = await Property.findOneWithCache("id", this.propertyId);
+    const property = await Property.findOneWithCache(this.propertyId);
 
     return {
       profileId: this.profileId,
@@ -109,7 +109,7 @@ export class ProfileProperty extends LoggedModel<ProfileProperty> {
   }
 
   async ensureProperty() {
-    const property = await Property.findOneWithCache("id", this.propertyId);
+    const property = await Property.findOneWithCache(this.propertyId);
     if (!property) {
       throw new Error(`property not found for propertyId ${this.propertyId}`);
     }

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -438,7 +438,7 @@ export class Property extends LoggedModel<Property> {
   @AfterDestroy
   static async invalidateCache() {
     Property.invalidateLocalCache();
-    await CLS.wrap(async () =>
+    await CLS.afterCommit(async () =>
       redis.doCluster("api.rpc.property.invalidateCache")
     );
   }

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -417,7 +417,7 @@ export class Property extends LoggedModel<Property> {
     return _cachedProperties.properties;
   }
 
-  static async findOneWithCache(key: string, value: string) {
+  static async findOneWithCache(value: string, key = "id") {
     const properties = await Property.findAllWithCache();
     let property = properties.find((p) => p[key] === value);
 

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -418,7 +418,15 @@ export class Property extends LoggedModel<Property> {
 
   static async findOneWithCache(key: string, value: string) {
     const properties = await Property.findAllWithCache();
-    return properties.find((p) => p[key] === value);
+    let property = properties.find((p) => p[key] === value);
+
+    if (!property) {
+      // fallback if not found
+      property = await Property.findOne({ where: { [key]: value } });
+      if (property) await Property.invalidateCache();
+    }
+
+    return property;
   }
 
   static invalidateLocalCache() {

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -435,7 +435,6 @@ export class Property extends LoggedModel<Property> {
   }
 
   @AfterSave
-  @AfterUpdate
   @AfterDestroy
   static async invalidateCache() {
     Property.invalidateLocalCache();

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -37,6 +37,7 @@ import { Mapping } from "./Mapping";
 import { PropertyOps } from "../modules/ops/property";
 import { LockableHelper } from "../modules/lockableHelper";
 import { APIData } from "../modules/apiData";
+import { CLS } from "../modules/cls";
 
 export function propertyJSToSQLType(jsType: string) {
   const map = {
@@ -437,7 +438,10 @@ export class Property extends LoggedModel<Property> {
   @AfterUpdate
   @AfterDestroy
   static async invalidateCache() {
-    await redis.doCluster("api.rpc.property.invalidateCache");
+    Property.invalidateLocalCache();
+    await CLS.wrap(async () =>
+      redis.doCluster("api.rpc.property.invalidateCache")
+    );
   }
 
   // --- Class Methods --- //

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -16,7 +16,6 @@ import {
   BeforeUpdate,
   BeforeCreate,
   AfterSave,
-  AfterUpdate,
 } from "sequelize-typescript";
 import { Op } from "sequelize";
 import { env, api, redis, config } from "actionhero";

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -66,7 +66,7 @@ const STATE_TRANSITIONS = [
   {
     from: "draft",
     to: "ready",
-    checks: [(instance: Schedule) => instance.validateOptions(null)],
+    checks: [(instance: Schedule) => instance.validateOptions()],
   },
 ];
 

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -42,7 +42,7 @@ const STATE_TRANSITIONS = [
     from: "draft",
     to: "ready",
     checks: [
-      (instance: Source) => instance.validateOptions(null),
+      (instance: Source) => instance.validateOptions(),
       (instance: Source) => instance.validateMapping(),
     ],
   },

--- a/core/src/modules/configLoaders/source.ts
+++ b/core/src/modules/configLoaders/source.ts
@@ -11,7 +11,6 @@ import {
 import { App, Source, Property } from "../..";
 import { Op } from "sequelize";
 import { log } from "actionhero";
-import { CLS } from "../cls";
 
 export async function loadSource(
   configObject: ConfigurationObject,

--- a/core/src/modules/groupExport.ts
+++ b/core/src/modules/groupExport.ts
@@ -12,7 +12,7 @@ import { Property } from "../models/Property";
  */
 export async function groupExportToCSV(group: Group, limit = 1000) {
   // get the headers
-  const numberedPropertyKeys = (await Property.findAll())
+  const numberedPropertyKeys = (await Property.findAllWithCache())
     .map((rule) => rule.key)
     .sort();
   const columns = ["id", "createdAt", "updatedAt"].concat(numberedPropertyKeys);

--- a/core/src/modules/mappingHelper.ts
+++ b/core/src/modules/mappingHelper.ts
@@ -3,6 +3,7 @@ import { Property } from "../models/Property";
 import { Source } from "./../models/Source";
 import { Destination } from "./../models/Destination";
 import { LockableHelper } from "./lockableHelper";
+import { LoggedModel } from "../classes/loggedModel";
 
 export namespace MappingHelper {
   export interface Mappings {
@@ -65,6 +66,7 @@ export namespace MappingHelper {
     }
 
     await instance.touch();
+    await LoggedModel.logUpdate(instance);
 
     // if there's an afterSetMapping hook and we want to commit our changes
     if (typeof instance["afterSetMapping"] === "function") {

--- a/core/src/modules/mappingHelper.ts
+++ b/core/src/modules/mappingHelper.ts
@@ -64,9 +64,7 @@ export namespace MappingHelper {
       });
     }
 
-    //@ts-ignore
-    instance.changed("updatedAt", true);
-    await instance.save();
+    await instance.touch();
 
     // if there's an afterSetMapping hook and we want to commit our changes
     if (typeof instance["afterSetMapping"] === "function") {

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -275,7 +275,7 @@ export namespace DestinationOps {
     const app = await destination.$get("app");
     const appOptions = await app.getOptions();
     await app.validateOptions(appOptions);
-    const properties = await Property.findAll();
+    const properties = await Property.findAllWithCache();
     const destinationGroupMemberships =
       await destination.getDestinationGroupMemberships();
     const mapping = await destination.getMapping();

--- a/core/src/modules/ops/event.ts
+++ b/core/src/modules/ops/event.ts
@@ -15,9 +15,10 @@ export namespace EventOps {
     identifyingPropertyId: string,
     isRetry = false
   ): Promise<Profile> {
-    const property = await Property.findOne({
-      where: { id: identifyingPropertyId },
-    });
+    const property = await Property.findOneWithCache(
+      "id",
+      identifyingPropertyId
+    );
     if (!property) {
       throw new Error(
         `cannot find Property for identifyingPropertyId ${identifyingPropertyId}`

--- a/core/src/modules/ops/event.ts
+++ b/core/src/modules/ops/event.ts
@@ -15,10 +15,7 @@ export namespace EventOps {
     identifyingPropertyId: string,
     isRetry = false
   ): Promise<Profile> {
-    const property = await Property.findOneWithCache(
-      "id",
-      identifyingPropertyId
-    );
+    const property = await Property.findOneWithCache(identifyingPropertyId);
     if (!property) {
       throw new Error(
         `cannot find Property for identifyingPropertyId ${identifyingPropertyId}`

--- a/core/src/modules/ops/property.ts
+++ b/core/src/modules/ops/property.ts
@@ -101,7 +101,7 @@ export namespace PropertyOps {
     const source = await property.$get("source");
     const sourceMapping = await source.getMapping();
     const ruleOptions = await property.getOptions();
-    const properties = await Property.findAll();
+    const properties = await Property.findAllWithCache();
 
     // does our source depend on another property to be mapped?
     const remoteMappingKeys = Object.values(sourceMapping);

--- a/core/src/modules/ops/schedule.ts
+++ b/core/src/modules/ops/schedule.ts
@@ -11,7 +11,7 @@ export namespace ScheduleOps {
     const options = await schedule.getOptions();
     const source = await schedule.$get("source");
     const app = await App.findById(source.appId);
-    const properties = await Property.findAll();
+    const properties = await Property.findAllWithCache();
     const { pluginConnection } = await source.getPlugin();
     const method = pluginConnection.methods.profiles;
 
@@ -115,7 +115,7 @@ export namespace ScheduleOps {
     const appOptions = await app.getOptions();
     const sourceOptions = await source.getOptions();
     const sourceMapping = await source.getMapping();
-    const properties = await Property.findAll();
+    const properties = await Property.findAllWithCache();
 
     for (const i in pluginConnection.scheduleOptions) {
       const opt = pluginConnection.scheduleOptions[i];

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -87,7 +87,9 @@ export namespace SourceOps {
   ) {
     if (property.state !== "ready" && !propertyOptionsOverride) return;
 
-    await property.validateOptions(propertyOptionsOverride, false, true);
+    if (propertyOptionsOverride) {
+      await property.validateOptions(propertyOptionsOverride, false);
+    }
 
     const { pluginConnection } = await source.getPlugin();
     if (!pluginConnection) {
@@ -174,7 +176,9 @@ export namespace SourceOps {
       return;
     }
 
-    await property.validateOptions(propertyOptionsOverride, false, true);
+    if (propertyOptionsOverride) {
+      await property.validateOptions(propertyOptionsOverride, false);
+    }
 
     const { pluginConnection } = await source.getPlugin();
     if (!pluginConnection) {

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -106,8 +106,8 @@ export namespace OptionHelper {
       });
     }
 
-    await LoggedModel.logUpdate(instance);
     await instance.touch();
+    await LoggedModel.logUpdate(instance);
 
     // if there's an afterSetMapping hook and we want to commit our changes
     if (typeof instance["afterSetOptions"] === "function") {

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -106,11 +106,8 @@ export namespace OptionHelper {
       });
     }
 
-    // @ts-ignore
-    instance.changed("updatedAt", true);
     await LoggedModel.logUpdate(instance);
-    // @ts-ignore
-    await instance.save({ hooks: false });
+    await instance.touch();
 
     // if there's an afterSetMapping hook and we want to commit our changes
     if (typeof instance["afterSetOptions"] === "function") {

--- a/core/src/modules/plugin.ts
+++ b/core/src/modules/plugin.ts
@@ -332,9 +332,9 @@ export namespace plugin {
   ): Promise<string> {
     if (string.indexOf("{{") < 0) return string;
 
-    const properties = await Property.findAll({
-      where: { isArray: false },
-    });
+    const properties = (await Property.findAllWithCache()).filter(
+      (p) => p.isArray === false
+    );
 
     const data = {};
     properties.forEach((rule) => {
@@ -353,7 +353,7 @@ export namespace plugin {
   ): Promise<string> {
     if (string.indexOf("{{") < 0) return string;
 
-    const properties = await Property.findAll();
+    const properties = await Property.findAllWithCache();
 
     const data = {};
     properties.forEach((rule) => {

--- a/core/src/modules/reset.ts
+++ b/core/src/modules/reset.ts
@@ -66,6 +66,8 @@ export namespace Reset {
       counts[model.name] = count;
     }
 
+    Property.invalidateCache();
+
     // reset the SetupSteps
     await SetupStep.update({ complete: false }, { where: { complete: true } });
 
@@ -95,6 +97,8 @@ export namespace Reset {
       { where: { profileId: { [Op.ne]: null } } }
     );
 
+    Property.invalidateCache();
+
     await clearRedis();
 
     await logMethod(callerId, "data");
@@ -106,6 +110,7 @@ export namespace Reset {
    * * clears resque
    */
   export async function cache(callerId: string) {
+    Property.invalidateCache();
     await clearRedis();
 
     await logMethod(callerId, "cache");

--- a/core/src/modules/reset.ts
+++ b/core/src/modules/reset.ts
@@ -66,11 +66,10 @@ export namespace Reset {
       counts[model.name] = count;
     }
 
-    Property.invalidateCache();
-
     // reset the SetupSteps
     await SetupStep.update({ complete: false }, { where: { complete: true } });
 
+    await clearLocalCaches();
     await clearRedis();
 
     await logMethod(callerId, "cluster", { counts });
@@ -97,8 +96,7 @@ export namespace Reset {
       { where: { profileId: { [Op.ne]: null } } }
     );
 
-    Property.invalidateCache();
-
+    await clearLocalCaches();
     await clearRedis();
 
     await logMethod(callerId, "data");
@@ -110,7 +108,7 @@ export namespace Reset {
    * * clears resque
    */
   export async function cache(callerId: string) {
-    Property.invalidateCache();
+    await clearLocalCaches();
     await clearRedis();
 
     await logMethod(callerId, "cache");
@@ -142,6 +140,10 @@ export namespace Reset {
       ownerId: callerId,
       data,
     });
+  }
+
+  export async function clearLocalCaches() {
+    await Property.invalidateCache();
   }
 
   export async function clearRedis() {

--- a/core/src/tasks/profile/completeImport.ts
+++ b/core/src/tasks/profile/completeImport.ts
@@ -24,8 +24,8 @@ export class ProfileCompleteImport extends RetryableTask {
     });
     if (!profile) return; // the profile may have been deleted or merged by the time this task ran
 
-    const properties = await Property.findAll();
-    const profileProperties = await profile.properties(properties);
+    const properties = await Property.findAllWithCache();
+    const profileProperties = await profile.properties();
     const pendingProfileProperty = Object.keys(profileProperties).find(
       (k) => profileProperties[k].state !== "ready" // a property may have gone back into the pending state
     );
@@ -54,10 +54,7 @@ export class ProfileCompleteImport extends RetryableTask {
       await profile.addOrUpdateProperties(mergedValues);
       await profile.updateGroupMembership();
 
-      const newProfileProperties = await profile.simplifiedProperties(
-        properties
-      );
-
+      const newProfileProperties = await profile.simplifiedProperties();
       const newGroups = await profile.$get("groups");
       const newGroupIds = newGroups.map((g) => g.id);
       const now = new Date();

--- a/core/src/tasks/profileProperty/enqueue.ts
+++ b/core/src/tasks/profileProperty/enqueue.ts
@@ -26,9 +26,7 @@ export class ProfilePropertiesEnqueue extends CLSTask {
       ).value
     );
 
-    const properties = await Property.findAll({
-      where: { state: "ready" },
-    });
+    const properties = await Property.findAllWithCache();
 
     for (const property of properties) {
       const pendingProfileProperties =

--- a/core/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/src/tasks/profileProperty/importProfileProperties.ts
@@ -29,7 +29,7 @@ export class ImportProfileProperties extends RetryableTask {
     });
     if (profiles.length === 0) return;
 
-    const property = await Property.findOneWithCache("id", params.propertyId);
+    const property = await Property.findOneWithCache(params.propertyId);
     if (!property) return;
     const source = await property.$get("source");
 

--- a/core/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/src/tasks/profileProperty/importProfileProperties.ts
@@ -29,10 +29,8 @@ export class ImportProfileProperties extends RetryableTask {
     });
     if (profiles.length === 0) return;
 
-    const property = await Property.findOne({
-      where: { id: params.propertyId },
-    });
-
+    const properties = await Property.findAll();
+    const property = properties.find((p) => p.id === params.propertyId);
     if (!property) return;
     const source = await property.$get("source");
 
@@ -42,7 +40,7 @@ export class ImportProfileProperties extends RetryableTask {
 
     for (const profile of profiles) {
       let ok = true;
-      const profileProperties = await profile.properties();
+      const profileProperties = await profile.properties(properties);
 
       if (profileProperties[property.key].state === "ready") ok = false;
 
@@ -96,7 +94,7 @@ export class ImportProfileProperties extends RetryableTask {
     for (const profileId in propertyValuesBatch) {
       const profile = profilesToImport.find((p) => p.id === profileId);
       const hash = { [property.id]: propertyValuesBatch[profileId] };
-      await profile.addOrUpdateProperties(hash, false, [property]); // we are disabling the profile lock here because the transaction will be saved out-of-band from the lock check
+      await profile.addOrUpdateProperties(hash, false, properties); // we are disabling the profile lock here because the transaction will be saved out-of-band from the lock check
     }
 
     // update the properties that got no data back

--- a/core/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/src/tasks/profileProperty/importProfileProperty.ts
@@ -33,9 +33,7 @@ export class ImportProfileProperty extends RetryableTask {
       });
     }
 
-    const property = await Property.findOne({
-      where: { id: params.propertyId },
-    });
+    const property = await Property.findOneWithCache("id", params.propertyId);
     if (!property) return;
     const profileProperties = await profile.properties();
     const source = await property.$get("source");
@@ -70,7 +68,7 @@ export class ImportProfileProperty extends RetryableTask {
       hash[property.id] = Array.isArray(propertyValues)
         ? propertyValues
         : [propertyValues];
-      await profile.addOrUpdateProperty(hash, [property]);
+      await profile.addOrUpdateProperty(hash);
     } else {
       await ProfileProperty.update(
         { state: "ready", stateChangedAt: new Date(), confirmedAt: new Date() },

--- a/core/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/src/tasks/profileProperty/importProfileProperty.ts
@@ -33,7 +33,7 @@ export class ImportProfileProperty extends RetryableTask {
       });
     }
 
-    const property = await Property.findOneWithCache("id", params.propertyId);
+    const property = await Property.findOneWithCache(params.propertyId);
     if (!property) return;
     const profileProperties = await profile.properties();
     const source = await property.$get("source");


### PR DESCRIPTION
The most heavily (re)-loaded model is `Property`.  This PR tries out the pattern that rather than preLoading known associations, we could keep all the Properties in memory.  Rather than use a redis cache (eg something like https://www.npmjs.com/package/sequelize-transparent-cache), this PR opts to keep the Property models in local memory as they are used so often.

This PR also doesn't investigate eager loading because in many cases the object in question (say an Import) doesn't know the properties related at the time of loading.

This PR implements a two-fold cache invalidation strategy: 
1) Timed (30 seconds)
2) Pub/Sub RPC on any Property model change.

This PR has the bonus side-effect of removing the preloading and passing of Properties added in https://github.com/grouparoo/grouparoo/pull/1782 and https://github.com/grouparoo/grouparoo/pull/1791

In `NODE_ENV=test`, the cache duration is -1, so the cache is instantly invalidated.

---

Test results (`./bin/timed_test staging-enterprise`)
* `main`: `🎉 Complete in 0hrs 2min 34sec [154 seconds]`
* `property-cache`: `🎉 Complete in 0hrs 1min 29sec [89 seconds]`
... 2x faster?!

---

Things to test:
- [x] That CLS Wrapping the RPC call works as expected
- [x] That a missed cache hit invalidates
