### PR TITLE
Fix for ui-enterprise test

### DIFF
--- a/ui/ui-components/pages/setup.tsx
+++ b/ui/ui-components/pages/setup.tsx
@@ -38,7 +38,7 @@ export default function Page(props) {
         <title>Grouparoo: Setup</title>
       </Head>
 
-      <h1>Setup Grouparoo</h1>
+      <h1 id="setup">Setup Grouparoo</h1>
       {currentStep ? (
         <p>
           Thanks for installing Grouparoo! There are few steps to get started

--- a/ui/ui-enterprise/__tests__/integration/happyPath.ts
+++ b/ui/ui-enterprise/__tests__/integration/happyPath.ts
@@ -89,7 +89,7 @@ describe("integration", () => {
   test(
     "I was taken to the setup page after creating the first team",
     async () => {
-      await browser.wait(until.elementLocated(by.className("alert")), 2 * 1000);
+      await browser.wait(until.elementLocated(by.id("setup")));
       const url = await browser.getCurrentUrl();
       expect(url).toMatch(/\/setup/);
       await browser.get(url);


### PR DESCRIPTION
Created a css id in the main DOM of the desired page and anchored the test to that.  This should be a more stable and consistent solution.

(Previously this test was anchored to the Alert element on the setup page.  This element sometimes renders before the redirect is complete and the rest of the DOM is loaded, causing the test to fail.)
