### PR TITLE
Speed up `imports:associateProfile` task

### DIFF
--- a/core/src/migrations/000067-profilePropertiesRawValueIndex.ts
+++ b/core/src/migrations/000067-profilePropertiesRawValueIndex.ts
@@ -1,9 +1,13 @@
 export default {
   up: async function (migration) {
     await migration.sequelize.transaction(async () => {
-      await migration.addIndex("profileProperties", ["profileId", "rawValue"], {
-        fields: ["profileId", "rawValue"],
-      });
+      await migration.addIndex(
+        "profileProperties",
+        ["propertyId", "rawValue"],
+        {
+          fields: ["propertyId", "rawValue"],
+        }
+      );
     });
   },
 
@@ -11,9 +15,9 @@ export default {
     await migration.sequelize.transaction(async () => {
       await migration.removeIndex(
         "profileProperties",
-        ["profileId", "rawValue"],
+        ["propertyId", "rawValue"],
         {
-          fields: ["profileId", "rawValue"],
+          fields: ["propertyId", "rawValue"],
         }
       );
     });

--- a/core/src/migrations/000067-profilePropertiesRawValueIndex.ts
+++ b/core/src/migrations/000067-profilePropertiesRawValueIndex.ts
@@ -1,0 +1,21 @@
+export default {
+  up: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.addIndex("profileProperties", ["profileId", "rawValue"], {
+        fields: ["profileId", "rawValue"],
+      });
+    });
+  },
+
+  down: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.removeIndex(
+        "profileProperties",
+        ["profileId", "rawValue"],
+        {
+          fields: ["profileId", "rawValue"],
+        }
+      );
+    });
+  },
+};

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -281,7 +281,7 @@ export class Export extends Model {
   }
 
   @BeforeSave
-  static async updateState(instance: Profile) {
+  static async updateState(instance: Export) {
     await StateMachine.transition(instance, STATE_TRANSITIONS);
   }
 

--- a/core/src/models/Log.ts
+++ b/core/src/models/Log.ts
@@ -8,6 +8,7 @@ import {
   ForeignKey,
   BeforeCreate,
   AfterCreate,
+  BeforeBulkCreate,
 } from "sequelize-typescript";
 import { DataTypes } from "sequelize";
 import * as uuid from "uuid";
@@ -90,6 +91,11 @@ export class Log extends Model {
   @BeforeCreate
   static generateId(instance: Log) {
     if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
+  }
+
+  @BeforeBulkCreate
+  static generateIds(instances: Log[]) {
+    instances.forEach((instance) => this.generateId(instance));
   }
 
   @BeforeCreate

--- a/core/src/modules/ops/export.ts
+++ b/core/src/modules/ops/export.ts
@@ -91,7 +91,6 @@ export namespace ExportOps {
           [Op.or]: [null, { [Op.lt]: new Date().getTime() - delayMs }],
         },
       },
-      order: [["sendAt", "asc"]],
       limit,
     });
 

--- a/core/src/modules/ops/import.ts
+++ b/core/src/modules/ops/import.ts
@@ -29,7 +29,6 @@ export namespace ImportOps {
         },
       },
       limit,
-      order: [["createdAt", "asc"]],
     });
 
     if (imports.length > 0) {

--- a/core/src/modules/ops/import.ts
+++ b/core/src/modules/ops/import.ts
@@ -76,6 +76,7 @@ export namespace ImportOps {
     const oldProfileProperties = await profile.simplifiedProperties();
     const oldGroups = await profile.$get("groups");
 
+    _import.createdProfile = isNew;
     _import.profileId = profile.id;
     _import.profileAssociatedAt = new Date();
 

--- a/core/src/modules/ops/profileProperty.ts
+++ b/core/src/modules/ops/profileProperty.ts
@@ -102,7 +102,6 @@ export namespace ProfilePropertyOps {
           [Op.or]: [null, { [Op.lt]: new Date().getTime() - delayMs }],
         },
       },
-      order: [["stateChangedAt", "ASC"]],
       limit,
     });
 

