### PR TITLE
Internal runs create/update Profile Properties in bulk

### DIFF
--- a/core/__tests__/integration/runs/internalRun.ts
+++ b/core/__tests__/integration/runs/internalRun.ts
@@ -41,7 +41,7 @@ describe("integration/runs/internalRun", () => {
       run = runs[0];
     });
 
-    test("the internalRun task will mark every profile as pending", async () => {
+    test("the internalRun task will mark every profile as pending and create imports", async () => {
       await specHelper.deleteEnqueuedTasks("run:internalRun", {
         runId: run.id,
       });
@@ -49,6 +49,10 @@ describe("integration/runs/internalRun", () => {
 
       await profile.reload();
       expect(profile.state).toBe("pending");
+
+      const imports = await Import.findAll();
+      expect(imports.length).toBe(1);
+      expect(imports[0].profileId).toBe(profile.id);
     });
 
     test("the run will be complete when all the profiles have been touched", async () => {
@@ -82,6 +86,9 @@ describe("integration/runs/internalRun", () => {
       // check the results of the run
       await run.updateTotals();
       expect(run.state).toBe("complete");
+      expect(run.importsCreated).toBe(1);
+      expect(run.profilesCreated).toBe(0);
+      expect(run.profilesImported).toBe(1);
     });
   });
 

--- a/core/src/models/Profile.ts
+++ b/core/src/models/Profile.ts
@@ -125,7 +125,7 @@ export class Profile extends LoggedModel<Profile> {
   }
 
   async buildNullProperties(state = "pending") {
-    return ProfileOps.buildNullProperties(this, state);
+    return ProfileOps.buildNullProperties([this], state);
   }
 
   async markPending() {

--- a/core/src/modules/internalRun.ts
+++ b/core/src/modules/internalRun.ts
@@ -1,4 +1,3 @@
-import { log, config } from "actionhero";
 import { Run } from "../models/Run";
 
 /**


### PR DESCRIPTION
This PR speeds up `run:internalRun` by doing more things in bulk.  It also confirms that is an Internal Run is created by a Property, on Profile Properties based on that Property will go into the "pending" state.  Otherwise, if the Internal Run is created by user request, then all Profile Properties will go into the "pending" state.

