### PR TITLE
Fix issues when deleting multiple objects at the same time

### DIFF
--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -183,13 +183,17 @@ describe("models/destination", () => {
       await profile.destroy();
     });
 
-    test("a destination can get options from a connection", async () => {
-      const connectionOptions =
-        await destination.destinationConnectionOptions();
-      expect(connectionOptions).toEqual({
-        table: { type: "list", options: ["users_out"] },
-      });
-    });
+    test.each(["deleted", "ready"])(
+      "a destination can get options from a connection with a %p app",
+      async (appState) => {
+        await app.update({ state: appState });
+        const connectionOptions =
+          await destination.destinationConnectionOptions();
+        expect(connectionOptions).toEqual({
+          table: { type: "list", options: ["users_out"] },
+        });
+      }
+    );
 
     test("partial options will be passed to destinationConnectionOptions", async () => {
       const connectionOptions = await destination.destinationConnectionOptions({

--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -680,19 +680,6 @@ describe("models/destination", () => {
           expect(runB.force).toBe(false);
         });
 
-        test("when the group being tracked is removed and it is in deleted state, it should not be re-exported", async () => {
-          const runA = await destination.trackGroup(group);
-
-          await group.update({ state: "deleted" });
-
-          // do not create a run- it will be created by `group:destroy` task
-          const runB = await destination.unTrackGroup();
-          expect(runB).toBeFalsy();
-
-          await runA.reload();
-          expect(runA.state).toBe("running");
-        });
-
         test("when the group being tracked is changed, the previous group should be exported one last time", async () => {
           const otherGroup = await helper.factories.group();
           await otherGroup.update({ state: "ready" });

--- a/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
+++ b/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
@@ -417,6 +417,34 @@ describe("models/destination", () => {
       await destination.destroy();
     });
 
+    test.each(["deleted", "ready"])(
+      "can get destinationMappingOptions with a %p app",
+      async (appState) => {
+        await app.update({ state: appState });
+
+        const opts = await destination.destinationMappingOptions();
+        expect(opts).toEqual({
+          labels: {
+            group: {
+              singular: "list",
+              plural: "lists",
+            },
+            property: {
+              singular: "var",
+              plural: "vars",
+            },
+          },
+          properties: {
+            required,
+            known,
+            allowOptionalFromProperties: true,
+          },
+        });
+
+        await app.update({ state: "ready" });
+      }
+    );
+
     test("mappings can be of the same type", async () => {
       required = [{ key: "remote-id", type: "integer" }];
       await destination.setMapping({ "remote-id": "userId" });

--- a/core/__tests__/models/destination/plugins/exportProfile.ts
+++ b/core/__tests__/models/destination/plugins/exportProfile.ts
@@ -6,133 +6,20 @@ import {
   Export,
   Group,
   Profile,
+  Property,
 } from "../../../../src";
 import { api, specHelper } from "actionhero";
 import { Op } from "sequelize";
 
 describe("models/destination", () => {
-  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
-  beforeAll(async () => await helper.factories.properties());
+  describe.each(["ready", "deleted"])("with app in %p state", (appState) => {
+    helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+    beforeAll(async () => await helper.factories.properties());
 
-  describe("with custom exportProfile plugin", () => {
-    let app: App;
-    let destination: Destination;
-    let exportArgs = {
-      app: null,
-      appOptions: null,
-      destination: null,
-      destinationOptions: null,
-      syncOperations: null,
-      profile: null,
-      oldProfileProperties: null,
-      newProfileProperties: null,
-      oldGroups: null,
-      newGroups: null,
-      toDelete: null,
-    };
-    let exportArrayProperties = [];
-    let parallelismResponse = Infinity;
-    let exportProfileResponse = {
-      success: true,
-      error: undefined,
-      retryDelay: undefined,
-    };
-    let exportProfileThrow = null;
-
-    beforeAll(async () => {
-      plugin.registerPlugin({
-        name: "test-export-plugin",
-        apps: [
-          {
-            name: "test-template-app",
-            options: [{ key: "test_key", required: true }],
-            methods: {
-              test: async () => {
-                return { success: true };
-              },
-              parallelism: async () => {
-                return parallelismResponse;
-              },
-            },
-          },
-        ],
-        connections: [
-          {
-            name: "export-from-test-app",
-            description: "a test app connection",
-            app: "test-template-app",
-            direction: "export",
-            options: [],
-            syncModes: ["sync", "enrich", "additive"],
-            methods: {
-              destinationMappingOptions: async () => {
-                return {
-                  labels: {
-                    group: {
-                      singular: "list",
-                      plural: "lists",
-                    },
-                    property: {
-                      singular: "var",
-                      plural: "vars",
-                    },
-                  },
-                  properties: {
-                    required: [],
-                    known: [],
-                    allowOptionalFromProperties: true,
-                  },
-                };
-              },
-              exportArrayProperties: async () => exportArrayProperties,
-              exportProfile: async ({
-                app,
-                appOptions,
-                destination,
-                destinationOptions,
-                syncOperations,
-                export: {
-                  profile,
-                  oldProfileProperties,
-                  newProfileProperties,
-                  oldGroups,
-                  newGroups,
-                  toDelete,
-                },
-              }) => {
-                exportArgs = {
-                  app,
-                  appOptions,
-                  destination,
-                  destinationOptions,
-                  syncOperations,
-                  profile,
-                  oldProfileProperties,
-                  newProfileProperties,
-                  oldGroups,
-                  newGroups,
-                  toDelete,
-                };
-                if (exportProfileThrow) {
-                  throw exportProfileThrow;
-                }
-                return exportProfileResponse;
-              },
-            },
-          },
-        ],
-      });
-
-      app = await App.create({
-        name: "test with real methods",
-        type: "test-template-app",
-      });
-      await app.setOptions({ test_key: "abc" });
-      await app.update({ state: "ready" });
-    });
-
-    beforeEach(async () => {
-      exportArgs = {
+    describe("with custom exportProfile plugin", () => {
+      let app: App;
+      let destination: Destination;
+      let exportArgs = {
         app: null,
         appOptions: null,
         destination: null,
@@ -145,356 +32,459 @@ describe("models/destination", () => {
         newGroups: null,
         toDelete: null,
       };
-    });
+      let exportArrayProperties = [];
+      let parallelismResponse = Infinity;
+      let exportProfileResponse = {
+        success: true,
+        error: undefined,
+        retryDelay: undefined,
+      };
+      let exportProfileThrow = null;
 
-    beforeEach(async () => {
-      destination = await Destination.create({
-        name: "test plugin destination",
-        type: "export-from-test-app",
-        syncMode: "sync",
-        appId: app.id,
-      });
-      await destination.update({ state: "ready" });
+      beforeAll(async () => {
+        plugin.registerPlugin({
+          name: "test-export-plugin",
+          apps: [
+            {
+              name: "test-template-app",
+              options: [{ key: "test_key", required: true }],
+              methods: {
+                test: async () => {
+                  return { success: true };
+                },
+                parallelism: async () => {
+                  return parallelismResponse;
+                },
+              },
+            },
+          ],
+          connections: [
+            {
+              name: "export-from-test-app",
+              description: "a test app connection",
+              app: "test-template-app",
+              direction: "export",
+              options: [],
+              syncModes: ["sync", "enrich", "additive"],
+              methods: {
+                destinationMappingOptions: async () => {
+                  return {
+                    labels: {
+                      group: {
+                        singular: "list",
+                        plural: "lists",
+                      },
+                      property: {
+                        singular: "var",
+                        plural: "vars",
+                      },
+                    },
+                    properties: {
+                      required: [],
+                      known: [],
+                      allowOptionalFromProperties: true,
+                    },
+                  };
+                },
+                exportArrayProperties: async () => exportArrayProperties,
+                exportProfile: async ({
+                  app,
+                  appOptions,
+                  destination,
+                  destinationOptions,
+                  syncOperations,
+                  export: {
+                    profile,
+                    oldProfileProperties,
+                    newProfileProperties,
+                    oldGroups,
+                    newGroups,
+                    toDelete,
+                  },
+                }) => {
+                  exportArgs = {
+                    app,
+                    appOptions,
+                    destination,
+                    destinationOptions,
+                    syncOperations,
+                    profile,
+                    oldProfileProperties,
+                    newProfileProperties,
+                    oldGroups,
+                    newGroups,
+                    toDelete,
+                  };
+                  if (exportProfileThrow) {
+                    throw exportProfileThrow;
+                  }
+                  return exportProfileResponse;
+                },
+              },
+            },
+          ],
+        });
 
-      await api.resque.queue.connection.redis.flushdb();
-    });
-
-    afterEach(async () => {
-      await destination.unTrackGroup();
-      await destination.destroy();
-    });
-
-    test("the app exportProfile method can be called by the destination and exports will be created and mappings followed", async () => {
-      await destination.setMapping({
-        uid: "userId",
-        customer_email: "email",
-      });
-
-      const groupA = await helper.factories.group();
-      const groupB = await helper.factories.group();
-
-      await destination.trackGroup(groupA);
-
-      // modify the membership name
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[groupA.id] = groupA.name + "+";
-      destinationGroupMemberships[groupB.id] = groupB.name + "+";
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      await profile.addOrUpdateProperties({ email: ["newemail@example.com"] });
-      await groupA.addProfile(profile);
-      await groupB.addProfile(profile);
-
-      const oldExport = await helper.factories.export(profile, destination, {
-        newProfileProperties: {
-          customer_email: { type: "email", rawValue: "oldmail@example.com" },
-        },
-        state: "complete",
-        newGroups: [],
-        startedAt: new Date(),
-        completedAt: new Date(),
-      });
-      await specHelper.deleteEnqueuedTasks("exports:send", {
-        id: oldExport.id,
-      });
-
-      await destination.exportProfile(profile);
-
-      await specHelper.runTask("export:enqueue", {});
-      const foundTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundTasks.length).toBe(1);
-      await specHelper.runTask("export:send", foundTasks[0].args[0]);
-
-      expect(exportArgs.destination.id).toEqual(destination.id);
-      expect(exportArgs.app.id).toEqual(app.id);
-      expect(exportArgs.profile.id).toEqual(profile.id);
-      expect(exportArgs.oldProfileProperties).toEqual({
-        customer_email: "oldmail@example.com",
-      });
-      expect(exportArgs.newProfileProperties).toEqual({
-        customer_email: "newemail@example.com",
-        uid: null,
-      });
-      expect(exportArgs.oldGroups).toEqual([]);
-      expect(exportArgs.newGroups).toEqual(
-        [groupA, groupB].map((g) => `${g.name}+`).sort()
-      );
-      expect(exportArgs.toDelete).toEqual(false);
-
-      const _exports = await Export.findAll({
-        where: { destinationId: destination.id },
-        order: [["createdAt", "asc"]],
-      });
-      expect(_exports.length).toBe(2);
-      expect(_exports[1].destinationId).toBe(destination.id);
-      expect(_exports[1].profileId).toBe(profile.id);
-      expect(
-        _exports[0].completedAt.getTime() - _exports[0].startedAt.getTime()
-      ).toBeGreaterThanOrEqual(0);
-      expect(_exports[1].errorMessage).toBeFalsy();
-      expect(_exports[1].oldProfileProperties).toEqual({
-        customer_email: "oldmail@example.com",
-      });
-      expect(_exports[1].newProfileProperties).toEqual({
-        customer_email: "newemail@example.com",
-        uid: null,
-      });
-      expect(_exports[1].oldGroups).toEqual([]);
-      expect(_exports[1].newGroups).toEqual(
-        [groupA, groupB].map((g) => `${g.name}+`).sort()
-      );
-
-      await profile.destroy();
-    });
-
-    test("profile properties previously mapped but now removed will be included as oldProfileProperties in the export", async () => {
-      await destination.setMapping({
-        uid: "userId",
-        customer_email: "email",
+        app = await App.create({
+          name: "test with real methods",
+          type: "test-template-app",
+        });
+        await app.setOptions({ test_key: "abc" });
+        await app.update({ state: "ready" });
       });
 
-      const groupA = await helper.factories.group();
-
-      await destination.trackGroup(groupA);
-
-      const profile = await helper.factories.profile();
-      await profile.addOrUpdateProperties({ email: ["newemail@example.com"] });
-      await groupA.addProfile(profile);
-
-      // create a previous export
-      const _export = await Export.create({
-        profileId: profile.id,
-        destinationId: destination.id,
-        newProfileProperties: {
-          gender: { type: "string", rawValue: "Male" },
-          customer_email: { type: "email", rawValue: "oldmail@example.com" },
-        },
-        oldProfileProperties: {},
-        oldGroups: [],
-        newGroups: [],
-        state: "complete",
+      beforeEach(async () => {
+        exportArgs = {
+          app: null,
+          appOptions: null,
+          destination: null,
+          destinationOptions: null,
+          syncOperations: null,
+          profile: null,
+          oldProfileProperties: null,
+          newProfileProperties: null,
+          oldGroups: null,
+          newGroups: null,
+          toDelete: null,
+        };
       });
 
-      await destination.exportProfile(profile);
+      beforeEach(async () => {
+        await app.update({ state: "ready" });
 
-      await specHelper.runTask("export:enqueue", {});
-      const foundTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundTasks.length).toBe(1);
-      for (const i in foundTasks) {
-        await specHelper.runTask("export:send", foundTasks[i].args[0]);
-      }
+        destination = await Destination.create({
+          name: "test plugin destination",
+          type: "export-from-test-app",
+          syncMode: "sync",
+          appId: app.id,
+        });
+        await destination.update({ state: "ready" });
+        await api.resque.queue.connection.redis.flushdb();
 
-      expect(exportArgs.oldProfileProperties).toEqual({
-        customer_email: "oldmail@example.com",
-        gender: "Male",
-      });
-      expect(exportArgs.newProfileProperties).toEqual({
-        customer_email: "newemail@example.com",
-        uid: null,
+        await app.update({ state: appState });
       });
 
-      await profile.destroy();
-    });
-
-    test("newly tagged groups will appear new in next export", async () => {
-      await destination.setMapping({
-        uid: "userId",
-        customer_email: "email",
+      afterEach(async () => {
+        await destination.unTrackGroup();
+        await destination.destroy();
       });
 
-      const group = await helper.factories.group();
-      await destination.trackGroup(group);
+      test("the app exportProfile method can be called by the destination and exports will be created and mappings followed", async () => {
+        await destination.setMapping({
+          uid: "userId",
+          customer_email: "email",
+        });
 
-      const profile = await helper.factories.profile();
-      await group.addProfile(profile);
+        const groupA = await helper.factories.group();
+        const groupB = await helper.factories.group();
 
-      // create a previous export
-      const _export = await Export.create({
-        profileId: profile.id,
-        destinationId: destination.id,
-        newProfileProperties: {},
-        oldProfileProperties: {},
-        oldGroups: [],
-        newGroups: [],
-        state: "complete",
+        await destination.trackGroup(groupA);
+
+        // modify the membership name
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[groupA.id] = groupA.name + "+";
+        destinationGroupMemberships[groupB.id] = groupB.name + "+";
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+        await profile.addOrUpdateProperties({
+          email: ["newemail@example.com"],
+        });
+        await groupA.addProfile(profile);
+        await groupB.addProfile(profile);
+
+        const oldExport = await helper.factories.export(profile, destination, {
+          newProfileProperties: {
+            customer_email: { type: "email", rawValue: "oldmail@example.com" },
+          },
+          state: "complete",
+          newGroups: [],
+          startedAt: new Date(),
+          completedAt: new Date(),
+        });
+        await specHelper.deleteEnqueuedTasks("exports:send", {
+          id: oldExport.id,
+        });
+
+        await destination.exportProfile(profile);
+
+        await specHelper.runTask("export:enqueue", {});
+        const foundTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundTasks.length).toBe(1);
+        await specHelper.runTask("export:send", foundTasks[0].args[0]);
+
+        expect(exportArgs.destination.id).toEqual(destination.id);
+        expect(exportArgs.app.id).toEqual(app.id);
+        expect(exportArgs.profile.id).toEqual(profile.id);
+        expect(exportArgs.oldProfileProperties).toEqual({
+          customer_email: "oldmail@example.com",
+        });
+        expect(exportArgs.newProfileProperties).toEqual({
+          customer_email: "newemail@example.com",
+          uid: null,
+        });
+        expect(exportArgs.oldGroups).toEqual([]);
+        expect(exportArgs.newGroups).toEqual(
+          [groupA, groupB].map((g) => `${g.name}+`).sort()
+        );
+        expect(exportArgs.toDelete).toEqual(false);
+
+        const _exports = await Export.findAll({
+          where: { destinationId: destination.id },
+          order: [["createdAt", "asc"]],
+        });
+        expect(_exports.length).toBe(2);
+        expect(_exports[1].destinationId).toBe(destination.id);
+        expect(_exports[1].profileId).toBe(profile.id);
+        expect(
+          _exports[0].completedAt.getTime() - _exports[0].startedAt.getTime()
+        ).toBeGreaterThanOrEqual(0);
+        expect(_exports[1].errorMessage).toBeFalsy();
+        expect(_exports[1].oldProfileProperties).toEqual({
+          customer_email: "oldmail@example.com",
+        });
+        expect(_exports[1].newProfileProperties).toEqual({
+          customer_email: "newemail@example.com",
+          uid: null,
+        });
+        expect(_exports[1].oldGroups).toEqual([]);
+        expect(_exports[1].newGroups).toEqual(
+          [groupA, groupB].map((g) => `${g.name}+`).sort()
+        );
+
+        await profile.destroy();
       });
 
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
+      test("profile properties previously mapped but now removed will be included as oldProfileProperties in the export", async () => {
+        await destination.setMapping({
+          uid: "userId",
+          customer_email: "email",
+        });
 
-      await destination.exportProfile(profile);
+        const groupA = await helper.factories.group();
 
-      await specHelper.runTask("export:enqueue", {});
-      const foundTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundTasks.length).toBe(1);
-      for (const i in foundTasks) {
-        await specHelper.runTask("export:send", foundTasks[i].args[0]);
-      }
+        await destination.trackGroup(groupA);
 
-      expect(exportArgs.oldGroups).toEqual([]);
-      expect(exportArgs.newGroups).toEqual([group.name]);
+        const profile = await helper.factories.profile();
+        await profile.addOrUpdateProperties({
+          email: ["newemail@example.com"],
+        });
+        await groupA.addProfile(profile);
 
-      await profile.destroy();
-    });
+        // create a previous export
+        const _export = await Export.create({
+          profileId: profile.id,
+          destinationId: destination.id,
+          newProfileProperties: {
+            gender: { type: "string", rawValue: "Male" },
+            customer_email: { type: "email", rawValue: "oldmail@example.com" },
+          },
+          oldProfileProperties: {},
+          oldGroups: [],
+          newGroups: [],
+          state: "complete",
+        });
 
-    test("newly un-tagged groups will be removed from the next export", async () => {
-      await destination.setMapping({
-        uid: "userId",
-        customer_email: "email",
+        await destination.exportProfile(profile);
+
+        await specHelper.runTask("export:enqueue", {});
+        const foundTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundTasks.length).toBe(1);
+        for (const i in foundTasks) {
+          await specHelper.runTask("export:send", foundTasks[i].args[0]);
+        }
+
+        expect(exportArgs.oldProfileProperties).toEqual({
+          customer_email: "oldmail@example.com",
+          gender: "Male",
+        });
+        expect(exportArgs.newProfileProperties).toEqual({
+          customer_email: "newemail@example.com",
+          uid: null,
+        });
+
+        await profile.destroy();
       });
 
-      const group = await helper.factories.group();
-      await destination.trackGroup(group);
+      test("properties in deleted state can be exported", async () => {
+        await destination.setMapping({
+          uid: "userId",
+          customer_email: "email",
+        });
 
-      const profile = await helper.factories.profile();
-      await group.addProfile(profile);
+        const emailProp = await Property.findOne({ where: { key: "email" } });
+        await emailProp.update({ state: "deleted" });
 
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
+        const groupA = await helper.factories.group();
+        await destination.trackGroup(groupA);
 
-      // create a previous export
-      const _export = await Export.create({
-        profileId: profile.id,
-        destinationId: destination.id,
-        newProfileProperties: {},
-        oldProfileProperties: {},
-        oldGroups: [group.name],
-        newGroups: [group.name],
-        state: "complete",
+        const profile = await helper.factories.profile();
+        await profile.addOrUpdateProperties({
+          email: ["newemail@example.com"],
+        });
+        await groupA.addProfile(profile);
+
+        await destination.exportProfile(profile);
+
+        await specHelper.runTask("export:enqueue", {});
+        const foundTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundTasks.length).toBe(1);
+        for (const i in foundTasks) {
+          await specHelper.runTask("export:send", foundTasks[i].args[0]);
+        }
+
+        expect(exportArgs.newProfileProperties).toEqual({
+          customer_email: "newemail@example.com",
+          uid: null,
+        });
+
+        await profile.destroy();
+        await emailProp.update({ state: "ready" });
       });
 
-      const _import = await helper.factories.import();
+      test("newly tagged groups will appear new in next export", async () => {
+        await destination.setMapping({
+          uid: "userId",
+          customer_email: "email",
+        });
 
-      await destination.setDestinationGroupMemberships({});
+        const group = await helper.factories.group();
+        await destination.trackGroup(group);
 
-      await destination.exportProfile(profile);
+        const profile = await helper.factories.profile();
+        await group.addProfile(profile);
 
-      await specHelper.runTask("export:enqueue", {});
-      const foundTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundTasks.length).toBe(1);
-      for (const i in foundTasks) {
-        await specHelper.runTask("export:send", foundTasks[i].args[0]);
-      }
+        // create a previous export
+        const _export = await Export.create({
+          profileId: profile.id,
+          destinationId: destination.id,
+          newProfileProperties: {},
+          oldProfileProperties: {},
+          oldGroups: [],
+          newGroups: [],
+          state: "complete",
+        });
 
-      expect(exportArgs.oldGroups).toEqual([group.name]);
-      expect(exportArgs.newGroups).toEqual([]);
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
 
-      await profile.destroy();
-    });
+        await destination.exportProfile(profile);
 
-    test("if a profile is removed from all groups tracked by this destination, toDelete is true", async () => {
-      await destination.setMapping({
-        uid: "userId",
-        customer_email: "email",
+        await specHelper.runTask("export:enqueue", {});
+        const foundTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundTasks.length).toBe(1);
+        for (const i in foundTasks) {
+          await specHelper.runTask("export:send", foundTasks[i].args[0]);
+        }
+
+        expect(exportArgs.oldGroups).toEqual([]);
+        expect(exportArgs.newGroups).toEqual([group.name]);
+
+        await profile.destroy();
       });
 
-      const groupA = await helper.factories.group();
-      const groupB = await helper.factories.group();
+      test("newly un-tagged groups will be removed from the next export", async () => {
+        await destination.setMapping({
+          uid: "userId",
+          customer_email: "email",
+        });
 
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[groupA.id] = groupA.name;
-      destinationGroupMemberships[groupB.id] = groupB.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
+        const group = await helper.factories.group();
+        await destination.trackGroup(group);
 
-      const profile = await helper.factories.profile();
+        const profile = await helper.factories.profile();
+        await group.addProfile(profile);
 
-      const oldExport = await helper.factories.export(profile, destination, {
-        newProfileProperties: {},
-        newGroups: [groupA.name, groupB.name].sort(),
-        startedAt: new Date(),
-        completedAt: new Date(),
-        state: "complete",
-      });
-      await specHelper.deleteEnqueuedTasks("exports:send", {
-        id: oldExport.id,
-      });
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
 
-      await destination.exportProfile(profile);
+        // create a previous export
+        const _export = await Export.create({
+          profileId: profile.id,
+          destinationId: destination.id,
+          newProfileProperties: {},
+          oldProfileProperties: {},
+          oldGroups: [group.name],
+          newGroups: [group.name],
+          state: "complete",
+        });
 
-      await specHelper.runTask("export:enqueue", {});
-      const foundTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundTasks.length).toBe(1);
-      await specHelper.runTask("export:send", foundTasks[0].args[0]);
+        const _import = await helper.factories.import();
 
-      expect(exportArgs.profile.id).toEqual(profile.id);
-      expect(exportArgs.oldGroups).toEqual(
-        [groupA, groupB].map((g) => g.name).sort()
-      );
-      expect(exportArgs.newGroups).toEqual([]);
-      expect(exportArgs.toDelete).toEqual(true);
+        await destination.setDestinationGroupMemberships({});
 
-      await profile.destroy();
-    });
+        await destination.exportProfile(profile);
 
-    test('if profile is removed from destination\'s tracked group in "sync" syncMode, toDelete is true', async () => {
-      expect(destination.syncMode).toBe("sync");
+        await specHelper.runTask("export:enqueue", {});
+        const foundTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundTasks.length).toBe(1);
+        for (const i in foundTasks) {
+          await specHelper.runTask("export:send", foundTasks[i].args[0]);
+        }
 
-      await destination.setMapping({
-        uid: "userId",
-        customer_email: "email",
-      });
+        expect(exportArgs.oldGroups).toEqual([group.name]);
+        expect(exportArgs.newGroups).toEqual([]);
 
-      const groupA = await helper.factories.group();
-      const groupB = await helper.factories.group();
-      const groupC = await helper.factories.group();
-
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[groupA.id] = groupA.name;
-      destinationGroupMemberships[groupB.id] = groupB.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      await groupA.addProfile(profile);
-      await groupB.addProfile(profile);
-
-      const oldExport = await helper.factories.export(profile, destination, {
-        newProfileProperties: {},
-        newGroups: [groupA.name, groupB.name].sort(),
-        startedAt: new Date(),
-        completedAt: new Date(),
-        state: "complete",
-      });
-      await specHelper.deleteEnqueuedTasks("exports:send", {
-        id: oldExport.id,
+        await profile.destroy();
       });
 
-      await destination.trackGroup(groupC);
-      await destination.exportProfile(profile);
+      test("if a profile is removed from all groups tracked by this destination, toDelete is true", async () => {
+        await destination.setMapping({
+          uid: "userId",
+          customer_email: "email",
+        });
 
-      await specHelper.runTask("export:enqueue", {});
-      const foundTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundTasks.length).toBe(1);
-      await specHelper.runTask("export:send", foundTasks[0].args[0]);
+        const groupA = await helper.factories.group();
+        const groupB = await helper.factories.group();
 
-      expect(exportArgs.profile.id).toEqual(profile.id);
-      expect(exportArgs.oldGroups).toEqual(
-        [groupA, groupB].map((g) => g.name).sort()
-      );
-      expect(exportArgs.newGroups).toEqual(
-        [groupA, groupB].map((g) => g.name).sort()
-      );
-      expect(exportArgs.toDelete).toEqual(true);
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[groupA.id] = groupA.name;
+        destinationGroupMemberships[groupB.id] = groupB.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
 
-      await profile.destroy();
-    });
+        const profile = await helper.factories.profile();
 
-    test.each(["additive", "enrich"])(
-      "if profile is removed from destination's tracked group in %p syncMode, toDelete is false and groups are cleared",
-      async (syncMode) => {
-        await destination.update({ syncMode });
+        const oldExport = await helper.factories.export(profile, destination, {
+          newProfileProperties: {},
+          newGroups: [groupA.name, groupB.name].sort(),
+          startedAt: new Date(),
+          completedAt: new Date(),
+          state: "complete",
+        });
+        await specHelper.deleteEnqueuedTasks("exports:send", {
+          id: oldExport.id,
+        });
+
+        await destination.exportProfile(profile);
+
+        await specHelper.runTask("export:enqueue", {});
+        const foundTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundTasks.length).toBe(1);
+        await specHelper.runTask("export:send", foundTasks[0].args[0]);
+
+        expect(exportArgs.profile.id).toEqual(profile.id);
+        expect(exportArgs.oldGroups).toEqual(
+          [groupA, groupB].map((g) => g.name).sort()
+        );
+        expect(exportArgs.newGroups).toEqual([]);
+        expect(exportArgs.toDelete).toEqual(true);
+
+        await profile.destroy();
+      });
+
+      test('if profile is removed from destination\'s tracked group in "sync" syncMode, toDelete is true', async () => {
+        expect(destination.syncMode).toBe("sync");
+
         await destination.setMapping({
           uid: "userId",
           customer_email: "email",
@@ -538,136 +528,154 @@ describe("models/destination", () => {
         expect(exportArgs.oldGroups).toEqual(
           [groupA, groupB].map((g) => g.name).sort()
         );
-        expect(exportArgs.toDelete).toEqual(false); // toDelete false
-        expect(exportArgs.newGroups).toEqual([]); // Groups cleared
+        expect(exportArgs.newGroups).toEqual(
+          [groupA, groupB].map((g) => g.name).sort()
+        );
+        expect(exportArgs.toDelete).toEqual(true);
 
         await profile.destroy();
-
-        await destination.update({ syncMode: "sync" });
-      }
-    );
-
-    test("if an export has the same data as the previous export, and force=false, it will not be sent to the destination", async () => {
-      const profile = await helper.factories.profile();
-      const group = await helper.factories.group();
-      await group.addProfile(profile);
-      await destination.trackGroup(group);
-
-      const oldExport = await Export.create({
-        destinationId: destination.id,
-        profileId: profile.id,
-        startedAt: new Date(),
-        completedAt: new Date(),
-        oldProfileProperties: {},
-        newProfileProperties: {},
-        oldGroups: [],
-        newGroups: [],
-        state: "complete",
       });
 
-      await destination.exportProfile(profile);
-      const newExport = await Export.findOne({
-        where: {
-          destinationId: destination.id,
-          id: { [Op.ne]: oldExport.id },
-        },
-      });
+      test.each(["additive", "enrich"])(
+        "if profile is removed from destination's tracked group in %p syncMode, toDelete is false and groups are cleared",
+        async (syncMode) => {
+          await destination.update({ syncMode });
+          await destination.setMapping({
+            uid: "userId",
+            customer_email: "email",
+          });
 
-      expect(newExport.toDelete).toBe(false);
-      expect(newExport.hasChanges).toBe(false);
-      expect(newExport.force).toBe(false);
+          const groupA = await helper.factories.group();
+          const groupB = await helper.factories.group();
+          const groupC = await helper.factories.group();
 
-      await destination.sendExport(newExport, true);
-      expect(exportArgs.profile).toBeNull(); // plugin#exportProfile not called
+          const destinationGroupMemberships = {};
+          destinationGroupMemberships[groupA.id] = groupA.name;
+          destinationGroupMemberships[groupB.id] = groupB.name;
+          await destination.setDestinationGroupMemberships(
+            destinationGroupMemberships
+          );
 
-      await newExport.reload();
-      expect(newExport.completedAt).toBeTruthy();
+          const profile = await helper.factories.profile();
+          await groupA.addProfile(profile);
+          await groupB.addProfile(profile);
 
-      await profile.destroy();
-    });
+          const oldExport = await helper.factories.export(
+            profile,
+            destination,
+            {
+              newProfileProperties: {},
+              newGroups: [groupA.name, groupB.name].sort(),
+              startedAt: new Date(),
+              completedAt: new Date(),
+              state: "complete",
+            }
+          );
+          await specHelper.deleteEnqueuedTasks("exports:send", {
+            id: oldExport.id,
+          });
 
-    test("if an export has the same data as the previous export, and force=true, it will be sent to the destination", async () => {
-      const profile = await helper.factories.profile();
-      const group = await helper.factories.group();
-      await group.addProfile(profile);
-      await destination.trackGroup(group);
+          await destination.trackGroup(groupC);
+          await destination.exportProfile(profile);
 
-      const oldExport = await Export.create({
-        destinationId: destination.id,
-        profileId: profile.id,
-        startedAt: new Date(),
-        completedAt: new Date(),
-        oldProfileProperties: {},
-        newProfileProperties: {},
-        oldGroups: [],
-        newGroups: [],
-        state: "complete",
-      });
+          await specHelper.runTask("export:enqueue", {});
+          const foundTasks = await specHelper.findEnqueuedTasks("export:send");
+          expect(foundTasks.length).toBe(1);
+          await specHelper.runTask("export:send", foundTasks[0].args[0]);
 
-      await destination.exportProfile(profile, false, true);
-      const newExport = await Export.findOne({
-        where: {
-          destinationId: destination.id,
-          id: { [Op.ne]: oldExport.id },
-        },
-      });
+          expect(exportArgs.profile.id).toEqual(profile.id);
+          expect(exportArgs.oldGroups).toEqual(
+            [groupA, groupB].map((g) => g.name).sort()
+          );
+          expect(exportArgs.toDelete).toEqual(false); // toDelete false
+          expect(exportArgs.newGroups).toEqual([]); // Groups cleared
 
-      expect(newExport.toDelete).toBe(false);
-      expect(newExport.hasChanges).toBe(true);
+          await profile.destroy();
 
-      await destination.sendExport(newExport, true);
-      expect(exportArgs.profile).not.toBeNull(); // plugin#exportProfile was called
-
-      await newExport.reload();
-      expect(newExport.completedAt).toBeTruthy();
-      expect(newExport.force).toBe(true);
-
-      await profile.destroy();
-    });
-
-    test("if there is no previous export, it will be sent to the destination and all data will be new", async () => {
-      const profile = await helper.factories.profile();
-      await profile.addOrUpdateProperties({ email: ["newEmail@example.com"] });
-      const group = await helper.factories.group();
-      await group.addProfile(profile);
-      await destination.trackGroup(group);
-
-      await destination.setMapping({
-        customer_email: "email",
-      });
-
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
+          await destination.update({ syncMode: "sync" });
+        }
       );
 
-      await destination.exportProfile(profile);
-      const newExport = await Export.findOne({
-        where: { destinationId: destination.id },
+      test("if an export has the same data as the previous export, and force=false, it will not be sent to the destination", async () => {
+        const profile = await helper.factories.profile();
+        const group = await helper.factories.group();
+        await group.addProfile(profile);
+        await destination.trackGroup(group);
+
+        const oldExport = await Export.create({
+          destinationId: destination.id,
+          profileId: profile.id,
+          startedAt: new Date(),
+          completedAt: new Date(),
+          oldProfileProperties: {},
+          newProfileProperties: {},
+          oldGroups: [],
+          newGroups: [],
+          state: "complete",
+        });
+
+        await destination.exportProfile(profile);
+        const newExport = await Export.findOne({
+          where: {
+            destinationId: destination.id,
+            id: { [Op.ne]: oldExport.id },
+          },
+        });
+
+        expect(newExport.toDelete).toBe(false);
+        expect(newExport.hasChanges).toBe(false);
+        expect(newExport.force).toBe(false);
+
+        await destination.sendExport(newExport, true);
+        expect(exportArgs.profile).toBeNull(); // plugin#exportProfile not called
+
+        await newExport.reload();
+        expect(newExport.completedAt).toBeTruthy();
+
+        await profile.destroy();
       });
 
-      expect(newExport.oldProfileProperties).toEqual({});
-      expect(newExport.newProfileProperties).toEqual({
-        customer_email: "newemail@example.com",
+      test("if an export has the same data as the previous export, and force=true, it will be sent to the destination", async () => {
+        const profile = await helper.factories.profile();
+        const group = await helper.factories.group();
+        await group.addProfile(profile);
+        await destination.trackGroup(group);
+
+        const oldExport = await Export.create({
+          destinationId: destination.id,
+          profileId: profile.id,
+          startedAt: new Date(),
+          completedAt: new Date(),
+          oldProfileProperties: {},
+          newProfileProperties: {},
+          oldGroups: [],
+          newGroups: [],
+          state: "complete",
+        });
+
+        await destination.exportProfile(profile, false, true);
+        const newExport = await Export.findOne({
+          where: {
+            destinationId: destination.id,
+            id: { [Op.ne]: oldExport.id },
+          },
+        });
+
+        expect(newExport.toDelete).toBe(false);
+        expect(newExport.hasChanges).toBe(true);
+
+        await destination.sendExport(newExport, true);
+        expect(exportArgs.profile).not.toBeNull(); // plugin#exportProfile was called
+
+        await newExport.reload();
+        expect(newExport.completedAt).toBeTruthy();
+        expect(newExport.force).toBe(true);
+
+        await profile.destroy();
       });
-      expect(newExport.oldGroups).toEqual([]);
-      expect(newExport.newGroups).toEqual([group.name]);
-      expect(newExport.toDelete).toBe(false);
-      expect(newExport.hasChanges).toBe(true);
 
-      await destination.sendExport(newExport, true);
-      expect(exportArgs.profile).not.toBeNull(); // plugin#exportProfile was called
-
-      await profile.destroy();
-    });
-
-    describe("sync mode operations", () => {
-      let profile = null;
-      let _export = null;
-
-      beforeEach(async () => {
-        profile = await helper.factories.profile();
+      test("if there is no previous export, it will be sent to the destination and all data will be new", async () => {
+        const profile = await helper.factories.profile();
         await profile.addOrUpdateProperties({
           email: ["newEmail@example.com"],
         });
@@ -686,448 +694,93 @@ describe("models/destination", () => {
         );
 
         await destination.exportProfile(profile);
-        _export = await Export.findOne({
+        const newExport = await Export.findOne({
           where: { destinationId: destination.id },
         });
-      });
 
-      afterEach(async () => {
-        await profile.destroy();
-      });
+        expect(newExport.oldProfileProperties).toEqual({});
+        expect(newExport.newProfileProperties).toEqual({
+          customer_email: "newemail@example.com",
+        });
+        expect(newExport.oldGroups).toEqual([]);
+        expect(newExport.newGroups).toEqual([group.name]);
+        expect(newExport.toDelete).toBe(false);
+        expect(newExport.hasChanges).toBe(true);
 
-      test("Sync syncMode allows creating, updating and deleting profiles", async () => {
-        await destination.update({ syncMode: "sync" });
-
-        await destination.sendExport(_export, true);
-        expect(exportArgs.syncOperations.create).toBe(true);
-        expect(exportArgs.syncOperations.update).toBe(true);
-        expect(exportArgs.syncOperations.delete).toBe(true);
-      });
-
-      test("Enrich syncMode only allows updating profiles", async () => {
-        await destination.update({ syncMode: "enrich" });
-
-        await destination.sendExport(_export, true);
-        expect(exportArgs.syncOperations.create).toBe(false);
-        expect(exportArgs.syncOperations.update).toBe(true);
-        expect(exportArgs.syncOperations.delete).toBe(false);
+        await destination.sendExport(newExport, true);
+        expect(exportArgs.profile).not.toBeNull(); // plugin#exportProfile was called
 
         await profile.destroy();
       });
 
-      test("Additive syncMode only allows creating and updating profiles", async () => {
-        await destination.update({ syncMode: "additive" });
-
-        await destination.sendExport(_export, true);
-        expect(exportArgs.syncOperations.create).toBe(true);
-        expect(exportArgs.syncOperations.update).toBe(true);
-        expect(exportArgs.syncOperations.delete).toBe(false);
-
-        await profile.destroy();
-      });
-    });
-
-    test("exportProfile can return that it is rate limited and the export will have a sendAt in the future", async () => {
-      // when the parallelism is not OK
-      parallelismResponse = 0;
-
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      await destination.exportProfile(profile);
-      const _export = await Export.findOne({
-        where: { destinationId: destination.id },
-      });
-
-      await specHelper.runTask("export:enqueue", {});
-
-      let foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundSendTasks.length).toBe(1);
-
-      await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
-
-      await _export.reload();
-      expect(_export.state).toBe("pending");
-      expect(_export.completedAt).toBeFalsy();
-      expect(_export.errorMessage).toBeFalsy();
-      expect(_export.sendAt.getTime()).toBeGreaterThan(new Date().getTime());
-      expect(_export.retryCount).toBe(1);
-
-      await _export.update({ sendAt: new Date() });
-
-      // when the parallelism is back to OK...
-      parallelismResponse = Infinity;
-      await api.resque.queue.connection.redis.flushdb();
-
-      await specHelper.runTask("export:enqueue", {});
-      foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundSendTasks.length).toBe(1);
-      await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
-
-      await _export.reload();
-      expect(_export.completedAt).toBeTruthy();
-      expect(_export.state).toBe("complete");
-
-      await profile.destroy();
-    });
-
-    test("sending an export with sync and producing a parallelism error will throw", async () => {
-      parallelismResponse = 0;
-
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      await expect(destination.exportProfile(profile, true)).rejects.toThrow(
-        /parallelism limit reached for test-template-app/
-      );
-
-      await Export.truncate();
-      parallelismResponse = Infinity;
-    });
-
-    test("the app can be rate-limited with an error and the export will have a sendAt in the future", async () => {
-      exportProfileResponse = {
-        success: false,
-        error: new Error("oh no!"),
-        retryDelay: 1000,
-      };
-
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      await destination.exportProfile(profile);
-      const _export = await Export.findOne({
-        where: { destinationId: destination.id },
-      });
-
-      await specHelper.runTask("export:enqueue", {});
-
-      let foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundSendTasks.length).toBe(1);
-
-      await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
-
-      await _export.reload();
-      expect(_export.startedAt).toBeFalsy();
-      expect(_export.sendAt.getTime()).toBeGreaterThan(new Date().getTime());
-      expect(_export.errorMessage).toMatch(/oh no!/);
-      expect(_export.errorLevel).toBe("error");
-      expect(_export.completedAt).toBeFalsy();
-      expect(_export.state).toBe("pending");
-      expect(_export.retryCount).toBe(1);
-
-      // when the response is back to success
-      exportProfileResponse = {
-        success: true,
-        error: undefined,
-        retryDelay: undefined,
-      };
-
-      await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
-      await _export.reload();
-      expect(_export.completedAt).toBeTruthy();
-      expect(_export.state).toBe("complete");
-    });
-
-    test("export:send task will be be retried on profile id error", async () => {
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      const error = new Error("oh no!");
-      error["profileId"] = profile.id;
-      exportProfileResponse = {
-        success: false,
-        error,
-        retryDelay: 1000,
-      };
-
-      await destination.exportProfile(profile);
-      const _export = await Export.findOne({
-        where: { destinationId: destination.id },
-      });
-
-      await specHelper.runTask("export:enqueue", {});
-
-      let foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundSendTasks.length).toBe(1);
-
-      // the task should be re-enqueued with no error
-      await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
-      foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
-
-      await _export.reload();
-      expect(_export.completedAt).toBeFalsy();
-      expect(_export.errorMessage).toMatch(/oh no!/);
-      expect(_export.errorLevel).toBe("error");
-      expect(_export.completedAt).toBeFalsy();
-      expect(_export.state).toBe("pending");
-      expect(_export.sendAt.getTime()).toBeGreaterThan(new Date().getTime());
-      expect(_export.retryCount).toBe(1);
-
-      // when the response is back to success
-      exportProfileResponse = {
-        success: true,
-        error: undefined,
-        retryDelay: undefined,
-      };
-
-      await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
-      await _export.reload();
-      expect(_export.completedAt).toBeTruthy();
-      expect(_export.state).toBe("complete");
-    });
-
-    test("export:send task will complete the export with an info error", async () => {
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      const error = new Error("oh no!");
-      error["profileId"] = profile.id;
-      error["errorLevel"] = "info";
-      exportProfileResponse = {
-        success: false,
-        error,
-        retryDelay: 1000,
-      };
-
-      await destination.exportProfile(profile);
-      const _export = await Export.findOne({
-        where: { destinationId: destination.id },
-      });
-
-      await specHelper.runTask("export:enqueue", {});
-
-      let foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundSendTasks.length).toBe(1);
-
-      await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
-
-      await _export.reload();
-      expect(_export.completedAt).toBeFalsy();
-      expect(_export.errorMessage).toMatch(/oh no!/);
-      expect(_export.errorLevel).toBe("info");
-      expect(_export.completedAt).toBeFalsy();
-      expect(_export.state).toBe("failed");
-    });
-
-    test("sending an export with sync and producing a retry error will throw", async () => {
-      exportProfileResponse = {
-        success: false,
-        error: new Error("oh no!"),
-        retryDelay: 1000,
-      };
-
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      await expect(destination.exportProfile(profile, true)).rejects.toThrow(
-        /: oh no!/
-      );
-
-      await Export.truncate();
-      exportProfileResponse = {
-        success: true,
-        error: undefined,
-        retryDelay: undefined,
-      };
-    });
-
-    test("sending an export with sync and throwing an error will throw", async () => {
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-
-      exportProfileThrow = new Error("oh no!");
-      await expect(destination.exportProfile(profile, true)).rejects.toThrow(
-        /: oh no!/
-      );
-      exportProfileThrow = null;
-
-      const newExport = await Export.findOne({
-        where: { profileId: profile.id, destinationId: destination.id },
-      });
-      expect(newExport.errorMessage).toMatch(/oh no!/);
-      expect(newExport.errorLevel).toBe("error");
-      expect(newExport.completedAt).toBeFalsy();
-
-      await Export.truncate();
-    });
-
-    test("sending an export and throwing an error with profile id will record it", async () => {
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-
-      exportProfileThrow = new Error("oh no!");
-      exportProfileThrow["profileId"] = profile.id;
-
-      await expect(destination.exportProfile(profile, true)).rejects.toThrow(
-        /: oh no!/
-      );
-      exportProfileThrow = null;
-
-      const newExport = await Export.findOne({
-        where: { profileId: profile.id, destinationId: destination.id },
-      });
-      expect(newExport.errorMessage).toMatch(/oh no!/);
-      expect(newExport.errorLevel).toBe("error");
-      expect(newExport.completedAt).toBeFalsy();
-
-      await Export.truncate();
-      exportProfileThrow = null;
-    });
-
-    test("sending an export and throwing an error with info level will record it and have success", async () => {
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-
-      exportProfileThrow = new Error("oh no!");
-      exportProfileThrow["profileId"] = profile.id;
-      exportProfileThrow["errorLevel"] = "info";
-
-      await destination.exportProfile(profile, true);
-      exportProfileThrow = null;
-
-      const newExport = await Export.findOne({
-        where: { profileId: profile.id, destinationId: destination.id },
-      });
-      expect(newExport.errorMessage).toMatch(/oh no!/);
-      expect(newExport.errorLevel).toBe("info");
-      expect(newExport.completedAt).toBeFalsy();
-
-      await Export.truncate();
-      exportProfileThrow = null;
-    });
-
-    describe("deletion validations with pending exports", () => {
-      let group: Group;
-      let profile: Profile;
-
-      beforeAll(async () => {
-        group = await helper.factories.group();
-
-        const destinationGroupMemberships = {};
-        destinationGroupMemberships[group.id] = group.name;
-        await destination.setDestinationGroupMemberships(
-          destinationGroupMemberships
-        );
-
-        profile = await helper.factories.profile();
-        await group.addProfile(profile);
-      });
-
-      afterAll(async () => {
-        await destination.destroy();
-        await group.destroy();
-        await profile.destroy();
-      });
-
-      test("a destination cannot be destroyed until all exports are complete", async () => {
-        const _export = await Export.create({
-          destinationId: destination.id,
-          profileId: profile.id,
-          startedAt: new Date(),
-          completedAt: null,
-          oldProfileProperties: {},
-          newProfileProperties: {},
-          oldGroups: [],
-          newGroups: [],
-          state: "pending",
+      describe("sync mode operations", () => {
+        let profile = null;
+        let _export = null;
+
+        beforeEach(async () => {
+          profile = await helper.factories.profile();
+          await profile.addOrUpdateProperties({
+            email: ["newEmail@example.com"],
+          });
+          const group = await helper.factories.group();
+          await group.addProfile(profile);
+          await destination.trackGroup(group);
+
+          await destination.setMapping({
+            customer_email: "email",
+          });
+
+          const destinationGroupMemberships = {};
+          destinationGroupMemberships[group.id] = group.name;
+          await destination.setDestinationGroupMemberships(
+            destinationGroupMemberships
+          );
+
+          await destination.exportProfile(profile);
+          _export = await Export.findOne({
+            where: { destinationId: destination.id },
+          });
         });
 
-        await expect(destination.destroy()).rejects.toThrow(
-          /cannot delete destination until all pending exports have been processed/
-        );
-
-        await _export.update({ state: "complete" });
-        await destination.destroy(); // does not throw
-      });
-
-      test("a destination cannot be destroyed until all exports are processed", async () => {
-        const _export = await Export.create({
-          destinationId: destination.id,
-          profileId: profile.id,
-          startedAt: new Date(),
-          completedAt: null,
-          oldProfileProperties: {},
-          newProfileProperties: {},
-          oldGroups: [],
-          newGroups: [],
-          state: "processing",
+        afterEach(async () => {
+          await profile.destroy();
         });
 
-        await expect(destination.destroy()).rejects.toThrow(
-          /cannot delete destination until all pending exports have been processed/
-        );
+        test("Sync syncMode allows creating, updating and deleting profiles", async () => {
+          await destination.update({ syncMode: "sync" });
 
-        await _export.update({ state: "complete" });
-        await destination.destroy(); // does not throw
+          await destination.sendExport(_export, true);
+          expect(exportArgs.syncOperations.create).toBe(true);
+          expect(exportArgs.syncOperations.update).toBe(true);
+          expect(exportArgs.syncOperations.delete).toBe(true);
+        });
+
+        test("Enrich syncMode only allows updating profiles", async () => {
+          await destination.update({ syncMode: "enrich" });
+
+          await destination.sendExport(_export, true);
+          expect(exportArgs.syncOperations.create).toBe(false);
+          expect(exportArgs.syncOperations.update).toBe(true);
+          expect(exportArgs.syncOperations.delete).toBe(false);
+
+          await profile.destroy();
+        });
+
+        test("Additive syncMode only allows creating and updating profiles", async () => {
+          await destination.update({ syncMode: "additive" });
+
+          await destination.sendExport(_export, true);
+          expect(exportArgs.syncOperations.create).toBe(true);
+          expect(exportArgs.syncOperations.update).toBe(true);
+          expect(exportArgs.syncOperations.delete).toBe(false);
+
+          await profile.destroy();
+        });
       });
-    });
 
-    describe("array exports", () => {
-      afterAll(() => {
-        exportArrayProperties = [];
-      });
-
-      test("mappings cannot use array profile properties if they are not allowed by exportArrayProperties", async () => {
-        await expect(
-          destination.setMapping({ purchases: "purchases" })
-        ).rejects.toThrow(
-          /purchases is an array profile property that .* cannot support/
-        );
-      });
-
-      test("exportArrayProperties can ask for an array profile property", async () => {
-        exportArrayProperties = ["purchases"];
-
-        await destination.setMapping({ purchases: "purchases" });
+      test("exportProfile can return that it is rate limited and the export will have a sendAt in the future", async () => {
+        // when the parallelism is not OK
+        parallelismResponse = 0;
 
         const group = await helper.factories.group();
         const destinationGroupMemberships = {};
@@ -1137,43 +790,45 @@ describe("models/destination", () => {
         );
 
         const profile = await helper.factories.profile();
-        await profile.addOrUpdateProperties({
-          purchases: ["hat", "mushroom", "star"],
-        });
-
-        const oldExport = await helper.factories.export(profile, destination, {
-          newProfileProperties: {
-            purchases: { type: "string", rawValue: ["hat", "mushroom"] },
-          },
-          newGroups: [group.name],
-          startedAt: new Date(),
-          completedAt: new Date(),
-          state: "complete",
-        });
-        await specHelper.deleteEnqueuedTasks("exports:send", {
-          id: oldExport.id,
-        });
-
         await destination.exportProfile(profile);
-
-        const _exports = await profile.$get("exports", {
-          order: [["createdAt", "asc"]],
-        });
-        expect(_exports.length).toBe(2);
-        expect(_exports[1].oldProfileProperties).toEqual({
-          purchases: ["hat", "mushroom"],
-        });
-        expect(_exports[1].newProfileProperties).toEqual({
-          purchases: ["hat", "mushroom", "star"],
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
         });
 
-        await Export.truncate();
+        await specHelper.runTask("export:enqueue", {});
+
+        let foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundSendTasks.length).toBe(1);
+
+        await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
+
+        await _export.reload();
+        expect(_export.state).toBe("pending");
+        expect(_export.completedAt).toBeFalsy();
+        expect(_export.errorMessage).toBeFalsy();
+        expect(_export.sendAt.getTime()).toBeGreaterThan(new Date().getTime());
+        expect(_export.retryCount).toBe(1);
+
+        await _export.update({ sendAt: new Date() });
+
+        // when the parallelism is back to OK...
+        parallelismResponse = Infinity;
+        await api.resque.queue.connection.redis.flushdb();
+
+        await specHelper.runTask("export:enqueue", {});
+        foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundSendTasks.length).toBe(1);
+        await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
+
+        await _export.reload();
+        expect(_export.completedAt).toBeTruthy();
+        expect(_export.state).toBe("complete");
+
+        await profile.destroy();
       });
 
-      test("exportArrayProperties can ask for all properties with *", async () => {
-        exportArrayProperties = ["*"];
-
-        await destination.setMapping({ purchases: "purchases" });
+      test("sending an export with sync and producing a parallelism error will throw", async () => {
+        parallelismResponse = 0;
 
         const group = await helper.factories.group();
         const destinationGroupMemberships = {};
@@ -1183,37 +838,442 @@ describe("models/destination", () => {
         );
 
         const profile = await helper.factories.profile();
-        await profile.addOrUpdateProperties({
-          purchases: ["hat", "mushroom", "star"],
-        });
-
-        const oldExport = await helper.factories.export(profile, destination, {
-          newProfileProperties: {
-            purchases: { type: "string", rawValue: ["hat", "mushroom"] },
-          },
-          newGroups: [group.name],
-          startedAt: new Date(),
-          completedAt: new Date(),
-          state: "complete",
-        });
-        await specHelper.deleteEnqueuedTasks("exports:send", {
-          id: oldExport.id,
-        });
-
-        await destination.exportProfile(profile);
-
-        const _exports = await profile.$get("exports", {
-          order: [["createdAt", "asc"]],
-        });
-        expect(_exports.length).toBe(2);
-        expect(_exports[1].oldProfileProperties).toEqual({
-          purchases: ["hat", "mushroom"],
-        });
-        expect(_exports[1].newProfileProperties).toEqual({
-          purchases: ["hat", "mushroom", "star"],
-        });
+        await expect(destination.exportProfile(profile, true)).rejects.toThrow(
+          /parallelism limit reached for test-template-app/
+        );
 
         await Export.truncate();
+        parallelismResponse = Infinity;
+      });
+
+      test("the app can be rate-limited with an error and the export will have a sendAt in the future", async () => {
+        exportProfileResponse = {
+          success: false,
+          error: new Error("oh no!"),
+          retryDelay: 1000,
+        };
+
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+        await destination.exportProfile(profile);
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
+
+        await specHelper.runTask("export:enqueue", {});
+
+        let foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundSendTasks.length).toBe(1);
+
+        await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
+
+        await _export.reload();
+        expect(_export.startedAt).toBeFalsy();
+        expect(_export.sendAt.getTime()).toBeGreaterThan(new Date().getTime());
+        expect(_export.errorMessage).toMatch(/oh no!/);
+        expect(_export.errorLevel).toBe("error");
+        expect(_export.completedAt).toBeFalsy();
+        expect(_export.state).toBe("pending");
+        expect(_export.retryCount).toBe(1);
+
+        // when the response is back to success
+        exportProfileResponse = {
+          success: true,
+          error: undefined,
+          retryDelay: undefined,
+        };
+
+        await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
+        await _export.reload();
+        expect(_export.completedAt).toBeTruthy();
+        expect(_export.state).toBe("complete");
+      });
+
+      test("export:send task will be be retried on profile id error", async () => {
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+        const error = new Error("oh no!");
+        error["profileId"] = profile.id;
+        exportProfileResponse = {
+          success: false,
+          error,
+          retryDelay: 1000,
+        };
+
+        await destination.exportProfile(profile);
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
+
+        await specHelper.runTask("export:enqueue", {});
+
+        let foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundSendTasks.length).toBe(1);
+
+        // the task should be re-enqueued with no error
+        await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
+        foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
+
+        await _export.reload();
+        expect(_export.completedAt).toBeFalsy();
+        expect(_export.errorMessage).toMatch(/oh no!/);
+        expect(_export.errorLevel).toBe("error");
+        expect(_export.completedAt).toBeFalsy();
+        expect(_export.state).toBe("pending");
+        expect(_export.sendAt.getTime()).toBeGreaterThan(new Date().getTime());
+        expect(_export.retryCount).toBe(1);
+
+        // when the response is back to success
+        exportProfileResponse = {
+          success: true,
+          error: undefined,
+          retryDelay: undefined,
+        };
+
+        await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
+        await _export.reload();
+        expect(_export.completedAt).toBeTruthy();
+        expect(_export.state).toBe("complete");
+      });
+
+      test("export:send task will complete the export with an info error", async () => {
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+        const error = new Error("oh no!");
+        error["profileId"] = profile.id;
+        error["errorLevel"] = "info";
+        exportProfileResponse = {
+          success: false,
+          error,
+          retryDelay: 1000,
+        };
+
+        await destination.exportProfile(profile);
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
+
+        await specHelper.runTask("export:enqueue", {});
+
+        let foundSendTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundSendTasks.length).toBe(1);
+
+        await specHelper.runTask("export:send", foundSendTasks[0].args[0]);
+
+        await _export.reload();
+        expect(_export.completedAt).toBeFalsy();
+        expect(_export.errorMessage).toMatch(/oh no!/);
+        expect(_export.errorLevel).toBe("info");
+        expect(_export.completedAt).toBeFalsy();
+        expect(_export.state).toBe("failed");
+      });
+
+      test("sending an export with sync and producing a retry error will throw", async () => {
+        exportProfileResponse = {
+          success: false,
+          error: new Error("oh no!"),
+          retryDelay: 1000,
+        };
+
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+        await expect(destination.exportProfile(profile, true)).rejects.toThrow(
+          /: oh no!/
+        );
+
+        await Export.truncate();
+        exportProfileResponse = {
+          success: true,
+          error: undefined,
+          retryDelay: undefined,
+        };
+      });
+
+      test("sending an export with sync and throwing an error will throw", async () => {
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+
+        exportProfileThrow = new Error("oh no!");
+        await expect(destination.exportProfile(profile, true)).rejects.toThrow(
+          /: oh no!/
+        );
+        exportProfileThrow = null;
+
+        const newExport = await Export.findOne({
+          where: { profileId: profile.id, destinationId: destination.id },
+        });
+        expect(newExport.errorMessage).toMatch(/oh no!/);
+        expect(newExport.errorLevel).toBe("error");
+        expect(newExport.completedAt).toBeFalsy();
+
+        await Export.truncate();
+      });
+
+      test("sending an export and throwing an error with profile id will record it", async () => {
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+
+        exportProfileThrow = new Error("oh no!");
+        exportProfileThrow["profileId"] = profile.id;
+
+        await expect(destination.exportProfile(profile, true)).rejects.toThrow(
+          /: oh no!/
+        );
+        exportProfileThrow = null;
+
+        const newExport = await Export.findOne({
+          where: { profileId: profile.id, destinationId: destination.id },
+        });
+        expect(newExport.errorMessage).toMatch(/oh no!/);
+        expect(newExport.errorLevel).toBe("error");
+        expect(newExport.completedAt).toBeFalsy();
+
+        await Export.truncate();
+        exportProfileThrow = null;
+      });
+
+      test("sending an export and throwing an error with info level will record it and have success", async () => {
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+
+        exportProfileThrow = new Error("oh no!");
+        exportProfileThrow["profileId"] = profile.id;
+        exportProfileThrow["errorLevel"] = "info";
+
+        await destination.exportProfile(profile, true);
+        exportProfileThrow = null;
+
+        const newExport = await Export.findOne({
+          where: { profileId: profile.id, destinationId: destination.id },
+        });
+        expect(newExport.errorMessage).toMatch(/oh no!/);
+        expect(newExport.errorLevel).toBe("info");
+        expect(newExport.completedAt).toBeFalsy();
+
+        await Export.truncate();
+        exportProfileThrow = null;
+      });
+
+      describe("deletion validations with pending exports", () => {
+        let group: Group;
+        let profile: Profile;
+
+        beforeAll(async () => {
+          group = await helper.factories.group();
+
+          const destinationGroupMemberships = {};
+          destinationGroupMemberships[group.id] = group.name;
+          await destination.setDestinationGroupMemberships(
+            destinationGroupMemberships
+          );
+
+          profile = await helper.factories.profile();
+          await group.addProfile(profile);
+        });
+
+        afterAll(async () => {
+          await destination.destroy();
+          await group.destroy();
+          await profile.destroy();
+        });
+
+        test("a destination cannot be destroyed until all exports are complete", async () => {
+          const _export = await Export.create({
+            destinationId: destination.id,
+            profileId: profile.id,
+            startedAt: new Date(),
+            completedAt: null,
+            oldProfileProperties: {},
+            newProfileProperties: {},
+            oldGroups: [],
+            newGroups: [],
+            state: "pending",
+          });
+
+          await expect(destination.destroy()).rejects.toThrow(
+            /cannot delete destination until all pending exports have been processed/
+          );
+
+          await _export.update({ state: "complete" });
+          await destination.destroy(); // does not throw
+        });
+
+        test("a destination cannot be destroyed until all exports are processed", async () => {
+          const _export = await Export.create({
+            destinationId: destination.id,
+            profileId: profile.id,
+            startedAt: new Date(),
+            completedAt: null,
+            oldProfileProperties: {},
+            newProfileProperties: {},
+            oldGroups: [],
+            newGroups: [],
+            state: "processing",
+          });
+
+          await expect(destination.destroy()).rejects.toThrow(
+            /cannot delete destination until all pending exports have been processed/
+          );
+
+          await _export.update({ state: "complete" });
+          await destination.destroy(); // does not throw
+        });
+      });
+
+      describe("array exports", () => {
+        afterAll(() => {
+          exportArrayProperties = [];
+        });
+
+        test("mappings cannot use array profile properties if they are not allowed by exportArrayProperties", async () => {
+          await expect(
+            destination.setMapping({ purchases: "purchases" })
+          ).rejects.toThrow(
+            /purchases is an array profile property that .* cannot support/
+          );
+        });
+
+        test("exportArrayProperties can ask for an array profile property", async () => {
+          exportArrayProperties = ["purchases"];
+
+          await destination.setMapping({ purchases: "purchases" });
+
+          const group = await helper.factories.group();
+          const destinationGroupMemberships = {};
+          destinationGroupMemberships[group.id] = group.name;
+          await destination.setDestinationGroupMemberships(
+            destinationGroupMemberships
+          );
+
+          const profile = await helper.factories.profile();
+          await profile.addOrUpdateProperties({
+            purchases: ["hat", "mushroom", "star"],
+          });
+
+          const oldExport = await helper.factories.export(
+            profile,
+            destination,
+            {
+              newProfileProperties: {
+                purchases: { type: "string", rawValue: ["hat", "mushroom"] },
+              },
+              newGroups: [group.name],
+              startedAt: new Date(),
+              completedAt: new Date(),
+              state: "complete",
+            }
+          );
+          await specHelper.deleteEnqueuedTasks("exports:send", {
+            id: oldExport.id,
+          });
+
+          await destination.exportProfile(profile);
+
+          const _exports = await profile.$get("exports", {
+            order: [["createdAt", "asc"]],
+          });
+          expect(_exports.length).toBe(2);
+          expect(_exports[1].oldProfileProperties).toEqual({
+            purchases: ["hat", "mushroom"],
+          });
+          expect(_exports[1].newProfileProperties).toEqual({
+            purchases: ["hat", "mushroom", "star"],
+          });
+
+          await Export.truncate();
+        });
+
+        test("exportArrayProperties can ask for all properties with *", async () => {
+          exportArrayProperties = ["*"];
+
+          await destination.setMapping({ purchases: "purchases" });
+
+          const group = await helper.factories.group();
+          const destinationGroupMemberships = {};
+          destinationGroupMemberships[group.id] = group.name;
+          await destination.setDestinationGroupMemberships(
+            destinationGroupMemberships
+          );
+
+          const profile = await helper.factories.profile();
+          await profile.addOrUpdateProperties({
+            purchases: ["hat", "mushroom", "star"],
+          });
+
+          const oldExport = await helper.factories.export(
+            profile,
+            destination,
+            {
+              newProfileProperties: {
+                purchases: { type: "string", rawValue: ["hat", "mushroom"] },
+              },
+              newGroups: [group.name],
+              startedAt: new Date(),
+              completedAt: new Date(),
+              state: "complete",
+            }
+          );
+          await specHelper.deleteEnqueuedTasks("exports:send", {
+            id: oldExport.id,
+          });
+
+          await destination.exportProfile(profile);
+
+          const _exports = await profile.$get("exports", {
+            order: [["createdAt", "asc"]],
+          });
+          expect(_exports.length).toBe(2);
+          expect(_exports[1].oldProfileProperties).toEqual({
+            purchases: ["hat", "mushroom"],
+          });
+          expect(_exports[1].newProfileProperties).toEqual({
+            purchases: ["hat", "mushroom", "star"],
+          });
+
+          await Export.truncate();
+        });
       });
     });
   });

--- a/core/__tests__/models/destination/plugins/exportProfiles.ts
+++ b/core/__tests__/models/destination/plugins/exportProfiles.ts
@@ -5,407 +5,351 @@ import { api, specHelper } from "actionhero";
 import { Op } from "sequelize";
 
 describe("models/destination", () => {
-  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
-  beforeAll(async () => await helper.factories.properties());
+  describe.each(["ready", "deleted"])("with app in %p state", (appState) => {
+    helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+    beforeAll(async () => await helper.factories.properties());
 
-  describe("with custom exportProfiles plugin", () => {
-    let app: App;
-    let destination: Destination;
-    let exportArgs = {
-      app: null,
-      appOptions: null,
-      destination: null,
-      destinationOptions: null,
-      exports: null,
-    };
-    let exportArrayProperties = [];
-    let parallelismResponse = Infinity;
-    let exportProfilesResponse = {
-      success: true,
-      errors: undefined,
-      retryDelay: undefined,
-    };
-    let exportProfilesThrow = null;
-
-    beforeEach(() => {
-      exportArgs = {
+    describe("with custom exportProfiles plugin", () => {
+      let app: App;
+      let destination: Destination;
+      let exportArgs = {
         app: null,
         appOptions: null,
         destination: null,
         destinationOptions: null,
-        exports: [],
+        exports: null,
       };
-    });
+      let exportArrayProperties = [];
+      let parallelismResponse = Infinity;
+      let exportProfilesResponse = {
+        success: true,
+        errors: undefined,
+        retryDelay: undefined,
+      };
+      let exportProfilesThrow = null;
 
-    beforeAll(async () => {
-      plugin.registerPlugin({
-        name: "test-plugin",
-        apps: [
-          {
-            name: "test-template-app",
-            options: [{ key: "test_key", required: true }],
-            methods: {
-              test: async () => {
-                return { success: true, errors: [] };
-              },
-              parallelism: async () => {
-                return parallelismResponse;
+      beforeEach(() => {
+        exportArgs = {
+          app: null,
+          appOptions: null,
+          destination: null,
+          destinationOptions: null,
+          exports: [],
+        };
+      });
+
+      beforeAll(async () => {
+        plugin.registerPlugin({
+          name: "test-plugin",
+          apps: [
+            {
+              name: "test-template-app",
+              options: [{ key: "test_key", required: true }],
+              methods: {
+                test: async () => {
+                  return { success: true, errors: [] };
+                },
+                parallelism: async () => {
+                  return parallelismResponse;
+                },
               },
             },
-          },
-        ],
-        connections: [
-          {
-            name: "export-from-test-template-app",
-            description: "a test app connection",
-            app: "test-template-app",
-            direction: "export",
-            syncModes: ["sync", "enrich", "additive"],
-            options: [],
-            methods: {
-              destinationMappingOptions: async () => {
-                return {
-                  labels: {
-                    group: {
-                      singular: "list",
-                      plural: "lists",
+          ],
+          connections: [
+            {
+              name: "export-from-test-template-app",
+              description: "a test app connection",
+              app: "test-template-app",
+              direction: "export",
+              syncModes: ["sync", "enrich", "additive"],
+              options: [],
+              methods: {
+                destinationMappingOptions: async () => {
+                  return {
+                    labels: {
+                      group: {
+                        singular: "list",
+                        plural: "lists",
+                      },
+                      property: {
+                        singular: "var",
+                        plural: "vars",
+                      },
                     },
-                    property: {
-                      singular: "var",
-                      plural: "vars",
+                    properties: {
+                      required: [],
+                      known: [],
+                      allowOptionalFromProperties: true,
                     },
-                  },
-                  properties: {
-                    required: [],
-                    known: [],
-                    allowOptionalFromProperties: true,
-                  },
-                };
-              },
-              exportArrayProperties: async () => exportArrayProperties,
-              exportProfiles: async ({
-                app,
-                appOptions,
-                destination,
-                destinationOptions,
-                exports,
-              }) => {
-                exportArgs = {
+                  };
+                },
+                exportArrayProperties: async () => exportArrayProperties,
+                exportProfiles: async ({
                   app,
                   appOptions,
                   destination,
                   destinationOptions,
                   exports,
-                };
-                if (exportProfilesThrow) {
-                  throw exportProfilesThrow;
-                }
-                return exportProfilesResponse;
+                }) => {
+                  exportArgs = {
+                    app,
+                    appOptions,
+                    destination,
+                    destinationOptions,
+                    exports,
+                  };
+                  if (exportProfilesThrow) {
+                    throw exportProfilesThrow;
+                  }
+                  return exportProfilesResponse;
+                },
               },
             },
+          ],
+        });
+
+        app = await App.create({
+          name: "test with real methods - batch",
+          type: "test-template-app",
+        });
+        await app.setOptions({ test_key: "abc" });
+        await app.update({ state: "ready" });
+      });
+
+      beforeEach(async () => {
+        await app.update({ state: "ready" });
+
+        destination = await Destination.create({
+          name: "test plugin destination",
+          type: "export-from-test-template-app",
+          syncMode: "sync",
+          appId: app.id,
+        });
+        await destination.update({ state: "ready" });
+
+        await api.resque.queue.connection.redis.flushdb();
+
+        await app.update({ state: appState });
+      });
+
+      afterEach(async () => {
+        await destination.unTrackGroup();
+        await destination.destroy();
+      });
+
+      test("the app exportProfiles method can be called by the destination and exports will be created and mappings followed", async () => {
+        await destination.setMapping({
+          uid: "userId",
+          customer_email: "email",
+        });
+
+        const groupA = await helper.factories.group();
+        const groupB = await helper.factories.group();
+
+        await destination.trackGroup(groupA);
+
+        const destinationGroupMemberships = {};
+        // modify the membership name
+        destinationGroupMemberships[groupA.id] = groupA.name + "+";
+        destinationGroupMemberships[groupB.id] = groupB.name + "+";
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+        await profile.addOrUpdateProperties({
+          email: ["newemail@example.com"],
+        });
+        await groupA.addProfile(profile);
+        await groupB.addProfile(profile);
+
+        const oldExport = await helper.factories.export(profile, destination, {
+          newProfileProperties: {
+            customer_email: { type: "email", rawValue: "oldmail@example.com" },
           },
-        ],
+          state: "complete",
+          newGroups: [],
+          startedAt: new Date(),
+          completedAt: new Date(),
+        });
+        await specHelper.deleteEnqueuedTasks("exports:send", {
+          id: oldExport.id,
+        });
+
+        await destination.exportProfile(profile);
+
+        // there should be no export:send tasks
+        let foundTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundTasks.length).toBe(0);
+
+        // there should be no export:sendBatch tasks until the run has completed
+        foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
+        expect(foundTasks.length).toBe(0);
+
+        await specHelper.runTask("export:enqueue", {});
+
+        foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
+        expect(foundTasks.length).toBe(1);
+        await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
+
+        expect(exportArgs.destination.id).toEqual(destination.id);
+        expect(exportArgs.app.id).toEqual(app.id);
+        expect(exportArgs.exports.length).toEqual(1);
+        expect(exportArgs.exports[0].profile.id).toEqual(profile.id);
+        expect(exportArgs.exports[0].oldProfileProperties).toEqual({
+          customer_email: "oldmail@example.com",
+        });
+        expect(exportArgs.exports[0].newProfileProperties).toEqual({
+          customer_email: "newemail@example.com",
+          uid: null,
+        });
+        expect(exportArgs.exports[0].oldGroups).toEqual([]);
+        expect(exportArgs.exports[0].newGroups).toEqual(
+          [groupA, groupB].map((g) => `${g.name}+`).sort()
+        );
+        expect(exportArgs.exports[0].toDelete).toEqual(false);
+
+        const _exports = await Export.findAll({
+          where: { destinationId: destination.id },
+          order: [["createdAt", "asc"]],
+        });
+        expect(_exports.length).toBe(2);
+        expect(_exports[1].destinationId).toBe(destination.id);
+        expect(_exports[1].profileId).toBe(profile.id);
+        expect(
+          _exports[1].completedAt.getTime() - _exports[0].startedAt.getTime()
+        ).toBeGreaterThan(0);
+        expect(_exports[1].errorMessage).toBeFalsy();
+        expect(_exports[1].oldProfileProperties).toEqual({
+          customer_email: "oldmail@example.com",
+        });
+        expect(_exports[1].newProfileProperties).toEqual({
+          customer_email: "newemail@example.com",
+          uid: null,
+        });
+        expect(_exports[1].oldGroups).toEqual([]);
+        expect(_exports[1].newGroups).toEqual(
+          [groupA, groupB].map((g) => `${g.name}+`).sort()
+        );
+
+        await profile.destroy();
       });
 
-      app = await App.create({
-        name: "test with real methods - batch",
-        type: "test-template-app",
-      });
-      await app.setOptions({ test_key: "abc" });
-      await app.update({ state: "ready" });
-    });
+      test("profile properties previously mapped but now removed will be included as oldProfileProperties in the export", async () => {
+        await destination.setMapping({
+          uid: "userId",
+          customer_email: "email",
+        });
 
-    beforeEach(async () => {
-      destination = await Destination.create({
-        name: "test plugin destination",
-        type: "export-from-test-template-app",
-        syncMode: "sync",
-        appId: app.id,
-      });
-      await destination.update({ state: "ready" });
+        const groupA = await helper.factories.group();
 
-      await api.resque.queue.connection.redis.flushdb();
-    });
+        await destination.trackGroup(groupA);
 
-    afterEach(async () => {
-      await destination.unTrackGroup();
-      await destination.destroy();
-    });
+        const profile = await helper.factories.profile();
+        await profile.addOrUpdateProperties({
+          email: ["newemail@example.com"],
+        });
 
-    test("the app exportProfiles method can be called by the destination and exports will be created and mappings followed", async () => {
-      await destination.setMapping({
-        uid: "userId",
-        customer_email: "email",
-      });
+        // create a previous export
+        const _export = await Export.create({
+          profileId: profile.id,
+          destinationId: destination.id,
+          newProfileProperties: {
+            customer_email: { type: "email", rawValue: "oldmail@example.com" },
+            gender: { type: "string", rawValue: "Male" },
+          },
+          oldProfileProperties: {},
+          oldGroups: [],
+          newGroups: [],
+          state: "complete",
+        });
 
-      const groupA = await helper.factories.group();
-      const groupB = await helper.factories.group();
+        await destination.exportProfile(profile);
 
-      await destination.trackGroup(groupA);
+        // there should be no export:send tasks
+        let foundTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundTasks.length).toBe(0);
 
-      const destinationGroupMemberships = {};
-      // modify the membership name
-      destinationGroupMemberships[groupA.id] = groupA.name + "+";
-      destinationGroupMemberships[groupB.id] = groupB.name + "+";
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
+        // there should be no export:sendBatch tasks until the run has completed
+        foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
+        expect(foundTasks.length).toBe(0);
 
-      const profile = await helper.factories.profile();
-      await profile.addOrUpdateProperties({ email: ["newemail@example.com"] });
-      await groupA.addProfile(profile);
-      await groupB.addProfile(profile);
+        await specHelper.runTask("export:enqueue", {});
 
-      const oldExport = await helper.factories.export(profile, destination, {
-        newProfileProperties: {
-          customer_email: { type: "email", rawValue: "oldmail@example.com" },
-        },
-        state: "complete",
-        newGroups: [],
-        startedAt: new Date(),
-        completedAt: new Date(),
-      });
-      await specHelper.deleteEnqueuedTasks("exports:send", {
-        id: oldExport.id,
+        foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
+        expect(foundTasks.length).toBe(1);
+        await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
+
+        expect(exportArgs.exports.length).toBe(1);
+        expect(exportArgs.exports[0].oldProfileProperties).toEqual({
+          customer_email: "oldmail@example.com",
+          gender: "Male",
+        });
+        expect(exportArgs.exports[0].newProfileProperties).toEqual({
+          customer_email: "newemail@example.com",
+          uid: null,
+        });
+
+        await profile.destroy();
       });
 
-      await destination.exportProfile(profile);
+      test('if a profile is removed from all groups tracked by this destination in "sync" syncMode, toDelete is true', async () => {
+        expect(destination.syncMode).toBe("sync");
 
-      // there should be no export:send tasks
-      let foundTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundTasks.length).toBe(0);
+        await destination.setMapping({
+          uid: "userId",
+          customer_email: "email",
+        });
 
-      // there should be no export:sendBatch tasks until the run has completed
-      foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(0);
+        const groupA = await helper.factories.group();
+        const groupB = await helper.factories.group();
 
-      await specHelper.runTask("export:enqueue", {});
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[groupA.id] = groupA.name;
+        destinationGroupMemberships[groupB.id] = groupB.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
 
-      foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(1);
-      await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
+        const profile = await helper.factories.profile();
 
-      expect(exportArgs.destination.id).toEqual(destination.id);
-      expect(exportArgs.app.id).toEqual(app.id);
-      expect(exportArgs.exports.length).toEqual(1);
-      expect(exportArgs.exports[0].profile.id).toEqual(profile.id);
-      expect(exportArgs.exports[0].oldProfileProperties).toEqual({
-        customer_email: "oldmail@example.com",
-      });
-      expect(exportArgs.exports[0].newProfileProperties).toEqual({
-        customer_email: "newemail@example.com",
-        uid: null,
-      });
-      expect(exportArgs.exports[0].oldGroups).toEqual([]);
-      expect(exportArgs.exports[0].newGroups).toEqual(
-        [groupA, groupB].map((g) => `${g.name}+`).sort()
-      );
-      expect(exportArgs.exports[0].toDelete).toEqual(false);
+        const oldExport = await helper.factories.export(profile, destination, {
+          newProfileProperties: {},
+          newGroups: [groupA.name, groupB.name].sort(),
+          startedAt: new Date(),
+          completedAt: new Date(),
+          state: "complete",
+        });
+        await specHelper.deleteEnqueuedTasks("exports:send", {
+          id: oldExport.id,
+        });
 
-      const _exports = await Export.findAll({
-        where: { destinationId: destination.id },
-        order: [["createdAt", "asc"]],
-      });
-      expect(_exports.length).toBe(2);
-      expect(_exports[1].destinationId).toBe(destination.id);
-      expect(_exports[1].profileId).toBe(profile.id);
-      expect(
-        _exports[1].completedAt.getTime() - _exports[0].startedAt.getTime()
-      ).toBeGreaterThan(0);
-      expect(_exports[1].errorMessage).toBeFalsy();
-      expect(_exports[1].oldProfileProperties).toEqual({
-        customer_email: "oldmail@example.com",
-      });
-      expect(_exports[1].newProfileProperties).toEqual({
-        customer_email: "newemail@example.com",
-        uid: null,
-      });
-      expect(_exports[1].oldGroups).toEqual([]);
-      expect(_exports[1].newGroups).toEqual(
-        [groupA, groupB].map((g) => `${g.name}+`).sort()
-      );
+        await destination.exportProfile(profile);
 
-      await profile.destroy();
-    });
+        // there should be no export:send tasks
+        let foundTasks = await specHelper.findEnqueuedTasks("export:send");
+        expect(foundTasks.length).toBe(0);
 
-    test("profile properties previously mapped but now removed will be included as oldProfileProperties in the export", async () => {
-      await destination.setMapping({
-        uid: "userId",
-        customer_email: "email",
+        // there should be no export:sendBatch tasks until the run has completed
+        foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
+        expect(foundTasks.length).toBe(0);
+
+        await specHelper.runTask("export:enqueue", {});
+
+        foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
+        expect(foundTasks.length).toBe(1);
+        await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
+
+        expect(exportArgs.exports.length).toBe(1);
+        expect(exportArgs.exports[0].profile.id).toEqual(profile.id);
+        expect(exportArgs.exports[0].oldGroups).toEqual(
+          [groupA, groupB].map((g) => g.name).sort()
+        );
+        expect(exportArgs.exports[0].newGroups).toEqual([]);
+        expect(exportArgs.exports[0].toDelete).toEqual(true);
       });
 
-      const groupA = await helper.factories.group();
-
-      await destination.trackGroup(groupA);
-
-      const profile = await helper.factories.profile();
-      await profile.addOrUpdateProperties({ email: ["newemail@example.com"] });
-
-      // create a previous export
-      const _export = await Export.create({
-        profileId: profile.id,
-        destinationId: destination.id,
-        newProfileProperties: {
-          customer_email: { type: "email", rawValue: "oldmail@example.com" },
-          gender: { type: "string", rawValue: "Male" },
-        },
-        oldProfileProperties: {},
-        oldGroups: [],
-        newGroups: [],
-        state: "complete",
-      });
-
-      await destination.exportProfile(profile);
-
-      // there should be no export:send tasks
-      let foundTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundTasks.length).toBe(0);
-
-      // there should be no export:sendBatch tasks until the run has completed
-      foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(0);
-
-      await specHelper.runTask("export:enqueue", {});
-
-      foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(1);
-      await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
-
-      expect(exportArgs.exports.length).toBe(1);
-      expect(exportArgs.exports[0].oldProfileProperties).toEqual({
-        customer_email: "oldmail@example.com",
-        gender: "Male",
-      });
-      expect(exportArgs.exports[0].newProfileProperties).toEqual({
-        customer_email: "newemail@example.com",
-        uid: null,
-      });
-
-      await profile.destroy();
-    });
-
-    test('if a profile is removed from all groups tracked by this destination in "sync" syncMode, toDelete is true', async () => {
-      expect(destination.syncMode).toBe("sync");
-
-      await destination.setMapping({
-        uid: "userId",
-        customer_email: "email",
-      });
-
-      const groupA = await helper.factories.group();
-      const groupB = await helper.factories.group();
-
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[groupA.id] = groupA.name;
-      destinationGroupMemberships[groupB.id] = groupB.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-
-      const oldExport = await helper.factories.export(profile, destination, {
-        newProfileProperties: {},
-        newGroups: [groupA.name, groupB.name].sort(),
-        startedAt: new Date(),
-        completedAt: new Date(),
-        state: "complete",
-      });
-      await specHelper.deleteEnqueuedTasks("exports:send", {
-        id: oldExport.id,
-      });
-
-      await destination.exportProfile(profile);
-
-      // there should be no export:send tasks
-      let foundTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundTasks.length).toBe(0);
-
-      // there should be no export:sendBatch tasks until the run has completed
-      foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(0);
-
-      await specHelper.runTask("export:enqueue", {});
-
-      foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(1);
-      await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
-
-      expect(exportArgs.exports.length).toBe(1);
-      expect(exportArgs.exports[0].profile.id).toEqual(profile.id);
-      expect(exportArgs.exports[0].oldGroups).toEqual(
-        [groupA, groupB].map((g) => g.name).sort()
-      );
-      expect(exportArgs.exports[0].newGroups).toEqual([]);
-      expect(exportArgs.exports[0].toDelete).toEqual(true);
-    });
-
-    test("if profile is removed from destination's tracked group, toDelete is true", async () => {
-      await destination.setMapping({
-        uid: "userId",
-        customer_email: "email",
-      });
-
-      const groupA = await helper.factories.group();
-      const groupB = await helper.factories.group();
-      const groupC = await helper.factories.group();
-
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[groupA.id] = groupA.name;
-      destinationGroupMemberships[groupB.id] = groupB.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      await groupA.addProfile(profile);
-      await groupB.addProfile(profile);
-
-      const oldExport = await helper.factories.export(profile, destination, {
-        newProfileProperties: {},
-        newGroups: [groupA.name, groupB.name].sort(),
-        startedAt: new Date(),
-        completedAt: new Date(),
-        state: "complete",
-      });
-      await specHelper.deleteEnqueuedTasks("exports:send", {
-        id: oldExport.id,
-      });
-
-      await destination.trackGroup(groupC);
-      await destination.exportProfile(profile);
-
-      // there should be no export:send tasks
-      let foundTasks = await specHelper.findEnqueuedTasks("export:send");
-      expect(foundTasks.length).toBe(0);
-
-      // there should be no export:sendBatch tasks until the run has completed
-      foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(0);
-
-      await specHelper.runTask("export:enqueue", {});
-
-      foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(1);
-      await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
-
-      expect(exportArgs.exports.length).toBe(1);
-      expect(exportArgs.exports[0].profile.id).toEqual(profile.id);
-      expect(exportArgs.exports[0].oldGroups).toEqual(
-        [groupA, groupB].map((g) => g.name).sort()
-      );
-      expect(exportArgs.exports[0].newGroups).toEqual(
-        [groupA, groupB].map((g) => g.name).sort() // no change in mapped groups
-      );
-      expect(exportArgs.exports[0].toDelete).toEqual(true); // delete
-
-      await profile.destroy();
-    });
-
-    test.each(["enrich", "additive"])(
-      "if profile is removed from destination's tracked group in %p syncMode, toDelete is false and groups are cleared",
-      async (syncMode) => {
-        await destination.update({ syncMode });
+      test("if profile is removed from destination's tracked group, toDelete is true", async () => {
         await destination.setMapping({
           uid: "userId",
           customer_email: "email",
@@ -459,491 +403,571 @@ describe("models/destination", () => {
         expect(exportArgs.exports[0].oldGroups).toEqual(
           [groupA, groupB].map((g) => g.name).sort()
         );
-        expect(exportArgs.exports[0].newGroups).toEqual([]); // groups cleared
-        expect(exportArgs.exports[0].toDelete).toEqual(false); // no delete
+        expect(exportArgs.exports[0].newGroups).toEqual(
+          [groupA, groupB].map((g) => g.name).sort() // no change in mapped groups
+        );
+        expect(exportArgs.exports[0].toDelete).toEqual(true); // delete
 
         await profile.destroy();
-        await destination.update({ syncMode: "sync" });
-      }
-    );
-
-    test("if an export has the same data as the previous export, and force=false, it will not be sent to the destination", async () => {
-      const profile = await helper.factories.profile();
-      const group = await helper.factories.group();
-      await group.addProfile(profile);
-      await destination.trackGroup(group);
-
-      const oldExport = await Export.create({
-        destinationId: destination.id,
-        profileId: profile.id,
-        startedAt: new Date(),
-        completedAt: new Date(),
-        oldProfileProperties: {},
-        newProfileProperties: {},
-        oldGroups: [],
-        newGroups: [],
-        state: "complete",
       });
 
-      await destination.exportProfile(profile);
-      const newExport = await Export.findOne({
-        where: {
+      test.each(["enrich", "additive"])(
+        "if profile is removed from destination's tracked group in %p syncMode, toDelete is false and groups are cleared",
+        async (syncMode) => {
+          await destination.update({ syncMode });
+          await destination.setMapping({
+            uid: "userId",
+            customer_email: "email",
+          });
+
+          const groupA = await helper.factories.group();
+          const groupB = await helper.factories.group();
+          const groupC = await helper.factories.group();
+
+          const destinationGroupMemberships = {};
+          destinationGroupMemberships[groupA.id] = groupA.name;
+          destinationGroupMemberships[groupB.id] = groupB.name;
+          await destination.setDestinationGroupMemberships(
+            destinationGroupMemberships
+          );
+
+          const profile = await helper.factories.profile();
+          await groupA.addProfile(profile);
+          await groupB.addProfile(profile);
+
+          const oldExport = await helper.factories.export(
+            profile,
+            destination,
+            {
+              newProfileProperties: {},
+              newGroups: [groupA.name, groupB.name].sort(),
+              startedAt: new Date(),
+              completedAt: new Date(),
+              state: "complete",
+            }
+          );
+          await specHelper.deleteEnqueuedTasks("exports:send", {
+            id: oldExport.id,
+          });
+
+          await destination.trackGroup(groupC);
+          await destination.exportProfile(profile);
+
+          // there should be no export:send tasks
+          let foundTasks = await specHelper.findEnqueuedTasks("export:send");
+          expect(foundTasks.length).toBe(0);
+
+          // there should be no export:sendBatch tasks until the run has completed
+          foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
+          expect(foundTasks.length).toBe(0);
+
+          await specHelper.runTask("export:enqueue", {});
+
+          foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
+          expect(foundTasks.length).toBe(1);
+          await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
+
+          expect(exportArgs.exports.length).toBe(1);
+          expect(exportArgs.exports[0].profile.id).toEqual(profile.id);
+          expect(exportArgs.exports[0].oldGroups).toEqual(
+            [groupA, groupB].map((g) => g.name).sort()
+          );
+          expect(exportArgs.exports[0].newGroups).toEqual([]); // groups cleared
+          expect(exportArgs.exports[0].toDelete).toEqual(false); // no delete
+
+          await profile.destroy();
+          await destination.update({ syncMode: "sync" });
+        }
+      );
+
+      test("if an export has the same data as the previous export, and force=false, it will not be sent to the destination", async () => {
+        const profile = await helper.factories.profile();
+        const group = await helper.factories.group();
+        await group.addProfile(profile);
+        await destination.trackGroup(group);
+
+        const oldExport = await Export.create({
           destinationId: destination.id,
-          id: { [Op.ne]: oldExport.id },
-        },
+          profileId: profile.id,
+          startedAt: new Date(),
+          completedAt: new Date(),
+          oldProfileProperties: {},
+          newProfileProperties: {},
+          oldGroups: [],
+          newGroups: [],
+          state: "complete",
+        });
+
+        await destination.exportProfile(profile);
+        const newExport = await Export.findOne({
+          where: {
+            destinationId: destination.id,
+            id: { [Op.ne]: oldExport.id },
+          },
+        });
+
+        expect(newExport.toDelete).toBe(false);
+        expect(newExport.hasChanges).toBe(false);
+        expect(newExport.force).toBe(false);
+
+        await specHelper.runTask("export:enqueue", {});
+
+        const foundTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+        expect(foundTasks.length).toBe(1);
+        await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
+
+        expect(exportArgs.exports.length).toBe(0); // plugin#exportProfile not called
+
+        await newExport.reload();
+        expect(newExport.completedAt).toBeTruthy();
       });
 
-      expect(newExport.toDelete).toBe(false);
-      expect(newExport.hasChanges).toBe(false);
-      expect(newExport.force).toBe(false);
+      test("if an export has the same data as the previous export, and force=true, it will be sent to the destination", async () => {
+        const profile = await helper.factories.profile();
+        const group = await helper.factories.group();
+        await group.addProfile(profile);
+        await destination.trackGroup(group);
 
-      await specHelper.runTask("export:enqueue", {});
-
-      const foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(1);
-      await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
-
-      expect(exportArgs.exports.length).toBe(0); // plugin#exportProfile not called
-
-      await newExport.reload();
-      expect(newExport.completedAt).toBeTruthy();
-    });
-
-    test("if an export has the same data as the previous export, and force=true, it will be sent to the destination", async () => {
-      const profile = await helper.factories.profile();
-      const group = await helper.factories.group();
-      await group.addProfile(profile);
-      await destination.trackGroup(group);
-
-      const oldExport = await Export.create({
-        destinationId: destination.id,
-        profileId: profile.id,
-        startedAt: new Date(),
-        completedAt: new Date(),
-        oldProfileProperties: {},
-        newProfileProperties: {},
-        oldGroups: [],
-        newGroups: [],
-        state: "complete",
-      });
-
-      await destination.exportProfile(profile, false, true);
-      const newExport = await Export.findOne({
-        where: {
+        const oldExport = await Export.create({
           destinationId: destination.id,
-          id: { [Op.ne]: oldExport.id },
-        },
+          profileId: profile.id,
+          startedAt: new Date(),
+          completedAt: new Date(),
+          oldProfileProperties: {},
+          newProfileProperties: {},
+          oldGroups: [],
+          newGroups: [],
+          state: "complete",
+        });
+
+        await destination.exportProfile(profile, false, true);
+        const newExport = await Export.findOne({
+          where: {
+            destinationId: destination.id,
+            id: { [Op.ne]: oldExport.id },
+          },
+        });
+
+        expect(newExport.toDelete).toBe(false);
+        expect(newExport.hasChanges).toBe(true);
+        expect(newExport.force).toBe(true);
+
+        await specHelper.runTask("export:enqueue", {});
+
+        const foundTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+        expect(foundTasks.length).toBe(1);
+        await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
+
+        expect(exportArgs.exports.length).toBe(1); // plugin#exportProfile was called
+
+        await newExport.reload();
+        expect(newExport.completedAt).toBeTruthy();
       });
 
-      expect(newExport.toDelete).toBe(false);
-      expect(newExport.hasChanges).toBe(true);
-      expect(newExport.force).toBe(true);
+      test("if there is no previous export, it will be sent to the destination and all data will be new", async () => {
+        const profile = await helper.factories.profile();
+        await profile.addOrUpdateProperties({
+          email: ["newEmail@example.com"],
+        });
+        const group = await helper.factories.group();
+        await group.addProfile(profile);
+        await destination.trackGroup(group);
 
-      await specHelper.runTask("export:enqueue", {});
+        await destination.setMapping({
+          customer_email: "email",
+        });
 
-      const foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(1);
-      await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
 
-      expect(exportArgs.exports.length).toBe(1); // plugin#exportProfile was called
+        await destination.exportProfile(profile);
+        const newExport = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
 
-      await newExport.reload();
-      expect(newExport.completedAt).toBeTruthy();
-    });
+        expect(newExport.oldProfileProperties).toEqual({});
+        expect(newExport.newProfileProperties).toEqual({
+          customer_email: "newemail@example.com",
+        });
+        expect(newExport.oldGroups).toEqual([]);
+        expect(newExport.newGroups).toEqual([group.name]);
+        expect(newExport.toDelete).toBe(false);
+        expect(newExport.hasChanges).toBe(true);
 
-    test("if there is no previous export, it will be sent to the destination and all data will be new", async () => {
-      const profile = await helper.factories.profile();
-      await profile.addOrUpdateProperties({ email: ["newEmail@example.com"] });
-      const group = await helper.factories.group();
-      await group.addProfile(profile);
-      await destination.trackGroup(group);
+        await specHelper.runTask("export:enqueue", {});
 
-      await destination.setMapping({
-        customer_email: "email",
+        const foundTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+        expect(foundTasks.length).toBe(1);
+        await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
+
+        expect(exportArgs.exports.length).toBe(1); // plugin#exportProfile was called
+
+        await profile.destroy();
       });
 
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
+      test("exportProfile can handle parallelsims export:sendBatch and the export can be retried", async () => {
+        parallelismResponse = 0;
 
-      await destination.exportProfile(profile);
-      const newExport = await Export.findOne({
-        where: { destinationId: destination.id },
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+
+        await destination.exportProfile(profile);
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
+
+        await specHelper.runTask("export:enqueue", {});
+
+        let foundSendBatchTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+        expect(foundSendBatchTasks.length).toBe(1);
+
+        await specHelper.runTask(
+          "export:sendBatch",
+          foundSendBatchTasks[0].args[0]
+        );
+
+        await _export.reload();
+        expect(_export.errorMessage).toBeNull();
+        expect(_export.errorLevel).toBeNull();
+        expect(_export.completedAt).toBeFalsy();
+        expect(_export.state).toBe("pending");
+        expect(_export.retryCount).toBe(1);
+
+        // when the parallelism is back to OK...
+        parallelismResponse = Infinity;
+
+        await specHelper.runTask(
+          "export:sendBatch",
+          foundSendBatchTasks[0].args[0]
+        );
+
+        await _export.reload();
+        expect(_export.completedAt).toBeTruthy();
+        expect(_export.state).toBe("complete");
       });
 
-      expect(newExport.oldProfileProperties).toEqual({});
-      expect(newExport.newProfileProperties).toEqual({
-        customer_email: "newemail@example.com",
-      });
-      expect(newExport.oldGroups).toEqual([]);
-      expect(newExport.newGroups).toEqual([group.name]);
-      expect(newExport.toDelete).toBe(false);
-      expect(newExport.hasChanges).toBe(true);
+      test("sending an export with sync and producing a parallelism error will throw", async () => {
+        parallelismResponse = 0;
 
-      await specHelper.runTask("export:enqueue", {});
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
 
-      const foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(1);
-      await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
+        const profile = await helper.factories.profile();
 
-      expect(exportArgs.exports.length).toBe(1); // plugin#exportProfile was called
+        await expect(destination.exportProfile(profile, true)).rejects.toThrow(
+          /parallelism limit reached for test-template-app/
+        );
 
-      await profile.destroy();
-    });
-
-    test("exportProfile can handle parallelsims export:sendBatch and the export can be retried", async () => {
-      parallelismResponse = 0;
-
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-
-      await destination.exportProfile(profile);
-      const _export = await Export.findOne({
-        where: { destinationId: destination.id },
+        await Export.truncate();
+        parallelismResponse = Infinity;
       });
 
-      await specHelper.runTask("export:enqueue", {});
+      test("sending an export with sync and throwing an error will throw in task", async () => {
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
 
-      let foundSendBatchTasks = await specHelper.findEnqueuedTasks(
-        "export:sendBatch"
-      );
-      expect(foundSendBatchTasks.length).toBe(1);
+        const profile = await helper.factories.profile();
+        const run = await helper.factories.run(group, { state: "running" });
 
-      await specHelper.runTask(
-        "export:sendBatch",
-        foundSendBatchTasks[0].args[0]
-      );
+        exportProfilesThrow = new Error("oh no!");
 
-      await _export.reload();
-      expect(_export.errorMessage).toBeNull();
-      expect(_export.errorLevel).toBeNull();
-      expect(_export.completedAt).toBeFalsy();
-      expect(_export.state).toBe("pending");
-      expect(_export.retryCount).toBe(1);
+        let thrownError: Error;
+        try {
+          await destination.exportProfile(profile, true);
+        } catch (error) {
+          thrownError = error;
+        }
 
-      // when the parallelism is back to OK...
-      parallelismResponse = Infinity;
+        exportProfilesThrow = null;
 
-      await specHelper.runTask(
-        "export:sendBatch",
-        foundSendBatchTasks[0].args[0]
-      );
+        expect(thrownError.message).toEqual("oh no!");
+        expect(thrownError["errors"]).toBeUndefined();
 
-      await _export.reload();
-      expect(_export.completedAt).toBeTruthy();
-      expect(_export.state).toBe("complete");
-    });
-
-    test("sending an export with sync and producing a parallelism error will throw", async () => {
-      parallelismResponse = 0;
-
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-
-      await expect(destination.exportProfile(profile, true)).rejects.toThrow(
-        /parallelism limit reached for test-template-app/
-      );
-
-      await Export.truncate();
-      parallelismResponse = Infinity;
-    });
-
-    test("sending an export with sync and throwing an error will throw in task", async () => {
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      const run = await helper.factories.run(group, { state: "running" });
-
-      exportProfilesThrow = new Error("oh no!");
-
-      let thrownError: Error;
-      try {
-        await destination.exportProfile(profile, true);
-      } catch (error) {
-        thrownError = error;
-      }
-
-      exportProfilesThrow = null;
-
-      expect(thrownError.message).toEqual("oh no!");
-      expect(thrownError["errors"]).toBeUndefined();
-
-      await run.stop();
-      await Export.truncate();
-    });
-
-    test("sending an export with sync and producing an error will throw combined of all sub errors", async () => {
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      const run = await helper.factories.run(group, { state: "running" });
-
-      const error = new Error("oh no!");
-      error["profileId"] = profile.id;
-
-      exportProfilesResponse = {
-        success: false,
-        errors: [error],
-        retryDelay: undefined,
-      };
-
-      let combinedError: Error;
-      try {
-        await destination.exportProfile(profile, true);
-      } catch (error) {
-        combinedError = error;
-      }
-
-      expect(combinedError.message).toMatch(
-        /error exporting 1 profiles to destination test plugin destination/
-      );
-      expect(combinedError.message).toMatch(/oh no!/);
-      expect(combinedError["errors"].map((e) => e.message)).toEqual(["oh no!"]);
-
-      await run.stop();
-      await Export.truncate();
-      exportProfilesResponse = {
-        success: true,
-        errors: undefined,
-        retryDelay: undefined,
-      };
-    });
-
-    test("the app can be rate-limited and the export:sendBatches can retry the export", async () => {
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      await destination.exportProfile(profile);
-      const _export = await Export.findOne({
-        where: { destinationId: destination.id },
+        await run.stop();
+        await Export.truncate();
       });
 
-      const profileError = new Error("oh no!");
-      profileError["profileId"] = profile.id;
-      exportProfilesResponse = {
-        success: false,
-        errors: [profileError],
-        retryDelay: 1000,
-      };
+      test("sending an export with sync and producing an error will throw combined of all sub errors", async () => {
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
 
-      await specHelper.runTask("export:enqueue", {});
+        const profile = await helper.factories.profile();
+        const run = await helper.factories.run(group, { state: "running" });
 
-      let foundSendBatchTasks = await specHelper.findEnqueuedTasks(
-        "export:sendBatch"
-      );
-      expect(foundSendBatchTasks.length).toBe(1);
+        const error = new Error("oh no!");
+        error["profileId"] = profile.id;
 
-      await specHelper.runTask(
-        "export:sendBatch",
-        foundSendBatchTasks[0].args[0]
-      );
+        exportProfilesResponse = {
+          success: false,
+          errors: [error],
+          retryDelay: undefined,
+        };
 
-      await _export.reload();
-      expect(_export.errorMessage).toMatch(/oh no!/);
-      expect(_export.errorLevel).toMatch("error");
-      expect(_export.completedAt).toBeFalsy();
-      expect(_export.state).toBe("pending");
-      expect(_export.retryCount).toBe(1);
+        let combinedError: Error;
+        try {
+          await destination.exportProfile(profile, true);
+        } catch (error) {
+          combinedError = error;
+        }
 
-      // when the response is back to success
-      exportProfilesResponse = {
-        success: true,
-        errors: undefined,
-        retryDelay: undefined,
-      };
+        expect(combinedError.message).toMatch(
+          /error exporting 1 profiles to destination test plugin destination/
+        );
+        expect(combinedError.message).toMatch(/oh no!/);
+        expect(combinedError["errors"].map((e) => e.message)).toEqual([
+          "oh no!",
+        ]);
 
-      await specHelper.runTask(
-        "export:sendBatch",
-        foundSendBatchTasks[0].args[0]
-      );
-      await _export.reload();
-      expect(_export.completedAt).toBeTruthy();
-      expect(_export.state).toBe("complete");
-    });
-
-    test("the app have export:sendBatches task with info level", async () => {
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
-
-      const profile = await helper.factories.profile();
-      await destination.exportProfile(profile);
-      const _export = await Export.findOne({
-        where: { destinationId: destination.id },
+        await run.stop();
+        await Export.truncate();
+        exportProfilesResponse = {
+          success: true,
+          errors: undefined,
+          retryDelay: undefined,
+        };
       });
 
-      const profileError = new Error("oh no!");
-      profileError["profileId"] = profile.id;
-      profileError["errorLevel"] = "info";
-      exportProfilesResponse = {
-        success: false,
-        errors: [profileError],
-        retryDelay: 1000,
-      };
+      test("the app can be rate-limited and the export:sendBatches can retry the export", async () => {
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
 
-      await specHelper.runTask("export:enqueue", {});
+        const profile = await helper.factories.profile();
+        await destination.exportProfile(profile);
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
 
-      let foundSendBatchTasks = await specHelper.findEnqueuedTasks(
-        "export:sendBatch"
-      );
-      expect(foundSendBatchTasks.length).toBe(1);
+        const profileError = new Error("oh no!");
+        profileError["profileId"] = profile.id;
+        exportProfilesResponse = {
+          success: false,
+          errors: [profileError],
+          retryDelay: 1000,
+        };
 
-      await specHelper.runTask(
-        "export:sendBatch",
-        foundSendBatchTasks[0].args[0]
-      );
-      foundSendBatchTasks = await specHelper.findEnqueuedTasks(
-        "export:sendBatch"
-      );
-      expect(foundSendBatchTasks.length).toBe(1 + 0); // actually fine!
+        await specHelper.runTask("export:enqueue", {});
 
-      await _export.reload();
-      expect(_export.errorMessage).toMatch(/oh no!/);
-      expect(_export.errorLevel).toMatch("info");
-      expect(_export.completedAt).toBeFalsy();
+        let foundSendBatchTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+        expect(foundSendBatchTasks.length).toBe(1);
 
-      // when the response is back to success
-      exportProfilesResponse = {
-        success: true,
-        errors: undefined,
-        retryDelay: undefined,
-      };
-    });
+        await specHelper.runTask(
+          "export:sendBatch",
+          foundSendBatchTasks[0].args[0]
+        );
 
-    test("the export can be retried for some profiles", async () => {
-      const group = await helper.factories.group();
-      const destinationGroupMemberships = {};
-      destinationGroupMemberships[group.id] = group.name;
-      await destination.setDestinationGroupMemberships(
-        destinationGroupMemberships
-      );
+        await _export.reload();
+        expect(_export.errorMessage).toMatch(/oh no!/);
+        expect(_export.errorLevel).toMatch("error");
+        expect(_export.completedAt).toBeFalsy();
+        expect(_export.state).toBe("pending");
+        expect(_export.retryCount).toBe(1);
 
-      const profile1 = await helper.factories.profile();
-      await destination.exportProfile(profile1);
-      const _export1 = await Export.findOne({
-        where: {
-          destinationId: destination.id,
-          profileId: profile1.id,
-        },
+        // when the response is back to success
+        exportProfilesResponse = {
+          success: true,
+          errors: undefined,
+          retryDelay: undefined,
+        };
+
+        await specHelper.runTask(
+          "export:sendBatch",
+          foundSendBatchTasks[0].args[0]
+        );
+        await _export.reload();
+        expect(_export.completedAt).toBeTruthy();
+        expect(_export.state).toBe("complete");
       });
 
-      const profile2 = await helper.factories.profile();
-      await destination.exportProfile(profile2);
-      const _export2 = await Export.findOne({
-        where: {
-          destinationId: destination.id,
-          profileId: profile2.id,
-        },
+      test("the app have export:sendBatches task with info level", async () => {
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile = await helper.factories.profile();
+        await destination.exportProfile(profile);
+        const _export = await Export.findOne({
+          where: { destinationId: destination.id },
+        });
+
+        const profileError = new Error("oh no!");
+        profileError["profileId"] = profile.id;
+        profileError["errorLevel"] = "info";
+        exportProfilesResponse = {
+          success: false,
+          errors: [profileError],
+          retryDelay: 1000,
+        };
+
+        await specHelper.runTask("export:enqueue", {});
+
+        let foundSendBatchTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+        expect(foundSendBatchTasks.length).toBe(1);
+
+        await specHelper.runTask(
+          "export:sendBatch",
+          foundSendBatchTasks[0].args[0]
+        );
+        foundSendBatchTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+        expect(foundSendBatchTasks.length).toBe(1 + 0); // actually fine!
+
+        await _export.reload();
+        expect(_export.errorMessage).toMatch(/oh no!/);
+        expect(_export.errorLevel).toMatch("info");
+        expect(_export.completedAt).toBeFalsy();
+
+        // when the response is back to success
+        exportProfilesResponse = {
+          success: true,
+          errors: undefined,
+          retryDelay: undefined,
+        };
       });
 
-      const profile3 = await helper.factories.profile();
-      await destination.exportProfile(profile3);
-      const _export3 = await Export.findOne({
-        where: {
-          destinationId: destination.id,
-          profileId: profile3.id,
-        },
+      test("the export can be retried for some profiles", async () => {
+        const group = await helper.factories.group();
+        const destinationGroupMemberships = {};
+        destinationGroupMemberships[group.id] = group.name;
+        await destination.setDestinationGroupMemberships(
+          destinationGroupMemberships
+        );
+
+        const profile1 = await helper.factories.profile();
+        await destination.exportProfile(profile1);
+        const _export1 = await Export.findOne({
+          where: {
+            destinationId: destination.id,
+            profileId: profile1.id,
+          },
+        });
+
+        const profile2 = await helper.factories.profile();
+        await destination.exportProfile(profile2);
+        const _export2 = await Export.findOne({
+          where: {
+            destinationId: destination.id,
+            profileId: profile2.id,
+          },
+        });
+
+        const profile3 = await helper.factories.profile();
+        await destination.exportProfile(profile3);
+        const _export3 = await Export.findOne({
+          where: {
+            destinationId: destination.id,
+            profileId: profile3.id,
+          },
+        });
+
+        const profileError1 = new Error("oh no!");
+        profileError1["profileId"] = profile1.id;
+        const profileError2 = new Error("inform me!");
+        profileError2["profileId"] = profile2.id;
+        profileError2["errorLevel"] = "info";
+        exportProfilesResponse = {
+          success: false,
+          errors: [profileError1, profileError2],
+          retryDelay: 1000,
+        };
+
+        await specHelper.runTask("export:enqueue", {});
+
+        let exportIds;
+        let foundSendBatchTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+        expect(foundSendBatchTasks.length).toBe(1);
+        exportIds = foundSendBatchTasks[0].args[0].exportIds;
+        expect(exportIds.length).toBe(3);
+        expect(exportIds.sort()).toEqual(
+          [_export1.id, _export2.id, _export3.id].sort()
+        );
+
+        await specHelper.runTask(
+          "export:sendBatch",
+          foundSendBatchTasks[0].args[0]
+        );
+
+        await _export1.reload();
+        expect(_export1.errorMessage).toMatch(/oh no!/);
+        expect(_export1.errorLevel).toMatch("error");
+        expect(_export1.completedAt).toBeFalsy();
+        expect(_export1.state).toBe("pending");
+
+        await _export2.reload();
+        expect(_export2.errorMessage).toMatch(/inform me!/);
+        expect(_export2.errorLevel).toMatch("info");
+        expect(_export2.completedAt).toBeFalsy();
+        expect(_export2.state).toBe("failed");
+
+        await _export3.reload();
+        expect(_export3.errorMessage).toBeNull();
+        expect(_export3.errorLevel).toBeNull();
+        expect(_export3.completedAt).toBeTruthy();
+        expect(_export3.state).toBe("complete");
+
+        // when the response is back to success
+        exportProfilesResponse = {
+          success: true,
+          errors: undefined,
+          retryDelay: undefined,
+        };
+
+        await specHelper.runTask(
+          "export:sendBatch",
+          foundSendBatchTasks[0].args[0]
+        );
+        foundSendBatchTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+
+        await _export1.reload();
+        expect(_export1.errorMessage).toBeNull();
+        expect(_export1.errorLevel).toBeNull();
+        expect(_export1.completedAt).toBeTruthy();
+        expect(_export1.state).toBe("complete");
       });
-
-      const profileError1 = new Error("oh no!");
-      profileError1["profileId"] = profile1.id;
-      const profileError2 = new Error("inform me!");
-      profileError2["profileId"] = profile2.id;
-      profileError2["errorLevel"] = "info";
-      exportProfilesResponse = {
-        success: false,
-        errors: [profileError1, profileError2],
-        retryDelay: 1000,
-      };
-
-      await specHelper.runTask("export:enqueue", {});
-
-      let exportIds;
-      let foundSendBatchTasks = await specHelper.findEnqueuedTasks(
-        "export:sendBatch"
-      );
-      expect(foundSendBatchTasks.length).toBe(1);
-      exportIds = foundSendBatchTasks[0].args[0].exportIds;
-      expect(exportIds.length).toBe(3);
-      expect(exportIds.sort()).toEqual(
-        [_export1.id, _export2.id, _export3.id].sort()
-      );
-
-      await specHelper.runTask(
-        "export:sendBatch",
-        foundSendBatchTasks[0].args[0]
-      );
-
-      await _export1.reload();
-      expect(_export1.errorMessage).toMatch(/oh no!/);
-      expect(_export1.errorLevel).toMatch("error");
-      expect(_export1.completedAt).toBeFalsy();
-      expect(_export1.state).toBe("pending");
-
-      await _export2.reload();
-      expect(_export2.errorMessage).toMatch(/inform me!/);
-      expect(_export2.errorLevel).toMatch("info");
-      expect(_export2.completedAt).toBeFalsy();
-      expect(_export2.state).toBe("failed");
-
-      await _export3.reload();
-      expect(_export3.errorMessage).toBeNull();
-      expect(_export3.errorLevel).toBeNull();
-      expect(_export3.completedAt).toBeTruthy();
-      expect(_export3.state).toBe("complete");
-
-      // when the response is back to success
-      exportProfilesResponse = {
-        success: true,
-        errors: undefined,
-        retryDelay: undefined,
-      };
-
-      await specHelper.runTask(
-        "export:sendBatch",
-        foundSendBatchTasks[0].args[0]
-      );
-      foundSendBatchTasks = await specHelper.findEnqueuedTasks(
-        "export:sendBatch"
-      );
-
-      await _export1.reload();
-      expect(_export1.errorMessage).toBeNull();
-      expect(_export1.errorLevel).toBeNull();
-      expect(_export1.completedAt).toBeTruthy();
-      expect(_export1.state).toBe("complete");
     });
   });
 });

--- a/core/__tests__/models/destination/plugins/processExportedProfiles.ts
+++ b/core/__tests__/models/destination/plugins/processExportedProfiles.ts
@@ -10,762 +10,772 @@ import {
 import { api, specHelper } from "actionhero";
 
 describe("models/destination", () => {
-  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
-  beforeAll(async () => await helper.factories.properties());
+  describe.each(["ready", "deleted"])("with app in %p state", (appState) => {
+    helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+    beforeAll(async () => await helper.factories.properties());
 
-  describe("with custom processExportedProfiles", () => {
-    let app: App;
-    let destination: Destination;
-    let exportArgs = {
-      app: null,
-      appOptions: null,
-      destination: null,
-      destinationOptions: null,
-      exports: null,
-    };
-    let processArgs = {
-      app: null,
-      appOptions: null,
-      destination: null,
-      destinationOptions: null,
-      exports: null,
-      remoteKey: null,
-    };
-    let exportArrayProperties = [];
-    let parallelismResponse = Infinity;
-    let exportProfilesResponse = {
-      success: true,
-      errors: undefined,
-      retryDelay: undefined,
-      processExports: undefined,
-    };
-    let processProfilesResponse = {
-      success: true,
-      errors: undefined,
-      retryDelay: undefined,
-      processExports: undefined,
-    };
-    let processExportedProfilesThrow = null;
-
-    beforeEach(() => {
-      exportArgs = {
+    describe("with custom processExportedProfiles", () => {
+      let app: App;
+      let destination: Destination;
+      let exportArgs = {
         app: null,
         appOptions: null,
         destination: null,
         destinationOptions: null,
-        exports: [],
+        exports: null,
       };
-      processArgs = {
+      let processArgs = {
         app: null,
         appOptions: null,
         destination: null,
         destinationOptions: null,
-        exports: [],
+        exports: null,
         remoteKey: null,
       };
-      processExportedProfilesThrow = null;
-    });
+      let exportArrayProperties = [];
+      let parallelismResponse = Infinity;
+      let exportProfilesResponse = {
+        success: true,
+        errors: undefined,
+        retryDelay: undefined,
+        processExports: undefined,
+      };
+      let processProfilesResponse = {
+        success: true,
+        errors: undefined,
+        retryDelay: undefined,
+        processExports: undefined,
+      };
+      let processExportedProfilesThrow = null;
 
-    beforeAll(async () => {
-      plugin.registerPlugin({
-        name: "test-plugin",
-        apps: [
-          {
-            name: "test-template-app",
-            options: [{ key: "test_key", required: true }],
-            methods: {
-              test: async () => {
-                return { success: true, errors: [] };
-              },
-              parallelism: async () => {
-                return parallelismResponse;
+      beforeEach(() => {
+        exportArgs = {
+          app: null,
+          appOptions: null,
+          destination: null,
+          destinationOptions: null,
+          exports: [],
+        };
+        processArgs = {
+          app: null,
+          appOptions: null,
+          destination: null,
+          destinationOptions: null,
+          exports: [],
+          remoteKey: null,
+        };
+        processExportedProfilesThrow = null;
+      });
+
+      beforeAll(async () => {
+        plugin.registerPlugin({
+          name: "test-plugin",
+          apps: [
+            {
+              name: "test-template-app",
+              options: [{ key: "test_key", required: true }],
+              methods: {
+                test: async () => {
+                  return { success: true, errors: [] };
+                },
+                parallelism: async () => {
+                  return parallelismResponse;
+                },
               },
             },
-          },
-        ],
-        connections: [
-          {
-            name: "export-from-test-template-app",
-            description: "a test app connection",
-            app: "test-template-app",
-            direction: "export",
-            syncModes: ["sync", "enrich", "additive"],
-            options: [],
-            methods: {
-              destinationMappingOptions: async () => {
-                return {
-                  labels: {
-                    group: {
-                      singular: "list",
-                      plural: "lists",
+          ],
+          connections: [
+            {
+              name: "export-from-test-template-app",
+              description: "a test app connection",
+              app: "test-template-app",
+              direction: "export",
+              syncModes: ["sync", "enrich", "additive"],
+              options: [],
+              methods: {
+                destinationMappingOptions: async () => {
+                  return {
+                    labels: {
+                      group: {
+                        singular: "list",
+                        plural: "lists",
+                      },
+                      property: {
+                        singular: "var",
+                        plural: "vars",
+                      },
                     },
-                    property: {
-                      singular: "var",
-                      plural: "vars",
+                    properties: {
+                      required: [],
+                      known: [],
+                      allowOptionalFromProperties: true,
                     },
-                  },
-                  properties: {
-                    required: [],
-                    known: [],
-                    allowOptionalFromProperties: true,
-                  },
-                };
-              },
-              exportArrayProperties: async () => exportArrayProperties,
-              exportProfiles: async ({
-                app,
-                appOptions,
-                destination,
-                destinationOptions,
-                exports,
-              }) => {
-                exportArgs = {
+                  };
+                },
+                exportArrayProperties: async () => exportArrayProperties,
+                exportProfiles: async ({
                   app,
                   appOptions,
                   destination,
                   destinationOptions,
                   exports,
-                };
+                }) => {
+                  exportArgs = {
+                    app,
+                    appOptions,
+                    destination,
+                    destinationOptions,
+                    exports,
+                  };
 
-                return exportProfilesResponse;
-              },
-              processExportedProfiles: async ({
-                app,
-                appOptions,
-                destination,
-                destinationOptions,
-                exports,
-                remoteKey,
-              }) => {
-                processArgs = {
+                  return exportProfilesResponse;
+                },
+                processExportedProfiles: async ({
                   app,
                   appOptions,
                   destination,
                   destinationOptions,
                   exports,
                   remoteKey,
-                };
+                }) => {
+                  processArgs = {
+                    app,
+                    appOptions,
+                    destination,
+                    destinationOptions,
+                    exports,
+                    remoteKey,
+                  };
 
-                if (processExportedProfilesThrow) {
-                  throw processExportedProfilesThrow;
-                }
+                  if (processExportedProfilesThrow) {
+                    throw processExportedProfilesThrow;
+                  }
 
-                return processProfilesResponse;
+                  return processProfilesResponse;
+                },
               },
             },
+          ],
+        });
+
+        app = await App.create({
+          name: "test with real methods - async exports",
+          type: "test-template-app",
+        });
+        await app.setOptions({ test_key: "abc" });
+        await app.update({ state: "ready" });
+      });
+
+      beforeEach(async () => {
+        await app.update({ state: "ready" });
+
+        destination = await Destination.create({
+          name: "test plugin destination",
+          type: "export-from-test-template-app",
+          syncMode: "sync",
+          appId: app.id,
+        });
+        await destination.update({ state: "ready" });
+
+        await api.resque.queue.connection.redis.flushdb();
+
+        await app.update({ state: appState });
+      });
+
+      afterEach(async () => {
+        await Export.truncate();
+        await destination.unTrackGroup();
+        await destination.destroy();
+      });
+
+      test("the exportProfiles method can indicate exports will be processed later and models will be created", async () => {
+        await destination.setMapping({
+          uid: "userId",
+          customer_email: "email",
+        });
+
+        const groupA = await helper.factories.group();
+        await destination.trackGroup(groupA);
+
+        const profile = await helper.factories.profile();
+        await profile.addOrUpdateProperties({
+          email: ["newemail@example.com"],
+        });
+        await groupA.addProfile(profile);
+
+        await destination.exportProfile(profile);
+        await specHelper.runTask("export:enqueue", {});
+
+        const foundTasks = await specHelper.findEnqueuedTasks(
+          "export:sendBatch"
+        );
+        expect(foundTasks.length).toBe(1);
+
+        exportProfilesResponse = {
+          success: true,
+          errors: null,
+          retryDelay: null,
+          processExports: {
+            profileIds: [profile.id],
+            processDelay: 1000,
+            remoteKey: "remote-import-id",
           },
-        ],
+        };
+
+        await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
+
+        expect(exportArgs.destination.id).toEqual(destination.id);
+        expect(exportArgs.app.id).toEqual(app.id);
+        expect(exportArgs.exports.length).toEqual(1);
+
+        const exportProcessors = await ExportProcessor.findAll({
+          where: { destinationId: destination.id },
+        });
+        expect(exportProcessors.length).toBe(1);
+        expect(exportProcessors[0].state).toBe("pending");
+        expect(exportProcessors[0].remoteKey).toBe("remote-import-id");
+
+        const _exports = await Export.findAll({
+          where: { destinationId: destination.id },
+        });
+        expect(_exports.length).toBe(1);
+        expect(_exports[0].destinationId).toBe(destination.id);
+        expect(_exports[0].profileId).toBe(profile.id);
+        expect(_exports[0].state).toBe("processing");
+        expect(_exports[0].startedAt).toBeTruthy();
+        expect(_exports[0].completedAt).toBeFalsy();
+        expect(_exports[0].exportProcessorId).toBe(exportProcessors[0].id);
+
+        await profile.destroy();
       });
 
-      app = await App.create({
-        name: "test with real methods - async exports",
-        type: "test-template-app",
-      });
-      await app.setOptions({ test_key: "abc" });
-      await app.update({ state: "ready" });
-    });
+      test("the processExportedProfiles method can be called by the destination", async () => {
+        const exportProcessor = await helper.factories.exportProcessor(
+          destination,
+          {
+            processAt: new Date(0),
+            remoteKey: "my-remote-key",
+          }
+        );
+        const profile1 = await helper.factories.profile();
+        const profile2 = await helper.factories.profile();
+        const export1 = await helper.factories.export(profile1, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
+        const export2 = await helper.factories.export(profile2, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
 
-    beforeEach(async () => {
-      destination = await Destination.create({
-        name: "test plugin destination",
-        type: "export-from-test-template-app",
-        syncMode: "sync",
-        appId: app.id,
-      });
-      await destination.update({ state: "ready" });
+        let foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(0);
 
-      await api.resque.queue.connection.redis.flushdb();
-    });
+        await specHelper.runTask("export:enqueueProcessors", {});
 
-    afterEach(async () => {
-      await Export.truncate();
-      await destination.unTrackGroup();
-      await destination.destroy();
-    });
+        foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(1);
 
-    test("the exportProfiles method can indicate exports will be processed later and models will be created", async () => {
-      await destination.setMapping({
-        uid: "userId",
-        customer_email: "email",
-      });
+        await specHelper.runTask("export:process", foundTasks[0].args[0]);
+        expect(processArgs.exports).toHaveLength(2);
+        expect(processArgs.remoteKey).toBe("my-remote-key");
 
-      const groupA = await helper.factories.group();
-      await destination.trackGroup(groupA);
+        await exportProcessor.reload();
+        expect(exportProcessor.state).toBe("complete");
+        expect(exportProcessor.completedAt).toBeTruthy();
+        expect(exportProcessor.errorMessage).toBeNull();
 
-      const profile = await helper.factories.profile();
-      await profile.addOrUpdateProperties({ email: ["newemail@example.com"] });
-      await groupA.addProfile(profile);
+        await export1.reload();
+        expect(export1.state).toBe("complete");
+        expect(export1.completedAt).toBeTruthy();
+        expect(export1.errorMessage).toBeNull();
 
-      await destination.exportProfile(profile);
-      await specHelper.runTask("export:enqueue", {});
+        await export2.reload();
+        expect(export2.state).toBe("complete");
+        expect(export2.completedAt).toBeTruthy();
+        expect(export2.errorMessage).toBeNull();
 
-      const foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(1);
-
-      exportProfilesResponse = {
-        success: true,
-        errors: null,
-        retryDelay: null,
-        processExports: {
-          profileIds: [profile.id],
-          processDelay: 1000,
-          remoteKey: "remote-import-id",
-        },
-      };
-
-      await specHelper.runTask("export:sendBatch", foundTasks[0].args[0]);
-
-      expect(exportArgs.destination.id).toEqual(destination.id);
-      expect(exportArgs.app.id).toEqual(app.id);
-      expect(exportArgs.exports.length).toEqual(1);
-
-      const exportProcessors = await ExportProcessor.findAll({
-        where: { destinationId: destination.id },
-      });
-      expect(exportProcessors.length).toBe(1);
-      expect(exportProcessors[0].state).toBe("pending");
-      expect(exportProcessors[0].remoteKey).toBe("remote-import-id");
-
-      const _exports = await Export.findAll({
-        where: { destinationId: destination.id },
-      });
-      expect(_exports.length).toBe(1);
-      expect(_exports[0].destinationId).toBe(destination.id);
-      expect(_exports[0].profileId).toBe(profile.id);
-      expect(_exports[0].state).toBe("processing");
-      expect(_exports[0].startedAt).toBeTruthy();
-      expect(_exports[0].completedAt).toBeFalsy();
-      expect(_exports[0].exportProcessorId).toBe(exportProcessors[0].id);
-
-      await profile.destroy();
-    });
-
-    test("the processExportedProfiles method can be called by the destination", async () => {
-      const exportProcessor = await helper.factories.exportProcessor(
-        destination,
-        {
-          processAt: new Date(0),
-          remoteKey: "my-remote-key",
-        }
-      );
-      const profile1 = await helper.factories.profile();
-      const profile2 = await helper.factories.profile();
-      const export1 = await helper.factories.export(profile1, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
-      });
-      const export2 = await helper.factories.export(profile2, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
+        await profile1.destroy();
+        await profile2.destroy();
       });
 
-      let foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(0);
+      test("the processExportedProfiles method can throw an error and it will be retried", async () => {
+        const exportProcessor = await helper.factories.exportProcessor(
+          destination,
+          {
+            processAt: new Date(0),
+          }
+        );
+        const profile = await helper.factories.profile();
+        const _export = await helper.factories.export(profile, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
 
-      await specHelper.runTask("export:enqueueProcessors", {});
+        let foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(0);
 
-      foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(1);
+        await specHelper.runTask("export:enqueueProcessors", {});
 
-      await specHelper.runTask("export:process", foundTasks[0].args[0]);
-      expect(processArgs.exports).toHaveLength(2);
-      expect(processArgs.remoteKey).toBe("my-remote-key");
+        foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(1);
 
-      await exportProcessor.reload();
-      expect(exportProcessor.state).toBe("complete");
-      expect(exportProcessor.completedAt).toBeTruthy();
-      expect(exportProcessor.errorMessage).toBeNull();
+        processExportedProfilesThrow = new Error("oops!");
 
-      await export1.reload();
-      expect(export1.state).toBe("complete");
-      expect(export1.completedAt).toBeTruthy();
-      expect(export1.errorMessage).toBeNull();
+        await specHelper.runTask("export:process", foundTasks[0].args[0]);
 
-      await export2.reload();
-      expect(export2.state).toBe("complete");
-      expect(export2.completedAt).toBeTruthy();
-      expect(export2.errorMessage).toBeNull();
+        // export processor retried and marked with error
+        await exportProcessor.reload();
+        expect(exportProcessor.state).toBe("pending");
+        expect(exportProcessor.retryCount).toBe(1);
+        expect(exportProcessor.completedAt).toBeFalsy();
+        expect(exportProcessor.errorMessage).toMatch(/oops!/);
+        expect(exportProcessor.processAt.getTime()).toBeGreaterThan(
+          new Date(0).getTime()
+        );
 
-      await profile1.destroy();
-      await profile2.destroy();
-    });
+        // exports still processing
+        await _export.reload();
+        expect(_export.state).toBe("processing");
+        expect(_export.completedAt).toBeFalsy();
+        expect(_export.errorMessage).toBeNull();
+        expect(_export.exportProcessorId).toBe(exportProcessor.id);
 
-    test("the processExportedProfiles method can throw an error and it will be retried", async () => {
-      const exportProcessor = await helper.factories.exportProcessor(
-        destination,
-        {
-          processAt: new Date(0),
-        }
-      );
-      const profile = await helper.factories.profile();
-      const _export = await helper.factories.export(profile, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
+        // try again without an error
+        processExportedProfilesThrow = null;
+        await specHelper.runTask("export:process", foundTasks[0].args[0]);
+
+        // processor is complete
+        await exportProcessor.reload();
+        expect(exportProcessor.state).toBe("complete");
+        expect(exportProcessor.completedAt).toBeTruthy();
+        expect(exportProcessor.errorMessage).toBeNull();
+        expect(exportProcessor.retryCount).toBe(1);
+
+        // exports are complete
+        await _export.reload();
+        expect(_export.state).toBe("complete");
+        expect(_export.completedAt).toBeTruthy();
+        expect(_export.errorMessage).toBeNull();
+
+        await profile.destroy();
       });
 
-      let foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(0);
+      test("the processExportedProfiles method can throw an error and the processor/exports will be marked as failed if retried too many times", async () => {
+        const setting = await Setting.findOne({
+          where: { key: "export-processors-max-retries-count" },
+        });
+        await setting.update({ value: 5 });
 
-      await specHelper.runTask("export:enqueueProcessors", {});
+        const exportProcessor = await helper.factories.exportProcessor(
+          destination,
+          {
+            processAt: new Date(0),
+            retryCount: 5,
+          }
+        );
+        const profile = await helper.factories.profile();
+        const _export = await helper.factories.export(profile, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
 
-      foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(1);
+        let foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(0);
 
-      processExportedProfilesThrow = new Error("oops!");
+        await specHelper.runTask("export:enqueueProcessors", {});
 
-      await specHelper.runTask("export:process", foundTasks[0].args[0]);
+        foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(1);
 
-      // export processor retried and marked with error
-      await exportProcessor.reload();
-      expect(exportProcessor.state).toBe("pending");
-      expect(exportProcessor.retryCount).toBe(1);
-      expect(exportProcessor.completedAt).toBeFalsy();
-      expect(exportProcessor.errorMessage).toMatch(/oops!/);
-      expect(exportProcessor.processAt.getTime()).toBeGreaterThan(
-        new Date(0).getTime()
-      );
+        processExportedProfilesThrow = new Error("oops!");
 
-      // exports still processing
-      await _export.reload();
-      expect(_export.state).toBe("processing");
-      expect(_export.completedAt).toBeFalsy();
-      expect(_export.errorMessage).toBeNull();
-      expect(_export.exportProcessorId).toBe(exportProcessor.id);
+        await specHelper.runTask("export:process", foundTasks[0].args[0]);
 
-      // try again without an error
-      processExportedProfilesThrow = null;
-      await specHelper.runTask("export:process", foundTasks[0].args[0]);
+        // export processor retried and failed
+        await exportProcessor.reload();
+        expect(exportProcessor.state).toBe("failed");
+        expect(exportProcessor.retryCount).toBe(6);
+        expect(exportProcessor.completedAt).toBeFalsy();
+        expect(exportProcessor.errorMessage).toMatch(/oops!/);
+        expect(exportProcessor.errorLevel).toBe("error");
 
-      // processor is complete
-      await exportProcessor.reload();
-      expect(exportProcessor.state).toBe("complete");
-      expect(exportProcessor.completedAt).toBeTruthy();
-      expect(exportProcessor.errorMessage).toBeNull();
-      expect(exportProcessor.retryCount).toBe(1);
+        // exports marked as failed
+        await _export.reload();
+        expect(_export.state).toBe("failed");
+        expect(_export.completedAt).toBeFalsy();
+        expect(_export.errorMessage).toBe(
+          "An error occurred while processing the export: oops!"
+        );
+        expect(_export.errorLevel).toBe("error");
+        expect(_export.exportProcessorId).toBe(exportProcessor.id);
 
-      // exports are complete
-      await _export.reload();
-      expect(_export.state).toBe("complete");
-      expect(_export.completedAt).toBeTruthy();
-      expect(_export.errorMessage).toBeNull();
-
-      await profile.destroy();
-    });
-
-    test("the processExportedProfiles method can throw an error and the processor/exports will be marked as failed if retried too many times", async () => {
-      const setting = await Setting.findOne({
-        where: { key: "export-processors-max-retries-count" },
-      });
-      await setting.update({ value: 5 });
-
-      const exportProcessor = await helper.factories.exportProcessor(
-        destination,
-        {
-          processAt: new Date(0),
-          retryCount: 5,
-        }
-      );
-      const profile = await helper.factories.profile();
-      const _export = await helper.factories.export(profile, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
+        await setting.update({ value: setting.defaultValue });
+        await profile.destroy();
       });
 
-      let foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(0);
+      test("some profiles can return an error and the processor will still be marked completed", async () => {
+        const exportProcessor = await helper.factories.exportProcessor(
+          destination,
+          {
+            processAt: new Date(0),
+          }
+        );
+        const profile1 = await helper.factories.profile();
+        const export1 = await helper.factories.export(profile1, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
+        const profile2 = await helper.factories.profile();
+        const export2 = await helper.factories.export(profile2, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
+        const profile3 = await helper.factories.profile();
+        const export3 = await helper.factories.export(profile3, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
 
-      await specHelper.runTask("export:enqueueProcessors", {});
+        const profileError1 = new Error("oh no!");
+        profileError1["profileId"] = profile1.id;
+        const profileError2 = new Error("info error!");
+        profileError2["profileId"] = profile2.id;
+        profileError2["errorLevel"] = "info";
 
-      foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(1);
+        await specHelper.runTask("export:enqueueProcessors", {});
 
-      processExportedProfilesThrow = new Error("oops!");
+        const foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(1);
 
-      await specHelper.runTask("export:process", foundTasks[0].args[0]);
+        processProfilesResponse = {
+          success: false,
+          errors: [profileError1, profileError2],
+          retryDelay: 1000,
+          processExports: null,
+        };
 
-      // export processor retried and failed
-      await exportProcessor.reload();
-      expect(exportProcessor.state).toBe("failed");
-      expect(exportProcessor.retryCount).toBe(6);
-      expect(exportProcessor.completedAt).toBeFalsy();
-      expect(exportProcessor.errorMessage).toMatch(/oops!/);
-      expect(exportProcessor.errorLevel).toBe("error");
+        await specHelper.runTask("export:process", foundTasks[0].args[0]);
 
-      // exports marked as failed
-      await _export.reload();
-      expect(_export.state).toBe("failed");
-      expect(_export.completedAt).toBeFalsy();
-      expect(_export.errorMessage).toBe(
-        "An error occurred while processing the export: oops!"
-      );
-      expect(_export.errorLevel).toBe("error");
-      expect(_export.exportProcessorId).toBe(exportProcessor.id);
+        // export processor marked as completed
+        await exportProcessor.reload();
+        expect(exportProcessor.state).toBe("complete");
+        expect(exportProcessor.completedAt).toBeTruthy();
+        expect(exportProcessor.errorMessage).toBeNull();
 
-      await setting.update({ value: setting.defaultValue });
-      await profile.destroy();
-    });
+        // Failed exports get their error set
+        await export1.reload();
+        expect(export1.profileId).toBe(profile1.id);
+        expect(export1.state).toBe("pending"); // kicked back to pending state
+        expect(export1.completedAt).toBeFalsy();
+        expect(export1.errorMessage).toBe("oh no!");
+        expect(export1.errorLevel).toBe("error");
+        expect(export1.exportProcessorId).toBeNull(); // cleared
 
-    test("some profiles can return an error and the processor will still be marked completed", async () => {
-      const exportProcessor = await helper.factories.exportProcessor(
-        destination,
-        {
-          processAt: new Date(0),
-        }
-      );
-      const profile1 = await helper.factories.profile();
-      const export1 = await helper.factories.export(profile1, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
-      });
-      const profile2 = await helper.factories.profile();
-      const export2 = await helper.factories.export(profile2, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
-      });
-      const profile3 = await helper.factories.profile();
-      const export3 = await helper.factories.export(profile3, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
-      });
+        await export2.reload();
+        expect(export2.profileId).toBe(profile2.id);
+        expect(export2.state).toBe("failed"); // marked as failed
+        expect(export2.completedAt).toBeFalsy();
+        expect(export2.errorMessage).toBe("info error!");
+        expect(export2.errorLevel).toBe("info");
+        expect(export2.exportProcessorId).toBe(exportProcessor.id);
 
-      const profileError1 = new Error("oh no!");
-      profileError1["profileId"] = profile1.id;
-      const profileError2 = new Error("info error!");
-      profileError2["profileId"] = profile2.id;
-      profileError2["errorLevel"] = "info";
+        // Successful exports will be marked as complete
+        await export3.reload();
+        expect(export3.profileId).toBe(profile3.id);
+        expect(export3.state).toBe("complete");
+        expect(export3.completedAt).toBeTruthy();
+        expect(export3.errorMessage).toBeNull();
+        expect(export3.exportProcessorId).toBe(exportProcessor.id);
 
-      await specHelper.runTask("export:enqueueProcessors", {});
-
-      const foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(1);
-
-      processProfilesResponse = {
-        success: false,
-        errors: [profileError1, profileError2],
-        retryDelay: 1000,
-        processExports: null,
-      };
-
-      await specHelper.runTask("export:process", foundTasks[0].args[0]);
-
-      // export processor marked as completed
-      await exportProcessor.reload();
-      expect(exportProcessor.state).toBe("complete");
-      expect(exportProcessor.completedAt).toBeTruthy();
-      expect(exportProcessor.errorMessage).toBeNull();
-
-      // Failed exports get their error set
-      await export1.reload();
-      expect(export1.profileId).toBe(profile1.id);
-      expect(export1.state).toBe("pending"); // kicked back to pending state
-      expect(export1.completedAt).toBeFalsy();
-      expect(export1.errorMessage).toBe("oh no!");
-      expect(export1.errorLevel).toBe("error");
-      expect(export1.exportProcessorId).toBeNull(); // cleared
-
-      await export2.reload();
-      expect(export2.profileId).toBe(profile2.id);
-      expect(export2.state).toBe("failed"); // marked as failed
-      expect(export2.completedAt).toBeFalsy();
-      expect(export2.errorMessage).toBe("info error!");
-      expect(export2.errorLevel).toBe("info");
-      expect(export2.exportProcessorId).toBe(exportProcessor.id);
-
-      // Successful exports will be marked as complete
-      await export3.reload();
-      expect(export3.profileId).toBe(profile3.id);
-      expect(export3.state).toBe("complete");
-      expect(export3.completedAt).toBeTruthy();
-      expect(export3.errorMessage).toBeNull();
-      expect(export3.exportProcessorId).toBe(exportProcessor.id);
-
-      await export1.destroy();
-      await profile1.destroy();
-      await profile2.destroy();
-      await profile3.destroy();
-    });
-
-    test("failed exports will be retried, sent back to pending and cleared of an exportProcessor", async () => {
-      const exportProcessor = await helper.factories.exportProcessor(
-        destination,
-        {
-          processAt: new Date(0),
-        }
-      );
-      const profile1 = await helper.factories.profile();
-      const export1 = await helper.factories.export(profile1, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
+        await export1.destroy();
+        await profile1.destroy();
+        await profile2.destroy();
+        await profile3.destroy();
       });
 
-      const profileError1 = new Error("oh no!");
-      profileError1["profileId"] = profile1.id;
+      test("failed exports will be retried, sent back to pending and cleared of an exportProcessor", async () => {
+        const exportProcessor = await helper.factories.exportProcessor(
+          destination,
+          {
+            processAt: new Date(0),
+          }
+        );
+        const profile1 = await helper.factories.profile();
+        const export1 = await helper.factories.export(profile1, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
 
-      await specHelper.runTask("export:enqueueProcessors", {});
+        const profileError1 = new Error("oh no!");
+        profileError1["profileId"] = profile1.id;
 
-      const foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(1);
+        await specHelper.runTask("export:enqueueProcessors", {});
 
-      processProfilesResponse = {
-        success: false,
-        errors: [profileError1],
-        retryDelay: 1000,
-        processExports: null,
-      };
+        const foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(1);
 
-      await specHelper.runTask("export:process", foundTasks[0].args[0]);
+        processProfilesResponse = {
+          success: false,
+          errors: [profileError1],
+          retryDelay: 1000,
+          processExports: null,
+        };
 
-      // export processor marked as completed
-      await exportProcessor.reload();
-      expect(exportProcessor.state).toBe("complete");
-      expect(exportProcessor.completedAt).toBeTruthy();
-      expect(exportProcessor.errorMessage).toBeNull();
+        await specHelper.runTask("export:process", foundTasks[0].args[0]);
 
-      // Failed export gets kicked back to pending, bump retry and clear processor
-      await export1.reload();
-      expect(export1.profileId).toBe(profile1.id);
-      expect(export1.state).toBe("pending"); // kicked back to pending state
-      expect(export1.completedAt).toBeFalsy();
-      expect(export1.errorMessage).toBe("oh no!");
-      expect(export1.errorLevel).toBe("error");
-      expect(export1.exportProcessorId).toBeNull(); // cleared
-      expect(export1.retryCount).toBe(1);
+        // export processor marked as completed
+        await exportProcessor.reload();
+        expect(exportProcessor.state).toBe("complete");
+        expect(exportProcessor.completedAt).toBeTruthy();
+        expect(exportProcessor.errorMessage).toBeNull();
 
-      await export1.destroy();
-      await profile1.destroy();
-    });
+        // Failed export gets kicked back to pending, bump retry and clear processor
+        await export1.reload();
+        expect(export1.profileId).toBe(profile1.id);
+        expect(export1.state).toBe("pending"); // kicked back to pending state
+        expect(export1.completedAt).toBeFalsy();
+        expect(export1.errorMessage).toBe("oh no!");
+        expect(export1.errorLevel).toBe("error");
+        expect(export1.exportProcessorId).toBeNull(); // cleared
+        expect(export1.retryCount).toBe(1);
 
-    test("the processExportedProfiles method can return processExports to have them reprocessed", async () => {
-      const exportProcessor = await helper.factories.exportProcessor(
-        destination,
-        {
-          processAt: new Date(0),
-          remoteKey: "my-remote-key",
-        }
-      );
-      const profile1 = await helper.factories.profile();
-      const profile2 = await helper.factories.profile();
-      const profile3 = await helper.factories.profile();
-      const export1 = await helper.factories.export(profile1, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
-      });
-      const export2 = await helper.factories.export(profile2, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
-      });
-      const export3 = await helper.factories.export(profile3, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
+        await export1.destroy();
+        await profile1.destroy();
       });
 
-      let foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(0);
+      test("the processExportedProfiles method can return processExports to have them reprocessed", async () => {
+        const exportProcessor = await helper.factories.exportProcessor(
+          destination,
+          {
+            processAt: new Date(0),
+            remoteKey: "my-remote-key",
+          }
+        );
+        const profile1 = await helper.factories.profile();
+        const profile2 = await helper.factories.profile();
+        const profile3 = await helper.factories.profile();
+        const export1 = await helper.factories.export(profile1, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
+        const export2 = await helper.factories.export(profile2, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
+        const export3 = await helper.factories.export(profile3, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
 
-      await specHelper.runTask("export:enqueueProcessors", {});
+        let foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(0);
 
-      foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(1);
+        await specHelper.runTask("export:enqueueProcessors", {});
 
-      processProfilesResponse = {
-        success: true,
-        processExports: {
-          profileIds: [profile1.id, profile2.id], // profile3 was successful
-          processDelay: 1000,
-        },
-        errors: null,
-        retryDelay: null,
-      };
+        foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(1);
 
-      await specHelper.runTask("export:process", foundTasks[0].args[0]);
-      expect(processArgs.exports).toHaveLength(3);
-      expect(processArgs.remoteKey).toBe("my-remote-key");
+        processProfilesResponse = {
+          success: true,
+          processExports: {
+            profileIds: [profile1.id, profile2.id], // profile3 was successful
+            processDelay: 1000,
+          },
+          errors: null,
+          retryDelay: null,
+        };
 
-      await exportProcessor.reload();
-      expect(exportProcessor.state).toBe("pending");
-      expect(exportProcessor.completedAt).toBeFalsy();
-      expect(exportProcessor.errorMessage).toBeNull();
-      expect(exportProcessor.retryCount).toBe(1); // count bumped!
+        await specHelper.runTask("export:process", foundTasks[0].args[0]);
+        expect(processArgs.exports).toHaveLength(3);
+        expect(processArgs.remoteKey).toBe("my-remote-key");
 
-      // exports still processing
-      await export1.reload();
-      expect(export1.state).toBe("processing");
-      expect(export1.completedAt).toBeFalsy();
-      expect(export1.exportProcessorId).toBe(exportProcessor.id);
+        await exportProcessor.reload();
+        expect(exportProcessor.state).toBe("pending");
+        expect(exportProcessor.completedAt).toBeFalsy();
+        expect(exportProcessor.errorMessage).toBeNull();
+        expect(exportProcessor.retryCount).toBe(1); // count bumped!
 
-      await export2.reload();
-      expect(export2.state).toBe("processing");
-      expect(export2.completedAt).toBeFalsy();
-      expect(export2.exportProcessorId).toBe(exportProcessor.id);
+        // exports still processing
+        await export1.reload();
+        expect(export1.state).toBe("processing");
+        expect(export1.completedAt).toBeFalsy();
+        expect(export1.exportProcessorId).toBe(exportProcessor.id);
 
-      // one export was successful
-      await export3.reload();
-      expect(export3.state).toBe("complete");
-      expect(export3.completedAt).toBeTruthy();
-      expect(export3.exportProcessorId).toBe(exportProcessor.id);
+        await export2.reload();
+        expect(export2.state).toBe("processing");
+        expect(export2.completedAt).toBeFalsy();
+        expect(export2.exportProcessorId).toBe(exportProcessor.id);
 
-      // process again, all are done
-      processProfilesResponse = {
-        success: true,
-        processExports: null,
-        errors: null,
-        retryDelay: null,
-      };
+        // one export was successful
+        await export3.reload();
+        expect(export3.state).toBe("complete");
+        expect(export3.completedAt).toBeTruthy();
+        expect(export3.exportProcessorId).toBe(exportProcessor.id);
 
-      await specHelper.runTask("export:process", foundTasks[0].args[0]);
-      expect(processArgs.exports).toHaveLength(2); // only 2 this time
-      expect(processArgs.remoteKey).toBe("my-remote-key");
+        // process again, all are done
+        processProfilesResponse = {
+          success: true,
+          processExports: null,
+          errors: null,
+          retryDelay: null,
+        };
 
-      await exportProcessor.reload();
-      expect(exportProcessor.state).toBe("complete");
-      expect(exportProcessor.completedAt).toBeTruthy();
-      expect(exportProcessor.errorMessage).toBeNull();
-      expect(exportProcessor.retryCount).toBe(1);
+        await specHelper.runTask("export:process", foundTasks[0].args[0]);
+        expect(processArgs.exports).toHaveLength(2); // only 2 this time
+        expect(processArgs.remoteKey).toBe("my-remote-key");
 
-      // exports done
-      await export1.reload();
-      expect(export1.state).toBe("complete");
-      expect(export1.completedAt).toBeTruthy();
-      expect(export1.exportProcessorId).toBe(exportProcessor.id);
+        await exportProcessor.reload();
+        expect(exportProcessor.state).toBe("complete");
+        expect(exportProcessor.completedAt).toBeTruthy();
+        expect(exportProcessor.errorMessage).toBeNull();
+        expect(exportProcessor.retryCount).toBe(1);
 
-      await export2.reload();
-      expect(export2.state).toBe("complete");
-      expect(export2.completedAt).toBeTruthy();
-      expect(export2.exportProcessorId).toBe(exportProcessor.id);
+        // exports done
+        await export1.reload();
+        expect(export1.state).toBe("complete");
+        expect(export1.completedAt).toBeTruthy();
+        expect(export1.exportProcessorId).toBe(exportProcessor.id);
 
-      await profile1.destroy();
-      await profile2.destroy();
-      await profile3.destroy();
-    });
+        await export2.reload();
+        expect(export2.state).toBe("complete");
+        expect(export2.completedAt).toBeTruthy();
+        expect(export2.exportProcessorId).toBe(exportProcessor.id);
 
-    test("the processor/exports will be marked as failed if the processExportedProfiles method returns processExports too many times", async () => {
-      const setting = await Setting.findOne({
-        where: { key: "export-processors-max-retries-count" },
-      });
-      await setting.update({ value: 5 });
-
-      const exportProcessor = await helper.factories.exportProcessor(
-        destination,
-        {
-          processAt: new Date(0),
-          retryCount: 5,
-        }
-      );
-      const profile = await helper.factories.profile();
-      const _export = await helper.factories.export(profile, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
-      });
-
-      let foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(0);
-
-      await specHelper.runTask("export:enqueueProcessors", {});
-
-      foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(1);
-
-      processProfilesResponse = {
-        success: true,
-        processExports: {
-          profileIds: [profile.id],
-          processDelay: 1000,
-        },
-        errors: null,
-        retryDelay: null,
-      };
-
-      await specHelper.runTask("export:process", foundTasks[0].args[0]);
-
-      // export processor retried too many times
-      await exportProcessor.reload();
-      expect(exportProcessor.state).toBe("failed");
-      expect(exportProcessor.retryCount).toBe(6);
-      expect(exportProcessor.completedAt).toBeFalsy();
-      expect(exportProcessor.errorMessage).toBeNull();
-
-      // exports marked as failed
-      await _export.reload();
-      expect(_export.state).toBe("failed");
-      expect(_export.completedAt).toBeFalsy();
-      expect(_export.errorMessage).toMatch(
-        /The maximum amount of retries was reached when trying to process this export/
-      );
-      expect(_export.errorLevel).toBe("info");
-      expect(_export.exportProcessorId).toBe(exportProcessor.id);
-
-      await setting.update({ value: setting.defaultValue });
-      await profile.destroy();
-    });
-
-    test("processExportedProfiles can handle parallelsim limits", async () => {
-      parallelismResponse = 0;
-
-      const exportProcessor = await helper.factories.exportProcessor(
-        destination,
-        {
-          processAt: new Date(0),
-        }
-      );
-      const profile1 = await helper.factories.profile();
-      const export1 = await helper.factories.export(profile1, destination, {
-        startedAt: new Date(),
-        state: "processing",
-        exportProcessorId: exportProcessor.id,
+        await profile1.destroy();
+        await profile2.destroy();
+        await profile3.destroy();
       });
 
-      await specHelper.runTask("export:enqueueProcessors", {});
+      test("the processor/exports will be marked as failed if the processExportedProfiles method returns processExports too many times", async () => {
+        const setting = await Setting.findOne({
+          where: { key: "export-processors-max-retries-count" },
+        });
+        await setting.update({ value: 5 });
 
-      const foundTasks = await specHelper.findEnqueuedTasks("export:process");
-      expect(foundTasks.length).toBe(1);
+        const exportProcessor = await helper.factories.exportProcessor(
+          destination,
+          {
+            processAt: new Date(0),
+            retryCount: 5,
+          }
+        );
+        const profile = await helper.factories.profile();
+        const _export = await helper.factories.export(profile, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
 
-      await specHelper.runTask("export:process", foundTasks[0].args[0]);
+        let foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(0);
 
-      // export processor retried and marked with error
-      await exportProcessor.reload();
-      expect(exportProcessor.state).toBe("pending");
-      expect(exportProcessor.retryCount).toBe(1);
-      expect(exportProcessor.completedAt).toBeFalsy();
-      expect(exportProcessor.errorMessage).toBeNull();
+        await specHelper.runTask("export:enqueueProcessors", {});
 
-      // exports still processing
-      await export1.reload();
-      expect(export1.state).toBe("processing");
-      expect(export1.completedAt).toBeFalsy();
-      expect(export1.errorMessage).toBeNull();
-      expect(export1.exportProcessorId).toBe(exportProcessor.id);
+        foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(1);
 
-      // when the parallelism is back to OK...
-      parallelismResponse = Infinity;
+        processProfilesResponse = {
+          success: true,
+          processExports: {
+            profileIds: [profile.id],
+            processDelay: 1000,
+          },
+          errors: null,
+          retryDelay: null,
+        };
 
-      await specHelper.runTask("export:process", foundTasks[0].args[0]);
+        await specHelper.runTask("export:process", foundTasks[0].args[0]);
 
-      // processor is complete
-      await exportProcessor.reload();
-      expect(exportProcessor.state).toBe("complete");
-      expect(exportProcessor.completedAt).toBeTruthy();
-      expect(exportProcessor.errorMessage).toBeNull();
-      expect(exportProcessor.retryCount).toBe(1);
+        // export processor retried too many times
+        await exportProcessor.reload();
+        expect(exportProcessor.state).toBe("failed");
+        expect(exportProcessor.retryCount).toBe(6);
+        expect(exportProcessor.completedAt).toBeFalsy();
+        expect(exportProcessor.errorMessage).toBeNull();
 
-      // exports are complete
-      await export1.reload();
-      expect(export1.state).toBe("complete");
-      expect(export1.completedAt).toBeTruthy();
-      expect(export1.errorMessage).toBeNull();
+        // exports marked as failed
+        await _export.reload();
+        expect(_export.state).toBe("failed");
+        expect(_export.completedAt).toBeFalsy();
+        expect(_export.errorMessage).toMatch(
+          /The maximum amount of retries was reached when trying to process this export/
+        );
+        expect(_export.errorLevel).toBe("info");
+        expect(_export.exportProcessorId).toBe(exportProcessor.id);
 
-      await profile1.destroy();
+        await setting.update({ value: setting.defaultValue });
+        await profile.destroy();
+      });
+
+      test("processExportedProfiles can handle parallelsim limits", async () => {
+        parallelismResponse = 0;
+
+        const exportProcessor = await helper.factories.exportProcessor(
+          destination,
+          {
+            processAt: new Date(0),
+          }
+        );
+        const profile1 = await helper.factories.profile();
+        const export1 = await helper.factories.export(profile1, destination, {
+          startedAt: new Date(),
+          state: "processing",
+          exportProcessorId: exportProcessor.id,
+        });
+
+        await specHelper.runTask("export:enqueueProcessors", {});
+
+        const foundTasks = await specHelper.findEnqueuedTasks("export:process");
+        expect(foundTasks.length).toBe(1);
+
+        await specHelper.runTask("export:process", foundTasks[0].args[0]);
+
+        // export processor retried and marked with error
+        await exportProcessor.reload();
+        expect(exportProcessor.state).toBe("pending");
+        expect(exportProcessor.retryCount).toBe(1);
+        expect(exportProcessor.completedAt).toBeFalsy();
+        expect(exportProcessor.errorMessage).toBeNull();
+
+        // exports still processing
+        await export1.reload();
+        expect(export1.state).toBe("processing");
+        expect(export1.completedAt).toBeFalsy();
+        expect(export1.errorMessage).toBeNull();
+        expect(export1.exportProcessorId).toBe(exportProcessor.id);
+
+        // when the parallelism is back to OK...
+        parallelismResponse = Infinity;
+
+        await specHelper.runTask("export:process", foundTasks[0].args[0]);
+
+        // processor is complete
+        await exportProcessor.reload();
+        expect(exportProcessor.state).toBe("complete");
+        expect(exportProcessor.completedAt).toBeTruthy();
+        expect(exportProcessor.errorMessage).toBeNull();
+        expect(exportProcessor.retryCount).toBe(1);
+
+        // exports are complete
+        await export1.reload();
+        expect(export1.state).toBe("complete");
+        expect(export1.completedAt).toBeTruthy();
+        expect(export1.errorMessage).toBeNull();
+
+        await profile1.destroy();
+      });
     });
   });
 });

--- a/core/__tests__/models/group/group.ts
+++ b/core/__tests__/models/group/group.ts
@@ -148,6 +148,24 @@ describe("models/group", () => {
         await group.destroy(); // does not throw
       });
 
+      test("a group cannot be deleted if a deleted destination is tracking it", async () => {
+        const group = await Group.create({
+          name: "tracked group",
+          type: "manual",
+        });
+
+        const destination = await helper.factories.destination();
+        await destination.trackGroup(group);
+        await destination.update({ state: "deleted" });
+
+        await expect(group.destroy()).rejects.toThrow(
+          /this group still in use by 1 destinations, cannot delete/
+        );
+
+        await destination.unTrackGroup();
+        await group.destroy(); // does not throw
+      });
+
       test("a group can be deleted even if a destination membership is using it", async () => {
         const group = await Group.create({
           name: "tracked group",

--- a/core/__tests__/models/group/group.ts
+++ b/core/__tests__/models/group/group.ts
@@ -1,5 +1,13 @@
 import { helper } from "@grouparoo/spec-helper";
-import { Log, Profile, Group, Import, GroupMember, Run } from "../../../src";
+import {
+  Log,
+  Profile,
+  Group,
+  Import,
+  GroupMember,
+  Run,
+  Destination,
+} from "../../../src";
 import { GroupOps } from "../../../src/modules/ops/group";
 
 describe("models/group", () => {
@@ -166,24 +174,68 @@ describe("models/group", () => {
         await group.destroy(); // does not throw
       });
 
-      test("a group can be deleted even if a destination membership is using it", async () => {
-        const group = await Group.create({
+      test.each(["ready", "deleted"])(
+        "a group can be deleted even if a %p destination membership is using it",
+        async (destinationState) => {
+          const group = await Group.create({
+            name: "tracked group",
+            type: "manual",
+            state: "ready",
+          });
+
+          const destination = await helper.factories.destination();
+          const destinationGroupMemberships = {};
+          destinationGroupMemberships[group.id] = "remote-tag";
+          await destination.setDestinationGroupMemberships(
+            destinationGroupMemberships
+          );
+
+          await destination.update({ state: destinationState });
+
+          await group.destroy(); // does not throw
+        }
+      );
+
+      test("deleting a group that a destination had as a membership will enqueue a run for that destinations group", async () => {
+        const trackedGroup = await Group.create({
           name: "tracked group",
           type: "manual",
           state: "ready",
         });
 
-        const destination = await helper.factories.destination();
+        const taggedGroup = await Group.create({
+          name: "taged group",
+          type: "manual",
+          state: "ready",
+        });
+
+        const destination: Destination = await helper.factories.destination();
+        const run = await destination.trackGroup(trackedGroup);
         const destinationGroupMemberships = {};
-        destinationGroupMemberships[group.id] = "remote-tag";
+        destinationGroupMemberships[taggedGroup.id] = "remote-tagged-group";
         await destination.setDestinationGroupMemberships(
           destinationGroupMemberships
         );
 
-        await group.destroy(); // does not throw
+        await trackedGroup.stopPreviousRuns();
+
+        await destination.update({ state: "ready" });
+        await taggedGroup.destroy(); // does not throw
+
+        const runningRuns = await Run.findAll({
+          where: { state: "running", creatorId: trackedGroup.id },
+        });
+        expect(runningRuns.length).toBe(1);
+        expect(runningRuns[0].destinationId).toBe(destination.id);
+        expect(runningRuns[0].force).toBe(false);
+        expect(runningRuns[0].id).not.toBe(run.id);
+
+        await destination.unTrackGroup();
+        await trackedGroup.destroy();
+        await taggedGroup.destroy();
       });
 
-      test("deleting a group that a destination had as a membership will enqueue a run for that destinations group", async () => {
+      test("deleting a group that a deleted destination had as a membership will not enqueue a run", async () => {
         const trackedGroup = await Group.create({
           name: "tracked group",
           type: "manual",
@@ -203,16 +255,15 @@ describe("models/group", () => {
         await destination.setDestinationGroupMemberships(
           destinationGroupMemberships
         );
-        await destination.update({ state: "ready" });
+
+        await trackedGroup.stopPreviousRuns();
+        await destination.update({ state: "deleted" });
         await taggedGroup.destroy(); // does not throw
 
         const runningRuns = await Run.findAll({
           where: { state: "running", creatorId: trackedGroup.id },
         });
-        expect(runningRuns.length).toBe(1);
-        expect(runningRuns[0].destinationId).toBe(destination.id);
-        expect(runningRuns[0].force).toBe(false);
-        expect(runningRuns[0].id).not.toBe(run.id);
+        expect(runningRuns.length).toBe(0);
       });
     });
   });

--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -766,26 +766,34 @@ describe("models/property", () => {
       });
     });
 
-    test("properties can retrieve their options from the source", async () => {
-      const property = await Property.create({
-        key: "test",
-        type: "string",
-        sourceId: source.id,
-      });
+    test.each(["deleted", "ready"])(
+      "properties can retrieve their options from the %p source",
+      async (state) => {
+        const property = await Property.create({
+          key: "test",
+          type: "string",
+          sourceId: source.id,
+        });
 
-      const pluginOptions = await property.pluginOptions();
-      expect(pluginOptions).toEqual([
-        {
-          description: "the column to choose",
-          key: "column",
-          options: [{ examples: [1, 2, 3], key: "id" }],
-          required: true,
-          type: "list",
-        },
-      ]);
+        await source.update({ state });
+        await app.update({ state });
 
-      await property.destroy();
-    });
+        const pluginOptions = await property.pluginOptions();
+        expect(pluginOptions).toEqual([
+          {
+            description: "the column to choose",
+            key: "column",
+            options: [{ examples: [1, 2, 3], key: "id" }],
+            required: true,
+            type: "list",
+          },
+        ]);
+
+        await property.destroy();
+        await source.update({ state: "ready" });
+        await app.update({ state: "ready" });
+      }
+    );
 
     test("creating or editing a property options will test the query against a profile", async () => {
       expect(queryCounter).toBe(0);

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -486,7 +486,7 @@ describe("modules/codeConfig", () => {
       expect(await Source.count()).toBe(1);
       expect(await Schedule.count()).toBe(0);
       expect(await Destination.count()).toBe(0);
-      expect(await Property.count()).toBe(2);
+      expect(await Property.count()).toBe(4);
       expect(await ApiKey.count()).toBe(0);
       expect(await Team.count()).toBe(0);
       expect(await TeamMember.count()).toBe(0);
@@ -578,18 +578,24 @@ describe("modules/codeConfig", () => {
       expect(await Schedule.count()).toBe(0);
       expect(await Destination.count()).toBe(0);
       expect(await Group.count()).toBe(0);
-      expect(await Property.count()).toBe(0);
+      expect(await Property.count()).toBe(2);
       expect(await ApiKey.count()).toBe(0);
       expect(await Team.count()).toBe(0);
       expect(await TeamMember.count()).toBe(0);
     });
 
     test("removed properties will be deleted", async () => {
-      const properties = await Property.scope(null).findAll();
-      expect(properties.length).toBe(1);
+      const properties = await Property.scope(null).findAll({
+        order: [["id", "asc"]],
+      });
+      expect(properties.length).toBe(2);
       expect(properties[0].id).toBe("email");
       expect(properties[0].state).toBe("deleted");
       expect(properties[0].locked).toBe(null);
+
+      expect(properties[1].id).toBe("user_id");
+      expect(properties[1].state).toBe("deleted");
+      expect(properties[1].locked).toBe(null);
     });
 
     test("a removed source will be deleted", async () => {

--- a/core/__tests__/tasks/destination/destroy.ts
+++ b/core/__tests__/tasks/destination/destroy.ts
@@ -31,127 +31,136 @@ describe("tasks/destination:destroy", () => {
     });
   });
 
-  describe("with tracked group", () => {
-    let group: Group;
-    let destination: Destination;
-    let mario: Profile;
-    let luigi: Profile;
-    let run: Run;
+  describe.each(["ready", "deleted"])(
+    "with a tracked group in %p state",
+    (groupState) => {
+      let group: Group;
+      let destination: Destination;
+      let mario: Profile;
+      let luigi: Profile;
+      let run: Run;
 
-    beforeAll(async () => {
-      destination = await helper.factories.destination();
-      group = await helper.factories.group();
-      mario = await helper.factories.profile();
-      luigi = await helper.factories.profile();
-      await group.addProfile(mario);
-      await group.addProfile(luigi);
-      await destination.trackGroup(group);
+      beforeAll(async () => {
+        destination = await helper.factories.destination();
+        group = await helper.factories.group();
+        mario = await helper.factories.profile();
+        luigi = await helper.factories.profile();
+        await group.addProfile(mario);
+        await group.addProfile(luigi);
+        await destination.trackGroup(group);
 
-      await api.resque.queue.connection.redis.flushdb();
-      await Run.truncate();
-    });
+        await group.update({ state: groupState });
 
-    test("a destination tracking a group cannot be deleted", async () => {
-      await expect(destination.destroy()).rejects.toThrow(
-        "cannot delete a destination that is tracking a group"
-      );
-    });
-
-    test("the task can be enqueued and create a run for the group", async () => {
-      await destination.update({ state: "deleted" });
-      await specHelper.runTask("destination:destroy", {
-        destinationId: destination.id,
+        await api.resque.queue.connection.redis.flushdb();
+        await Run.truncate();
       });
 
-      run = await Run.findOne({
-        where: { creatorId: group.id, destinationId: destination.id },
-      });
-      expect(run.state).toBe("running");
-      expect(run.force).toBe(false);
-
-      destination = await Destination.findById(destination.id);
-      expect(destination.state).toBe("deleted");
-      expect(destination.groupId).toBeNull();
-    });
-
-    test("the destination will not be deleted yet (running run)", async () => {
-      await utils.sleep(1000);
-      await specHelper.runTask("destination:destroy", {
-        destinationId: destination.id,
+      test("a destination tracking a group cannot be deleted", async () => {
+        await expect(destination.destroy()).rejects.toThrow(
+          "cannot delete a destination that is tracking a group"
+        );
       });
 
-      destination = await Destination.findById(destination.id);
-      expect(destination.state).toBe("deleted");
-    });
+      test("the task can be enqueued and create a run for the group", async () => {
+        await destination.update({ state: "deleted" });
+        await specHelper.runTask("destination:destroy", {
+          destinationId: destination.id,
+        });
 
-    test("the group run can be completed and create exports", async () => {
-      await specHelper.runTask("group:run", { runId: run.id });
-      await specHelper.runTask("group:run", { runId: run.id });
-      await specHelper.runTask("group:run", { runId: run.id });
-      await specHelper.runTask("group:run", { runId: run.id });
+        run = await Run.findOne({
+          where: { creatorId: group.id, destinationId: destination.id },
+        });
+        expect(run.state).toBe("running");
+        expect(run.force).toBe(false);
 
-      await ImportWorkflow();
-
-      await specHelper.runTask("group:run", { runId: run.id });
-
-      run = await run.reload();
-      group = await Group.findById(group.id);
-      expect(group.state).toBe("ready");
-      expect(run.state).toBe("complete");
-
-      // create exports
-      const exportTasks = await specHelper.findEnqueuedTasks("profile:export");
-      await Promise.all(
-        exportTasks.map((t) => specHelper.runTask("profile:export", t.args[0]))
-      );
-    });
-
-    test("the destination will not be deleted yet (pending exports)", async () => {
-      await utils.sleep(1000);
-      await specHelper.runTask("destination:destroy", {
-        destinationId: destination.id,
+        destination = await Destination.findById(destination.id);
+        expect(destination.state).toBe("deleted");
+        expect(destination.groupId).toBeNull();
       });
 
-      destination = await Destination.findById(destination.id);
-      expect(destination.state).toBe("deleted");
-    });
+      test("the destination will not be deleted yet (running run)", async () => {
+        await utils.sleep(1000);
+        await specHelper.runTask("destination:destroy", {
+          destinationId: destination.id,
+        });
 
-    test("the exports can be exported", async () => {
-      await specHelper.runTask("export:enqueue", {});
-      const foundExportSendTasks = await specHelper.findEnqueuedTasks(
-        "export:send"
-      );
-      expect(foundExportSendTasks.length).toBe(2);
-      await Promise.all(
-        foundExportSendTasks.map((t) =>
-          specHelper.runTask("export:send", t.args[0])
-        )
-      );
-    });
-
-    test("the destination will not be deleted yet (not enough time has passed)", async () => {
-      await api.resque.queue.connection.redis.flushdb();
-      await specHelper.runTask("destination:destroy", {
-        destinationId: destination.id,
+        destination = await Destination.findById(destination.id);
+        expect(destination.state).toBe("deleted");
       });
 
-      destination = await Destination.findById(destination.id);
-      expect(destination.state).toBe("deleted");
-    });
+      test("the group run can be completed and create exports", async () => {
+        await specHelper.runTask("group:run", { runId: run.id });
+        await specHelper.runTask("group:run", { runId: run.id });
+        await specHelper.runTask("group:run", { runId: run.id });
+        await specHelper.runTask("group:run", { runId: run.id });
 
-    test("time passes", async () => {
-      await utils.sleep(1000);
-    });
+        await ImportWorkflow();
 
-    test("now the destination can be deleted", async () => {
-      await utils.sleep(1000);
-      await specHelper.runTask("destination:destroy", {
-        destinationId: destination.id,
+        await specHelper.runTask("group:run", { runId: run.id });
+
+        run = await run.reload();
+        group = await Group.findById(group.id);
+        expect(group.state).toBe(groupState);
+        expect(run.state).toBe("complete");
+
+        // create exports
+        const exportTasks = await specHelper.findEnqueuedTasks(
+          "profile:export"
+        );
+        await Promise.all(
+          exportTasks.map((t) =>
+            specHelper.runTask("profile:export", t.args[0])
+          )
+        );
       });
 
-      await expect(Destination.findById(destination.id)).rejects.toThrow(
-        /cannot find Destination/
-      );
-    });
-  });
+      test("the destination will not be deleted yet (pending exports)", async () => {
+        await utils.sleep(1000);
+        await specHelper.runTask("destination:destroy", {
+          destinationId: destination.id,
+        });
+
+        destination = await Destination.findById(destination.id);
+        expect(destination.state).toBe("deleted");
+      });
+
+      test("the exports can be exported", async () => {
+        await specHelper.runTask("export:enqueue", {});
+        const foundExportSendTasks = await specHelper.findEnqueuedTasks(
+          "export:send"
+        );
+        expect(foundExportSendTasks.length).toBe(2);
+        await Promise.all(
+          foundExportSendTasks.map((t) =>
+            specHelper.runTask("export:send", t.args[0])
+          )
+        );
+      });
+
+      test("the destination will not be deleted yet (not enough time has passed)", async () => {
+        await api.resque.queue.connection.redis.flushdb();
+        await specHelper.runTask("destination:destroy", {
+          destinationId: destination.id,
+        });
+
+        destination = await Destination.findById(destination.id);
+        expect(destination.state).toBe("deleted");
+      });
+
+      test("time passes", async () => {
+        await utils.sleep(1000);
+      });
+
+      test("now the destination can be deleted", async () => {
+        await utils.sleep(1000);
+        await specHelper.runTask("destination:destroy", {
+          destinationId: destination.id,
+        });
+
+        await expect(Destination.findById(destination.id)).rejects.toThrow(
+          /cannot find Destination/
+        );
+      });
+    }
+  );
 });

--- a/core/src/actions/properties.ts
+++ b/core/src/actions/properties.ts
@@ -259,7 +259,7 @@ export class PropertyView extends AuthenticatedAction {
 
   async runWithinTransaction({ params }) {
     const property = await Property.findById(params.id);
-    const source = await property.$get("source");
+    const source = await property.$get("source", { scope: null });
 
     return {
       property: await property.apiData(),
@@ -333,7 +333,7 @@ export class PropertyProfilePreview extends AuthenticatedAction {
     }
 
     const apiData = await profile.apiData();
-    const source = await property.$get("source");
+    const source = await property.$get("source", { scope: null });
 
     let newPropertyValues: Array<string | number | boolean | Date>;
     let errorMessage: string;

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -54,7 +54,7 @@ const STATE_TRANSITIONS = [
 ];
 
 @DefaultScope(() => ({
-  where: { state: ["ready", "deleted"] },
+  where: { state: "ready" },
 }))
 @Table({ tableName: "apps", paranoid: false })
 export class App extends LoggedModel<App> {

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -54,7 +54,7 @@ const STATE_TRANSITIONS = [
 ];
 
 @DefaultScope(() => ({
-  where: { state: "ready" },
+  where: { state: ["ready", "deleted"] },
 }))
 @Table({ tableName: "apps", paranoid: false })
 export class App extends LoggedModel<App> {

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -639,7 +639,7 @@ export class Destination extends LoggedModel<Destination> {
   static async cannotDeleteDestinationWithTrackedGroup(instance: Destination) {
     if (process.env.GROUPAROO_RUN_MODE === "cli:config") return;
     if (instance.groupId) {
-      const group = await Group.findOne({
+      const group = await Group.scope("notDraft").findOne({
         where: { id: instance.groupId },
       });
       if (group) {

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -14,6 +14,7 @@ import {
   DataType,
   DefaultScope,
   BeforeDestroy,
+  Scopes,
 } from "sequelize-typescript";
 import { LoggedModel } from "../classes/loggedModel";
 import { App } from "./App";
@@ -113,6 +114,13 @@ const STATE_TRANSITIONS = [
 
 @DefaultScope(() => ({
   where: { state: "ready" },
+}))
+@Scopes(() => ({
+  notDraft: {
+    where: {
+      state: { [Op.notIn]: ["draft"] },
+    },
+  },
 }))
 @Table({ tableName: "destinations", paranoid: false })
 export class Destination extends LoggedModel<Destination> {

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -691,7 +691,10 @@ export class Group extends LoggedModel<Group> {
 
   @BeforeDestroy
   static async ensureNotInUse(instance: Group) {
-    const count = await instance.$count("destinations");
+    const count = await Destination.count({
+      where: { groupId: instance.id, state: { [Op.in]: ["ready", "deleted"] } },
+    });
+
     if (count > 0) {
       throw new Error(
         `this group still in use by ${count} destinations, cannot delete`

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -691,9 +691,7 @@ export class Group extends LoggedModel<Group> {
 
   @BeforeDestroy
   static async ensureNotInUse(instance: Group) {
-    const count = await Destination.count({
-      where: { groupId: instance.id, state: { [Op.in]: ["ready", "deleted"] } },
-    });
+    const count = await instance.$count("destinations", { scope: "notDraft" });
 
     if (count > 0) {
       throw new Error(

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -725,10 +725,14 @@ export class Group extends LoggedModel<Group> {
 
     for (const i in destinationGroupMemberships) {
       const destination = await destinationGroupMemberships[i].$get(
-        "destination"
+        "destination",
+        { scope: "notDraft" }
       );
       await destinationGroupMemberships[i].destroy();
-      await destination.exportGroupMembers(false);
+
+      if (destination && destination.state === "ready") {
+        await destination.exportGroupMembers(false);
+      }
     }
   }
 

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -725,12 +725,11 @@ export class Group extends LoggedModel<Group> {
 
     for (const i in destinationGroupMemberships) {
       const destination = await destinationGroupMemberships[i].$get(
-        "destination",
-        { scope: "notDraft" }
+        "destination"
       );
       await destinationGroupMemberships[i].destroy();
 
-      if (destination && destination.state === "ready") {
+      if (destination) {
         await destination.exportGroupMembers(false);
       }
     }

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -129,7 +129,7 @@ export const CachedProperties: { expires: number; properties: Property[] } = {
 };
 
 @DefaultScope(() => ({
-  where: { state: "ready" },
+  where: { state: { [Op.notIn]: ["draft"] } },
 }))
 @Table({ tableName: "properties", paranoid: false })
 export class Property extends LoggedModel<Property> {

--- a/core/src/models/Run.ts
+++ b/core/src/models/Run.ts
@@ -302,7 +302,7 @@ export class Run extends Model {
         name = property.key;
       } else if (this.creatorType === "schedule") {
         const schedule = await Schedule.findById(this.creatorId);
-        const source = await schedule.$get("source");
+        const source = await schedule.$get("source", { scope: null });
         name = source.name;
       } else if (this.creatorType === "teamMember") {
         const teamMember = await TeamMember.findById(this.creatorId);

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -302,13 +302,13 @@ export class Schedule extends LoggedModel<Schedule> {
   }
 
   @AfterDestroy
-  static async stopRuns(instance: Schedule) {
+  static async destroyRuns(instance: Schedule) {
     const runs = await Run.findAll({
-      where: { creatorId: instance.id, state: "running" },
+      where: { creatorId: instance.id },
     });
 
     for (const i in runs) {
-      await runs[i].update({ state: "stopped" });
+      await runs[i].destroy();
     }
   }
 }

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -318,12 +318,7 @@ export async function deleteLockedObjects(seenIds) {
   deletedIds["schedule"] = await deleteSchedules(seenIds.schedule);
   deletedIds["group"] = await deleteGroups(seenIds.group);
   deletedIds["property"] = await deleteProperties(seenIds.property);
-  // might return a bootstrapped property, needs special processing
-  const deletedSourceIds = await deleteSources(seenIds.source);
-  deletedIds["source"] = deletedSourceIds.source;
-  deletedSourceIds.property.map((id) => {
-    if (!deletedIds["property"].includes(id)) deletedIds["property"].push(id);
-  });
+  deletedIds["source"] = await deleteSources(seenIds.source);
   // back to normal
   deletedIds["app"] = await deleteApps(seenIds.app);
 

--- a/core/src/modules/configLoaders/property.ts
+++ b/core/src/modules/configLoaders/property.ts
@@ -73,7 +73,6 @@ export async function deleteProperties(ids: string[]) {
 
   for (const i in properties) {
     const property = properties[i];
-    if (property.directlyMapped) continue;
     await property.update({ state: "deleted", locked: null });
     logModel(property, "deleted");
   }

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -81,9 +81,7 @@ export namespace DestinationOps {
 
     if (oldGroupId) {
       const oldGroup = await Group.findById(oldGroupId);
-      if (oldGroup.state !== "deleted") {
-        return oldGroup.run(force, destination.id);
-      }
+      return oldGroup.run(force, destination.id);
     }
   }
 

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -165,7 +165,10 @@ export namespace DestinationOps {
     destinationOptions: SimpleDestinationOptions = {}
   ) {
     const { pluginConnection } = await destination.getPlugin();
-    const app = await destination.$get("app", { include: [Option] });
+    const app = await destination.$get("app", {
+      scope: null,
+      include: [Option],
+    });
     const connection = await app.getConnection();
     const appOptions = await app.getOptions(true);
 
@@ -214,7 +217,10 @@ export namespace DestinationOps {
     }
 
     const { pluginConnection } = await destination.getPlugin();
-    const app = await destination.$get("app", { include: [Option] });
+    const app = await destination.$get("app", {
+      scope: null,
+      include: [Option],
+    });
     const connection = await app.getConnection();
     const appOptions = await app.getOptions(true);
     const destinationOptions = await destination.getOptions(true);
@@ -243,7 +249,10 @@ export namespace DestinationOps {
 
   export async function getExportArrayProperties(destination: Destination) {
     const { pluginConnection } = await destination.getPlugin();
-    const app = await destination.$get("app", { include: [Option] });
+    const app = await destination.$get("app", {
+      scope: null,
+      include: [Option],
+    });
     const connection = await app.getConnection();
     const appOptions = await app.getOptions(true);
     const destinationOptions = await destination.getOptions(true);
@@ -275,7 +284,10 @@ export namespace DestinationOps {
     force = false,
     saveExports = true
   ) {
-    const app = await destination.$get("app", { include: [Option] });
+    const app = await destination.$get("app", {
+      scope: null,
+      include: [Option],
+    });
     const appOptions = await app.getOptions();
     await app.validateOptions(appOptions);
     const properties = await Property.findAllWithCache();
@@ -720,7 +732,10 @@ export namespace DestinationOps {
     }
 
     const options = await destination.getOptions();
-    const app = await destination.$get("app", { include: [Option] });
+    const app = await destination.$get("app", {
+      scope: null,
+      include: [Option],
+    });
     const appOptions = await app.getOptions();
     const connection = await app.getConnection();
 
@@ -822,7 +837,10 @@ export namespace DestinationOps {
       : DestinationSyncModeData.sync.operations; // if destination does not support sync modes, allow all
 
     const options = await destination.getOptions();
-    const app = await destination.$get("app", { include: [Option] });
+    const app = await destination.$get("app", {
+      scope: null,
+      include: [Option],
+    });
     const appOptions = await app.getOptions();
     const connection = await app.getConnection();
 

--- a/core/src/modules/ops/export.ts
+++ b/core/src/modules/ops/export.ts
@@ -78,7 +78,10 @@ export namespace ExportOps {
       delayMs = defaultExportProcessingDelay;
     }
 
-    const app = await destination.$get("app", { include: [Option] });
+    const app = await destination.$get("app", {
+      scope: null,
+      include: [Option],
+    });
     const { pluginConnection } = await destination.getPlugin();
 
     let _exports: Export[];

--- a/core/src/modules/ops/exportProcessor.ts
+++ b/core/src/modules/ops/exportProcessor.ts
@@ -50,7 +50,7 @@ export namespace ExportProcessorOps {
       // in SQLite this isn't possible, but contention is far less likely
       if (updateResponse[1]) exportProcessors = updateResponse[1];
 
-      const app = await destination.$get("app");
+      const app = await destination.$get("app", { scope: null });
 
       await Promise.all(
         exportProcessors.map((processor) =>

--- a/core/src/modules/ops/group.ts
+++ b/core/src/modules/ops/group.ts
@@ -20,7 +20,10 @@ export namespace GroupOps {
     if (process.env.GROUPAROO_RUN_MODE === "cli:validate") return;
 
     await group.stopPreviousRuns();
-    await group.update({ state: "updating" });
+
+    if (group.state !== "deleted") {
+      await group.update({ state: "updating" });
+    }
 
     const run = await Run.create({
       creatorId: group.id,

--- a/core/src/modules/ops/property.ts
+++ b/core/src/modules/ops/property.ts
@@ -103,6 +103,7 @@ export namespace PropertyOps {
   export async function dependencies(property: Property) {
     const dependencies: Property[] = [];
     const source = await property.$get("source", {
+      scope: null,
       include: [Option, Mapping],
     });
     const sourceMapping = await source.getMapping();

--- a/core/src/modules/ops/schedule.ts
+++ b/core/src/modules/ops/schedule.ts
@@ -93,6 +93,7 @@ export namespace ScheduleOps {
    */
   export async function pluginOptions(schedule: Schedule) {
     const source = await schedule.$get("source", {
+      scope: null,
       include: [Option, Mapping],
     });
     const { pluginConnection } = await source.getPlugin();

--- a/core/src/modules/ops/schedule.ts
+++ b/core/src/modules/ops/schedule.ts
@@ -10,6 +10,7 @@ export namespace ScheduleOps {
   export async function run(schedule: Schedule, run: Run) {
     const options = await schedule.getOptions();
     const source = await schedule.$get("source", {
+      scope: null,
       include: [Option, Mapping],
     });
     const app = await source.$get("app", { include: [Option], scope: null });
@@ -114,7 +115,7 @@ export namespace ScheduleOps {
 
     if (!pluginConnection.scheduleOptions) return response;
 
-    const app = await source.$get("app", { include: [Option] });
+    const app = await source.$get("app", { scope: null, include: [Option] });
     const connection = await app.getConnection();
     const appOptions = await app.getOptions();
     const sourceOptions = await source.getOptions();
@@ -152,6 +153,7 @@ export namespace ScheduleOps {
    */
   export async function runPercentComplete(schedule: Schedule, run: Run) {
     const source = await schedule.$get("source", {
+      scope: null,
       include: [Option, Mapping],
     });
 
@@ -159,7 +161,7 @@ export namespace ScheduleOps {
     const method = pluginConnection.methods.sourceRunPercentComplete;
     if (!method) return 0;
 
-    const app = await source.$get("app", { include: [Option] });
+    const app = await source.$get("app", { scope: null, include: [Option] });
     const appOptions = await app.getOptions();
     const sourceOptions = await source.getOptions();
     const sourceMapping = await source.getMapping();

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -18,7 +18,7 @@ export namespace SourceOps {
     sourceOptions: SimpleSourceOptions = {}
   ) {
     const { pluginConnection } = await source.getPlugin();
-    const app = await source.$get("app", { include: [Option] });
+    const app = await source.$get("app", { scope: null, include: [Option] });
     const connection = await app.getConnection();
     const appOptions = await app.getOptions(true);
 
@@ -50,7 +50,7 @@ export namespace SourceOps {
     }
 
     const { pluginConnection } = await source.getPlugin();
-    const app = await source.$get("app", { include: [Option] });
+    const app = await source.$get("app", { scope: null, include: [Option] });
     const connection = await app.getConnection();
     const appOptions = await app.getOptions(true);
 
@@ -103,7 +103,8 @@ export namespace SourceOps {
     if (!method) return;
 
     const app =
-      preloadedArgs.app || (await source.$get("app", { include: [Option] }));
+      preloadedArgs.app ||
+      (await source.$get("app", { scope: null, include: [Option] }));
     const connection = preloadedArgs.connection || (await app.getConnection());
     const appOptions = preloadedArgs.appOptions || (await app.getOptions());
     const sourceOptions =
@@ -246,7 +247,7 @@ export namespace SourceOps {
     });
 
     const profileProperties = await profile.properties();
-    const app = await source.$get("app", { include: [Option] });
+    const app = await source.$get("app", { scope: null, include: [Option] });
     const appOptions = await app.getOptions();
     const connection = await app.getConnection();
     const sourceOptions = await source.getOptions();

--- a/core/src/tasks/export/enqueueProcessors.ts
+++ b/core/src/tasks/export/enqueueProcessors.ts
@@ -27,7 +27,7 @@ export class EnqueueExportProcessors extends RetryableTask {
       ) * 1000;
 
     let totalEnqueued = 0;
-    const destinations = await Destination.findAll();
+    const destinations = await Destination.scope(null).findAll();
 
     for (const i in destinations) {
       const enqueuedProcessorsCount =

--- a/core/src/tasks/export/process.ts
+++ b/core/src/tasks/export/process.ts
@@ -24,6 +24,7 @@ export class ProcessExports extends CLSTask {
 
     const destination = await exportProcessor.$get("destination", {
       include: [Option, Mapping],
+      scope: null,
     });
     await destination.runExportProcessor(exportProcessor);
   }

--- a/core/src/tasks/export/send.ts
+++ b/core/src/tasks/export/send.ts
@@ -23,7 +23,6 @@ export class ExportSend extends CLSTask {
       include: [Option, Mapping],
     });
     if (!destination) return;
-
     const _export = await Export.findOne({
       where: { id: params.exportId },
     });

--- a/core/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/src/tasks/profileProperty/importProfileProperties.ts
@@ -35,6 +35,7 @@ export class ImportProfileProperties extends RetryableTask {
     if (!property) return;
     const source = await property.$get("source", {
       include: [Option, Mapping],
+      scope: null,
     });
 
     const profilesToImport: Profile[] = [];

--- a/core/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/src/tasks/profileProperty/importProfileProperty.ts
@@ -39,6 +39,7 @@ export class ImportProfileProperty extends RetryableTask {
     if (!property) return;
     const profileProperties = await profile.properties();
     const source = await property.$get("source", {
+      scope: null,
       include: [Option, Mapping],
     });
     const dependencies = await PropertyOps.dependencies(property);

--- a/core/src/tasks/source/destroy.ts
+++ b/core/src/tasks/source/destroy.ts
@@ -23,6 +23,16 @@ export class SourceDestroy extends CLSTask {
     // the source may have been force-deleted
     if (!source) return;
 
+    // check if we still have properties
+    try {
+      await Source.ensureNotInUse(source, true);
+    } catch (error) {
+      if (error.message.match(/cannot delete a source that has a property/)) {
+        return; // check back later
+      }
+      throw error;
+    }
+
     const directlyMappedProperty = await Property.scope(null).findOne({
       where: { sourceId: source.id, directlyMapped: true },
     });
@@ -34,17 +44,6 @@ export class SourceDestroy extends CLSTask {
       await Property.destroyOptions(directlyMappedProperty);
       await Property.destroyPropertyFilters(directlyMappedProperty);
       await Property.destroyProfileProperties(directlyMappedProperty);
-    }
-
-    // check if we still have properties
-    try {
-      await Source.ensureNotInUse(source);
-    } catch (error) {
-      if (error.message.match(/cannot delete a source that has a property/)) {
-        return; // check back later
-      }
-
-      throw error;
     }
 
     // no properties, let's delete it

--- a/ui/ui-components/pages/properties.tsx
+++ b/ui/ui-components/pages/properties.tsx
@@ -115,6 +115,8 @@ export default function Page(props) {
     );
   }
 
+  const readySources = sources.filter((s) => s.state === "ready");
+
   return (
     <>
       <Head>
@@ -212,7 +214,7 @@ export default function Page(props) {
         onPress={setOffset}
       />
 
-      {sources.length > 0 &&
+      {readySources.length > 0 &&
       process.env.GROUPAROO_UI_EDITION !== "community" ? (
         <>
           <hr />
@@ -228,7 +230,7 @@ export default function Page(props) {
                   setNewRuleSourceId(e.target.value);
                 }}
               >
-                {sources.map((source) => (
+                {readySources.map((source) => (
                   <option key={`opt-source-${source.id}`} value={source.id}>
                     {source.name}
                   </option>
@@ -258,6 +260,8 @@ Page.getInitialProps = async (ctx) => {
     limit,
     offset,
   });
-  const { sources } = await execApi("get", "/sources", { state: "ready" });
+  const { sources } = await execApi("get", "/sources", {
+    state: ["ready", "deleted"],
+  });
   return { properties, total, examples, sources };
 };


### PR DESCRIPTION
This PR addresses a few issues that occur when deleting multiple models at the same time (through code config). In general, deleting each model individually was working fine but when many or all of these are in the deleted state, there were some weird interactions between them that prevented things from happening, such as exporting people one last time to the group.

- **Test with dependencies in `deleted` state**: In multiple places, like export profiles, I'm now running through the tests twice, once with apps/sources/properties in `ready` state and another with them in `deleted` state. In most cases, all of these should still work fine if things are deleted. For example, we need to use the app to get API credentials when exporting people one last time.
- **destinations:destroy kicks off a run even if the group is deleted**: Previouslty there was a condition to prevent this from happening. However, because the destination was deleted before getting to the group run, the final export would not occur.
- **Relax the used scope for destinations/sources**: There were some checks to prevent deletion of dependent models like Groups if they were still being used by a destination. However, because deleted destinations werent being included, the groups were being deleted before the destination was able to 
- **Properties' default scope includes `deleted` props**: This is one I'm unsure about, because it affects the default set of properties returned. However, in all places I could find you still want to be able to access deleted properties and use them. Something that pushed me over the edge to do this is that when exporting profiles we get the properties with `.findAllWithCache`, which needs to include those that have been deleted to properly export.
- **Bootstrapped property is also enqueued to be deleted**: Before, it was deleted immediately when the config file was removed, which caused issues down the line because the property was missing. Now it's deleted when the source:destroy task deletes the source.
- **Destroying schedules now deletes their runs**: Previously, runs were just stopped. While this isn't directly an issue that prevents proper deletion of models, it means that if you bring it back with the same ID the profiles would not be re-imported. This is because the highWatermark is stored on the previous run, which still existed. We're now deleting previous runs so that if you bring it back everything is reimported properly.