### PR TITLE
Groups don't have "updating" state in Config UI

### DIFF
--- a/apps/staging-config/README.md
+++ b/apps/staging-config/README.md
@@ -10,6 +10,11 @@ To get started running config mode:
 
     $ npm run config
 
+This command will delete and recreate your SQLite config database. But it will leave user authentication in place. If you want a completely fresh start, you can manually delete your `.local` directory.
+
+    $ rm -rf .local
+    $ npm run config
+
 ## Seeding Configuration
 
 You can pre-populate a set of configuration files using our demo command. First, ensure the `DEMO_DATABASE_URL` environment variable is set in your `.env` file in this project and points to a local Postgres database. Here's an example:

--- a/apps/staging-config/package.json
+++ b/apps/staging-config/package.json
@@ -17,11 +17,12 @@
   "devDependencies": {
     "@grouparoo/spec-helper": "0.4.0-alpha.1",
     "@grouparoo/ui-config": "0.4.0-alpha.1",
+    "grouparoo": "0.4.0-alpha.1",
     "jest": "26.6.3"
   },
   "scripts": {
-    "config": "rm grouparoo_config.sqlite; rm -rf .local; CONFIG_DATABASE_URL=\"sqlite://grouparoo_config.sqlite\" NEXT_DEVELOPMENT_MODE=true ./node_modules/@grouparoo/core/node_modules/.bin/grouparoo config",
-    "demo": "./node_modules/@grouparoo/core/node_modules/.bin/grouparoo demo purchases --config"
+    "config": "rm grouparoo_config.sqlite; rm -rf .local; CONFIG_DATABASE_URL=\"sqlite://grouparoo_config.sqlite\" NEXT_DEVELOPMENT_MODE=true ./node_modules/.bin/grouparoo config",
+    "demo": "./node_modules/.bin/grouparoo demo purchases --config"
   },
   "grouparoo": {
     "grouparoo_monorepo_app": "staging-config",

--- a/apps/staging-config/package.json
+++ b/apps/staging-config/package.json
@@ -21,7 +21,7 @@
     "jest": "26.6.3"
   },
   "scripts": {
-    "config": "rm grouparoo_config.sqlite; rm -rf .local; CONFIG_DATABASE_URL=\"sqlite://grouparoo_config.sqlite\" NEXT_DEVELOPMENT_MODE=true ./node_modules/.bin/grouparoo config",
+    "config": "rm grouparoo_config.sqlite; CONFIG_DATABASE_URL=\"sqlite://grouparoo_config.sqlite\" NEXT_DEVELOPMENT_MODE=true ./node_modules/.bin/grouparoo config",
     "demo": "./node_modules/.bin/grouparoo demo purchases --config"
   },
   "grouparoo": {

--- a/core/src/modules/ops/group.ts
+++ b/core/src/modules/ops/group.ts
@@ -22,7 +22,9 @@ export namespace GroupOps {
     await group.stopPreviousRuns();
 
     if (group.state !== "deleted") {
-      await group.update({ state: "updating" });
+      const state =
+        process.env.GROUPAROO_RUN_MODE === "cli:config" ? "ready" : "updating";
+      await group.update({ state });
     }
 
     const run = await Run.create({

--- a/core/src/modules/ops/group.ts
+++ b/core/src/modules/ops/group.ts
@@ -18,13 +18,12 @@ export namespace GroupOps {
     destinationId?: string
   ) {
     if (process.env.GROUPAROO_RUN_MODE === "cli:validate") return;
+    if (process.env.GROUPAROO_RUN_MODE === "cli:config") return;
 
     await group.stopPreviousRuns();
 
     if (group.state !== "deleted") {
-      const state =
-        process.env.GROUPAROO_RUN_MODE === "cli:config" ? "ready" : "updating";
-      await group.update({ state });
+      await group.update({ state: "updating" });
     }
 
     const run = await Run.create({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,7 @@ importers:
       '@grouparoo/spec-helper': 0.4.0-alpha.1
       '@grouparoo/sqlite': 0.4.0-alpha.1
       '@grouparoo/ui-config': 0.4.0-alpha.1
+      grouparoo: 0.4.0-alpha.1
       jest: 26.6.3
     dependencies:
       '@grouparoo/core': link:../../core
@@ -104,6 +105,7 @@ importers:
     devDependencies:
       '@grouparoo/spec-helper': link:../../plugins/@grouparoo/spec-helper
       '@grouparoo/ui-config': link:../../ui/ui-config
+      grouparoo: link:../../cli
       jest: 26.6.3
 
   apps/staging-enterprise:
@@ -14447,7 +14449,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3
+      jest: 26.6.3_ts-node@10.0.0
       jest-util: 26.6.2
       json5: 2.2.0
       lodash: 4.17.21


### PR DESCRIPTION
This approach says that groups can't have a run in config mode. It seemed like that was the preference.

I don't see where we are testing this method elsewhere, and felt like that would be getting into a whole can of worms. If you can show me where we are testing already, or if you feel strongly that I should add new tests for this method, I can spend some time with it.

_Note: There are also some updates (fixes) to the staging-config commands._