### PR TITLE
Only consider ready profiles to add to groups

### DIFF
--- a/core/__tests__/tasks/group/run.ts
+++ b/core/__tests__/tasks/group/run.ts
@@ -1,6 +1,14 @@
 import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
 import { api, specHelper, task } from "actionhero";
-import { Group, Import, Profile, GroupMember, Run, plugin } from "../../../src";
+import {
+  Group,
+  Import,
+  Profile,
+  GroupMember,
+  Run,
+  plugin,
+  ProfileProperty,
+} from "../../../src";
 
 describe("tasks/group:run", () => {
   helper.grouparooTestServer({
@@ -69,6 +77,9 @@ describe("tasks/group:run", () => {
         lastName: ["Toadstool"],
         email: ["toad@example.com"],
       });
+
+      await ProfileProperty.update({ state: "ready" }, { where: {} });
+      await Profile.update({ state: "ready" }, { where: {} });
     });
 
     test("can be enqueued", async () => {

--- a/core/__tests__/utils/prepareSharedGroupTest.ts
+++ b/core/__tests__/utils/prepareSharedGroupTest.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { Profile, Group, Run, Import } from "../../src";
+import { Profile, Group, Run, Import, ProfileProperty } from "../../src";
 import { specHelper } from "actionhero";
 
 export namespace SharedGroupTests {
@@ -87,6 +87,16 @@ export namespace SharedGroupTests {
     await group.update({ matchType: "all" });
 
     run = await helper.factories.run();
+
+    await ProfileProperty.update(
+      { state: "ready" },
+      { where: { profileId: [mario.id, luigi.id, peach.id, toad.id] } }
+    );
+
+    await mario.update({ state: "ready" });
+    await luigi.update({ state: "ready" });
+    await peach.update({ state: "ready" });
+    await toad.update({ state: "ready" });
 
     return { group, run };
   }

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -435,7 +435,8 @@ export class Group extends LoggedModel<Group> {
    */
   async _buildGroupMemberQueryParts(
     rules?: GroupRuleWithKey[],
-    matchType: typeof matchTypes[number] = this.matchType
+    matchType: typeof matchTypes[number] = this.matchType,
+    profileState?: string
   ) {
     if (this.type !== "calculated") {
       throw new Error("only calculated groups can be calculated");
@@ -444,8 +445,10 @@ export class Group extends LoggedModel<Group> {
     if (!rules) rules = await this.getRules();
 
     const include = [];
-    const wheres: WhereAttributeHash[] = [{ state: "ready" }];
+    const wheres: WhereAttributeHash[] = [];
     const localNumbers = [].concat(numbers);
+
+    if (profileState) wheres.push({ state: profileState });
 
     for (const i in rules) {
       const rule = rules[i];

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -15,7 +15,7 @@ import {
   Scopes,
 } from "sequelize-typescript";
 import { api, config } from "actionhero";
-import { Op } from "sequelize";
+import { Op, WhereAttributeHash } from "sequelize";
 import Moment from "moment";
 import { LoggedModel } from "../classes/loggedModel";
 import { GroupMember } from "./GroupMember";
@@ -444,7 +444,7 @@ export class Group extends LoggedModel<Group> {
     if (!rules) rules = await this.getRules();
 
     const include = [];
-    const wheres = [{ state: "ready" }];
+    const wheres: WhereAttributeHash[] = [{ state: "ready" }];
     const localNumbers = [].concat(numbers);
 
     for (const i in rules) {

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -444,7 +444,7 @@ export class Group extends LoggedModel<Group> {
     if (!rules) rules = await this.getRules();
 
     const include = [];
-    const wheres = [];
+    const wheres = [{ state: "ready" }];
     const localNumbers = [].concat(numbers);
 
     for (const i in rules) {

--- a/core/src/models/ProfileMultipleAssociationShim.ts
+++ b/core/src/models/ProfileMultipleAssociationShim.ts
@@ -9,6 +9,9 @@ export class ProfileMultipleAssociationShim extends Model {
   @Column
   createdAt: Date;
 
+  @Column
+  state: string;
+
   // include multiple associations to ProfileProperty for group membership searching
   @HasMany(() => ProfileProperty, {
     as: "ProfileProperties_1",

--- a/core/src/modules/ops/group.ts
+++ b/core/src/modules/ops/group.ts
@@ -231,7 +231,11 @@ export namespace GroupOps {
         return { groupMembersCount: 0, nextHighWaterMark: 0, nextOffset: 0 };
       }
 
-      const { where, include } = await group._buildGroupMemberQueryParts(rules);
+      const { where, include } = await group._buildGroupMemberQueryParts(
+        rules,
+        group.matchType,
+        "ready"
+      );
 
       where["createdAt"] = { [Op.and]: [{ [Op.lt]: run.createdAt }] };
       if (highWaterMark) {


### PR DESCRIPTION
Prior to this PR, all Profiles are being considered. This means that we keep creating imports to check on Profiles that should be in a group, but aren't yet. This is silly, as their membership will be updated soon anyway as the profile is imported normally.

