### PR TITLE
Add scripts to staging-config to make it easier to work in config mode

### DIFF
--- a/apps/staging-config/README.md
+++ b/apps/staging-config/README.md
@@ -1,0 +1,25 @@
+# Config UI Example App
+
+This example exists as a starting point for new Grouparoo applications. It includes only a limited number of plugins necessary to get started.
+
+It is also configured to make it a little easier to work with the CLI within this monorepo, making the process of installing plugins on the fly easier (although there are still problems).
+
+## Config Mode
+
+To get started running config mode:
+
+    $ npm run config
+
+## Seeding Configuration
+
+You can pre-populate a set of configuration files using our demo command. First, ensure the `DEMO_DATABASE_URL` environment variable is set in your `.env` file in this project and points to a local Postgres database. Here's an example:
+
+```bash
+DEMO_DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
+```
+
+Assuming this database exists, you can then run the `demo` script to populate the database with some examples.
+
+    $ npm run demo
+
+This will generate a series of config files in your local `config` directory, which will be loaded in when booting in config mode.

--- a/apps/staging-config/package.json
+++ b/apps/staging-config/package.json
@@ -20,8 +20,8 @@
     "jest": "26.6.3"
   },
   "scripts": {
-    "config": "rm grouparoo_config.sqlite; rm -rf .local; CONFIG_DATABASE_URL=\"sqlite://grouparoo_config.sqlite\" NEXT_DEVELOPMENT_MODE=true ./node_modules/.bin/grouparoo config",
-    "demo": "./node_modules/.bin/grouparoo demo purchases --config"
+    "config": "rm grouparoo_config.sqlite; rm -rf .local; CONFIG_DATABASE_URL=\"sqlite://grouparoo_config.sqlite\" NEXT_DEVELOPMENT_MODE=true ./node_modules/@grouparoo/core/node_modules/.bin/grouparoo config",
+    "demo": "./node_modules/@grouparoo/core/node_modules/.bin/grouparoo demo purchases --config"
   },
   "grouparoo": {
     "grouparoo_monorepo_app": "staging-config",

--- a/apps/staging-config/package.json
+++ b/apps/staging-config/package.json
@@ -20,8 +20,8 @@
     "jest": "26.6.3"
   },
   "scripts": {
-    "start": "cd node_modules/@grouparoo/core && ./bin/start",
-    "dev": "cd node_modules/@grouparoo/core && ./bin/dev"
+    "config": "rm grouparoo_config.sqlite; rm -rf .local; CONFIG_DATABASE_URL=\"sqlite://grouparoo_config.sqlite\" NEXT_DEVELOPMENT_MODE=true ./node_modules/.bin/grouparoo config",
+    "demo": "./node_modules/.bin/grouparoo demo purchases --config"
   },
   "grouparoo": {
     "grouparoo_monorepo_app": "staging-config",


### PR DESCRIPTION
Adds two scripts that are explained in a new README file in the staging-config demo project.