### PR TITLE
Run summary count fix

### DIFF
--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -189,7 +189,7 @@ export namespace GrouparooCLI {
 
     export function finalSummary(
       finalSummaryLogs: FinalSummary.FinalSummaryLogArray,
-      secondaryTitle = `@ ${new Date().toISOString()}`
+      secondaryTitle = `${new Date().toISOString()}`
     ) {
       const formattedTitle = `┌-- 🦘 Run Completed @ ${secondaryTitle} ---`;
 

--- a/core/src/modules/statusReporters.ts
+++ b/core/src/modules/statusReporters.ts
@@ -434,7 +434,8 @@ export namespace FinalSummaryReporters {
       const sources: { [id: string]: SourceData } = {};
       for (const run of runs) {
         let source = null;
-        const schedule = await Schedule.findById(run.creatorId);
+        const schedule = await Schedule.findByPk(run.creatorId);
+
         if (schedule) {
           source = await schedule.$get("source");
         }
@@ -468,11 +469,11 @@ export namespace FinalSummaryReporters {
     export async function getData() {
       const out: ProfileData[] = [];
       const profilesUpdated = await Profile.count({
-        where: { updatedAt: { [Op.gt]: lastRunStart } },
+        where: { updatedAt: { [Op.gte]: lastRunStart } },
       });
 
       const profilesCreated = await Profile.count({
-        where: { createdAt: { [Op.gt]: lastRunStart } },
+        where: { createdAt: { [Op.gte]: lastRunStart } },
       });
       const name = null;
       const allProfiles = await Profile.count();
@@ -507,7 +508,7 @@ export namespace FinalSummaryReporters {
             "exportsCreated",
           ],
         ],
-        where: { createdAt: { [Op.gt]: lastRunStart } },
+        where: { createdAt: { [Op.gte]: lastRunStart } },
         group: ["destinationId"],
       });
       for (const exp of exports) {
@@ -518,7 +519,7 @@ export namespace FinalSummaryReporters {
         const exportsFailed = await Export.count({
           where: {
             state: "failed",
-            updatedAt: { [Op.gt]: lastRunStart },
+            updatedAt: { [Op.gte]: lastRunStart },
             destinationId: destination.id,
           },
         });
@@ -526,7 +527,7 @@ export namespace FinalSummaryReporters {
         const exportsComplete = await Export.count({
           where: {
             state: "complete",
-            updatedAt: { [Op.gt]: lastRunStart },
+            updatedAt: { [Op.gte]: lastRunStart },
             destinationId: destination.id,
           },
         });


### PR DESCRIPTION
Summary after `roo run` was not generating accurate counts, specifically # of imports from sources on a first run with a new db.

Changing `findById` to `findByPk` seems to have solved the issue (`findById` was deprecated a few versions ago in sequelize)

I've tried running multiple times, both using the same db for multiple runs in a row and destroying/rebuilding and am now consistently getting the same (accurate) counts.