### PR TITLE
Speed up `profile:checkReady` with a custom query

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -759,6 +759,37 @@ jobs:
           command: cd core/ && ./node_modules/.bin/jest __tests__/actions --ci --maxWorkers 2
           environment:
             DB_DIALECT: sqlite
+  test-core-local-tasks:
+    docker:
+      - image: circleci/node:14
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: redis:latest
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+    steps:
+      - checkout
+      - restore_cache:
+          <<: *module-other-cache-options
+      - restore_cache:
+          <<: *plugin-1-cache-options
+      - restore_cache:
+          <<: *plugin-2-cache-options
+      - restore_cache:
+          <<: *plugin-3-cache-options
+      - restore_cache:
+          <<: *plugin-4-cache-options
+      - restore_cache:
+          <<: *dist-cache-options
+      - restore_cache:
+          <<: *core-cache-options
+      - run:
+          name: test
+          command: cd core/ && ./node_modules/.bin/jest __tests__/tasks --ci --maxWorkers 2
+          environment:
+            DB_DIALECT: sqlite
   test-ui-components:
     docker:
       - image: circleci/node:14
@@ -2770,6 +2801,11 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
+      - test-core-local-tasks:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
       - test-ui-components:
           filters:
             <<: *ignored-branches
@@ -2989,6 +3025,7 @@ workflows:
             - test-core-tasks
             - test-core-local-models
             - test-core-local-actions
+            - test-core-local-tasks
             - test-ui-components
             - test-ui-community
             - test-ui-enterprise

--- a/core/__tests__/tasks/import/associateProfile.ts
+++ b/core/__tests__/tasks/import/associateProfile.ts
@@ -30,8 +30,8 @@ describe("tasks/import:associateProfile", () => {
         email: "toad@example.com",
         firstName: "Toad",
       });
-      expect(_import.profileId).toBeNull();
-      expect(_import.profileAssociatedAt).toBeNull();
+      expect(_import.profileId).toBeFalsy();
+      expect(_import.profileAssociatedAt).toBeFalsy();
 
       let profilesCount = await Profile.count();
       expect(profilesCount).toBe(0);

