### PR TITLE
Privacy Policy linked

### DIFF
--- a/ui/ui-components/pages/team/initialize.tsx
+++ b/ui/ui-components/pages/team/initialize.tsx
@@ -154,6 +154,11 @@ export default function TeamInitializePage(props) {
                 ref={register}
               />
             </Form.Group>
+            <p>
+              <a href="https://www.grouparoo.com/legal/privacy" target="_blank">
+                Privacy Policy
+              </a>
+            </p>
           </Card.Body>
         </Card>
 

--- a/ui/ui-components/pages/teamMember/new.tsx
+++ b/ui/ui-components/pages/teamMember/new.tsx
@@ -136,8 +136,11 @@ export default function Page(props) {
             disabled={loading}
           />
         </Form.Group>
-
-        <br />
+        <p>
+          <a href="https://www.grouparoo.com/legal/privacy" target="_blank">
+            Privacy Policy
+          </a>
+        </p>
 
         <LoadingButton variant="primary" type="submit" disabled={loading}>
           Submit

--- a/ui/ui-config/pages/session/sign-in.tsx
+++ b/ui/ui-config/pages/session/sign-in.tsx
@@ -84,7 +84,11 @@ export default function SignInPage(props) {
                 disabled={loading}
               />
             </Form.Group>
-
+            <p>
+              <a href="https://www.grouparoo.com/legal/privacy" target="_blank">
+                Privacy Policy
+              </a>
+            </p>
             <LoadingButton disabled={loading} variant="primary" type="submit">
               Register
             </LoadingButton>


### PR DESCRIPTION
Each page that collects an email address for the first time now links to our privacy policy opening in a new tab.
- /team/initialize
- /teamMember/new
- /session/sign-in (config-ui only)

example:
<img width="314" alt="Screen Shot 2021-06-08 at 3 39 27 PM" src="https://user-images.githubusercontent.com/63751206/121266633-b8115200-c86f-11eb-84c6-14a60af25f22.png">
