### PR TITLE
CLI Sets NEXT_DEVELOPMENT_MODE=false & Better CLI Tests

### DIFF
--- a/cli/__tests__/test.sh
+++ b/cli/__tests__/test.sh
@@ -157,7 +157,8 @@ echo ""
 ## try the start command
 echo ""
 echo "--- test: start ---"
-cd $WORKDIR && grouparoo start &
+cd $WORKDIR
+grouparoo start &
 PID=$!
 echo ""
 echo ""
@@ -169,6 +170,7 @@ echo "--- test: status ---"
 curl http://localhost:3000/api/v1/status/public
 
 kill $PID
+sleep 10
 
 ## reset the NPM links
 cd "$MONOREPO/cli" && npm unlink .
@@ -176,3 +178,5 @@ echo "--- npm unlinked ---"
 
 echo ""
 echo "🎉🎉🎉 TESTS PASSED 🎉🎉🎉"
+
+exit 0

--- a/core/src/bin/apply.ts
+++ b/core/src/bin/apply.ts
@@ -29,6 +29,7 @@ export class Apply extends CLI {
 
   preInitialize = () => {
     GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
   };
 
   async run({ params }) {

--- a/core/src/bin/config.ts
+++ b/core/src/bin/config.ts
@@ -13,6 +13,7 @@ export class Apply extends CLI {
 
   preInitialize = () => {
     GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
 
     // use temporary databases
     process.env.DATABASE_URL =

--- a/core/src/bin/console.ts
+++ b/core/src/bin/console.ts
@@ -14,6 +14,7 @@ export class Console extends CLI {
 
   preInitialize = () => {
     GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
   };
 
   async run() {

--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -109,6 +109,7 @@ Commands:
 
   preInitialize = () => {
     GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
   };
 
   async run({ params }) {

--- a/core/src/bin/reset.ts
+++ b/core/src/bin/reset.ts
@@ -22,6 +22,7 @@ export class ResetCLI extends CLI {
 
   preInitialize = () => {
     GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
   };
 
   async run({ params }) {

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -42,6 +42,7 @@ export class RunCLI extends CLI {
 
   preInitialize = () => {
     GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
   };
 
   async run({ params }) {

--- a/core/src/bin/start.ts
+++ b/core/src/bin/start.ts
@@ -13,6 +13,7 @@ export class Start extends CLI {
 
   preInitialize = () => {
     GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
   };
 
   async run() {

--- a/core/src/bin/status.ts
+++ b/core/src/bin/status.ts
@@ -17,6 +17,7 @@ export class StatusCLI extends CLI {
 
   preInitialize = () => {
     GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
   };
 
   async run({ params }) {

--- a/core/src/bin/sync.ts
+++ b/core/src/bin/sync.ts
@@ -30,6 +30,7 @@ export class SyncCLI extends CLI {
 
   preInitialize = () => {
     GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
   };
 
   async run({ params }) {

--- a/core/src/bin/validate.ts
+++ b/core/src/bin/validate.ts
@@ -28,6 +28,7 @@ export class Validate extends CLI {
 
   preInitialize = () => {
     GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
   };
 
   async run({ params }) {

--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -44,6 +44,12 @@ export namespace GrouparooCLI {
     process.env.GROUPAROO_RUN_MODE = `cli:${cli.name}`;
   }
 
+  export function setNextDevelopmentMode(nextDevelopmentMode = false) {
+    if (process.env.NEXT_DEVELOPMENT_MODE === undefined) {
+      process.env.NEXT_DEVELOPMENT_MODE = nextDevelopmentMode.toString();
+    }
+  }
+
   export function logCLI(name: string, announcePlugins = true) {
     if (announcePlugins) api.plugins.announcePlugins();
 


### PR DESCRIPTION
Prevents a class of bugs in which using the `grouparoo` cli (eg: `grouparoo start`, `grouparoo apply`, etc) would throw an error looking for typescript

```
It looks like you're trying to use TypeScript but do not have the required package(s) installed.

Please install typescript by running:

	npm install --save-dev typescript

If you are not trying to use TypeScript, please remove the tsconfig.json file from your package root (and any TypeScript files in your pages directory).
```

This test is still a little brittle, as it relies on published versions of packages for the first install

