### PR TITLE
`properties:list` action should not always include examples

### DIFF
--- a/core/__tests__/actions/properties.ts
+++ b/core/__tests__/actions/properties.ts
@@ -260,11 +260,14 @@ describe("actions/properties", () => {
 
       connection.params = {
         csrfToken,
+        includeExamples: true,
       };
+
       const { error, properties, examples, total } = await specHelper.runAction(
         "properties:list",
         connection
       );
+
       expect(error).toBeUndefined();
       expect(properties.length).toBe(2); // this + userId
       expect(properties[1].sourceId).toBe(source.id);
@@ -275,6 +278,17 @@ describe("actions/properties", () => {
       expect(total).toBe(2);
 
       expect(examples[properties[0].id]).toEqual(["person@example.com"]);
+
+      connection.params = {
+        csrfToken,
+        includeExamples: false,
+      };
+
+      const secondRequest = await specHelper.runAction(
+        "properties:list",
+        connection
+      );
+      expect(secondRequest.examples).toBeUndefined();
 
       await profile.destroy();
     });

--- a/ui/ui-components/pages/properties.tsx
+++ b/ui/ui-components/pages/properties.tsx
@@ -52,6 +52,7 @@ export default function Page(props) {
       "get",
       `/properties`,
       {
+        includeExamples: true,
         limit: limit * (total === 0 ? 1 : total),
         offset: 0,
       }
@@ -253,6 +254,7 @@ Page.getInitialProps = async (ctx) => {
   const { execApi } = useApi(ctx);
   const { limit, offset } = ctx.query;
   const { properties, total, examples } = await execApi("get", `/properties`, {
+    includeExamples: true,
     limit,
     offset,
   });

--- a/ui/ui-components/pages/source/[id]/mapping.tsx
+++ b/ui/ui-components/pages/source/[id]/mapping.tsx
@@ -58,10 +58,7 @@ export default function Page(props) {
         const prrResponse: Actions.PropertiesList = await execApi(
           "get",
           `/properties`,
-          {
-            unique: true,
-            state: "ready",
-          }
+          { includeExamples: true, unique: true, state: "ready" }
         );
         if (prrResponse?.properties) {
           setProperties(prrResponse.properties);
@@ -357,10 +354,7 @@ Page.getInitialProps = async (ctx) => {
   const { properties, examples: propertyExamples } = await execApi(
     "get",
     `/properties`,
-    {
-      state: "ready",
-      unique: true,
-    }
+    { includeExamples: true, state: "ready", unique: true }
   );
   const { types } = await execApi("get", `/propertyOptions`);
   const { total: scheduleCount } = await execApi("get", `/schedules`);


### PR DESCRIPTION
This PR makes the `properties:list` action optionally include examples via a new `includeExamples` param