### PR TITLE
Mongo `options.query` should be a string

### DIFF
--- a/plugins/@grouparoo/mongo/public/templates/query-property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mongo/public/templates/query-property/{{{id}}}.js.template
@@ -10,7 +10,7 @@ exports.default = async function buildConfig() {
       identifying: false, // Should we consider this property Identifying in the UI? Only one Property can be identifying.
       isArray: false, // Is this an Array Property?
       options: {
-        query: [
+        query: JSON.stringify([
              {
                $match: {
                  user_id: 1, //You can use mustache variables here instead.
@@ -29,7 +29,7 @@ exports.default = async function buildConfig() {
                  _id: 0,
                },
              },
-           ], // The query to extract the property. You can use mustache variables (https://github.com/janl/mustache.js#variables) to represent the keys of other properties in the system.
+           ]), // The query to extract the property. You can use mustache variables (https://github.com/janl/mustache.js#variables) to represent the keys of other properties in the system.
       },
     },
   ];


### PR DESCRIPTION
Fixes a bug with https://github.com/grouparoo/grouparoo/pull/1911