### PR TITLE
Speed up `profile:list` action

### DIFF
--- a/core/__tests__/actions/profiles.ts
+++ b/core/__tests__/actions/profiles.ts
@@ -348,7 +348,7 @@ describe("actions/profiles", () => {
         expect(groups[0].name).toBe("new group");
       });
 
-      test("the profiles in the group can be listed, and then include when the profile joined the group", async () => {
+      test("the profiles in the group can be listed", async () => {
         connection.params = {
           csrfToken,
           groupId: group.id,
@@ -361,7 +361,6 @@ describe("actions/profiles", () => {
         expect(error).toBeUndefined();
         expect(profiles.length).toBe(1);
         expect(total).toBe(1);
-        expect(profiles[0].joinedAt).toBeTruthy();
       });
 
       test("a writer can remove a profile from a manual group", async () => {
@@ -517,7 +516,7 @@ describe("actions/profiles", () => {
         expect(total).toBe(2);
       });
 
-      test("returns exact matches when there is a search (all), returning searched property", async () => {
+      test("returns exact matches when there is a search (all), returning all properties", async () => {
         connection.params = {
           csrfToken,
           searchKey: "email",
@@ -536,11 +535,12 @@ describe("actions/profiles", () => {
         expect(total).toBe(1);
       });
 
-      test("returns case-insensitive matches when there is a search (all), returning searched property", async () => {
+      test("returns case-insensitive matches when there is a search (all), returning all properties", async () => {
         connection.params = {
           csrfToken,
           searchKey: "email",
           searchValue: "PEACH@MushRoom-kingdom.gov",
+          caseSensitive: false,
         };
         const { error, profiles, total } = await specHelper.runAction(
           "profiles:list",
@@ -553,16 +553,28 @@ describe("actions/profiles", () => {
         ]);
         expect(simpleProfileValues(profiles[0].properties).userId).toEqual([4]);
         expect(total).toBe(1);
+
+        connection.params = {
+          csrfToken,
+          searchKey: "email",
+          searchValue: "PEACH@MushRoom-kingdom.gov",
+          caseSensitive: true,
+        };
+        const { total: caseSensitiveTotal } = await specHelper.runAction(
+          "profiles:list",
+          connection
+        );
+        expect(caseSensitiveTotal).toBe(0);
       });
 
-      test("returns exact matches when there is a search (group), returning searched property", async () => {
+      test("returns exact matches when there is a search (group), returning all properties", async () => {
         connection.params = {
           csrfToken,
           groupId: group.id,
           searchKey: "email",
           searchValue: "peach@mushroom-kingdom.gov",
         };
-        const { error, profiles } = await specHelper.runAction(
+        const { error, profiles, total } = await specHelper.runAction(
           "profiles:list",
           connection
         );
@@ -571,22 +583,19 @@ describe("actions/profiles", () => {
         expect(simpleProfileValues(profiles[0].properties).email).toEqual([
           "peach@mushroom-kingdom.gov",
         ]);
-        expect(
-          simpleProfileValues(profiles[0].properties).userId
-        ).toBeUndefined();
-
-        // TODO: we need to do a double join to check group member's properties.  The profiles returned are good, but not the total counts
-        // expect(total).toBe(1)
+        expect(simpleProfileValues(profiles[0].properties).userId).toEqual([4]);
+        expect(total).toBe(1);
       });
 
-      test("returns case-insensitive matches when there is a search (group), returning searched property", async () => {
+      test("returns case-insensitive matches when there is a search (group), returning all properties", async () => {
         connection.params = {
           csrfToken,
           groupId: group.id,
           searchKey: "email",
           searchValue: "PEACH@MUSHroom-kingdom.gov",
+          caseSensitive: false,
         };
-        const { error, profiles } = await specHelper.runAction(
+        const { error, profiles, total } = await specHelper.runAction(
           "profiles:list",
           connection
         );
@@ -595,15 +604,24 @@ describe("actions/profiles", () => {
         expect(simpleProfileValues(profiles[0].properties).email).toEqual([
           "peach@mushroom-kingdom.gov",
         ]);
-        expect(
-          simpleProfileValues(profiles[0].properties).userId
-        ).toBeUndefined();
+        expect(simpleProfileValues(profiles[0].properties).userId).toEqual([4]);
+        expect(total).toBe(1);
 
-        // TODO: we need to do a double join to check group member's properties.  The profiles returned are good, but not the total counts
-        // expect(total).toBe(1)
+        connection.params = {
+          csrfToken,
+          groupId: group.id,
+          searchKey: "email",
+          searchValue: "PEACH@MushRoom-kingdom.gov",
+          caseSensitive: true,
+        };
+        const { total: caseSensitiveTotal } = await specHelper.runAction(
+          "profiles:list",
+          connection
+        );
+        expect(caseSensitiveTotal).toBe(0);
       });
 
-      test("returns fuzzy matching profiles and counts when there is a search (all), returning searched property", async () => {
+      test("returns fuzzy matching profiles and counts when there is a search (all), returning all properties", async () => {
         connection.params = {
           csrfToken,
           searchKey: "email",
@@ -618,11 +636,12 @@ describe("actions/profiles", () => {
         expect(total).toBe(2);
       });
 
-      test("returns fuzzy matching profiles and counts when there is a search (all) ignoring case, returning searched property", async () => {
+      test("returns fuzzy matching profiles and counts when there is a search (all) ignoring case, returning all properties", async () => {
         connection.params = {
           csrfToken,
           searchKey: "email",
           searchValue: "%@MuShRoom-kingdom.GOV",
+          caseSensitive: false,
         };
         const { error, profiles, total } = await specHelper.runAction(
           "profiles:list",
@@ -633,7 +652,7 @@ describe("actions/profiles", () => {
         expect(total).toBe(2);
       });
 
-      test("returns fuzzy matching profiles and counts when there is no search (group), returning searched property", async () => {
+      test("returns fuzzy matching profiles and counts when there is no search (group), returning all properties", async () => {
         connection.params = {
           csrfToken,
           groupId: group.id,
@@ -649,12 +668,8 @@ describe("actions/profiles", () => {
         expect(simpleProfileValues(profiles[0].properties).email).toEqual([
           "peach@mushroom-kingdom.gov",
         ]);
-        expect(
-          simpleProfileValues(profiles[0].properties).userId
-        ).toBeUndefined();
-
-        // TODO: we need to do a double join to check group member's properties.  The profiles returned are good, but not the total counts
-        // expect(total).toBe(1)
+        expect(simpleProfileValues(profiles[0].properties).userId).toEqual([4]);
+        expect(total).toBe(1);
       });
 
       test("without a search, profiles without properties are returned", async () => {

--- a/core/src/actions/profiles.ts
+++ b/core/src/actions/profiles.ts
@@ -2,12 +2,11 @@ import { api, config } from "actionhero";
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { Profile } from "../models/Profile";
 import { ProfileProperty } from "../models/ProfileProperty";
-import { Group } from "../models/Group";
-import { GroupMember } from "../models/GroupMember";
-import { Property } from "../models/Property";
 import { internalRun } from "../modules/internalRun";
 import { Op } from "sequelize";
 import { ConfigWriter } from "../modules/configWriter";
+import { ProfileOps } from "../modules/ops/profile";
+import { AsyncReturnType } from "type-fest";
 
 export class ProfilesList extends AuthenticatedAction {
   constructor() {
@@ -31,146 +30,13 @@ export class ProfilesList extends AuthenticatedAction {
   }
 
   async runWithinTransaction({ params }) {
-    const searchWhere: { [propertyId: string]: any } = {};
-
-    if (
-      params.searchKey &&
-      params.searchValue &&
-      params.searchValue.length > 0
-    ) {
-      const property = await Property.findOne({
-        where: { key: params.searchKey },
-      });
-      if (!property) {
-        throw new Error(`cannot find a property for ${params.searchKey}`);
-      }
-
-      searchWhere.propertyId = property.id;
-      if (
-        params.searchValue.toLowerCase() === "null" ||
-        params.searchValue === ""
-      ) {
-        searchWhere.rawValue = { [Op.eq]: null };
-      } else {
-        const op = config.sequelize.dialect === "postgres" ? Op.iLike : Op.like;
-        const rawValueWhereClause = {};
-        rawValueWhereClause[op] = `${params.searchValue}`;
-        searchWhere.rawValue = rawValueWhereClause;
-      }
+    const { profiles, total } = await ProfileOps.search(params);
+    const profileData: AsyncReturnType<typeof Profile.prototype.apiData>[] = [];
+    for (const profile of profiles) {
+      profileData.push(await profile.apiData());
     }
 
-    const hasSearch = Object.keys(searchWhere).length > 0 ? true : false;
-    const searchIncludeItem = {
-      model: ProfileProperty,
-      where: searchWhere,
-      required: true,
-    };
-    const profileWhere = {
-      state: params.state ? params.state : { [Op.ne]: null },
-    };
-    const profileIncludeItem = { model: ProfileProperty };
-
-    if (params.groupId) {
-      const group = await Group.findById(params.groupId);
-
-      const groupMembers: Array<GroupMember> = await group.$get(
-        "groupMembers",
-        {
-          offset: params.offset,
-          limit: params.limit,
-        }
-      );
-
-      const groupInclude: Array<any> = [{ model: GroupMember }];
-      if (hasSearch) {
-        groupInclude.push(searchIncludeItem);
-      } else {
-        groupInclude.push(profileIncludeItem);
-      }
-
-      profileWhere["id"] = {
-        [Op.in]: groupMembers.map((mem) => mem.profileId),
-      };
-
-      const profiles = await Profile.findAll({
-        where: profileWhere,
-        include: groupInclude,
-        order: params.order,
-      });
-
-      const total = await group.profilesCount({
-        distinct: true,
-        include: [],
-      });
-
-      return {
-        total,
-        profiles: await Promise.all(
-          profiles.map(async (p) => {
-            const apiData = await p.apiData();
-            const memberData = { joinedAt: p.groupMembers[0].createdAt };
-            return Object.assign(apiData, memberData);
-          })
-        ),
-      };
-    } else if (hasSearch) {
-      const found = await Profile.findAll({
-        offset: params.offset,
-        limit: params.limit,
-        where: profileWhere,
-        include: [searchIncludeItem],
-        order: params.order,
-      });
-
-      let profiles: Profile[] = [];
-      if (found.length > 0) {
-        // fetch to get full profile
-        profiles = await Profile.findAll({
-          where: { id: found.map((p) => p.id) },
-          include: [profileIncludeItem],
-        });
-      }
-
-      const total = await Profile.count({
-        distinct: true,
-        where: profileWhere,
-        include: [searchIncludeItem],
-      });
-
-      const profileData = [];
-      for (let p of profiles) {
-        profileData.push(await p.apiData());
-      }
-      return {
-        total,
-        profiles: profileData,
-      };
-    } else {
-      // regular list based on state
-      const profiles = await Profile.findAll({
-        offset: params.offset,
-        limit: params.limit,
-        where: profileWhere,
-        include: [profileIncludeItem],
-        order: params.order,
-      });
-
-      const total = await Profile.count({
-        distinct: true,
-        where: profileWhere,
-        include: [],
-      });
-
-      const profileData = [];
-      for (let p of profiles) {
-        profileData.push(await p.apiData());
-      }
-
-      return {
-        total,
-        profiles: profileData,
-      };
-    }
+    return { total, profiles: profileData };
   }
 }
 

--- a/core/src/actions/profiles.ts
+++ b/core/src/actions/profiles.ts
@@ -20,6 +20,11 @@ export class ProfilesList extends AuthenticatedAction {
       searchKey: { required: false },
       searchValue: { required: false },
       state: { required: false },
+      caseSensitive: {
+        required: false,
+        formatter: (p: string | boolean) =>
+          p.toString().toLowerCase() === "true",
+      },
       limit: { required: true, default: 100 },
       offset: { required: true, default: 0 },
       order: {

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -197,6 +197,7 @@ export namespace ProfileOps {
 
     const profiles = await Profile.findAll({
       where: { id: profileIds },
+      order,
       include: [ProfileProperty],
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,37 +20,37 @@ importers:
 
   apps/staging-community:
     specifiers:
-      '@grouparoo/bigquery': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/csv': 0.4.0-alpha.0
-      '@grouparoo/customerio': 0.4.0-alpha.0
-      '@grouparoo/demo': 0.4.0-alpha.0
-      '@grouparoo/facebook': 0.4.0-alpha.0
-      '@grouparoo/files-s3': 0.4.0-alpha.0
-      '@grouparoo/google-sheets': 0.4.0-alpha.0
-      '@grouparoo/hubspot': 0.4.0-alpha.0
-      '@grouparoo/intercom': 0.4.0-alpha.0
-      '@grouparoo/iterable': 0.4.0-alpha.0
-      '@grouparoo/logger': 0.4.0-alpha.0
-      '@grouparoo/mailchimp': 0.4.0-alpha.0
-      '@grouparoo/marketo': 0.4.0-alpha.0
-      '@grouparoo/mongo': 0.4.0-alpha.0
-      '@grouparoo/mysql': 0.4.0-alpha.0
-      '@grouparoo/onesignal': 0.4.0-alpha.0
-      '@grouparoo/pardot': 0.4.0-alpha.0
-      '@grouparoo/pipedrive': 0.4.0-alpha.0
-      '@grouparoo/postgres': 0.4.0-alpha.0
-      '@grouparoo/redshift': 0.4.0-alpha.0
-      '@grouparoo/sailthru': 0.4.0-alpha.0
-      '@grouparoo/salesforce': 0.4.0-alpha.0
-      '@grouparoo/sendgrid': 0.4.0-alpha.0
-      '@grouparoo/sentry': 0.4.0-alpha.0
-      '@grouparoo/snowflake': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
-      '@grouparoo/sqlite': 0.4.0-alpha.0
-      '@grouparoo/ui-community': 0.4.0-alpha.0
-      '@grouparoo/ui-config': 0.4.0-alpha.0
-      '@grouparoo/zendesk': 0.4.0-alpha.0
+      '@grouparoo/bigquery': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/csv': 0.4.0-alpha.1
+      '@grouparoo/customerio': 0.4.0-alpha.1
+      '@grouparoo/demo': 0.4.0-alpha.1
+      '@grouparoo/facebook': 0.4.0-alpha.1
+      '@grouparoo/files-s3': 0.4.0-alpha.1
+      '@grouparoo/google-sheets': 0.4.0-alpha.1
+      '@grouparoo/hubspot': 0.4.0-alpha.1
+      '@grouparoo/intercom': 0.4.0-alpha.1
+      '@grouparoo/iterable': 0.4.0-alpha.1
+      '@grouparoo/logger': 0.4.0-alpha.1
+      '@grouparoo/mailchimp': 0.4.0-alpha.1
+      '@grouparoo/marketo': 0.4.0-alpha.1
+      '@grouparoo/mongo': 0.4.0-alpha.1
+      '@grouparoo/mysql': 0.4.0-alpha.1
+      '@grouparoo/onesignal': 0.4.0-alpha.1
+      '@grouparoo/pardot': 0.4.0-alpha.1
+      '@grouparoo/pipedrive': 0.4.0-alpha.1
+      '@grouparoo/postgres': 0.4.0-alpha.1
+      '@grouparoo/redshift': 0.4.0-alpha.1
+      '@grouparoo/sailthru': 0.4.0-alpha.1
+      '@grouparoo/salesforce': 0.4.0-alpha.1
+      '@grouparoo/sendgrid': 0.4.0-alpha.1
+      '@grouparoo/sentry': 0.4.0-alpha.1
+      '@grouparoo/snowflake': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
+      '@grouparoo/sqlite': 0.4.0-alpha.1
+      '@grouparoo/ui-community': 0.4.0-alpha.1
+      '@grouparoo/ui-config': 0.4.0-alpha.1
+      '@grouparoo/zendesk': 0.4.0-alpha.1
       jest: 26.6.3
     dependencies:
       '@grouparoo/bigquery': link:../../plugins/@grouparoo/bigquery
@@ -89,12 +89,12 @@ importers:
 
   apps/staging-config:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/demo': 0.4.0-alpha.0
-      '@grouparoo/postgres': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
-      '@grouparoo/sqlite': 0.4.0-alpha.0
-      '@grouparoo/ui-config': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/demo': 0.4.0-alpha.1
+      '@grouparoo/postgres': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
+      '@grouparoo/sqlite': 0.4.0-alpha.1
+      '@grouparoo/ui-config': 0.4.0-alpha.1
       jest: 26.6.3
     dependencies:
       '@grouparoo/core': link:../../core
@@ -108,37 +108,37 @@ importers:
 
   apps/staging-enterprise:
     specifiers:
-      '@grouparoo/bigquery': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/csv': 0.4.0-alpha.0
-      '@grouparoo/customerio': 0.4.0-alpha.0
-      '@grouparoo/demo': 0.4.0-alpha.0
-      '@grouparoo/facebook': 0.4.0-alpha.0
-      '@grouparoo/files-s3': 0.4.0-alpha.0
-      '@grouparoo/google-sheets': 0.4.0-alpha.0
-      '@grouparoo/hubspot': 0.4.0-alpha.0
-      '@grouparoo/intercom': 0.4.0-alpha.0
-      '@grouparoo/iterable': 0.4.0-alpha.0
-      '@grouparoo/logger': 0.4.0-alpha.0
-      '@grouparoo/mailchimp': 0.4.0-alpha.0
-      '@grouparoo/marketo': 0.4.0-alpha.0
-      '@grouparoo/mongo': 0.4.0-alpha.0
-      '@grouparoo/mysql': 0.4.0-alpha.0
-      '@grouparoo/onesignal': 0.4.0-alpha.0
-      '@grouparoo/pardot': 0.4.0-alpha.0
-      '@grouparoo/pipedrive': 0.4.0-alpha.0
-      '@grouparoo/postgres': 0.4.0-alpha.0
-      '@grouparoo/redshift': 0.4.0-alpha.0
-      '@grouparoo/sailthru': 0.4.0-alpha.0
-      '@grouparoo/salesforce': 0.4.0-alpha.0
-      '@grouparoo/sendgrid': 0.4.0-alpha.0
-      '@grouparoo/sentry': 0.4.0-alpha.0
-      '@grouparoo/snowflake': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
-      '@grouparoo/sqlite': 0.4.0-alpha.0
-      '@grouparoo/ui-config': 0.4.0-alpha.0
-      '@grouparoo/ui-enterprise': 0.4.0-alpha.0
-      '@grouparoo/zendesk': 0.4.0-alpha.0
+      '@grouparoo/bigquery': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/csv': 0.4.0-alpha.1
+      '@grouparoo/customerio': 0.4.0-alpha.1
+      '@grouparoo/demo': 0.4.0-alpha.1
+      '@grouparoo/facebook': 0.4.0-alpha.1
+      '@grouparoo/files-s3': 0.4.0-alpha.1
+      '@grouparoo/google-sheets': 0.4.0-alpha.1
+      '@grouparoo/hubspot': 0.4.0-alpha.1
+      '@grouparoo/intercom': 0.4.0-alpha.1
+      '@grouparoo/iterable': 0.4.0-alpha.1
+      '@grouparoo/logger': 0.4.0-alpha.1
+      '@grouparoo/mailchimp': 0.4.0-alpha.1
+      '@grouparoo/marketo': 0.4.0-alpha.1
+      '@grouparoo/mongo': 0.4.0-alpha.1
+      '@grouparoo/mysql': 0.4.0-alpha.1
+      '@grouparoo/onesignal': 0.4.0-alpha.1
+      '@grouparoo/pardot': 0.4.0-alpha.1
+      '@grouparoo/pipedrive': 0.4.0-alpha.1
+      '@grouparoo/postgres': 0.4.0-alpha.1
+      '@grouparoo/redshift': 0.4.0-alpha.1
+      '@grouparoo/sailthru': 0.4.0-alpha.1
+      '@grouparoo/salesforce': 0.4.0-alpha.1
+      '@grouparoo/sendgrid': 0.4.0-alpha.1
+      '@grouparoo/sentry': 0.4.0-alpha.1
+      '@grouparoo/snowflake': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
+      '@grouparoo/sqlite': 0.4.0-alpha.1
+      '@grouparoo/ui-config': 0.4.0-alpha.1
+      '@grouparoo/ui-enterprise': 0.4.0-alpha.1
+      '@grouparoo/zendesk': 0.4.0-alpha.1
       jest: 26.6.3
     dependencies:
       '@grouparoo/bigquery': link:../../plugins/@grouparoo/bigquery
@@ -230,8 +230,8 @@ importers:
 
   core:
     specifiers:
-      '@grouparoo/client-web': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/client-web': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/fs-extra': '*'
       '@types/jest': '*'
       '@types/node': '*'
@@ -251,7 +251,7 @@ importers:
       dotenv: 10.0.0
       fs-extra: 10.0.0
       glob: 7.1.7
-      grouparoo: 0.4.0-alpha.0
+      grouparoo: 0.4.0-alpha.1
       ioredis: 4.27.3
       ioredis-mock: 5.6.0
       isomorphic-fetch: 3.0.0
@@ -343,8 +343,8 @@ importers:
 
   plugins/@grouparoo/app-templates:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       '@types/uuid': '*'
@@ -372,9 +372,9 @@ importers:
   plugins/@grouparoo/bigquery:
     specifiers:
       '@google-cloud/bigquery': 5.6.0
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -404,8 +404,8 @@ importers:
 
   plugins/@grouparoo/csv:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -433,9 +433,9 @@ importers:
 
   plugins/@grouparoo/customerio:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -468,8 +468,8 @@ importers:
 
   plugins/@grouparoo/dbt:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -495,8 +495,8 @@ importers:
 
   plugins/@grouparoo/demo:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -536,9 +536,9 @@ importers:
 
   plugins/@grouparoo/facebook:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -575,7 +575,7 @@ importers:
 
   plugins/@grouparoo/files-local:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -598,7 +598,7 @@ importers:
 
   plugins/@grouparoo/files-s3:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -623,8 +623,8 @@ importers:
 
   plugins/@grouparoo/google-sheets:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -654,9 +654,9 @@ importers:
 
   plugins/@grouparoo/hubspot:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -689,9 +689,9 @@ importers:
 
   plugins/@grouparoo/intercom:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -722,9 +722,9 @@ importers:
 
   plugins/@grouparoo/iterable:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -755,9 +755,9 @@ importers:
 
   plugins/@grouparoo/logger:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -780,9 +780,9 @@ importers:
 
   plugins/@grouparoo/mailchimp:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -813,10 +813,10 @@ importers:
 
   plugins/@grouparoo/marketo:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
       '@grouparoo/node-marketo-rest': 0.7.10
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -846,9 +846,9 @@ importers:
 
   plugins/@grouparoo/mongo:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -877,9 +877,9 @@ importers:
 
   plugins/@grouparoo/mysql:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/mysql': '*'
       '@types/node': '*'
@@ -908,8 +908,8 @@ importers:
 
   plugins/@grouparoo/newrelic:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -933,9 +933,9 @@ importers:
 
   plugins/@grouparoo/onesignal:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -966,9 +966,9 @@ importers:
 
   plugins/@grouparoo/pardot:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -1003,9 +1003,9 @@ importers:
 
   plugins/@grouparoo/pipedrive:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -1036,9 +1036,9 @@ importers:
 
   plugins/@grouparoo/postgres:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       '@types/pg': '*'
@@ -1075,10 +1075,10 @@ importers:
 
   plugins/@grouparoo/redshift:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/postgres': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/postgres': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       '@types/pg': '*'
@@ -1104,9 +1104,9 @@ importers:
 
   plugins/@grouparoo/sailthru:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -1137,9 +1137,9 @@ importers:
 
   plugins/@grouparoo/salesforce:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -1170,9 +1170,9 @@ importers:
 
   plugins/@grouparoo/sendgrid:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@sendgrid/client': 7.4.3
       '@types/jest': '*'
       '@types/node': '*'
@@ -1203,8 +1203,8 @@ importers:
 
   plugins/@grouparoo/sentry:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@sentry/node': 6.5.0
       '@sentry/tracing': 6.5.0
       '@types/jest': '*'
@@ -1230,9 +1230,9 @@ importers:
 
   plugins/@grouparoo/snowflake:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -1265,7 +1265,7 @@ importers:
 
   plugins/@grouparoo/spec-helper:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
       '@types/faker': '*'
       '@types/jest': '*'
       '@types/node': '*'
@@ -1300,9 +1300,9 @@ importers:
 
   plugins/@grouparoo/sqlite:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       '@types/pg': '*'
@@ -1335,9 +1335,9 @@ importers:
 
   plugins/@grouparoo/zendesk:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.0
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/app-templates': 0.4.0-alpha.1
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -1372,9 +1372,9 @@ importers:
       '@fortawesome/free-brands-svg-icons': 5.15.3
       '@fortawesome/free-solid-svg-icons': 5.15.3
       '@fortawesome/react-fontawesome': 0.1.14
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
-      '@grouparoo/ui-components': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
+      '@grouparoo/ui-components': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1457,8 +1457,8 @@ importers:
       '@fortawesome/free-brands-svg-icons': 5.15.3
       '@fortawesome/free-solid-svg-icons': 5.15.3
       '@fortawesome/react-fontawesome': 0.1.14
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1541,9 +1541,9 @@ importers:
       '@fortawesome/free-brands-svg-icons': 5.15.3
       '@fortawesome/free-solid-svg-icons': 5.15.3
       '@fortawesome/react-fontawesome': 0.1.14
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
-      '@grouparoo/ui-components': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
+      '@grouparoo/ui-components': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1628,9 +1628,9 @@ importers:
       '@fortawesome/free-brands-svg-icons': 5.15.3
       '@fortawesome/free-solid-svg-icons': 5.15.3
       '@fortawesome/react-fontawesome': 0.1.14
-      '@grouparoo/core': 0.4.0-alpha.0
-      '@grouparoo/spec-helper': 0.4.0-alpha.0
-      '@grouparoo/ui-components': 0.4.0-alpha.0
+      '@grouparoo/core': 0.4.0-alpha.1
+      '@grouparoo/spec-helper': 0.4.0-alpha.1
+      '@grouparoo/ui-components': 0.4.0-alpha.1
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'


### PR DESCRIPTION
Speeds up `profile:list` action. Still supports:
* Filtering by state
* Searching for Profiles that match a full or partial profileProperty value
* Searching for Profiles which are in a specific Group
* Any combination of the above

Aside from refactoring the query to use no inner-selects, the next biggest slowdown was due to check the values provided for matching a (partial) profileProperty in a case-insensitive way.  To that end, the UI now allows users to make that choice:

<img width="1285" alt="Screen Shot 2021-06-04 at 2 53 58 PM" src="https://user-images.githubusercontent.com/303226/120867118-225f8500-c546-11eb-83a4-e2555f26628a.png">
 

Speedups:
* No more sub-queries
* Only use `LIKE` if a `%` is present.  This is dramatically slower, but might still be wanted. 
* Only use case-insensitive comparisons (`LOWER()`) when requested.  This is dramatically slower, but might still be wanted. 

Notes:
* Adding an index on `LOWER(rawValue)` didn't help much
* The `ORDER BY` wasn't causing significant slowdown, and deterministic pagination seems like a good idea 