### PR TITLE
Force delete destinations and groups in config mode

### DIFF
--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -617,6 +617,7 @@ export class Destination extends LoggedModel<Destination> {
 
   @BeforeDestroy
   static async cannotDeleteDestinationWithTrackedGroup(instance: Destination) {
+    if (process.env.GROUPAROO_RUN_MODE === "cli:config") return;
     if (instance.groupId) {
       const group = await Group.findOne({
         where: { id: instance.groupId },

--- a/ui/ui-components/pages/destination/[id]/edit.tsx
+++ b/ui/ui-components/pages/destination/[id]/edit.tsx
@@ -92,7 +92,8 @@ export default function Page(props) {
       setLoading(true);
       const { success }: Actions.DestinationDestroy = await execApi(
         "delete",
-        `/destination/${id}`
+        `/destination/${id}`,
+        { force: process.env.GROUPAROO_UI_EDITION === "config" }
       );
       if (success) {
         router.push("/destinations");

--- a/ui/ui-components/pages/destination/[id]/edit.tsx
+++ b/ui/ui-components/pages/destination/[id]/edit.tsx
@@ -87,13 +87,13 @@ export default function Page(props) {
     setLoadingOptions(false);
   }
 
-  async function handleDelete() {
+  async function handleDelete(force = false) {
     if (window.confirm("are you sure?")) {
       setLoading(true);
       const { success }: Actions.DestinationDestroy = await execApi(
         "delete",
         `/destination/${id}`,
-        { force: process.env.GROUPAROO_UI_EDITION === "config" }
+        { force }
       );
       if (success) {
         router.push("/destinations");
@@ -392,7 +392,7 @@ export default function Page(props) {
                 size="sm"
                 disabled={loading}
                 onClick={() => {
-                  handleDelete();
+                  handleDelete(process.env.GROUPAROO_UI_EDITION === "config");
                 }}
               >
                 Delete

--- a/ui/ui-components/pages/group/[id]/edit.tsx
+++ b/ui/ui-components/pages/group/[id]/edit.tsx
@@ -158,7 +158,7 @@ export default function Page(props) {
                   disabled={loading}
                   size="sm"
                   onClick={() => {
-                    handleDelete();
+                    handleDelete(process.env.GROUPAROO_UI_EDITION === "config");
                   }}
                 >
                   Delete


### PR DESCRIPTION
I did a lot of digging through the weeds here, but I could really only find that destinations and groups had this deleted state. And they already had a simple way to force it. I feel like I'm missing something.