### PR TITLE
Bulk write ProfileProperties 

### DIFF
--- a/core/__tests__/integration/events.ts
+++ b/core/__tests__/integration/events.ts
@@ -1,6 +1,13 @@
 import { helper } from "@grouparoo/spec-helper";
 import { api, Connection, specHelper } from "actionhero";
-import { Property, Profile, Option, Event, EventData } from "../../src";
+import {
+  Property,
+  Profile,
+  Option,
+  Event,
+  EventData,
+  ProfileProperty,
+} from "../../src";
 
 describe("integration/events", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -588,248 +595,248 @@ describe("integration/events", () => {
           properties = await profile.properties();
           expect(properties["test-rule"].values).toEqual([0]);
         });
-      });
 
-      describe("aggregations", () => {
-        let property: Property;
-        beforeAll(async () => {
-          property = await Property.findById(propertyId);
-          await property.setFilters([]);
-        });
-
-        test("all values", async () => {
-          await property.update({ type: "string", isArray: true });
-          await property.setOptions({
-            column: "[data]-path",
-            aggregationMethod: "all values",
+        describe("aggregations", () => {
+          let property: Property;
+          beforeAll(async () => {
+            property = await Property.findById(propertyId);
+            await property.setFilters([]);
           });
-          await profile.import();
-          const properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual([
-            "/",
-            "/about",
-            "/web-sign-in",
-            "/mobile-sign-in",
-          ]);
-          await property.update({ type: "string", isArray: false });
-        });
 
-        test("most recent value", async () => {
-          await property.update({ type: "string" });
-          await property.setOptions({
-            column: "[data]-path",
-            aggregationMethod: "most recent value",
+          test("all values", async () => {
+            await property.update({ type: "string", isArray: true });
+            await property.setOptions({
+              column: "[data]-path",
+              aggregationMethod: "all values",
+            });
+            await profile.import();
+            const properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual([
+              "/",
+              "/about",
+              "/web-sign-in",
+              "/mobile-sign-in",
+            ]);
+            await property.update({ type: "string", isArray: false });
           });
-          await profile.import();
-          const properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual(["/mobile-sign-in"]);
-        });
 
-        test("least recent value", async () => {
-          await property.update({ type: "string" });
-          await property.setOptions({
-            column: "[data]-path",
-            aggregationMethod: "least recent value",
+          test("most recent value", async () => {
+            await property.update({ type: "string" });
+            await property.setOptions({
+              column: "[data]-path",
+              aggregationMethod: "most recent value",
+            });
+            await profile.import();
+            const properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual(["/mobile-sign-in"]);
           });
-          await profile.import();
-          const properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual(["/"]);
-        });
 
-        test("avg", async () => {
-          await property.update({ type: "float" });
-          await property.setOptions({
-            column: "[data]-loadTime",
-            aggregationMethod: "avg",
+          test("least recent value", async () => {
+            await property.update({ type: "string" });
+            await property.setOptions({
+              column: "[data]-path",
+              aggregationMethod: "least recent value",
+            });
+            await profile.import();
+            const properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual(["/"]);
           });
-          await profile.import();
-          const properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual([125]);
-        });
 
-        test("count", async () => {
-          await property.update({ type: "integer" });
-          await property.setOptions({
-            column: "[data]-path",
-            aggregationMethod: "count",
+          test("avg", async () => {
+            await property.update({ type: "float" });
+            await property.setOptions({
+              column: "[data]-loadTime",
+              aggregationMethod: "avg",
+            });
+            await profile.import();
+            const properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual([125]);
           });
-          await profile.import();
-          const properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual([4]);
-        });
 
-        test("sum", async () => {
-          await property.update({ type: "integer" });
-          await property.setOptions({
-            column: "[data]-loadTime",
-            aggregationMethod: "sum",
+          test("count", async () => {
+            await property.update({ type: "integer" });
+            await property.setOptions({
+              column: "[data]-path",
+              aggregationMethod: "count",
+            });
+            await profile.import();
+            const properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual([4]);
           });
-          await profile.import();
-          const properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual([500]);
-        });
 
-        test("min", async () => {
-          await property.update({ type: "integer" });
-          await property.setOptions({
-            column: "[data]-loadTime",
-            aggregationMethod: "min",
+          test("sum", async () => {
+            await property.update({ type: "integer" });
+            await property.setOptions({
+              column: "[data]-loadTime",
+              aggregationMethod: "sum",
+            });
+            await profile.import();
+            const properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual([500]);
           });
-          await profile.import();
-          const properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual([100]);
-        });
 
-        test("max", async () => {
-          await property.update({ type: "integer" });
-          await property.setOptions({
-            column: "[data]-loadTime",
-            aggregationMethod: "max",
+          test("min", async () => {
+            await property.update({ type: "integer" });
+            await property.setOptions({
+              column: "[data]-loadTime",
+              aggregationMethod: "min",
+            });
+            await profile.import();
+            const properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual([100]);
           });
-          await profile.import();
-          const properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual([200]);
-        });
-      });
 
-      describe("filters", () => {
-        let property: Property;
-        beforeAll(async () => {
-          property = await Property.findById(propertyId);
-          await property.update({ type: "string", isArray: true });
-          await property.setOptions({
-            column: "[data]-path",
-            aggregationMethod: "all values",
+          test("max", async () => {
+            await property.update({ type: "integer" });
+            await property.setOptions({
+              column: "[data]-loadTime",
+              aggregationMethod: "max",
+            });
+            await profile.import();
+            const properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual([200]);
           });
         });
 
-        beforeEach(async () => {
-          await property.setFilters([]);
-        });
-
-        test("on event properties - userId", async () => {
-          await property.setFilters([
-            { key: "userId", op: "equals", match: "x" },
-          ]);
-          await profile.import();
-          let properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual([null]);
-        });
-
-        test("on event properties - type", async () => {
-          await property.setFilters([
-            { key: "type", op: "equals", match: "x" },
-          ]);
-          await profile.import();
-          let properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual([null]);
-
-          await property.setFilters([
-            { key: "type", op: "equals", match: "pageview" },
-          ]);
-          await profile.import();
-          properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual([
-            "/",
-            "/about",
-            "/web-sign-in",
-            "/mobile-sign-in",
-          ]);
-        });
-
-        test("on event properties - occurredAt", async () => {
-          const event = await Event.findOne({
-            where: { profileId: profile.id },
-            include: [{ model: EventData, where: { value: "/web-sign-in" } }],
+        describe("filters", () => {
+          let property: Property;
+          beforeAll(async () => {
+            property = await Property.findById(propertyId);
+            await property.update({ type: "string", isArray: true });
+            await property.setOptions({
+              column: "[data]-path",
+              aggregationMethod: "all values",
+            });
           });
 
-          await property.setFilters([
-            {
-              key: "occurredAt",
-              op: "greater than",
-              match: event.createdAt.getTime().toString(),
-            },
-          ]);
+          beforeEach(async () => {
+            await property.setFilters([]);
+          });
 
-          await profile.import();
-          let properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual(["/mobile-sign-in"]);
+          test("on event properties - userId", async () => {
+            await property.setFilters([
+              { key: "userId", op: "equals", match: "x" },
+            ]);
+            await profile.import();
+            let properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual([null]);
+          });
 
-          await property.setFilters([
-            { key: "occurredAt", op: "greater than", match: "0" },
-          ]);
-          await profile.import();
-          properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual([
-            "/",
-            "/about",
-            "/web-sign-in",
-            "/mobile-sign-in",
-          ]);
-        });
+          test("on event properties - type", async () => {
+            await property.setFilters([
+              { key: "type", op: "equals", match: "x" },
+            ]);
+            await profile.import();
+            let properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual([null]);
 
-        test("on data properties - equals", async () => {
-          await property.setFilters([
-            {
-              key: "[data]-path",
-              op: "equals",
-              match: "/about",
-            },
-          ]);
+            await property.setFilters([
+              { key: "type", op: "equals", match: "pageview" },
+            ]);
+            await profile.import();
+            properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual([
+              "/",
+              "/about",
+              "/web-sign-in",
+              "/mobile-sign-in",
+            ]);
+          });
 
-          await profile.import();
-          let properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual(["/about"]);
-        });
+          test("on event properties - occurredAt", async () => {
+            const event = await Event.findOne({
+              where: { profileId: profile.id },
+              include: [{ model: EventData, where: { value: "/web-sign-in" } }],
+            });
 
-        test("on data properties - does not equal", async () => {
-          await property.setFilters([
-            {
-              key: "[data]-path",
-              op: "does not equal",
-              match: "/about",
-            },
-          ]);
+            await property.setFilters([
+              {
+                key: "occurredAt",
+                op: "greater than",
+                match: event.createdAt.getTime().toString(),
+              },
+            ]);
 
-          await profile.import();
-          let properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual([
-            "/",
-            "/web-sign-in",
-            "/mobile-sign-in",
-          ]);
-        });
+            await profile.import();
+            let properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual(["/mobile-sign-in"]);
 
-        test("on data properties - contains", async () => {
-          await property.setFilters([
-            {
-              key: "[data]-path",
-              op: "contains",
-              match: "a",
-            },
-          ]);
+            await property.setFilters([
+              { key: "occurredAt", op: "greater than", match: "0" },
+            ]);
+            await profile.import();
+            properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual([
+              "/",
+              "/about",
+              "/web-sign-in",
+              "/mobile-sign-in",
+            ]);
+          });
 
-          await profile.import();
-          let properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual(["/about"]);
-        });
+          test("on data properties - equals", async () => {
+            await property.setFilters([
+              {
+                key: "[data]-path",
+                op: "equals",
+                match: "/about",
+              },
+            ]);
 
-        test("on data properties - does not contain", async () => {
-          await property.setFilters([
-            {
-              key: "[data]-path",
-              op: "does not contain",
-              match: "a",
-            },
-          ]);
+            await profile.import();
+            let properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual(["/about"]);
+          });
 
-          await profile.import();
-          let properties = await profile.properties();
-          expect(properties["test-rule"].values).toEqual([
-            "/",
-            "/web-sign-in",
-            "/mobile-sign-in",
-          ]);
+          test("on data properties - does not equal", async () => {
+            await property.setFilters([
+              {
+                key: "[data]-path",
+                op: "does not equal",
+                match: "/about",
+              },
+            ]);
+
+            await profile.import();
+            let properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual([
+              "/",
+              "/web-sign-in",
+              "/mobile-sign-in",
+            ]);
+          });
+
+          test("on data properties - contains", async () => {
+            await property.setFilters([
+              {
+                key: "[data]-path",
+                op: "contains",
+                match: "a",
+              },
+            ]);
+
+            await profile.import();
+            let properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual(["/about"]);
+          });
+
+          test("on data properties - does not contain", async () => {
+            await property.setFilters([
+              {
+                key: "[data]-path",
+                op: "does not contain",
+                match: "a",
+              },
+            ]);
+
+            await profile.import();
+            let properties = await profile.properties();
+            expect(properties["test-rule"].values).toEqual([
+              "/",
+              "/web-sign-in",
+              "/mobile-sign-in",
+            ]);
+          });
         });
       });
     });

--- a/core/__tests__/models/profileProperty.ts
+++ b/core/__tests__/models/profileProperty.ts
@@ -172,7 +172,7 @@ describe("models/profileProperty", () => {
           propertyId: purchasesProperty.id,
           rawValue: "hat",
         })
-      ).rejects.toThrow(/There is already a ProfileProperty/);
+      ).rejects.toThrow(/Validation error/);
 
       await property.destroy();
     });
@@ -462,9 +462,7 @@ describe("models/profileProperty", () => {
         secondProfile.addOrUpdateProperties({
           email: ["mario@example.com"],
         })
-      ).rejects.toThrow(
-        /Another profile already has the value mario@example.com for property email/
-      );
+      ).rejects.toThrow(/Validation error/);
     });
 
     test("editing the key of a property renames all the profile properties that have that key", async () => {

--- a/core/__tests__/tasks/property/updateProfileProperties.ts
+++ b/core/__tests__/tasks/property/updateProfileProperties.ts
@@ -1,0 +1,65 @@
+import { helper } from "@grouparoo/spec-helper";
+import { api, task, specHelper } from "actionhero";
+import { Profile, ProfileProperty, Property, Source } from "./../../../src";
+
+describe("tasks/property:updateProfileProperties", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  let source: Source;
+
+  beforeEach(async () => {
+    await api.resque.queue.connection.redis.flushdb();
+  });
+
+  beforeAll(async () => {
+    await helper.factories.properties();
+
+    source = await helper.factories.source();
+    await source.setOptions({ table: "some table" });
+    await source.setMapping({ id: "userId" });
+    await source.update({ state: "ready" });
+  });
+
+  test("can be enqueued", async () => {
+    await task.enqueue("property:updateProfileProperties", {
+      propertyId: "abc123",
+    });
+    const found = await specHelper.findEnqueuedTasks(
+      "property:updateProfileProperties"
+    );
+    expect(found.length).toEqual(1);
+    expect(found[0].args[0].propertyId).toBe("abc123");
+  });
+
+  test("will update the uniqueness of profileProperties", async () => {
+    const property = await Property.create({
+      sourceId: source.id,
+      key: "test_property",
+      type: "string",
+      unique: false,
+    });
+    await property.setOptions({ column: "col" });
+    await property.update({ state: "ready" });
+
+    const profile: Profile = await helper.factories.profile();
+    await profile.buildNullProperties();
+    const profileProperty = await ProfileProperty.findOne({
+      where: { profileId: profile.id, propertyId: property.id },
+    });
+    expect(profileProperty.unique).toBe(false);
+
+    await property.update({ unique: true });
+    let foundTasks = await specHelper.findEnqueuedTasks(
+      "property:updateProfileProperties"
+    );
+    expect(foundTasks.length).toBe(1);
+    expect(foundTasks[0].args[0].propertyId).toBe(property.id);
+
+    await specHelper.runTask(
+      "property:updateProfileProperties",
+      foundTasks[0].args[0]
+    );
+
+    await profileProperty.reload();
+    expect(profileProperty.unique).toBe(true);
+  });
+});

--- a/core/src/migrations/000068-profilePropertyCompositeUniqueIndex.ts
+++ b/core/src/migrations/000068-profilePropertyCompositeUniqueIndex.ts
@@ -1,3 +1,4 @@
+import { config } from "actionhero";
 import { Op } from "sequelize";
 
 export default {
@@ -35,6 +36,14 @@ export default {
           where: { unique: { [Op.eq]: true } },
         }
       );
+
+      // All previous SQLite indexes had been removed (migration 000053), but we need to manually apply the per-profile position/value lock
+      // We cannot use Sequelize to apply the second index as it clobbers the first (https://github.com/sequelize/sequelize/issues/12823)
+      if (config.sequelize.dialect === "sqlite") {
+        await migration.sequelize.query(
+          "CREATE UNIQUE INDEX `profile_properties_profile_guid_profile_property_rule_guid_posi` ON `profileProperties` (`profileId`, `propertyId`, `position`)"
+        );
+      }
     });
   },
 

--- a/core/src/migrations/000068-profilePropertyCompositeUniqueIndex.ts
+++ b/core/src/migrations/000068-profilePropertyCompositeUniqueIndex.ts
@@ -1,0 +1,56 @@
+import { Op } from "sequelize";
+
+export default {
+  up: async function (migration, DataTypes) {
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("profileProperties", "unique", {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+        allowNull: true,
+      });
+
+      const [properties] = await migration.sequelize.query(
+        "SELECT * FROM \"properties\" WHERE state = 'ready'"
+      );
+      const uniqueProperties = properties.filter(
+        (p) => p.unique === 1 || p.unique === "1" || p.unique === true
+      );
+
+      if (uniqueProperties.length > 0) {
+        await migration.sequelize.query(
+          `UPDATE "profileProperties" SET "unique"='${
+            uniqueProperties[0].unique
+          }' WHERE "propertyId" IN (${uniqueProperties
+            .map((p) => `'${p.id}'`)
+            .join(", ")})`
+        );
+      }
+
+      await migration.addIndex(
+        "profileProperties",
+        ["propertyId", "rawValue", "position", "unique"],
+        {
+          unique: true,
+          fields: ["propertyId", "rawValue", "position", "unique"],
+          where: { unique: { [Op.eq]: true } },
+        }
+      );
+    });
+  },
+
+  down: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.removeIndex(
+        "profileProperties",
+        ["propertyId", "rawValue", "position", "unique"],
+        {
+          unique: true,
+          fields: ["propertyId", "rawValue", "position", "unique"],
+          where: { unique: { [Op.eq]: true } },
+        }
+      );
+
+      await migration.removeColumn("profileProperties", "unique");
+    });
+  },
+};

--- a/core/src/migrations/000068-profilePropertyCompositeUniqueIndex.ts
+++ b/core/src/migrations/000068-profilePropertyCompositeUniqueIndex.ts
@@ -1,5 +1,5 @@
-import { config } from "actionhero";
 import { Op } from "sequelize";
+import { config } from "actionhero";
 
 export default {
   up: async function (migration, DataTypes) {
@@ -19,13 +19,26 @@ export default {
 
       if (uniqueProperties.length > 0) {
         await migration.sequelize.query(
-          `UPDATE "profileProperties" SET "unique"='${
-            uniqueProperties[0].unique
-          }' WHERE "propertyId" IN (${uniqueProperties
+          `UPDATE "profileProperties" SET "unique"=true WHERE "propertyId" IN (${uniqueProperties
             .map((p) => `'${p.id}'`)
             .join(", ")})`
         );
+
+        await migration.sequelize.query(
+          `UPDATE "profileProperties" SET "unique"=false WHERE "propertyId" NOT IN (${uniqueProperties
+            .map((p) => `'${p.id}'`)
+            .join(", ")})`
+        );
+      } else {
+        await migration.sequelize.query(
+          `UPDATE "profileProperties" SET "unique"=false`
+        );
       }
+
+      await migration.changeColumn("profileProperties", "unique", {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+      });
 
       await migration.addIndex(
         "profileProperties",

--- a/core/src/models/Profile.ts
+++ b/core/src/models/Profile.ts
@@ -101,19 +101,13 @@ export class Profile extends LoggedModel<Profile> {
     return simpleProperties;
   }
 
-  async addOrUpdateProperty(properties: {
-    [key: string]: Array<string | number | boolean | Date>;
-  }) {
-    return ProfileOps.addOrUpdateProperty(this, properties);
-  }
-
   async addOrUpdateProperties(
     properties: {
       [key: string]: Array<string | number | boolean | Date>;
     },
     toLock = true
   ) {
-    return ProfileOps.addOrUpdateProperties(this, properties, toLock);
+    return ProfileOps.addOrUpdateProperties([this], [properties], toLock);
   }
 
   async removeProperty(key: string) {

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -579,6 +579,15 @@ export class Property extends LoggedModel<Property> {
     }
   }
 
+  @AfterSave
+  // TODO: Background Job
+  static async updateProfilePropertyUniqueness(instance: Property) {
+    await ProfileProperty.update(
+      { unique: instance.unique },
+      { where: { propertyId: instance.id } }
+    );
+  }
+
   @BeforeDestroy
   static async ensureNotInUse(instance: Property) {
     const groupRule = await GroupRule.findOne({

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -579,13 +579,13 @@ export class Property extends LoggedModel<Property> {
     }
   }
 
-  @AfterSave
-  // TODO: Background Job
+  @BeforeSave
   static async updateProfilePropertyUniqueness(instance: Property) {
-    await ProfileProperty.update(
-      { unique: instance.unique },
-      { where: { propertyId: instance.id } }
-    );
+    if (!instance.isNewRecord && instance.changed("unique")) {
+      CLS.enqueueTask("property:updateProfileProperties", {
+        propertyId: instance.id,
+      });
+    }
   }
 
   @BeforeDestroy

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -115,7 +115,7 @@ export namespace ProfileOps {
 
     const releaseLocks: Function[] = [];
     const bulkCreates = [];
-    const bulkDeletes = { where: { [Op.and]: [] } };
+    const bulkDeletes = { where: { [Op.or]: [] } };
     const properties = await Property.findAllWithCache();
     const now = new Date();
 
@@ -198,7 +198,7 @@ export namespace ProfileOps {
           }
 
           // delete old properties we didn't update
-          bulkDeletes.where[Op.and].push({
+          bulkDeletes.where[Op.or].push({
             profileId: profile.id,
             propertyId: property.id,
             position: { [Op.gte]: position },
@@ -220,7 +220,7 @@ export namespace ProfileOps {
           ],
         });
       }
-      if (bulkDeletes.where[Op.and].length > 0) {
+      if (bulkDeletes.where[Op.or].length > 0) {
         await ProfileProperty.destroy(bulkDeletes);
       }
     } finally {

--- a/core/src/tasks/profile/completeImport.ts
+++ b/core/src/tasks/profile/completeImport.ts
@@ -29,8 +29,8 @@ export class ProfileCompleteImport extends RetryableTask {
     if (!profile) return; // the profile may have been deleted or merged by the time this task ran
 
     const properties = await Property.findAllWithCache();
-    const pendingProfileProperty = Object.keys(profile.profileProperties).find(
-      (k) => profile.profileProperties[k].state !== "ready" // a property may have gone back into the pending state
+    const pendingProfileProperty = profile.profileProperties.find(
+      (p) => p.state !== "ready" // a property may have gone back into the pending state
     );
 
     if (profile.state !== "ready" || pendingProfileProperty) {

--- a/core/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/src/tasks/profileProperty/importProfileProperty.ts
@@ -68,7 +68,7 @@ export class ImportProfileProperty extends RetryableTask {
       hash[property.id] = Array.isArray(propertyValues)
         ? propertyValues
         : [propertyValues];
-      await profile.addOrUpdateProperty(hash);
+      await profile.addOrUpdateProperties(hash);
     } else {
       await ProfileProperty.update(
         { state: "ready", stateChangedAt: new Date(), confirmedAt: new Date() },

--- a/core/src/tasks/property/updateProfileProperties.ts
+++ b/core/src/tasks/property/updateProfileProperties.ts
@@ -1,0 +1,29 @@
+import { CLSTask } from "../../classes/tasks/clsTask";
+import { Property } from "../../models/Property";
+import { ProfileProperty } from "../../models/ProfileProperty";
+
+export class PropertyDestroy extends CLSTask {
+  constructor() {
+    super();
+    this.name = "property:updateProfileProperties";
+    this.description =
+      "update related information on profile properties when a property changes";
+    this.frequency = 0;
+    this.queue = "properties";
+    this.inputs = {
+      propertyId: { required: true },
+    };
+  }
+
+  async runWithinTransaction(params) {
+    const property = await Property.findOne({
+      where: { id: params.propertyId },
+    });
+    if (!property) return;
+
+    await ProfileProperty.update(
+      { unique: property.unique },
+      { where: { propertyId: property.id } }
+    );
+  }
+}

--- a/lerna.json
+++ b/lerna.json
@@ -13,10 +13,7 @@
       "ignore": "@grouparoo/app-local*"
     },
     "version": {
-      "allowBranch": [
-        "main",
-        "stable"
-      ],
+      "allowBranch": ["main", "stable"],
       "message": "chore(release): publish %s [ci skip]"
     }
   }


### PR DESCRIPTION
This PR aims to speed up all instances of writing ProfileProperties by writing them in bulk.  This will have a material speed increase for the `profile:completeImport` task, and every update ProfileProperties should be helped a little as well.

The main change is that we've come up with a conditional/partial index for the database which can do the unique ProfileProperty validation so we don't need to do it in code (hooks).  This required copying over the value of Property.unique (boolean) to the ProfileProperties table so the index could use it.   This allowed the logic for updating ProfileProperties to be moved to a single bulk method.

Notes:
* This will trigger v0.4 of Grouparoo because of the slow migrations.  Release notes here https://github.com/grouparoo/www.grouparoo.com/pull/485


TODO:
- [x] Sort out what's going on with the Event integration tests (array ProfileProperties)
- [x] Move the `@AfterSave` for Properties to update all thier ProfileProperties.unique values to a task, as this could be very slow. 