--- a/core/__tests__/tasks/profile/completeImport.ts
+++ b/core/__tests__/tasks/profile/completeImport.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { api, task, specHelper } from "actionhero";
+import { api, config, task, specHelper } from "actionhero";
 import { Group, Profile, ProfileProperty, Property } from "../../../src";
 
 describe("tasks/profile:completeImport", () => {
@@ -16,7 +16,9 @@ describe("tasks/profile:completeImport", () => {
       {
         key: "lastName",
         match: "Mario",
-        operation: { op: "iLike" },
+        operation: {
+          op: config.sequelize.dialect === "postgres" ? "iLike" : "like",
+        },
       },
     ]);
     await group.update({ state: "ready" });

--- a/core/__tests__/tasks/profileProperty/importProfileProperties.ts
+++ b/core/__tests__/tasks/profileProperty/importProfileProperties.ts
@@ -168,24 +168,20 @@ describe("tasks/profileProperty:importProfileProperties", () => {
       const properties = await Property.findAll();
 
       // run once to set userId
-      await Promise.all(
-        properties.map((property) =>
-          specHelper.runTask("profileProperty:importProfileProperties", {
-            profileIds: [profileA.id, profileB.id, profileC.id],
-            propertyId: property.id,
-          })
-        )
-      );
+      for (const property of properties) {
+        await specHelper.runTask("profileProperty:importProfileProperties", {
+          profileIds: [profileA.id, profileB.id, profileC.id],
+          propertyId: property.id,
+        });
+      }
 
       // run again for other properties
-      await Promise.all(
-        properties.map((property) =>
-          specHelper.runTask("profileProperty:importProfileProperties", {
-            profileIds: [profileA.id, profileB.id, profileC.id],
-            propertyId: property.id,
-          })
-        )
-      );
+      for (const property of properties) {
+        await specHelper.runTask("profileProperty:importProfileProperties", {
+          profileIds: [profileA.id, profileB.id, profileC.id],
+          propertyId: property.id,
+        });
+      }
 
       const profileProperties = await profileA.properties();
       expect(profileProperties.firstName.values).toEqual(["Mario"]);

--- a/core/__tests__/tasks/schedule/run.ts
+++ b/core/__tests__/tasks/schedule/run.ts
@@ -139,7 +139,7 @@ describe("tasks/schedule:run", () => {
         state: "running",
       });
 
-      specHelper.runTask("schedule:run", {
+      await specHelper.runTask("schedule:run", {
         scheduleId: schedule.id,
         runId: run.id,
       });

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -625,12 +625,10 @@ export namespace ProfileOps {
           api.sequelize.where(
             api.sequelize.fn(
               "COUNT",
-              // api.sequelize.col(
               api.sequelize.fn(
                 "DISTINCT",
                 api.sequelize.col("profileProperties.state")
               )
-              // )
             ),
             "=",
             1

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -599,7 +599,8 @@ export namespace ProfileOps {
           profiles.state = 'pending'
         GROUP BY profiles.id
         HAVING
-          COUNT(DISTINCT "profileProperties".state) = 1
+          MAX("profileProperties".state) = 'ready'
+          AND COUNT(DISTINCT "profileProperties".state) = 1
         LIMIT ${limit};
         ;`,
       { type: QueryTypes.SELECT }

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -637,7 +637,6 @@ export namespace ProfileOps {
           ),
         ],
       },
-      logging: true,
     });
 
     const updateResponse = await Profile.update(

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -589,8 +589,7 @@ export namespace ProfileOps {
    */
   export async function makeReady(limit = 100, toExport = true) {
     let profiles: Profile[] = await api.sequelize.query(
-      `
-        SELECT
+      `SELECT
           profiles.id as id
         FROM profiles
         JOIN
@@ -601,7 +600,7 @@ export namespace ProfileOps {
         HAVING
           MAX("profileProperties".state) = 'ready'
           AND COUNT(DISTINCT "profileProperties".state) = 1
-        LIMIT ${limit};
+        LIMIT ${limit}
         ;`,
       { type: QueryTypes.SELECT }
     );

--- a/plugins/@grouparoo/spec-helper/src/lib/workflows/import.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/workflows/import.ts
@@ -16,21 +16,23 @@ export async function ImportWorkflow() {
     importTasks = await specHelper.findEnqueuedTasks(
       "profileProperty:importProfileProperties"
     );
-    await Promise.all(
-      importTasks.map((t) =>
-        specHelper.runTask("profileProperty:importProfileProperties", t.args[0])
-      )
-    );
+    for (const t of importTasks) {
+      await specHelper.runTask(
+        "profileProperty:importProfileProperties",
+        t.args[0]
+      );
+    }
 
     // single
     importTasks = await specHelper.findEnqueuedTasks(
       "profileProperty:importProfileProperty"
     );
-    await Promise.all(
-      importTasks.map((t) =>
-        specHelper.runTask("profileProperty:importProfileProperty", t.args[0])
-      )
-    );
+    for (const t of importTasks) {
+      await specHelper.runTask(
+        "profileProperty:importProfileProperty",
+        t.args[0]
+      );
+    }
 
     await specHelper.runTask("profiles:checkReady", {});
 
@@ -46,10 +48,7 @@ export async function ImportWorkflow() {
   const completeTasks = await specHelper.findEnqueuedTasks(
     "profile:completeImport"
   );
-
-  await Promise.all(
-    completeTasks.map((t) =>
-      specHelper.runTask("profile:completeImport", t.args[0])
-    )
-  );
+  for (const t of completeTasks) {
+    await specHelper.runTask("profile:completeImport", t.args[0]);
+  }
 }

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -106,6 +106,13 @@ class Generator {
       relative_path: `core`,
       name: "actions",
     });
+
+    this.jobList.push({
+      type: "core-local",
+      job_name: `test-core-local-tasks`,
+      relative_path: `core`,
+      name: "tasks",
+    });
   }
 
   addUiComponents() {


### PR DESCRIPTION
The previous query `ProfileOps.makeReady()` used failed with larger datasets:

```SQL
SELECT * FROM "profiles" AS "Profile" 
WHERE "Profile"."state" = 'pending' 
AND "Profile"."id" NOT IN (
	SELECT DISTINCT("profileId") FROM "profileProperties" WHERE "profileProperties"."state" = 'pending') 
ORDER BY "Profile"."id" ASC 
LIMIT 100;
```

This PR adds a better query, one without a sub-select.

```sql
SELECT
  profiles.id as id
FROM profiles
JOIN
  "profileProperties" on "profileProperties"."profileId" = profiles.id
WHERE
  profiles.state = 'pending'
GROUP BY profiles.id
HAVING
  COUNT(DISTINCT "profileProperties".state) = 1
  AND MAX("profileProperties".state) = 'ready'
LIMIT 100;
```

--- 

This PR also adds a test suite running all Tasks against a SQLite database