### PR TITLE
removed `build_static_refs` objects for property rules

### DIFF
--- a/core/__tests__/bin/build_static_refs.ts
+++ b/core/__tests__/bin/build_static_refs.ts
@@ -2,8 +2,6 @@
 // import { RunCLI } from "../../src/bin/run";
 // import { Run } from "../../src";
 
-import { buildPropertyOpsDictionary } from "../../src/modules/ruleOpsDictionary";
-
 import fs from "fs";
 import cp from "child_process";
 import path from "path";

--- a/core/__tests__/bin/build_static_refs.ts
+++ b/core/__tests__/bin/build_static_refs.ts
@@ -10,41 +10,13 @@ import path from "path";
 
 const outputDir = path.join(__dirname, "../../bin/static_refs");
 
-const pgFilePath = path.join(
-  outputDir,
-  "property-ops-dictionary--postgres.json"
-);
-const sqliteFilePath = path.join(
-  outputDir,
-  "property-ops-dictionary--sqlite.json"
-);
 const cliFilePath = path.join(outputDir, "cli-commands.json");
 
 const scriptPath = path.join(__dirname, "../../bin/build_static_refs");
 
 describe("bin/build_static_refs", () => {
   beforeEach(() => {
-    if (fs.existsSync(pgFilePath)) fs.unlinkSync(pgFilePath);
-    if (fs.existsSync(sqliteFilePath)) fs.unlinkSync(sqliteFilePath);
     if (fs.existsSync(cliFilePath)) fs.unlinkSync(cliFilePath);
-  });
-
-  test("writes two files with the appropriate data", () => {
-    expect(fs.existsSync(pgFilePath)).toBe(false);
-    expect(fs.existsSync(sqliteFilePath)).toBe(false);
-    cp.execSync(`node ${scriptPath}`);
-    const pgData = buildPropertyOpsDictionary({
-      sequelize: { dialect: "postgres" },
-    });
-    expect(fs.readFileSync(pgFilePath).toString()).toBe(
-      JSON.stringify(pgData, null, 2)
-    );
-    const sqliteData = buildPropertyOpsDictionary({
-      sequelize: { dialect: "sqlite" },
-    });
-    expect(fs.readFileSync(sqliteFilePath).toString()).toBe(
-      JSON.stringify(sqliteData, null, 2)
-    );
   });
 
   test("generates CLI data", async () => {

--- a/core/bin/build_static_refs
+++ b/core/bin/build_static_refs
@@ -10,18 +10,6 @@ const { enumerateCLICommands } = require("../dist/utils/cli");
 
 const data = [
   {
-    name: "property-ops-dictionary--postgres",
-    data: buildPropertyOpsDictionary({
-      sequelize: { dialect: "postgres" },
-    }),
-  },
-  {
-    name: "property-ops-dictionary--sqlite",
-    data: buildPropertyOpsDictionary({
-      sequelize: { dialect: "sqlite" },
-    }),
-  },
-  {
     name: "cli-commands",
     data: enumerateCLICommands(),
   },

--- a/core/bin/build_static_refs
+++ b/core/bin/build_static_refs
@@ -3,9 +3,6 @@
 const fs = require("fs-extra");
 const path = require("path");
 
-const {
-  buildPropertyOpsDictionary,
-} = require("../dist/modules/ruleOpsDictionary");
 const { enumerateCLICommands } = require("../dist/utils/cli");
 
 const data = [


### PR DESCRIPTION
Per a discussion in [this PR](https://github.com/grouparoo/www.grouparoo.com/pull/481) we no longer want these being auto-generated from Core as we need to do a bit of manipulation (namely, adding an example and a caption) before it ends up in the www.