### PR TITLE
Task speedup

### DIFF
--- a/core/src/migrations/000070-speedIndexes.ts
+++ b/core/src/migrations/000070-speedIndexes.ts
@@ -1,0 +1,31 @@
+export default {
+  up: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.addIndex("imports", ["createdProfile"], {
+        fields: ["createdProfile"],
+      });
+
+      await migration.addIndex("imports", ["exportedAt"], {
+        fields: ["exportedAt"],
+      });
+
+      await migration.addIndex("profileProperties", ["rawValue"], {
+        fields: ["rawValue"],
+      });
+    });
+  },
+
+  down: async function (migration) {
+    await migration.removeIndex("imports", ["createdProfile"], {
+      fields: ["createdProfile"],
+    });
+
+    await migration.removeIndex("imports", ["exportedAt"], {
+      fields: ["exportedAt"],
+    });
+
+    await migration.removeIndex("profileProperties", ["rawValue"], {
+      fields: ["rawValue"],
+    });
+  },
+};

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -8,7 +8,7 @@ import { Event } from "../../models/Event";
 import { GroupMember } from "../../models/GroupMember";
 import { Log } from "../../models/Log";
 import { api } from "actionhero";
-import { Op, OrderItem, WhereAttributeHash } from "sequelize";
+import { Op, OrderItem, WhereAttributeHash, QueryTypes } from "sequelize";
 import { waitForLock } from "../locks";
 import { ProfilePropertyOps } from "./profileProperty";
 import { CLS } from "../../modules/cls";
@@ -686,54 +686,19 @@ export namespace ProfileOps {
    * Task `profile:completeImport` will be enqueued for each Profile.
    */
   export async function makeReady(limit = 100, toExport = true) {
-    // let profiles: Profile[] = await api.sequelize.query(
-    //   `SELECT
-    //       profiles.id as id
-    //     FROM profiles
-    //     JOIN
-    //       "profileProperties" on "profileProperties"."profileId" = profiles.id
-    //     WHERE
-    //       profiles.state = 'pending'
-    //     GROUP BY profiles.id
-    //     HAVING
-    //       MAX("profileProperties".state) = 'ready'
-    //       AND COUNT(DISTINCT "profileProperties".state) = 1
-    //     LIMIT ${limit}
-    //     ;`,
-    //   { type: QueryTypes.SELECT }
-    // );
-
-    let profiles = await Profile.findAll({
-      subQuery: false,
-      attributes: ["id"],
-      where: { state: "pending" },
-      include: [{ model: ProfileProperty, required: true, attributes: [] }],
-      group: "Profile.id",
-      limit,
-      having: {
-        [Op.and]: [
-          api.sequelize.where(
-            api.sequelize.fn(
-              "MAX",
-              api.sequelize.col("profileProperties.state")
-            ),
-            "=",
-            "ready"
-          ),
-          api.sequelize.where(
-            api.sequelize.fn(
-              "COUNT",
-              api.sequelize.fn(
-                "DISTINCT",
-                api.sequelize.col("profileProperties.state")
-              )
-            ),
-            "=",
-            1
-          ),
-        ],
-      },
-    });
+    let profiles: Profile[] = await api.sequelize.query(
+      `
+    SELECT "id" from "profiles" where "state" = 'pending'
+    EXCEPT
+    SELECT DISTINCT("profileId") FROM "profileProperties" WHERE "state" = 'pending'
+    LIMIT ${limit}
+    ;
+    `,
+      {
+        type: QueryTypes.SELECT,
+        model: Profile,
+      }
+    );
 
     const updateResponse = await Profile.update(
       { state: "ready" },

--- a/core/src/tasks/profileProperty/sweep.ts
+++ b/core/src/tasks/profileProperty/sweep.ts
@@ -10,7 +10,7 @@ export class ProfilePropertySweep extends CLSTask {
     this.name = "profileProperties:sweep";
     this.description =
       "Double check that all profile properties are removed that don't belong to a profile or property";
-    this.frequency = 1000 * 30;
+    this.frequency = 1000 * 60 * 60;
     this.queue = "profileProperties";
     this.inputs = {};
   }
@@ -41,16 +41,20 @@ export class ProfilePropertySweep extends CLSTask {
       limit,
     });
 
-    for (const i in profilePropertiesMissingProfile) {
-      await profilePropertiesMissingProfile[i].destroy();
-    }
-
-    for (const i in profilePropertiesMissingRule) {
-      await profilePropertiesMissingRule[i].destroy();
-    }
-
     count += profilePropertiesMissingProfile.length;
     count += profilePropertiesMissingRule.length;
+
+    if (count > 0) {
+      await ProfileProperty.destroy({
+        where: {
+          id: [].concat(
+            profilePropertiesMissingProfile.map((p) => p.id),
+            profilePropertiesMissingRule.map((p) => p.id)
+          ),
+        },
+      });
+    }
+
     return count;
   }
 }


