### PR TITLE
Test `timed_run` weekly with 100,000 profiles

### DIFF
--- a/.github/workflows/timed-run.yml
+++ b/.github/workflows/timed-run.yml
@@ -1,0 +1,77 @@
+name: timed-run
+
+on:
+  schedule:
+    - cron: "0 2 * * 5"
+  workflow_dispatch:
+    inputs:
+      app:
+        description: "app to test?"
+        required: true
+        default: "staging_community"
+      scale:
+        description: "scale of sample data?"
+        required: true
+        default: "100"
+      log_level:
+        description: "log level?"
+        required: true
+        default: "notice"
+
+jobs:
+  test-timed-run:
+    env:
+      APP: "staging_community"
+      SCALE: "100"
+      LOG_LEVEL: "notice"
+
+    services:
+      postgres:
+        image: postgres:10.8
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432/tcp
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+      redis:
+        image: redis
+        ports:
+          - 6379/tcp
+        options: --entrypoint redis-server
+
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'grouparoo/grouparoo' }}
+    steps:
+      - uses: actions/checkout@master
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Update APP ENV
+        if: github.event.inputs.app != ''
+        run: echo "APP=${{ github.event.inputs.app }}" >> $GITHUB_ENV
+      - name: Update SCALE ENV
+        if: github.event.inputs.scale != ''
+        run: echo "SCALE=${{ github.event.inputs.scale }}" >> $GITHUB_ENV
+      - name: Update LOG_LEVEL ENV
+        if: github.event.inputs.log_level != ''
+        run: echo "LOG_LEVEL=${{ github.event.inputs.log_level }}" >> $GITHUB_ENV
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - run: npm install -g pnpm
+      - run: pnpm install
+      - name: timed-run
+        run: ./bin/timed_run $APP $SCALE $LOG_LEVEL
+        env:
+          SERVER_TOKEN: foo
+          DATABASE_URL: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres
+          REDIS_URL: redis://localhost:${{ job.services.redis.ports[6379] }}/0
+          PORT: 3000
+          WEB_SERVER: false
+          WORKERS: 5
+          GROUPAROO_TELEMETRY_ENABLED: false
+          SENTRY_TRACE_SAMPLE_RATE: 0.1
+          SENTRY_DSN: ${{ secrets.GROUPAROO_TIMED_RUN_SENTRY_DSN }}


### PR DESCRIPTION
This PR adds a Github Action which will run `./bin/timed_run` every week against a demo database of 100,000 profiles.  Running this regularly will let us learn about performance improvements or reductions.  This action can also be run upon request with a workflow_dispatch

* Will report traces to a special Sentry.io project called `grouparoo-timed-run-action` (10% of all tasks)
* Uses the demo dataset with a scale of 100 (1000 * 100 = 100,000 Profiles)
* Uses `LOG_LEVEL=alert` to be a little less noisy.

We should be OK as long as the total runtime is under 6 hours: https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration#usage-limits