### PR TITLE
Auth workflow for Config UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coverage
 *.sqlite-*
 apps/*/config/*
 apps/*/*.log
+apps/*/.local
 .pnpm-debug.log
 
 # API

--- a/core/__tests__/actions/config.ts
+++ b/core/__tests__/actions/config.ts
@@ -21,6 +21,10 @@ describe("actions/config", () => {
     };
   });
 
+  afterAll(async () => {
+    await helper.resetSettings();
+  });
+
   beforeEach(async () => {
     process.env.GROUPAROO_RUN_MODE = "cli:config";
   });

--- a/core/__tests__/actions/config.ts
+++ b/core/__tests__/actions/config.ts
@@ -1,0 +1,49 @@
+import { helper } from "@grouparoo/spec-helper";
+import { specHelper } from "actionhero";
+import os from "os";
+
+const workerId = process.env.JEST_WORKER_ID;
+const configDir = `${os.tmpdir()}/test/${workerId}/configUser/config`;
+
+process.env.GROUPAROO_CONFIG_DIR = configDir;
+
+describe("actions/config", () => {
+  let connection;
+
+  helper.grouparooTestServer({ truncate: true, resetSettings: true });
+
+  beforeAll(async () => {
+    connection = await specHelper.buildConnection();
+    connection.params = {
+      email: "mario@example.com",
+      subscribed: false,
+      company: "Nintendo",
+    };
+  });
+
+  beforeEach(async () => {
+    process.env.GROUPAROO_RUN_MODE = "cli:config";
+  });
+
+  afterEach(async () => {
+    process.env.GROUPAROO_RUN_MODE = undefined;
+  });
+
+  test("throws an error unless in config mode", async () => {
+    process.env.GROUPAROO_RUN_MODE = undefined;
+    const { error } = await specHelper.runAction(
+      "config:user:create",
+      connection
+    );
+    expect(error.message).toEqual("Action only available in config mode.");
+  });
+
+  test("does not throw an error in config mode", async () => {
+    const { error, user } = await specHelper.runAction(
+      "config:user:create",
+      connection
+    );
+    expect(error).toBeUndefined();
+    expect(user.email).toEqual(true);
+  });
+});

--- a/core/__tests__/actions/navigation.ts
+++ b/core/__tests__/actions/navigation.ts
@@ -24,7 +24,9 @@ describe("actions/navigation", () => {
 
   test("the navigation action includes the clusterName", async () => {
     const { clusterName } = await specHelper.runAction("navigation:list");
-    expect(clusterName).toBe("My Grouparoo Cluster");
+    expect(clusterName).toEqual(
+      expect.objectContaining({ default: true, value: "My Grouparoo Cluster" })
+    );
   });
 
   describe("with session", () => {

--- a/core/__tests__/actions/settings.ts
+++ b/core/__tests__/actions/settings.ts
@@ -3,6 +3,8 @@ import { specHelper } from "actionhero";
 import { Setting, plugin } from "../../src";
 
 describe("actions/settings", () => {
+  let connection;
+
   helper.grouparooTestServer({ truncate: true, resetSettings: true });
 
   beforeAll(async () => {
@@ -12,10 +14,33 @@ describe("actions/settings", () => {
       password: "P@ssw0rd!",
       email: "mario@example.com",
     });
+
+    connection = await specHelper.buildConnection();
+
+    await Setting.truncate();
+  });
+
+  test("can publicly read the cluster name", async () => {
+    const setting = await plugin.registerSetting(
+      "testPlugin",
+      "cluster-name",
+      "My Grouparoo Cluster",
+      "My Grouparoo Cluster",
+      "Name of the cluster",
+      "string"
+    );
+    const {
+      error,
+      clusterName,
+      default: defaultValue,
+    } = await specHelper.runAction("settings:clusterName:view", connection);
+    expect(error).toBeUndefined();
+    expect(clusterName).not.toBeUndefined();
+    expect(clusterName).toEqual(setting.value);
+    expect(defaultValue).toEqual(true);
   });
 
   describe("reader signed in", () => {
-    let connection;
     let csrfToken;
     let id;
 

--- a/core/__tests__/actions/settings.ts
+++ b/core/__tests__/actions/settings.ts
@@ -20,26 +20,6 @@ describe("actions/settings", () => {
     await Setting.truncate();
   });
 
-  test("can publicly read the cluster name", async () => {
-    const setting = await plugin.registerSetting(
-      "testPlugin",
-      "cluster-name",
-      "My Grouparoo Cluster",
-      "My Grouparoo Cluster",
-      "Name of the cluster",
-      "string"
-    );
-    const {
-      error,
-      clusterName,
-      default: defaultValue,
-    } = await specHelper.runAction("settings:clusterName:view", connection);
-    expect(error).toBeUndefined();
-    expect(clusterName).not.toBeUndefined();
-    expect(clusterName).toEqual(setting.value);
-    expect(defaultValue).toEqual(true);
-  });
-
   describe("reader signed in", () => {
     let csrfToken;
     let id;

--- a/core/__tests__/actions/status.ts
+++ b/core/__tests__/actions/status.ts
@@ -36,6 +36,7 @@ describe("actions/status", () => {
         afterEach(async () => {
           process.env.GROUPAROO_RUN_MODE = undefined;
           if (fs.existsSync(localFile)) fs.rmSync(localFile);
+          await helper.resetSettings();
         });
 
         test("cannot use status:private with a local users file in run mode", async () => {

--- a/core/__tests__/actions/status.ts
+++ b/core/__tests__/actions/status.ts
@@ -32,6 +32,10 @@ describe("actions/status", () => {
 
         beforeEach(async () => {
           process.env.GROUPAROO_RUN_MODE = "cli:config";
+          await ConfigUser.create({
+            email: "mario@example.com",
+            company: "Nintendo",
+          });
         });
         afterEach(async () => {
           process.env.GROUPAROO_RUN_MODE = undefined;
@@ -41,7 +45,6 @@ describe("actions/status", () => {
 
         test("cannot use status:private with a local users file in run mode", async () => {
           process.env.GROUPAROO_RUN_MODE = "cli:run";
-          fs.writeFileSync(localFile, JSON.stringify({ email: true }));
           const { error, metrics } = await specHelper.runAction(
             "status:private"
           );
@@ -49,10 +52,6 @@ describe("actions/status", () => {
           expect(metrics).toBeUndefined();
         });
         test("can use status:private with a local users file in run mode", async () => {
-          await ConfigUser.create({
-            company: "Nintendo",
-            email: "mario@example.com",
-          });
           const { error, metrics } = await specHelper.runAction(
             "status:private"
           );

--- a/core/__tests__/actions/status.ts
+++ b/core/__tests__/actions/status.ts
@@ -1,5 +1,13 @@
 import { helper } from "@grouparoo/spec-helper";
 import { specHelper } from "actionhero";
+import os from "os";
+import fs from "fs";
+import { ConfigUser } from "../../src/modules/configUser";
+
+const workerId = process.env.JEST_WORKER_ID;
+const configDir = `${os.tmpdir()}/test/${workerId}/configUser/config`;
+
+process.env.GROUPAROO_CONFIG_DIR = configDir;
 
 describe("actions/status", () => {
   helper.grouparooTestServer({ truncate: true, resetSettings: true });
@@ -17,6 +25,39 @@ describe("actions/status", () => {
         const { error, metrics } = await specHelper.runAction("status:private");
         expect(error.code).toBe("AUTHENTICATION_ERROR");
         expect(metrics).toBeUndefined();
+      });
+
+      describe("config mode", () => {
+        const localFile = ConfigUser.localUserFilePath();
+
+        beforeEach(async () => {
+          process.env.GROUPAROO_RUN_MODE = "cli:config";
+        });
+        afterEach(async () => {
+          process.env.GROUPAROO_RUN_MODE = undefined;
+          if (fs.existsSync(localFile)) fs.rmSync(localFile);
+        });
+
+        test("cannot use status:private with a local users file in run mode", async () => {
+          process.env.GROUPAROO_RUN_MODE = "cli:run";
+          fs.writeFileSync(localFile, JSON.stringify({ email: true }));
+          const { error, metrics } = await specHelper.runAction(
+            "status:private"
+          );
+          expect(error.code).toBe("AUTHENTICATION_ERROR");
+          expect(metrics).toBeUndefined();
+        });
+        test("can use status:private with a local users file in run mode", async () => {
+          await ConfigUser.create({
+            company: "Nintendo",
+            email: "mario@example.com",
+          });
+          const { error, metrics } = await specHelper.runAction(
+            "status:private"
+          );
+          expect(error).toBeUndefined();
+          expect(metrics).toEqual([]);
+        });
       });
     });
   });

--- a/core/__tests__/actions/teamMembers.ts
+++ b/core/__tests__/actions/teamMembers.ts
@@ -1,6 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { specHelper } from "actionhero";
-import { TeamMember, Setting } from "../../src";
+import { TeamMember } from "../../src";
 
 const GrouparooSubscriptionModule = require("../../src/modules/grouparooSubscription");
 GrouparooSubscriptionModule.GrouparooSubscription = jest.fn();
@@ -72,12 +72,12 @@ describe("actions/teamMembers", () => {
       ).toHaveBeenCalledTimes(1);
       expect(
         GrouparooSubscriptionModule.GrouparooSubscription
-      ).toHaveBeenCalledWith(
-        expect.objectContaining({
+      ).toHaveBeenCalledWith({
+        teamMember: expect.objectContaining({
           email: "toad@example.com",
         }),
-        true
-      );
+        subscribed: true,
+      });
 
       GrouparooSubscriptionModule.GrouparooSubscription.mockReset();
 
@@ -96,12 +96,12 @@ describe("actions/teamMembers", () => {
       ).toHaveBeenCalledTimes(1);
       expect(
         GrouparooSubscriptionModule.GrouparooSubscription
-      ).toHaveBeenCalledWith(
-        expect.objectContaining({
+      ).toHaveBeenCalledWith({
+        teamMember: expect.objectContaining({
           email: "yoshi@example.com",
         }),
-        false
-      );
+        subscribed: false,
+      });
     });
 
     test("an administrator can view a team member", async () => {

--- a/core/__tests__/actions/teams.ts
+++ b/core/__tests__/actions/teams.ts
@@ -27,12 +27,12 @@ describe("actions/teams", () => {
 
       expect(
         GrouparooSubscriptionModule.GrouparooSubscription
-      ).toHaveBeenCalledWith(
-        expect.objectContaining({
+      ).toHaveBeenCalledWith({
+        teamMember: expect.objectContaining({
           email: "mario@example.com",
         }),
-        true
-      );
+        subscribed: true,
+      });
     });
 
     test("the company name will be used to set the clusterName setting", async () => {

--- a/core/__tests__/modules/configUser.ts
+++ b/core/__tests__/modules/configUser.ts
@@ -26,6 +26,18 @@ describe("modules/ConfigUser", () => {
     if (fs.existsSync(localFile)) fs.rmSync(localFile);
   });
 
+  test("does nothing unless in cli:config mode", async () => {
+    process.env.GROUPAROO_RUN_MODE = undefined;
+    expect(fs.existsSync(ConfigUser.localUserFilePath())).toEqual(false);
+    await ConfigUser.create({
+      email: "demo@grouparoo.com",
+      company: "My Company",
+    });
+    expect(fs.existsSync(ConfigUser.localUserFilePath())).toEqual(false);
+    const user = await ConfigUser.get();
+    expect(user).toEqual(null);
+  });
+
   // also tests the get() method
   test("writes a file to .local/user.json", async () => {
     expect(fs.existsSync(ConfigUser.localUserFilePath())).toEqual(false);

--- a/core/__tests__/modules/configUser.ts
+++ b/core/__tests__/modules/configUser.ts
@@ -1,0 +1,58 @@
+import fs from "fs";
+import os from "os";
+import { helper } from "@grouparoo/spec-helper";
+
+import { ConfigUser } from "../../src/modules/configUser";
+import { Setting, plugin } from "../../src";
+
+const workerId = process.env.JEST_WORKER_ID;
+const configDir = `${os.tmpdir()}/test/${workerId}/configUser/config`;
+
+process.env.GROUPAROO_CONFIG_DIR = configDir;
+
+describe("modules/ConfigUser", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
+  beforeEach(async () => {
+    process.env.GROUPAROO_RUN_MODE = "cli:config";
+    const localFile = ConfigUser.localUserFilePath();
+    if (fs.existsSync(localFile)) fs.rmSync(localFile);
+    await Setting.truncate();
+  });
+
+  afterEach(async () => {
+    process.env.GROUPAROO_RUN_MODE = undefined;
+    const localFile = ConfigUser.localUserFilePath();
+    if (fs.existsSync(localFile)) fs.rmSync(localFile);
+  });
+
+  // also tests the get() method
+  test("writes a file to .local/user.json", async () => {
+    expect(fs.existsSync(ConfigUser.localUserFilePath())).toEqual(false);
+    await ConfigUser.create({
+      email: "demo@grouparoo.com",
+      company: "My Company",
+    });
+    expect(fs.existsSync(ConfigUser.localUserFilePath())).toEqual(true);
+    const user = await ConfigUser.get();
+    expect(Object.keys(user)).toEqual(["email"]);
+    expect(user.email).toEqual(true);
+  });
+
+  test("stores the company as the cluster name", async () => {
+    await plugin.registerSetting(
+      "testPlugin",
+      "cluster-name",
+      "My Grouparoo Cluster",
+      "My Grouparoo Cluster",
+      "Name of the cluster",
+      "string"
+    );
+    await ConfigUser.create({
+      email: "demo@grouparoo.com",
+      company: "My Company",
+    });
+    const setting = await Setting.findOne({ where: { key: "cluster-name" } });
+    expect(setting.value).toEqual("My Company");
+  });
+});

--- a/core/src/actions/config.ts
+++ b/core/src/actions/config.ts
@@ -1,5 +1,7 @@
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
+import { OptionallyAuthenticatedAction } from "../classes/actions/optionallyAuthenticatedAction";
 import { spawnPromise } from "../modules/spawnPromise";
+import { ConfigUser } from "../modules/configUser";
 
 export class ConfigValidate extends AuthenticatedAction {
   constructor() {
@@ -67,5 +69,26 @@ export class ConfigGenerate extends AuthenticatedAction {
       params.id,
       params.parentId,
     ]);
+  }
+}
+
+export class ConfigUserCreate extends OptionallyAuthenticatedAction {
+  constructor() {
+    super();
+    this.name = "config:user:create";
+    this.description = "I write user details to a .local file.";
+    this.permission = { topic: "system", mode: "write" };
+    this.inputs = {
+      email: { required: true },
+      company: { required: true },
+      subscribed: { required: false },
+    };
+    this.outputExample = {};
+  }
+
+  async runWithinTransaction({ params }) {
+    ConfigUser.create();
+    const user = ConfigUser.get();
+    return { user };
   }
 }

--- a/core/src/actions/config.ts
+++ b/core/src/actions/config.ts
@@ -87,6 +87,9 @@ export class ConfigUserCreate extends OptionallyAuthenticatedAction {
   }
 
   async runWithinTransaction({ params }) {
+    if (process.env.GROUPAROO_RUN_MODE !== "cli:config") {
+      throw new Error("Action only available in config mode.");
+    }
     await ConfigUser.create(params);
     const user = await ConfigUser.get();
     return { user };

--- a/core/src/actions/config.ts
+++ b/core/src/actions/config.ts
@@ -87,8 +87,8 @@ export class ConfigUserCreate extends OptionallyAuthenticatedAction {
   }
 
   async runWithinTransaction({ params }) {
-    ConfigUser.create();
-    const user = ConfigUser.get();
+    await ConfigUser.create(params);
+    const user = await ConfigUser.get();
     return { user };
   }
 }

--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -2,6 +2,7 @@ import { OptionallyAuthenticatedAction } from "../classes/actions/optionallyAuth
 import { Setting } from "../models/Setting";
 import { Team } from "../models/Team";
 import { TeamMember } from "../models/TeamMember";
+import { ConfigUser } from "../modules/configUser";
 
 export class NavigationList extends OptionallyAuthenticatedAction {
   constructor() {
@@ -192,16 +193,48 @@ export class NavigationList extends OptionallyAuthenticatedAction {
     }
 
     if (navigationMode === "config") {
-      navigationItems = [
-        { type: "link", title: "Apps", href: "/apps" },
-        { type: "link", title: "Sources", href: "/sources" },
-        { type: "link", title: "Properties", href: "/properties" },
-        { type: "link", title: "Profiles", href: "/profiles" },
-        { type: "link", title: "Groups", href: "/groups" },
-        { type: "link", title: "Destinations", href: "/destinations" },
-        { type: "link", title: "Plugins", href: "/plugins" },
-        { type: "link", title: "Validate", href: "/validate" },
-      ];
+      const user = await ConfigUser.get();
+      if (user) {
+        navigationItems = [
+          {
+            type: "link",
+            title: "Apps",
+            href: "/apps",
+          },
+          {
+            type: "link",
+            title: "Sources",
+            href: "/sources",
+            icon: "file-import",
+          },
+          {
+            type: "link",
+            title: "Properties",
+            href: "/properties",
+            icon: "address-card",
+          },
+          {
+            type: "link",
+            title: "Profiles",
+            href: "/profiles",
+            icon: "user",
+          },
+          {
+            type: "link",
+            title: "Groups",
+            href: "/groups",
+            icon: "users",
+          },
+          {
+            type: "link",
+            title: "Destinations",
+            href: "/destinations",
+            icon: "file-export",
+          },
+          // { type: "link", title: "Plugins", href: "/plugins" },
+          // { type: "link", title: "Validate", href: "/validate" },
+        ];
+      }
     }
 
     const clusterNameSetting = await Setting.findOne({

--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -200,6 +200,7 @@ export class NavigationList extends OptionallyAuthenticatedAction {
             type: "link",
             title: "Apps",
             href: "/apps",
+            icon: "th-large",
           },
           {
             type: "link",
@@ -231,8 +232,6 @@ export class NavigationList extends OptionallyAuthenticatedAction {
             href: "/destinations",
             icon: "file-export",
           },
-          // { type: "link", title: "Plugins", href: "/plugins" },
-          // { type: "link", title: "Validate", href: "/validate" },
         ];
       }
     }
@@ -246,7 +245,7 @@ export class NavigationList extends OptionallyAuthenticatedAction {
       clusterName: {
         default:
           clusterNameSetting?.value &&
-          clusterNameSetting.value !== clusterNameSetting.defaultValue,
+          clusterNameSetting.value === clusterNameSetting.defaultValue,
         value: clusterNameSetting?.value || "",
       },
       teamMember: teamMember ? await teamMember.apiData() : undefined,

--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -243,7 +243,12 @@ export class NavigationList extends OptionallyAuthenticatedAction {
 
     return {
       navigationMode,
-      clusterName: clusterNameSetting?.value || "",
+      clusterName: {
+        default:
+          clusterNameSetting?.value &&
+          clusterNameSetting.value !== clusterNameSetting.defaultValue,
+        value: clusterNameSetting?.value || "",
+      },
       teamMember: teamMember ? await teamMember.apiData() : undefined,
       navigation: {
         navigationItems,

--- a/core/src/actions/settings.ts
+++ b/core/src/actions/settings.ts
@@ -1,4 +1,5 @@
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
+import { OptionallyAuthenticatedAction } from "../classes/actions/optionallyAuthenticatedAction";
 import { plugin } from "../modules/plugin";
 import { Setting } from "../models/Setting";
 
@@ -25,6 +26,29 @@ export class SettingsList extends AuthenticatedAction {
     const setting = await Setting.findAll({ order: params.order });
     return {
       settings: await Promise.all(setting.map(async (s) => await s.apiData())),
+    };
+  }
+}
+
+export class SettingClusterNameView extends OptionallyAuthenticatedAction {
+  constructor() {
+    super();
+    this.name = "settings:clusterName:view";
+    this.description =
+      "Return the cluster name setting and whether it's been changed";
+    this.outputExample = {};
+    this.permission = { topic: "system", mode: "read" };
+    this.inputs = {};
+  }
+
+  async runWithinTransaction() {
+    const setting: Setting = await Setting.findOne({
+      where: { key: "cluster-name" },
+    });
+    return {
+      id: setting.id,
+      clusterName: setting.value,
+      default: setting.value === setting.defaultValue,
     };
   }
 }

--- a/core/src/actions/settings.ts
+++ b/core/src/actions/settings.ts
@@ -46,7 +46,6 @@ export class SettingClusterNameView extends OptionallyAuthenticatedAction {
       where: { key: "cluster-name" },
     });
     return {
-      id: setting.id,
       clusterName: setting.value,
       default: setting.value === setting.defaultValue,
     };

--- a/core/src/actions/settings.ts
+++ b/core/src/actions/settings.ts
@@ -30,28 +30,6 @@ export class SettingsList extends AuthenticatedAction {
   }
 }
 
-export class SettingClusterNameView extends OptionallyAuthenticatedAction {
-  constructor() {
-    super();
-    this.name = "settings:clusterName:view";
-    this.description =
-      "Return the cluster name setting and whether it's been changed";
-    this.outputExample = {};
-    this.permission = { topic: "system", mode: "read" };
-    this.inputs = {};
-  }
-
-  async runWithinTransaction() {
-    const setting: Setting = await Setting.findOne({
-      where: { key: "cluster-name" },
-    });
-    return {
-      clusterName: setting.value,
-      default: setting.value === setting.defaultValue,
-    };
-  }
-}
-
 export class SettingEdit extends AuthenticatedAction {
   constructor() {
     super();

--- a/core/src/actions/teamMembers.ts
+++ b/core/src/actions/teamMembers.ts
@@ -64,7 +64,7 @@ export class TeamMemberCreate extends AuthenticatedAction {
     await teamMember.save();
     await teamMember.updatePassword(params.password);
 
-    await GrouparooSubscription(teamMember, params.subscribed);
+    await GrouparooSubscription({ teamMember, subscribed: params.subscribed });
 
     return { teamMember: await teamMember.apiData() };
   }

--- a/core/src/actions/teams.ts
+++ b/core/src/actions/teams.ts
@@ -47,7 +47,7 @@ export class TeamInitialize extends CLSAction {
 
     await teamMember.updatePassword(params.password);
 
-    await GrouparooSubscription(teamMember, params.subscribed);
+    await GrouparooSubscription({ teamMember, subscribed: params.subscribed });
 
     if (params.companyName) {
       const clusterNameSetting = await Setting.findOne({

--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -51,6 +51,7 @@ export const DEFAULT = {
         { path: "/v:apiVersion/profile/:profileId/logs", action: "logs:list" },
         { path: "/v:apiVersion/account", action: "account:view" },
         { path: "/v:apiVersion/settings", action: "settings:list" },
+        { path: "/v:apiVersion/settings/clusterName", action: "settings:clusterName:view" },
         { path: "/v:apiVersion/events", action: "events:list" },
         { path: "/v:apiVersion/events/counts", action: "events:counts" },
         { path: "/v:apiVersion/events/types", action: "events:types" },

--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -51,7 +51,6 @@ export const DEFAULT = {
         { path: "/v:apiVersion/profile/:profileId/logs", action: "logs:list" },
         { path: "/v:apiVersion/account", action: "account:view" },
         { path: "/v:apiVersion/settings", action: "settings:list" },
-        { path: "/v:apiVersion/settings/clusterName", action: "settings:clusterName:view" },
         { path: "/v:apiVersion/events", action: "events:list" },
         { path: "/v:apiVersion/events/counts", action: "events:counts" },
         { path: "/v:apiVersion/events/types", action: "events:types" },

--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -92,6 +92,7 @@ export const DEFAULT = {
         { path: "/v:apiVersion/config/validate", action: "config:validate" },
         { path: "/v:apiVersion/config/apply", action: "config:apply" },
         { path: "/v:apiVersion/config/generate", action: "config:generate" },
+        { path: "/v:apiVersion/config/user", action: "config:user:create" },
         { path: "/v:apiVersion/team", action: "team:create" },
         { path: "/v:apiVersion/team/initialize", action: "team:initialize" },
         { path: "/v:apiVersion/team/member", action: "teamMember:create" },

--- a/core/src/modules/configUser.ts
+++ b/core/src/modules/configUser.ts
@@ -46,6 +46,7 @@ export namespace ConfigUser {
     subscribed?: boolean;
     company: string;
   }) {
+    if (process.env.GROUPAROO_RUN_MODE !== "cli:config") return;
     store();
     if (subscribed) await subscribe(email, subscribed);
     await storeCompanyName(company);

--- a/core/src/modules/configUser.ts
+++ b/core/src/modules/configUser.ts
@@ -3,6 +3,8 @@ import path from "path";
 
 import { getConfigDir } from "../utils/pluginDetails";
 import { GrouparooSubscription } from "./grouparooSubscription";
+import { plugin } from "../modules/plugin";
+import { Setting } from "../models/Setting";
 
 const localUserFilePath = path.join(getConfigDir(), "../.local/user.json");
 
@@ -21,6 +23,18 @@ export namespace ConfigUser {
     await GrouparooSubscription({ email, subscribed });
   }
 
+  async function storeCompanyName(company: string) {
+    let setting = await Setting.findOne({ where: { key: "cluster-name" } });
+    if (setting) {
+      setting = await plugin.updateSetting(
+        setting.pluginName,
+        setting.key,
+        company
+      );
+    }
+    return setting;
+  }
+
   export async function create({
     email,
     subscribed = true,
@@ -32,6 +46,7 @@ export namespace ConfigUser {
   }) {
     store();
     if (subscribed) await subscribe(email, subscribed);
+    await storeCompanyName(company);
   }
 
   export async function get() {

--- a/core/src/modules/configUser.ts
+++ b/core/src/modules/configUser.ts
@@ -2,11 +2,12 @@ import fs from "fs";
 import path from "path";
 
 import { getConfigDir } from "../utils/pluginDetails";
+import { GrouparooSubscription } from "./grouparooSubscription";
 
 const localUserFilePath = path.join(getConfigDir(), "../.local/user.json");
 
 export namespace ConfigUser {
-  export function create() {
+  function store() {
     const localFileDir = path.dirname(localUserFilePath);
     if (!fs.existsSync(localFileDir)) {
       fs.mkdirSync(localFileDir, { recursive: true });
@@ -15,7 +16,25 @@ export namespace ConfigUser {
     fs.writeFileSync(localUserFilePath, JSON.stringify(fileContent, null, 2));
   }
 
-  export function get() {
+  async function subscribe(email: string, subscribed: boolean = true) {
+    if (!subscribed) return null;
+    await GrouparooSubscription({ email, subscribed });
+  }
+
+  export async function create({
+    email,
+    subscribed = true,
+    company,
+  }: {
+    email: string;
+    subscribed?: boolean;
+    company: string;
+  }) {
+    store();
+    if (subscribed) await subscribe(email, subscribed);
+  }
+
+  export async function get() {
     if (!fs.existsSync(localUserFilePath)) return null;
     const fileContent = fs.readFileSync(localUserFilePath).toString();
     return JSON.parse(fileContent);

--- a/core/src/modules/configUser.ts
+++ b/core/src/modules/configUser.ts
@@ -6,16 +6,18 @@ import { GrouparooSubscription } from "./grouparooSubscription";
 import { plugin } from "../modules/plugin";
 import { Setting } from "../models/Setting";
 
-const localUserFilePath = path.join(getConfigDir(), "../.local/user.json");
-
 export namespace ConfigUser {
+  export function localUserFilePath() {
+    return path.join(getConfigDir(), "../.local/user.json");
+  }
+
   function store() {
-    const localFileDir = path.dirname(localUserFilePath);
+    const localFileDir = path.dirname(localUserFilePath());
     if (!fs.existsSync(localFileDir)) {
       fs.mkdirSync(localFileDir, { recursive: true });
     }
     const fileContent = { email: true };
-    fs.writeFileSync(localUserFilePath, JSON.stringify(fileContent, null, 2));
+    fs.writeFileSync(localUserFilePath(), JSON.stringify(fileContent, null, 2));
   }
 
   async function subscribe(email: string, subscribed: boolean = true) {
@@ -50,8 +52,8 @@ export namespace ConfigUser {
   }
 
   export async function get() {
-    if (!fs.existsSync(localUserFilePath)) return null;
-    const fileContent = fs.readFileSync(localUserFilePath).toString();
+    if (!fs.existsSync(localUserFilePath())) return null;
+    const fileContent = fs.readFileSync(localUserFilePath()).toString();
     return JSON.parse(fileContent);
   }
 }

--- a/core/src/modules/configUser.ts
+++ b/core/src/modules/configUser.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 import { getConfigDir } from "../utils/pluginDetails";
 
-const localUserFilePath = path.join(getConfigDir(), ".local/user.json");
+const localUserFilePath = path.join(getConfigDir(), "../.local/user.json");
 
 export namespace ConfigUser {
   export function create() {

--- a/core/src/modules/configUser.ts
+++ b/core/src/modules/configUser.ts
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+
+import { getConfigDir } from "../utils/pluginDetails";
+
+const localUserFilePath = path.join(getConfigDir(), ".local/user.json");
+
+export namespace ConfigUser {
+  export function create() {
+    const localFileDir = path.dirname(localUserFilePath);
+    if (!fs.existsSync(localFileDir)) {
+      fs.mkdirSync(localFileDir, { recursive: true });
+    }
+    const fileContent = { email: true };
+    fs.writeFileSync(localUserFilePath, JSON.stringify(fileContent, null, 2));
+  }
+
+  export function get() {
+    if (!fs.existsSync(localUserFilePath)) return null;
+    const fileContent = fs.readFileSync(localUserFilePath).toString();
+    return JSON.parse(fileContent);
+  }
+}

--- a/core/src/modules/configWriter.ts
+++ b/core/src/modules/configWriter.ts
@@ -4,7 +4,6 @@ import path from "path";
 
 import { App } from "../models/App";
 import { Source } from "../models/Source";
-import { Schedule } from "../models/Schedule";
 import { Property } from "../models/Property";
 import { Group } from "../models/Group";
 import { Destination } from "../models/Destination";

--- a/core/src/modules/grouparooSubscription.ts
+++ b/core/src/modules/grouparooSubscription.ts
@@ -17,12 +17,18 @@ const campaign = `v${packageJSON.version}`;
  * We also want to allow for this method to fail, and not block anything else in the server.
  * Therefore, we don't await the top-level CLS.afterCommit method
  */