### PR DESCRIPTION
This PR attempts to speed up 3 tasks:
* `profiles:checkReady`
* `system:status`
* `runs:updateCounts`
* `profileProperties:sweep`

**Interesting Learnings**
* With larger datasets (~10M Profile Properties) an `EXCLUDE` query is faster than a sub-query, a CTE, or even a join

--- 

Raw Notes

```sql
-- *** runs:updateCounts ***

-- Before: 10s
-- Resolution: CREATE INDEX "imports_created_profile" ON "imports" ("createdProfile")
-- After: 3s
EXPLAIN ANALYZE 
SELECT count(*) AS "count" FROM "imports" AS "Import" WHERE "Import"."creatorId" = 'run_4473c0af-47cb-4506-80f8-b4ecddb33185' AND "Import"."createdProfile" = true;


-- Before: 5s
-- Resolution: CREATE INDEX "profile_properties_raw_value" ON "profileProperties" ("rawValue")
-- After: 1s
EXPLAIN ANALYZE 
SELECT count(DISTINCT("ProfileMultipleAssociationShim"."id")) AS "count" FROM "profiles" AS "ProfileMultipleAssociationShim" INNER JOIN "profileProperties" AS "ProfileProperties_10" ON "ProfileMultipleAssociationShim"."id" = "ProfileProperties_10"."profileId" AND "ProfileProperties_10"."propertyId" = 'ltv' INNER JOIN "profileProperties" AS "ProfileProperties_9" ON "ProfileMultipleAssociationShim"."id" = "ProfileProperties_9"."profileId" AND "ProfileProperties_9"."propertyId" = 'last_purchase_date' INNER JOIN "profileProperties" AS "ProfileProperties_8" ON "ProfileMultipleAssociationShim"."id" = "ProfileProperties_8"."profileId" AND "ProfileProperties_8"."propertyId" = 'last_purchase_category' WHERE ((CAST("ProfileProperties_10"."rawValue" AS FLOAT) > '100') AND (CAST("ProfileProperties_9"."rawValue" AS BIGINT) > 1617739845527 AND CAST("ProfileProperties_9"."rawValue" AS BIGINT) <= 1622923845527) AND (CAST("ProfileProperties_8"."rawValue" AS TEXT) = 'Automotive'));

--- *** system:status ***

-- Before: 7s
-- Resolution: CREATE INDEX "imports_exported_at" ON "imports" ("exportedAt")
-- After: 0.3s
EXPLAIN ANALYZE
SELECT count(*) AS "count" FROM "imports" AS "Import" WHERE "Import"."exportedAt" IS NULL;

-- Before: 9s
-- Resolution: CREATE INDEX "profile_properties_state" ON "profileProperties" ("state")
-- After: 4s
-- This one is still going to be slow - `SELECT COUNT(DISTINCT("profileId")) from "profileProperties"` takes 4 seconds on its own
EXPLAIN ANALYZE 
SELECT "Property"."sourceId", COUNT(DISTINCT("profileId")) AS "count" FROM "properties" AS "Property" INNER JOIN "profileProperties" AS "ProfileProperties" ON "Property"."id" = "ProfileProperties"."propertyId" AND "ProfileProperties"."state" = 'pending' WHERE "Property"."state" NOT IN ('draft') GROUP BY "sourceId";


--- *** profiles:checkReady ***

-- Before: 30s
-- Resolution: (indexes added above)  
-- After: 17s
-- This one is still going to be slow as we need to compare /all/ the profile properties for pending profiles
EXPLAIN ANALYZE
SELECT "Profile"."id" FROM "profiles" AS "Profile" INNER JOIN "profileProperties" AS "profileProperties" ON "Profile"."id" = "profileProperties"."profileId" WHERE "Profile"."state" = 'pending' GROUP BY "Profile"."id" HAVING (MAX("profileProperties"."state") = 'ready' AND COUNT(DISTINCT("profileProperties"."state")) = 1) LIMIT 1000;

SELECT "profileProperties"."profileId" FROM "profileProperties" INNER JOIN "profiles" AS "Profile" ON "Profile"."id" = "profileProperties"."profileId" WHERE "Profile"."state" = 'pending' GROUP BY "profileProperties"."profileId" HAVING (MAX("profileProperties"."state") = 'ready' AND COUNT(DISTINCT("profileProperties"."state")) = 1) LIMIT 1000;

-- 5 seconds
SELECT id from profiles where state = 'pending' 
EXCEPT 
SELECT distinct("profileId") FROM "profileProperties" where state = 'pending'
LIMIT 1000
;

-- +1 minute
SELECT id from profiles where state = 'pending' AND id NOT IN (SELECT "profileId" FROM "profileProperties" where state = 'pending') LIMIT 1000
;

-- +1 minute
WITH "readyProfileProperties" as (SELECT "profileId" FROM "profileProperties" where state = 'pending') 
SELECT id from profiles where state = 'pending' AND id NOT IN (select "profileId" from "readyProfileProperties") LIMIT 1000
;
```