### PR TITLE
Include no-op `schedule:updateSchedules` task to prevent resque errors

### DIFF
--- a/core/src/tasks/schedule/updateSchedules.ts
+++ b/core/src/tasks/schedule/updateSchedules.ts
@@ -1,0 +1,14 @@
+import { Task } from "actionhero";
+
+export class ScheduleUpdateSchedules extends Task {
+  constructor() {
+    super();
+    this.name = "schedule:updateSchedules";
+    this.description = "deprecated";
+    this.frequency = 0;
+    this.queue = "schedules";
+  }
+
+  // deprecated
+  async run() {}
+}


### PR DESCRIPTION
Task `schedule:updateSchedules` was removed in https://github.com/grouparoo/grouparoo/pull/1761.  But, the previous task was recurring and will rail once as people upgrade.  This PR adds back he `schedule:updateSchedules` task, doing nothing, so the resque task won't fail.

We can remove this task in a few months, after another version bump