### PR TITLE
Support upper-case MySQL INFORMATION_SCHEMA

### DIFF
--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -271,6 +271,7 @@ export async function processConfigObjects(
         configObject.key || configObject.name
       }\` (${configObject.id}): ${message}`;
       errors.push(errorMessage);
+      log(error?.stack || error, "debug");
       if (fields.length === 0) {
         log(errorMessage, "warning");
         continue;

--- a/plugins/@grouparoo/mysql/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/destinationMappingOptions.ts
@@ -6,7 +6,7 @@ import {
 export const destinationMappingOptions: DestinationMappingOptionsMethod =
   async ({ connection, appOptions, destinationOptions }) => {
     const rows = await connection.asyncQuery(
-      `SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = ? AND table_name = ?`,
+      `SELECT column_name AS column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = ? AND table_name = ?`,
       [appOptions.database, destinationOptions.table]
     );
 

--- a/plugins/@grouparoo/mysql/src/lib/export/destinationOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/destinationOptions.ts
@@ -10,7 +10,7 @@ export const destinationOptions: DestinationOptionsMethod = async ({
 }) => {
   async function getColumns(tableName: string) {
     const colRows = await connection.asyncQuery(
-      `SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = ? AND table_name = ?`,
+      `SELECT column_name AS column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = ? AND table_name = ?`,
       [appOptions.database, tableName]
     );
 
@@ -28,7 +28,7 @@ export const destinationOptions: DestinationOptionsMethod = async ({
   const tables = [];
 
   const rows = await connection.asyncQuery(
-    `SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = ?`,
+    `SELECT table_name AS table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = ?`,
     [appOptions.database]
   );
 

--- a/plugins/@grouparoo/mysql/src/lib/table-import/getColumns.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/getColumns.ts
@@ -11,7 +11,7 @@ export const getColumns: GetColumnDefinitionsMethod = async ({
   tableName,
 }) => {
   const rows = await connection.asyncQuery(
-    `SELECT column_name, data_type FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = ? AND table_name = ?`,
+    `SELECT column_name AS column_name, data_type AS data_type FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = ? AND table_name = ?`,
     [appOptions.database, tableName]
   );
 

--- a/plugins/@grouparoo/mysql/src/lib/table-import/getTables.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/getTables.ts
@@ -8,7 +8,7 @@ export const getTables: GetTablesMethod = async ({
   appOptions,
 }) => {
   const rows = await connection.asyncQuery(
-    `SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = ?`,
+    `SELECT table_name AS table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = ?`,
     [appOptions.database]
   );
 


### PR DESCRIPTION
It seems that the information_schema in MySQL can return uppercase column names in some users' environments.
Normalize, so things work as expected.