### PR TITLE
fix: correctly save destinationGroupMemberships for Destination config object

### DIFF
--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -447,7 +447,9 @@ describe("modules/configWriter", () => {
         syncMode,
         options,
         mapping,
-        destinationGroupMemberships,
+        destinationGroupMemberships: {
+          "My Dest Tag": group.id,
+        },
       });
     });
   });

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -537,7 +537,7 @@ export class Destination extends LoggedModel<Destination> {
       where: { destinationId: id },
     });
     const destinationGroupMemberships = Object.fromEntries(
-      dgm.map((dgm) => [dgm.groupId, dgm.remoteKey])
+      dgm.map((dgm) => [dgm.remoteKey, dgm.groupId])
     );
 
     return {


### PR DESCRIPTION
A bit unintuitively, in the config object keys are actually the name in the destination and values are group IDs (which is backwards from the object used by `setDestinationGroupMemberships`)