### PR TITLE
Add ability to edit config files

### DIFF
--- a/core/src/modules/configLoaders/app.ts
+++ b/core/src/modules/configLoaders/app.ts
@@ -19,34 +19,22 @@ export async function loadApp(
   let isNew = false;
   validateConfigObjectKeys(App, configObject);
 
-  let locked: string;
-  if (process.env.GROUPAROO_RUN_MODE !== "cli:config") {
-    locked = getCodeConfigLockKey();
-  } else if (ConfigWriter.isLockable(configObject)) {
-    locked = ConfigWriter.getLockKey();
-  }
-
-  let getParams: { id: string; locked?: string } = { id: configObject.id };
-  if (locked) getParams.locked = locked;
-
-  let createParams: {
-    id: string;
-    name: string;
-    type: string;
-    locked?: string;
-  } = {
-    id: configObject.id,
-    name: configObject.name,
-    type: configObject.type,
-  };
-  if (locked) createParams.locked = locked;
-
+  // We assume we will always have to create a new object when in config mode,
+  // so it is safe to leave locked in the find query.
   let app = await App.scope(null).findOne({
-    where: getParams,
+    where: {
+      id: configObject.id,
+      locked: getCodeConfigLockKey(),
+    },
   });
   if (!app) {
     isNew = true;
-    app = await App.create(createParams);
+    app = await App.create({
+      id: configObject.id,
+      name: configObject.name,
+      type: configObject.type,
+      locked: ConfigWriter.getLockKey(configObject),
+    });
   }
 
   await app.update({ type: configObject.type, name: configObject.name });
@@ -71,6 +59,9 @@ export async function loadApp(
 }
 
 export async function deleteApps(ids: string[]) {
+  // Since this method is only used when config is loaded and because we assume
+  // the db is ephemeral, we can target locked objects, even though this will
+  // always return zero objects when in config mode.
   const apps = await App.scope(null).findAll({
     where: { locked: getCodeConfigLockKey(), id: { [Op.notIn]: ids } },
   });

--- a/core/src/modules/configLoaders/app.ts
+++ b/core/src/modules/configLoaders/app.ts
@@ -19,8 +19,6 @@ export async function loadApp(
   let isNew = false;
   validateConfigObjectKeys(App, configObject);
 
-  // We assume we will always have to create a new object when in config mode,
-  // so it is safe to leave locked in the find query.
   let app = await App.scope(null).findOne({
     where: {
       id: configObject.id,
@@ -59,9 +57,6 @@ export async function loadApp(
 }
 
 export async function deleteApps(ids: string[]) {
-  // Since this method is only used when config is loaded and because we assume
-  // the db is ephemeral, we can target locked objects, even though this will
-  // always return zero objects when in config mode.
   const apps = await App.scope(null).findAll({
     where: { locked: getCodeConfigLockKey(), id: { [Op.notIn]: ids } },
   });

--- a/core/src/modules/configLoaders/destination.ts
+++ b/core/src/modules/configLoaders/destination.ts
@@ -23,8 +23,6 @@ export async function loadDestination(
 
   validateConfigObjectKeys(Destination, configObject);
 
-  // We assume we will always have to create a new object when in config mode,
-  // so it is safe to leave locked in the find query.
   let destination = await Destination.scope(null).findOne({
     where: { id: configObject.id, appId: app.id },
   });
@@ -87,9 +85,6 @@ export async function loadDestination(
 }
 
 export async function deleteDestinations(ids: string[]) {
-  // Since this method is only used when config is loaded and because we assume
-  // the db is ephemeral, we can target locked objects, even though this will
-  // always return zero objects when in config mode.
   const destinations = await Destination.scope(null).findAll({
     where: { locked: getCodeConfigLockKey(), id: { [Op.notIn]: ids } },
   });

--- a/core/src/modules/configLoaders/group.ts
+++ b/core/src/modules/configLoaders/group.ts
@@ -19,8 +19,6 @@ export async function loadGroup(
   let isNew = false;
   validateConfigObjectKeys(Group, configObject);
 
-  // We assume we will always have to create a new object when in config mode,
-  // so it is safe to leave locked in the find query.
   let group = await Group.scope(null).findOne({
     where: { id: configObject.id, locked: getCodeConfigLockKey() },
   });
@@ -57,9 +55,6 @@ export async function loadGroup(
 }
 
 export async function deleteGroups(ids: string[]) {
-  // Since this method is only used when config is loaded and because we assume
-  // the db is ephemeral, we can target locked objects, even though this will
-  // always return zero objects when in config mode.
   const groups = await Group.scope(null).findAll({
     where: {
       locked: getCodeConfigLockKey(),

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -80,7 +80,8 @@ async function loadConfigFile(file: string): Promise<ConfigurationObject> {
 
   if (typeof payload === "function") payload = await payload(config);
 
-  ConfigWriter.setFileLoaded(file);
+  const objects = Array.isArray(payload) ? payload : [payload];
+  ConfigWriter.cacheConfigFile({ absFilePath: file, objects });
 
   return payload;
 }

--- a/core/src/modules/configLoaders/property.ts
+++ b/core/src/modules/configLoaders/property.ts
@@ -22,8 +22,6 @@ export async function loadProperty(
 
   validateConfigObjectKeys(Property, configObject, ["name"]);
 
-  // We assume we will always have to create a new object when in config mode,
-  // so it is safe to leave locked in the find query.
   let property = await Property.scope(null).findOne({
     where: { locked: getCodeConfigLockKey(), id: configObject.id },
   });
@@ -63,9 +61,6 @@ export async function loadProperty(
 }
 
 export async function deleteProperties(ids: string[]) {
-  // Since this method is only used when config is loaded and because we assume
-  // the db is ephemeral, we can target locked objects, even though this will
-  // always return zero objects when in config mode.
   const properties = await Property.scope(null).findAll({
     where: { locked: getCodeConfigLockKey(), id: { [Op.notIn]: ids } },
   });

--- a/core/src/modules/configLoaders/schedule.ts
+++ b/core/src/modules/configLoaders/schedule.ts
@@ -21,8 +21,6 @@ export async function loadSchedule(
   validateConfigObjectKeys(Schedule, configObject);
   const source: Source = await getParentByName(Source, configObject.sourceId);
 
-  // We assume we will always have to create a new object when in config mode,
-  // so it is safe to leave locked in the find query.
   let schedule = await Schedule.scope(null).findOne({
     where: { id: configObject.id, locked: getCodeConfigLockKey() },
   });
@@ -52,9 +50,6 @@ export async function loadSchedule(
 }
 
 export async function deleteSchedules(ids: string[]) {
-  // Since this method is only used when config is loaded and because we assume
-  // the db is ephemeral, we can target locked objects, even though this will
-  // always return zero objects when in config mode.
   const schedules = await Schedule.scope(null).findAll({
     where: { locked: getCodeConfigLockKey(), id: { [Op.notIn]: ids } },
   });

--- a/core/src/modules/configLoaders/source.ts
+++ b/core/src/modules/configLoaders/source.ts
@@ -12,6 +12,8 @@ import { App, Source, Property } from "../..";
 import { Op } from "sequelize";
 import { log } from "actionhero";
 
+import { ConfigWriter } from "../configWriter";
+
 export async function loadSource(
   configObject: ConfigurationObject,
   configObjects: ConfigurationObject[],
@@ -24,6 +26,8 @@ export async function loadSource(
 
   validateConfigObjectKeys(Source, configObject);
 
+  // We assume we will always have to create a new object when in config mode,
+  // so it is safe to leave locked in the find query.
   let source = await Source.scope(null).findOne({
     where: {
       id: configObject.id,
@@ -35,7 +39,7 @@ export async function loadSource(
     isNew = true;
     source = await Source.create({
       id: configObject.id,
-      locked: getCodeConfigLockKey(),
+      locked: ConfigWriter.getLockKey(configObject),
       name: configObject.name,
       type: configObject.type,
       appId: app.id,
@@ -137,6 +141,9 @@ export async function deleteSources(ids: string[]) {
     source: [],
   };
 
+  // Since this method is only used when config is loaded and because we assume
+  // the db is ephemeral, we can target locked objects, even though this will
+  // always return zero objects when in config mode.
   const sources = await Source.scope(null).findAll({
     where: { locked: getCodeConfigLockKey(), id: { [Op.notIn]: ids } },
   });

--- a/core/src/modules/configLoaders/source.ts
+++ b/core/src/modules/configLoaders/source.ts
@@ -26,8 +26,6 @@ export async function loadSource(
 
   validateConfigObjectKeys(Source, configObject);
 
-  // We assume we will always have to create a new object when in config mode,
-  // so it is safe to leave locked in the find query.
   let source = await Source.scope(null).findOne({
     where: {
       id: configObject.id,
@@ -141,9 +139,6 @@ export async function deleteSources(ids: string[]) {
     source: [],
   };
 
-  // Since this method is only used when config is loaded and because we assume
-  // the db is ephemeral, we can target locked objects, even though this will
-  // always return zero objects when in config mode.
   const sources = await Source.scope(null).findAll({
     where: { locked: getCodeConfigLockKey(), id: { [Op.notIn]: ids } },
   });

--- a/core/src/modules/configWriter.ts
+++ b/core/src/modules/configWriter.ts
@@ -103,6 +103,8 @@ export namespace ConfigWriter {
     if (isLockable(configObject)) {
       return "config:writer";
     }
+    // If we are in config mode and the file is not lockable (it is JSON file),
+    // we return null. A null value is equivalent to the object being unlocked.
     return null;
   }
 

--- a/core/src/modules/configWriter.ts
+++ b/core/src/modules/configWriter.ts
@@ -111,7 +111,7 @@ export namespace ConfigWriter {
   function fileIsLockable(absFilePath: string): boolean {
     // Otherwise, it is lockable if it is a JS file.
     const ext = path.extname(absFilePath);
-    return ext === ".js";
+    return ext !== ".json";
   }
 
   function isLockable(object: ConfigurationObject) {

--- a/core/src/modules/configWriter.ts
+++ b/core/src/modules/configWriter.ts
@@ -26,6 +26,26 @@ type CachedConfigFile = {
   objects: ConfigurationObject[];
 };
 
+/**
+ * Loading
+ * ----------------------------------------
+ * 1. Loader tells Writer to cache all files it read.
+ * 2. Writer caches files that are writable (i.e. not locked). It ignores locked
+ *    files.
+ * 3. Individual loaders ask the writer for a lock key. Writer responds with the
+ *    key unless it has a cached object.
+ *
+ *
+ * Writing
+ * ----------------------------------------
+ * 1. Delete all files in the cache.
+ * 2. Query the database for all writable objects. These are UNLOCKED Apps,
+ *    Sources (and their Schedules), Properties, Groups, and Destinations.
+ * 3. Each config object is retrieved from the model, written to file, and then
+ *    cached.
+ *
+ */
+
 let CONFIG_FILE_CACHE: CachedConfigFile[] = [];
 
 export namespace ConfigWriter {
@@ -46,13 +66,14 @@ export namespace ConfigWriter {
 
   export async function getConfigObjects(): Promise<WritableConfigObject[]> {
     let objects = [];
-    // Note: Sources bring their schedule.
+
+    const queryParams = { where: { locked: null } };
     const queries = {
-      apps: await App.findAll(),
-      sources: await Source.findAll(),
-      properties: await Property.findAll(),
-      groups: await Group.findAll(),
-      destinations: await Destination.findAll(),
+      apps: await App.findAll(queryParams),
+      sources: await Source.findAll(queryParams),
+      properties: await Property.findAll(queryParams),
+      groups: await Group.findAll(queryParams),
+      destinations: await Destination.findAll(queryParams),
     };
 
     for (let [type, instances] of Object.entries(queries)) {
@@ -85,20 +106,26 @@ export namespace ConfigWriter {
     return null;
   }
 
+  function fileIsLockable(absFilePath: string): boolean {
+    // Otherwise, it is lockable if it is a JS file.
+    const ext = path.extname(absFilePath);
+    return ext === ".js";
+  }
+
   function isLockable(object: ConfigurationObject) {
     const isMatch = (o) => o.id === object.id && o.class === object.class;
     const cachedFileObj: CachedConfigFile = CONFIG_FILE_CACHE.find(
       (cache) => cache.objects.filter(isMatch).length > 0
     );
-    // If there is no cached file, we assume the file doesn't exist and so the
-    // object is not lockable.
-    if (!cachedFileObj) return false;
-    // Otherwise, it is lockable if it is a JS file.
-    const ext = path.extname(cachedFileObj.absFilePath);
-    return ext === ".js";
+    // If there is no cached file, we assume the file is locked. This is because
+    // the Writer does not cache locked files.
+    if (!cachedFileObj) return true;
+    // Otherwise, check the file itself.
+    return fileIsLockable(cachedFileObj.absFilePath);
   }
 
   export async function cacheConfigFile(cacheObj: CachedConfigFile) {
+    if (fileIsLockable(cacheObj.absFilePath)) return null;
     CONFIG_FILE_CACHE.push(cacheObj);
   }
 


### PR DESCRIPTION
This adjusts the current locking mechanism for code config when in Config UI mode (i.e. `process.env.GROUPAROO_RUN_MODE = "cli:config"`). Objects that are loaded from JSON files are unlocked, while JS files are locked. This should not adjust the locking pattern when in start/run mode for either Community or Enterprise.

Note that we're now assuming that there is parity between the Loader(s) and the Writer — that all appropriate loaders cache the proper `locked` value in the database. The Writer then does not cached files it expects to be locked, such that it simply ignores them altogether.

I added some comments to that effect in the individual config loaders. I also added a big comment with updated logic on how the Loader and Writer work together with one another.