--- a/core/src/tasks/import/associateProfile.ts
+++ b/core/src/tasks/import/associateProfile.ts
@@ -30,16 +30,7 @@ export class ImportAssociateProfile extends Task {
           if (!_import) return;
           if (_import.profileId) return;
 
-          const { profile, isNew } = await _import.associateProfile();
-
-          const oldProfileProperties = await profile.simplifiedProperties();
-          const oldGroups = await profile.$get("groups");
-
-          await _import.update({
-            createdProfile: isNew,
-            oldProfileProperties,
-            oldGroupIds: oldGroups.map((g) => g.id),
-          });
+          const { profile } = await _import.associateProfile();
 
           await profile.markPending();
         },


### PR DESCRIPTION
## What's Inside:

1. Add an index to the `profileProperties` table on `["propertyId", "rawValue"]`- this speeds up the `import:associateProfile` task significantly (`findOrCreateByUniqueProfileProperties`), as it makes finding an existing matching profileProperty faster. 
2. Remove a 'double-set' of OldProfileProperties and OldGroups when updating an import (we were doing it twice)
3. Remove the SORT from our batch tasks (eg `import:associateProfiles` -> `processPendingImportsForAssociation`).  This was the biggest source of the slowdown in finding which Imports, ProfileProperties or Exports to move along in the next batch.
   * **Side Effect** -> This means that the first imported Profiles will likely not be the first exported.  The order will be more random.  With Exports, this delays even more the the time between when they were calculated from when they will be sent 
4. `createNullProperties` now makes a single insert statement, and writes all the logs as one insert statement too
4. Non-CLS Tasks are now instrumented with APM (Sentry)

## Ideas:
* remove locks
* do things in batches
* pre-load things
* remove redundant things
* Indices in the DB?

## Investigation Notes:

Disabling the locks (`waitForLock`) in the `findOrCreateByUniqueProfileProperties` method did not make a noticeable speed difference.

---

Confirmed that it is NOT faster to 2 to queries than one query with an OR (at least in this case):

```sql
--- 1 Query ---
EXPLAIN ANALYZE SELECT * FROM "profileProperties" AS "ProfileProperty" WHERE "ProfileProperty"."propertyId" = 'email' AND "ProfileProperty"."state" = 'pending' AND ("ProfileProperty"."startedAt" IS NULL OR "ProfileProperty"."startedAt" < '2021-05-22 18:38:00.182 +00:00') ORDER BY "ProfileProperty"."stateChangedAt" ASC LIMIT 500;
-- 40ms

--- 2 queries ---
EXPLAIN ANALYZE SELECT * FROM "profileProperties" AS "ProfileProperty" WHERE "ProfileProperty"."propertyId" = 'email' AND "ProfileProperty"."state" = 'pending' AND ( "ProfileProperty"."startedAt" < '2021-05-22 18:38:00.182 +00:00') ORDER BY "ProfileProperty"."stateChangedAt" ASC LIMIT 500;
-- 34ms
-- + 
EXPLAIN ANALYZE SELECT * FROM "profileProperties" AS "ProfileProperty" WHERE "ProfileProperty"."propertyId" = 'email' AND "ProfileProperty"."state" = 'pending' AND ("ProfileProperty"."startedAt" IS NULL) ORDER BY "ProfileProperty"."stateChangedAt" ASC LIMIT 500;
-- 40ms
-- = 74ms total
```

On the other hand, the ORDER BY was the thing causing the biggest slowdown

```sql
EXPLAIN ANALYZE 
SELECT * FROM "profileProperties" AS "ProfileProperty" 
WHERE 
	"ProfileProperty"."propertyId" = 'email' 
	AND "ProfileProperty"."state" = 'pending' 
	AND ("ProfileProperty"."startedAt" IS NULL OR "ProfileProperty"."startedAt" < '2021-05-22 18:38:00.182 +00:00') 
LIMIT 500;
-- 2ms
```

---