### PR TITLE
Date group rules to not require `"type": "date"`

### DIFF
--- a/core/__tests__/fixtures/codeConfig/group-rule-with-date/config.js
+++ b/core/__tests__/fixtures/codeConfig/group-rule-with-date/config.js
@@ -46,13 +46,11 @@ module.exports = async function getConfig() {
           propertyId: "last_purchase_date",
           operation: { op: "lt" },
           match: "2020-03-01", // date only
-          type: "date",
         },
         {
           propertyId: "last_appointment_date",
           operation: { op: "gte" },
           match: "2019-10-10T14:48:00.000+09:00", //date with time and timezone
-          type: "date",
         },
         {
           propertyId: "last_email_date",

--- a/core/src/modules/configLoaders/group.ts
+++ b/core/src/modules/configLoaders/group.ts
@@ -57,7 +57,7 @@ export async function loadGroup(
         rules[i].key = property.key;
 
         // if calculating based on a date, parse to unix timestamp
-        if (calculatesWithDate.indexOf(rules[i]["operation"]["op"]) >= 0) {
+        if (calculatesWithDate.includes(rules[i]["operation"]["op"])) {
           if (property.type === "date") {
             rules[i]["match"] = Date.parse(rules[i]["match"].toString());
           }

--- a/core/src/modules/configLoaders/group.ts
+++ b/core/src/modules/configLoaders/group.ts
@@ -49,19 +49,19 @@ export async function loadGroup(
   if (configObject.rules) {
     const rules = [...configObject.rules];
     const calculatesWithDate = ["lte", "gt", "lt", "gte", "eq", "ne"];
+
     for (const i in rules) {
       if (rules[i]["propertyId"]) {
         const property = await Property.findById(rules[i]["propertyId"]);
         delete rules[i]["propertyId"];
         rules[i].key = property.key;
-      }
 
-      //parses to epoch time if calculated date rule
-      if (
-        calculatesWithDate.indexOf(rules[i]["operation"]["op"]) >= 0 &&
-        rules[i]["type"] === "date"
-      ) {
-        rules[i]["match"] = Date.parse(rules[i]["match"].toString());
+        // if calculating based on a date, parse to unix timestamp
+        if (calculatesWithDate.indexOf(rules[i]["operation"]["op"]) >= 0) {
+          if (property.type === "date") {
+            rules[i]["match"] = Date.parse(rules[i]["match"].toString());
+          }
+        }
       }
     }
 


### PR DESCRIPTION
BEFORE: had to feed a "type" to the config file for date based rules

NOW: If a group rule is based on a calculation, check the associated property's type to see if it's a date.  If so, it is parsed to unix timestamp.