### PR TITLE
profile list speedup

### DIFF
--- a/core/src/actions/profiles.ts
+++ b/core/src/actions/profiles.ts
@@ -7,7 +7,6 @@ import { GroupMember } from "../models/GroupMember";
 import { Property } from "../models/Property";
 import { internalRun } from "../modules/internalRun";
 import { Op } from "sequelize";
-import { profile } from "winston";
 
 export class ProfilesList extends AuthenticatedAction {
   constructor() {

--- a/core/src/actions/profiles.ts
+++ b/core/src/actions/profiles.ts
@@ -131,8 +131,7 @@ export class ProfilesList extends AuthenticatedAction {
         total,
         profiles: await Promise.all(
           profiles.map(async (p) => {
-            const profile = await Profile.findById(p.id);
-            return profile.apiData();
+            return p.apiData();
           })
         ),
       };

--- a/core/src/actions/profiles.ts
+++ b/core/src/actions/profiles.ts
@@ -127,13 +127,14 @@ export class ProfilesList extends AuthenticatedAction {
         include: countInclude,
       });
 
+      const profileData = [];
+      for (const p of profiles) {
+        profileData.push(await p.apiData());
+      }
+
       return {
         total,
-        profiles: await Promise.all(
-          profiles.map(async (p) => {
-            return p.apiData();
-          })
-        ),
+        profiles: profileData,
       };
     }
   }

--- a/core/src/actions/profiles.ts
+++ b/core/src/actions/profiles.ts
@@ -105,19 +105,26 @@ export class ProfilesList extends AuthenticatedAction {
       };
     } else {
       const requiredJoin = Object.keys(where).length > 0 ? true : false;
+      const profileWhere = {
+        state: params.state ? params.state : { [Op.ne]: null },
+      };
+      const profileInclude = requiredJoin
+        ? [{ model: ProfileProperty, where, required: true }]
+        : [ProfileProperty];
+      const countInclude = requiredJoin ? profileInclude : [];
 
       profiles = await Profile.findAll({
         offset: params.offset,
         limit: params.limit,
-        where: { state: params.state ? params.state : { [Op.ne]: null } },
-        include: [{ model: ProfileProperty, where, required: requiredJoin }],
+        where: profileWhere,
+        include: profileInclude,
         order: params.order,
       });
 
       const total = await Profile.count({
         distinct: true,
-        where: { state: params.state ? params.state : { [Op.ne]: null } },
-        include: [{ model: ProfileProperty, where, required: requiredJoin }],
+        where: profileWhere,
+        include: countInclude,
       });
 
       return {


### PR DESCRIPTION
The query was particularly slow, but in the common case, we don't have to do a join.
Also leaned heavier on the cached properties.

Went from 15 seconds to less than 1 with db with 1.5M rows.