### PR TITLE
Remove run references in Config UI

### DIFF
--- a/ui/ui-components/pages/source/[id]/overview.tsx
+++ b/ui/ui-components/pages/source/[id]/overview.tsx
@@ -148,83 +148,90 @@ export default function Page({
                     <StateBadge state={source.schedule.state} />
                   </p>
                 </Col>
-                <Col>
-                  <Alert variant="success">
-                    <strong>Most Recent Run</strong>
-                    {run ? (
-                      <>
-                        <br /> State: {run.state}
-                        <br />
-                        {run.createdAt ? (
-                          <>
-                            Started <Moment fromNow>{run.createdAt}</Moment>
-                            <ul>
-                              <li>Imports Created: {run.importsCreated}</li>
-                              <li>Profiles Created: {run.profilesCreated}</li>
-                              <li>Profiles Imported: {run.profilesImported}</li>
-                            </ul>
-                          </>
-                        ) : (
-                          <span>never run</span>
-                        )}
-                        {run.completedAt ? (
-                          <p>
-                            Completed <Moment fromNow>{run.completedAt}</Moment>
-                          </p>
-                        ) : null}
-                        <p>
-                          <Link
-                            href="/run/[id]/edit"
-                            as={`/run/${run.id}/edit`}
-                          >
-                            <a>See More</a>
-                          </Link>
-                        </p>
-                      </>
-                    ) : (
-                      <p>no runs yet</p>
-                    )}{" "}
-                  </Alert>
-                </Col>
-                <Col>
-                  <Alert variant="info">
-                    <p>
-                      <strong>Next Run</strong>
-                      <br />
-                      {run?.updatedAt &&
-                      new Date(run.updatedAt).getTime() +
-                        source.schedule.recurringFrequency >
-                        new Date().getTime() &&
-                      recurringFrequencyMinutes > 0 ? (
+                {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                  <Col>
+                    <Alert variant="success">
+                      <strong>Most Recent Run</strong>
+                      {run ? (
                         <>
-                          in{" "}
-                          <Moment
-                            add={{
-                              minutes: recurringFrequencyMinutes,
-                            }}
-                            toNow
-                            ago
-                          >
-                            {run.updatedAt}
-                          </Moment>
+                          <br /> State: {run.state}
+                          <br />
+                          {run.createdAt ? (
+                            <>
+                              Started <Moment fromNow>{run.createdAt}</Moment>
+                              <ul>
+                                <li>Imports Created: {run.importsCreated}</li>
+                                <li>Profiles Created: {run.profilesCreated}</li>
+                                <li>
+                                  Profiles Imported: {run.profilesImported}
+                                </li>
+                              </ul>
+                            </>
+                          ) : (
+                            <span>never run</span>
+                          )}
+                          {run.completedAt ? (
+                            <p>
+                              Completed{" "}
+                              <Moment fromNow>{run.completedAt}</Moment>
+                            </p>
+                          ) : null}
+                          <p>
+                            <Link
+                              href="/run/[id]/edit"
+                              as={`/run/${run.id}/edit`}
+                            >
+                              <a>See More</a>
+                            </Link>
+                          </p>
                         </>
-                      ) : null}
-
-                      {(run?.updatedAt &&
+                      ) : (
+                        <p>no runs yet</p>
+                      )}{" "}
+                    </Alert>
+                  </Col>
+                )}
+                {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                  <Col>
+                    <Alert variant="info">
+                      <p>
+                        <strong>Next Run</strong>
+                        <br />
+                        {run?.updatedAt &&
                         new Date(run.updatedAt).getTime() +
-                          source.schedule.recurringFrequency <=
+                          source.schedule.recurringFrequency >
                           new Date().getTime() &&
-                        recurringFrequencyMinutes) ||
-                      !run ? (
-                        source.schedule.recurring ? (
-                          <strong>Soon</strong>
-                        ) : (
-                          "N/A"
-                        )
-                      ) : null}
-                    </p>
-                  </Alert>
-                </Col>
+                        recurringFrequencyMinutes > 0 ? (
+                          <>
+                            in{" "}
+                            <Moment
+                              add={{
+                                minutes: recurringFrequencyMinutes,
+                              }}
+                              toNow
+                              ago
+                            >
+                              {run.updatedAt}
+                            </Moment>
+                          </>
+                        ) : null}
+
+                        {(run?.updatedAt &&
+                          new Date(run.updatedAt).getTime() +
+                            source.schedule.recurringFrequency <=
+                            new Date().getTime() &&
+                          recurringFrequencyMinutes) ||
+                        !run ? (
+                          source.schedule.recurring ? (
+                            <strong>Soon</strong>
+                          ) : (
+                            "N/A"
+                          )
+                        ) : null}
+                      </p>
+                    </Alert>
+                  </Col>
+                )}
               </Row>
             ) : (
               <ScheduleAddButton

--- a/ui/ui-components/pages/source/[id]/schedule.tsx
+++ b/ui/ui-components/pages/source/[id]/schedule.tsx
@@ -147,86 +147,92 @@ export default function Page(props) {
                       />
                     </Form.Group>
                   </Col>
-                  <Col>
-                    <Alert variant="success">
-                      <strong>Most Recent Run</strong>
-                      {run ? (
-                        <>
-                          <br /> State: {run.state}
-                          <br />
-                          {run.createdAt ? (
-                            <>
-                              Started <Moment fromNow>{run.createdAt}</Moment>
-                              <ul>
-                                <li>Imports Created: {run.importsCreated}</li>
-                                <li>Profiles Created: {run.profilesCreated}</li>
-                                <li>
-                                  Profiles Imported: {run.profilesImported}
-                                </li>
-                              </ul>
-                            </>
-                          ) : (
-                            <span>never run</span>
-                          )}
-                          {run.completedAt ? (
-                            <p>
-                              Completed{" "}
-                              <Moment fromNow>{run.completedAt}</Moment>
-                            </p>
-                          ) : null}
-                          <p>
-                            <Link
-                              href="/run/[id]/edit"
-                              as={`/run/${run.id}/edit`}
-                            >
-                              <a>See More</a>
-                            </Link>
-                          </p>
-                        </>
-                      ) : (
-                        <p>no runs yet</p>
-                      )}{" "}
-                    </Alert>
-                  </Col>
-                  <Col>
-                    <Alert variant="info">
-                      <p>
-                        <strong>Next Run</strong>
-                        <br />
-                        {run?.updatedAt &&
-                        new Date(run.updatedAt).getTime() +
-                          schedule.recurringFrequency >
-                          new Date().getTime() &&
-                        recurringFrequencyMinutes > 0 ? (
+                  {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                    <Col>
+                      <Alert variant="success">
+                        <strong>Most Recent Run</strong>
+                        {run ? (
                           <>
-                            in{" "}
-                            <Moment
-                              add={{
-                                minutes: recurringFrequencyMinutes,
-                              }}
-                              toNow
-                              ago
-                            >
-                              {run.updatedAt}
-                            </Moment>
+                            <br /> State: {run.state}
+                            <br />
+                            {run.createdAt ? (
+                              <>
+                                Started <Moment fromNow>{run.createdAt}</Moment>
+                                <ul>
+                                  <li>Imports Created: {run.importsCreated}</li>
+                                  <li>
+                                    Profiles Created: {run.profilesCreated}
+                                  </li>
+                                  <li>
+                                    Profiles Imported: {run.profilesImported}
+                                  </li>
+                                </ul>
+                              </>
+                            ) : (
+                              <span>never run</span>
+                            )}
+                            {run.completedAt ? (
+                              <p>
+                                Completed{" "}
+                                <Moment fromNow>{run.completedAt}</Moment>
+                              </p>
+                            ) : null}
+                            <p>
+                              <Link
+                                href="/run/[id]/edit"
+                                as={`/run/${run.id}/edit`}
+                              >
+                                <a>See More</a>
+                              </Link>
+                            </p>
                           </>
-                        ) : null}
-
-                        {(run?.updatedAt &&
+                        ) : (
+                          <p>no runs yet</p>
+                        )}{" "}
+                      </Alert>
+                    </Col>
+                  )}
+                  {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                    <Col>
+                      <Alert variant="info">
+                        <p>
+                          <strong>Next Run</strong>
+                          <br />
+                          {run?.updatedAt &&
                           new Date(run.updatedAt).getTime() +
-                            schedule.recurringFrequency <=
+                            schedule.recurringFrequency >
                             new Date().getTime() &&
-                          recurringFrequencyMinutes) ||
-                        !run ? (
-                          schedule.recurring ? (
-                            <strong>Soon</strong>
-                          ) : (
-                            "N/A"
-                          )
-                        ) : null}
-                      </p>
-                    </Alert>
-                  </Col>
+                          recurringFrequencyMinutes > 0 ? (
+                            <>
+                              in{" "}
+                              <Moment
+                                add={{
+                                  minutes: recurringFrequencyMinutes,
+                                }}
+                                toNow
+                                ago
+                              >
+                                {run.updatedAt}
+                              </Moment>
+                            </>
+                          ) : null}
+
+                          {(run?.updatedAt &&
+                            new Date(run.updatedAt).getTime() +
+                              schedule.recurringFrequency <=
+                              new Date().getTime() &&
+                            recurringFrequencyMinutes) ||
+                          !run ? (
+                            schedule.recurring ? (
+                              <strong>Soon</strong>
+                            ) : (
+                              "N/A"
+                            )
+                          ) : null}
+                        </p>
+                      </Alert>
+                    </Col>
+                  )}
                 </Row>
               ) : null}
               <>

