### PR TITLE
`run.updateTotals` before run summary

### DIFF
--- a/core/__tests__/modules/status.ts
+++ b/core/__tests__/modules/status.ts
@@ -245,7 +245,6 @@ describe("modules/status", () => {
           profileUpdatedAt: now,
           groupsUpdatedAt: now,
         });
-        await run.updateTotals();
 
         const sources = await FinalSummaryReporters.Sources.getData();
         expect(sources[0].name).toEqual(source.name);

--- a/core/src/modules/statusReporters.ts
+++ b/core/src/modules/statusReporters.ts
@@ -434,6 +434,7 @@ export namespace FinalSummaryReporters {
       const sources: { [id: string]: SourceData } = {};
       for (const run of runs) {
         let source = null;
+        await run.updateTotals();
         const schedule = await Schedule.findByPk(run.creatorId);
 
         if (schedule) {


### PR DESCRIPTION
Issue: totals weren't updated in the database at the end of a run resulting in inaccurate run summary counts (specifically for sources)

Solution: now updateCounts is executed for each run that was completed before it gathers the counts.