-export async function GrouparooSubscription(
-  teamMember: TeamMember,
-  subscribed = true
-) {
+export async function GrouparooSubscription({
+  teamMember,
+  email,
+  subscribed = true,
+}: {
+  teamMember?: TeamMember;
+  email?: string;
+  subscribed: boolean;
+}) {
   if (process.env.NODE_ENV === "test") return;
   if (!config.telemetry.enabled) return;
+  if (!teamMember && !email) return;
 
   CLS.afterCommit(async () => {
     const setting = await plugin.readSetting("telemetry", "customer-id");
@@ -33,9 +39,9 @@ export async function GrouparooSubscription(
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          email: teamMember.email,
-          firstName: teamMember.firstName,
-          lastName: teamMember.lastName,
+          email: teamMember?.email || email,
+          firstName: teamMember?.firstName,
+          lastName: teamMember?.lastName,
           source,
           medium,
           campaign,

--- a/core/src/modules/middleware/authentication.ts
+++ b/core/src/modules/middleware/authentication.ts
@@ -116,7 +116,7 @@ async function authenticateTeamMember(
 
   if (
     process.env.GROUPAROO_RUN_MODE === "cli:config" &&
-    env === "development"
+    ["development", "test"].includes(env)
   ) {
     error = await authenticateConfigUser(data, optional);
   } else {

--- a/core/src/modules/middleware/authentication.ts
+++ b/core/src/modules/middleware/authentication.ts
@@ -90,13 +90,13 @@ async function authenticateTeamMemberFromSession(
 }
 
 // Authenticate user from file in .local directory
-function authenticateConfigUser(
+async function authenticateConfigUser(
   data: { [key: string]: any },
   optional: boolean
 ) {
   if (optional) return;
   try {
-    const user = ConfigUser.get();
+    const user = await ConfigUser.get();
     if (user?.email !== true) {
       const error = new Error("Config user not properly set.");
       error["code"] = "AUTHENTICATION_ERROR";
@@ -118,7 +118,7 @@ async function authenticateTeamMember(
     process.env.GROUPAROO_RUN_MODE === "cli:config" &&
     env === "development"
   ) {
-    error = authenticateConfigUser(data, optional);
+    error = await authenticateConfigUser(data, optional);
   } else {
     error = await authenticateTeamMemberFromSession(data, optional);
   }

--- a/ui/ui-components/components/icons.ts
+++ b/ui/ui-components/components/icons.ts
@@ -13,6 +13,7 @@ import {
   faTerminal,
   faStream,
   faExchangeAlt,
+  faThLarge,
 } from "@fortawesome/free-solid-svg-icons";
 
 import { faSlack } from "@fortawesome/free-brands-svg-icons";
@@ -29,5 +30,6 @@ library.add(
   faTerminal,
   faSlack,
   faStream,
-  faExchangeAlt
+  faExchangeAlt,
+  faThLarge
 );

--- a/ui/ui-components/components/navigation.tsx
+++ b/ui/ui-components/components/navigation.tsx
@@ -161,7 +161,9 @@ export default function Navigation(props) {
             <Link href="/settings/[tab]" as="/settings/core">
               <a>
                 <Badge variant="secondary">
-                  {truncate(clusterName.value, 30)}
+                  {clusterName
+                    ? truncate(clusterName.value, 30)
+                    : "Name not set"}
                 </Badge>
               </a>
             </Link>

--- a/ui/ui-components/components/navigation.tsx
+++ b/ui/ui-components/components/navigation.tsx
@@ -44,7 +44,7 @@ export default function Navigation(props) {
   }: {
     navigationMode: Actions.NavigationList["navigationMode"];
     navigation: Actions.NavigationList["navigation"];
-    clusterName: string;
+    clusterName: { value: string; default: boolean };
     navExpanded: boolean;
     toggleNavExpanded: () => {};
     errorHandler: ErrorHandler;
@@ -160,7 +160,9 @@ export default function Navigation(props) {
             <br />
             <Link href="/settings/[tab]" as="/settings/core">
               <a>
-                <Badge variant="secondary">{truncate(clusterName, 30)}</Badge>
+                <Badge variant="secondary">
+                  {truncate(clusterName.value, 30)}
+                </Badge>
               </a>
             </Link>
           </div>

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -170,6 +170,7 @@ import {
   ConfigValidate,
   ConfigApply,
   ConfigGenerate,
+  ConfigUserCreate,
 } from "@grouparoo/core/src/actions/config";
 import {
   PropertyCreate,
@@ -507,6 +508,9 @@ export namespace Actions {
   >;
   export type ConfigGenerate = AsyncReturnType<
     typeof ConfigGenerate.prototype.runWithinTransaction
+  >;
+  export type ConfigUserCreate = AsyncReturnType<
+    typeof ConfigUserCreate.prototype.runWithinTransaction
   >;
 
   export type PropertyCreate = AsyncReturnType<

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -232,7 +232,6 @@ import {
 import {
   SettingEdit,
   SettingsList,
-  SettingClusterNameView,
 } from "@grouparoo/core/src/actions/settings";
 import {
   SetupStepEdit,
@@ -672,9 +671,6 @@ export namespace Actions {
   >;
   export type SettingsList = AsyncReturnType<
     typeof SettingsList.prototype.runWithinTransaction
-  >;
-  export type SettingClusterNameView = AsyncReturnType<
-    typeof SettingClusterNameView.prototype.runWithinTransaction
   >;
 
   export type SetupStepEdit = AsyncReturnType<

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -232,6 +232,7 @@ import {
 import {
   SettingEdit,
   SettingsList,
+  SettingClusterNameView,
 } from "@grouparoo/core/src/actions/settings";
 import {
   SetupStepEdit,
@@ -671,6 +672,9 @@ export namespace Actions {
   >;
   export type SettingsList = AsyncReturnType<
     typeof SettingsList.prototype.runWithinTransaction
+  >;
+  export type SettingClusterNameView = AsyncReturnType<
+    typeof SettingClusterNameView.prototype.runWithinTransaction
   >;
 
   export type SetupStepEdit = AsyncReturnType<

--- a/ui/ui-config/__tests__/integration/happyPath.ts
+++ b/ui/ui-config/__tests__/integration/happyPath.ts
@@ -33,11 +33,11 @@ describe("integration", () => {
   });
 
   test(
-    "it renders the home page",
+    "it renders the registration page",
     async () => {
       await browser.get(env.url);
       const header = await browser.findElement(by.tagName("h1")).getText();
-      expect(header).toContain("Hello from @grouparoo/ui-config");
+      expect(header).toContain("Register");
     },
     helper.mediumTime
   );

--- a/ui/ui-config/pages/index.tsx
+++ b/ui/ui-config/pages/index.tsx
@@ -1,6 +1,8 @@
 import Head from "next/head";
 import { Row, Col } from "react-bootstrap";
 import Link from "next/link";
+import { useApi } from "@grouparoo/ui-components/hooks/useApi";
+import { Actions } from "@grouparoo/ui-components/utils/apiData";
 
 export default function IndexPage() {
   return (
@@ -33,3 +35,13 @@ export default function IndexPage() {
     </>
   );
 }
+
+IndexPage.getInitialProps = async (ctx) => {
+  const { execApi } = useApi(ctx);
+  // Hit an auth route so that we redirect to sign in if not already signed in.
+  const apiStatus: Actions.PrivateStatus = await execApi(
+    "get",
+    `/status/private`
+  );
+  return { apiStatus };
+};

--- a/ui/ui-config/pages/session/sign-in.tsx
+++ b/ui/ui-config/pages/session/sign-in.tsx
@@ -9,7 +9,7 @@ import { Actions } from "@grouparoo/ui-components/utils/apiData";
 import LoadingButton from "@grouparoo/ui-components/components/loadingButton";
 
 export default function SignInPage(props) {
-  const { errorHandler, setting } = props;
+  const { clusterName, errorHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const { handleSubmit, register } = useForm();
   const [loading, setLoading] = useState(false);
@@ -51,7 +51,7 @@ export default function SignInPage(props) {
                 type="text"
                 placeholder="Company Name"
                 ref={register}
-                defaultValue={setting.default ? "" : setting.clusterName}
+                defaultValue={clusterName.default ? "" : clusterName.value}
               />
               <Form.Control.Feedback type="invalid">
                 Company name is required
@@ -94,12 +94,3 @@ export default function SignInPage(props) {
     </>
   );
 }
-
-SignInPage.getInitialProps = async (ctx) => {
-  const { execApi } = useApi(ctx);
-  const setting: Actions.SettingClusterNameView = await execApi(
-    "get",
-    `/settings/clusterName`
-  );
-  return { setting };
-};

--- a/ui/ui-config/pages/session/sign-in.tsx
+++ b/ui/ui-config/pages/session/sign-in.tsx
@@ -51,7 +51,7 @@ export default function SignInPage(props) {
                 type="text"
                 placeholder="Company Name"
                 ref={register}
-                defaultValue={setting.default ? null : setting.clusterName}
+                defaultValue={setting.default ? "" : setting.clusterName}
               />
               <Form.Control.Feedback type="invalid">
                 Company name is required

--- a/ui/ui-config/pages/session/sign-in.tsx
+++ b/ui/ui-config/pages/session/sign-in.tsx
@@ -1,21 +1,93 @@
-import { Row, Col } from "react-bootstrap";
+import { useState } from "react";
+import { Row, Col, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
 import Head from "next/head";
-// import { useApi } from "@grouparoo/ui-components/hooks/useApi";
-// import SignIn from "@grouparoo/ui-components/components/session/signIn";
+import { useRouter } from "next/router";
+import { useApi } from "@grouparoo/ui-components/hooks/useApi";
+import { Actions } from "@grouparoo/ui-components/utils/apiData";
+
+import LoadingButton from "@grouparoo/ui-components/components/loadingButton";
 
 export default function SignInPage(props) {
+  const { errorHandler } = props;
+  const { execApi } = useApi(props, errorHandler);
+  const { handleSubmit, register } = useForm();
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+  const { nextPage } = router.query;
+
+  const onSubmit = async (data) => {
+    setLoading(true);
+    const response: Actions.ConfigUserCreate = await execApi(
+      "post",
+      "/config/user",
+      data
+    );
+    setLoading(false);
+
+    if (response?.user?.email) {
+      router.push(nextPage ? nextPage.toString() : "/");
+    }
+  };
+
   return (
     <>
       <Head>
         <title>Grouparoo: Sign In</title>
       </Head>
 
-      <h1>Sign In</h1>
+      <h1>Register</h1>
 
       <Row className="border-between-columns">
         <Col>
-          {/* <SignIn {...props} useApi={useApi} /> */}
-          Sign in form goes here ...
+          <Form id="form" onSubmit={handleSubmit(onSubmit)}>
+            <Form.Group>
+              <Form.Label>Company Name</Form.Label>
+              <Form.Control
+                disabled={loading}
+                autoFocus
+                required
+                name="company"
+                type="text"
+                placeholder="Company Name"
+                ref={register}
+              />
+              <Form.Control.Feedback type="invalid">
+                Company name is required
+              </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group>
+              <Form.Label>Email Address</Form.Label>
+              <Form.Control
+                disabled={loading}
+                autoFocus
+                required
+                name="email"
+                type="email"
+                placeholder="Email Address"
+                ref={register}
+              />
+              <Form.Control.Feedback type="invalid">
+                Email is required
+              </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group>
+              <Form.Check
+                type="checkbox"
+                name="subscribed"
+                label={`Subscribe to the Grouparoo Newsletter`}
+                defaultChecked
+                ref={register}
+                disabled={loading}
+              />
+            </Form.Group>
+
+            <LoadingButton disabled={loading} variant="primary" type="submit">
+              Register
+            </LoadingButton>
+          </Form>
         </Col>
       </Row>
     </>

--- a/ui/ui-config/pages/session/sign-in.tsx
+++ b/ui/ui-config/pages/session/sign-in.tsx
@@ -9,7 +9,7 @@ import { Actions } from "@grouparoo/ui-components/utils/apiData";
 import LoadingButton from "@grouparoo/ui-components/components/loadingButton";
 
 export default function SignInPage(props) {
-  const { errorHandler } = props;
+  const { errorHandler, setting } = props;
   const { execApi } = useApi(props, errorHandler);
   const { handleSubmit, register } = useForm();
   const [loading, setLoading] = useState(false);
@@ -51,6 +51,7 @@ export default function SignInPage(props) {
                 type="text"
                 placeholder="Company Name"
                 ref={register}
+                defaultValue={setting.default ? null : setting.clusterName}
               />
               <Form.Control.Feedback type="invalid">
                 Company name is required
@@ -93,3 +94,12 @@ export default function SignInPage(props) {
     </>
   );
 }
+
+SignInPage.getInitialProps = async (ctx) => {
+  const { execApi } = useApi(ctx);
+  const setting: Actions.SettingClusterNameView = await execApi(
+    "get",
+    `/settings/clusterName`
+  );
+  return { setting };
+};

--- a/ui/ui-config/pages/session/sign-in.tsx
+++ b/ui/ui-config/pages/session/sign-in.tsx
@@ -1,0 +1,23 @@
+import { Row, Col } from "react-bootstrap";
+import Head from "next/head";
+// import { useApi } from "@grouparoo/ui-components/hooks/useApi";
+// import SignIn from "@grouparoo/ui-components/components/session/signIn";
+
+export default function SignInPage(props) {
+  return (
+    <>
+      <Head>
+        <title>Grouparoo: Sign In</title>
+      </Head>
+
+      <h1>Sign In</h1>
+
+      <Row className="border-between-columns">
+        <Col>
+          {/* <SignIn {...props} useApi={useApi} /> */}
+          Sign in form goes here ...
+        </Col>
+      </Row>
+    </>
+  );
+}


### PR DESCRIPTION
Adds  an authentication workflow to Config UI.

## Workflow

This piggy-backs off the current auth middleware, adding a conditional for being in configland. I could have chosen to use a separate middleware, but decided to keep it together for the time being.

1. Authenticated requests look for a `.local/user.json` file with an object containing `email: true`. If it find that, auth is passed.
2. Otherwise, redirect to the registration form.
3. Registration form will load company name from cluster name setting if it has been changed. Otherwise, it's a blank form field.
4. When submitting, company gets saved to cluster name setting (not written to file yet, see below), subscribed will trigger a call to Telemetry, and the email address triggers creation of a `.local/user.json` file with contents `{ email: true }`.
5. Redirect to index page.

## Other Notable Items

- I added some icons to the navigation, but didn't pick one for Apps, thinking @tealjulia could help me out there. Also didn't make a story for that, considering the change is so small.
- There are no navigation items when not authenticated in configland.
- Created a new action that returns the cluster name without authentication. This was to be able to pre-populate the company name in the form.
- Adjusted GrouparooSubscription to allow for sending a subscribe request when we have only an email, not a full team member.

## Not Addressed

To get this merged and so @tealjulia can continue her work, I've broken out the following out into other stories:

- [Write cluster name to file idempotently when ConfigWriter runs](https://www.pivotaltracker.com/story/show/178336436), and run it after updating a setting.
- [Refactor navigation action](https://www.pivotaltracker.com/story/show/178336448). It's messy.