### PR TITLE
Webpack artifact improvements 

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -95,6 +95,13 @@ echo ""
 echo "-----> INSTALL DEPENDENCIES & BUILD PACKAGES"
 echo ""
 
+# Clear build caches
+rm -rf core/dist
+rm -rf clients/*/*/dist
+rm -rf cli/dist
+rm -rf plugins/*/*/dist
+rm -rf ui/*/.next
+
 pnpm install --prefer-frozen-lockfile
 git checkout pnpm-lock.yaml # the other github action will take care of this, but we need a clean working directory to publish
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "spell-checker": "./tools/spell-checker/check",
     "lint": "pnpm run --stream -r lint --workspace-concurrency=2 --filter !'@grouparoo/grouparoo'",
     "test": "pnpm run test --stream --workspace-concurrency=1 --filter !'@grouparoo/grouparoo'",
-    "nuke": "rm -rf pnpm-lock.yaml && rm -rf node_modules && rm -rf core/node_modules rm -rf ui/*/node_modules && rm -rf cli/node_modules && rm -rf clients/*/*/node_modules && rm -rf plugins/*/*/node_modules && rm -rf apps/*/node_modules && rm -rf core/dist && rm -rf clients/*/*/dist && rm -rf cli/dist && rm -rf plugins/*/*/dist",
+    "nuke": "rm -rf pnpm-lock.yaml && rm -rf node_modules && rm -rf core/node_modules rm -rf ui/*/node_modules && rm -rf cli/node_modules && rm -rf clients/*/*/node_modules && rm -rf plugins/*/*/node_modules && rm -rf apps/*/node_modules && rm -rf core/dist && rm -rf clients/*/*/dist && rm -rf cli/dist && rm -rf plugins/*/*/dist && rm -rf ui/*/.next",
     "update": "npm-check-updates -u && pnpm exec -- npm-check-updates -u && npm run nuke && pnpm install",
     "heroku-prebuild": "npm install -g pnpm",
     "heroku-postbuild": "pnpm install"

--- a/ui/ui-community/.npmignore
+++ b/ui/ui-community/.npmignore
@@ -9,3 +9,4 @@ yarn-error.log
 dump.rdb
 *.retry
 coverage
+.next/cache/*

--- a/ui/ui-community/package.json
+++ b/ui/ui-community/package.json
@@ -21,7 +21,7 @@
     "directory": "ui/ui-community"
   },
   "scripts": {
-    "prepare": "rm -rf .next && next build",
+    "prepare": "next build",
     "start": "next start --port $PORT",
     "dev": "next dev",
     "pretest": "npm run lint && npm run prepare",

--- a/ui/ui-components/.npmignore
+++ b/ui/ui-components/.npmignore
@@ -9,3 +9,4 @@ yarn-error.log
 dump.rdb
 *.retry
 coverage
+.next/cache/*

--- a/ui/ui-config/.npmignore
+++ b/ui/ui-config/.npmignore
@@ -9,3 +9,4 @@ yarn-error.log
 dump.rdb
 *.retry
 coverage
+.next/cache/*

--- a/ui/ui-config/package.json
+++ b/ui/ui-config/package.json
@@ -21,7 +21,7 @@
     "directory": "ui/ui-config"
   },
   "scripts": {
-    "prepare": "rm -rf .next && next build",
+    "prepare": "next build",
     "start": "next start --port $PORT",
     "dev": "next dev",
     "pretest": "npm run lint && npm run prepare",

--- a/ui/ui-enterprise/.npmignore
+++ b/ui/ui-enterprise/.npmignore
@@ -9,3 +9,4 @@ yarn-error.log
 dump.rdb
 *.retry
 coverage
+.next/cache/*

--- a/ui/ui-enterprise/package.json
+++ b/ui/ui-enterprise/package.json
@@ -21,7 +21,7 @@
     "directory": "ui/ui-enterprise"
   },
   "scripts": {
-    "prepare": "rm -rf .next && next build",
+    "prepare": "next build",
     "start": "next start --port $PORT",
     "dev": "next dev",
     "pretest": "npm run lint && npm run prepare",


### PR DESCRIPTION
A few improvements regarding how we handle webpack artifacts:

1. Do not include `.next/cache/*.pack` files in our npm packages.  These are not needed at run time and are HUGE.  This will make our UI NPM packages ~200mb smaller!
2. We don't need to clear the whole `.next` directory on `npm prepare`. We can keep the cache around, and sped up subsequent build (triggered by `pnpm install`) by ~2x!
   a. **fresh build** - npm run prepare  130.36s user 7.85s system 220% cpu 1:02.77 total
   b. **with cache** - npm run prepare  28.56s user 2.78s system 154% cpu 20.251 total
3. We do want to ensure that we include fresh buildfiles in our releases, so the nuke and prepare scripts will now remove the .next cache and rebuild from scratch before publishing.