--- a/ui/ui-components/pages/sources.tsx
+++ b/ui/ui-components/pages/sources.tsx
@@ -152,22 +152,26 @@ export default function Page(props) {
                         {schedule.recurring
                           ? `Every ${recurringFrequencyMinutes} minutes`
                           : "Not recurring"}
-                        <br />
-                        Last Run:{" "}
-                        {run ? (
-                          <Moment fromNow>{run?.createdAt}</Moment>
-                        ) : (
-                          "Never"
+                        {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                          <>
+                            <br />
+                            Last Run:{" "}
+                            {run ? (
+                              <Moment fromNow>{run?.createdAt}</Moment>
+                            ) : (
+                              "Never"
+                            )}
+                            <br />
+                            <Button
+                              variant="outline-success"
+                              size="sm"
+                              disabled={run?.state === "running"}
+                              onClick={() => enqueueScheduleRun(source)}
+                            >
+                              Run Now
+                            </Button>
+                          </>
                         )}
-                        <br />
-                        <Button
-                          variant="outline-success"
-                          size="sm"
-                          disabled={run?.state === "running"}
-                          onClick={() => enqueueScheduleRun(source)}
-                        >
-                          Run Now
-                        </Button>
                       </>
                     ) : (
                       "No Schedule"


### PR DESCRIPTION
There's probably some refactoring we could do here, especially since some of these components look so similar. Right now I'm just trying to move quickly.

Would you rather I take the time to refactor here and clean up the UI, or is this show/hide based on UI edition enough for MVP for config?