### PR TITLE
Clean up SQLite plugin queries

### DIFF
--- a/plugins/@grouparoo/sqlite/__tests__/export/export-profile.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/export/export-profile.ts
@@ -49,7 +49,7 @@ const { appOptions, usersTableName, groupsDestinationTableName } = getConfig();
 
 async function getUser(userId) {
   const result = await client.asyncQuery(
-    `SELECT * FROM ${usersTableName} WHERE "id" = ${userId}`
+    `SELECT * FROM "${usersTableName}" WHERE "id" = ${userId}`
   );
   if (result.length > 0) {
     return result[0];
@@ -61,7 +61,7 @@ async function getUserGroups(userId) {
   let { groupsTable, groupForeignKey, groupColumnName } =
     await destination.parameterizedOptions();
   const result = await client.asyncQuery(
-    `SELECT "${groupColumnName}" FROM ${groupsTable} WHERE ${groupForeignKey} = ${userId}`
+    `SELECT "${groupColumnName}" FROM "${groupsTable}" WHERE ${groupForeignKey} = ${userId}`
   );
   return result.map((groupEntry) => Object.values(groupEntry)[0]);
 }

--- a/plugins/@grouparoo/sqlite/__tests__/integration/cli-generate-from.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/integration/cli-generate-from.ts
@@ -15,6 +15,7 @@ import {
   afterData,
   appOptions,
   usersTableName,
+  usersTableSlug,
 } from "../utils/data";
 
 process.env.GROUPAROO_CONFIG_DIR = `${os.tmpdir()}/test/${
@@ -99,14 +100,14 @@ describe("sqlite cli tests", () => {
       },
     });
 
-    const file = `${process.env.GROUPAROO_CONFIG_DIR}/sources/${usersTableName}.js`;
+    const file = `${process.env.GROUPAROO_CONFIG_DIR}/sources/${usersTableSlug}.js`;
     const output = messages.join(" ");
     expect(output).toContain(`wrote ${file}`);
 
     const contents = fs.readFileSync(file).toString();
     expect(contents).toContain('class: "source"');
-    expect(contents).toContain(`id: "${usersTableName}"`);
-    expect(contents).toContain(`name: "${usersTableName}"`);
+    expect(contents).toContain(`id: "${usersTableSlug}"`);
+    expect(contents).toContain(`name: "${usersTableSlug}"`);
 
     fs.unlinkSync(file);
   });
@@ -152,14 +153,14 @@ describe("sqlite cli tests", () => {
       },
     });
 
-    const file = `${process.env.GROUPAROO_CONFIG_DIR}/sources/${usersTableName}.js`;
+    const file = `${process.env.GROUPAROO_CONFIG_DIR}/sources/${usersTableSlug}.js`;
     const output = messages.join("\n");
     expect(output).toContain(`wrote ${file}`);
 
     const contents = fs.readFileSync(file).toString();
     expect(contents).toContain('class: "source"');
-    expect(contents).toContain(`id: "${usersTableName}"`);
-    expect(contents).toContain(`name: "${usersTableName}"`);
+    expect(contents).toContain(`id: "${usersTableSlug}"`);
+    expect(contents).toContain(`name: "${usersTableSlug}"`);
 
     expect(contents).toContain(`id: "user_id",`); // mapping
     expect(contents).toContain(`column: "stamp",`); // schedule

--- a/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-query-import.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-query-import.ts
@@ -110,7 +110,7 @@ describe("integration/runs/sqlite", () => {
       csrfToken,
       id: property.id,
       options: {
-        query: `select email from ${usersTableName} where id = {{ userId }}`,
+        query: `SELECT email FROM "${usersTableName}" WHERE id = {{ userId }}`,
       },
       state: "ready",
     };

--- a/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-table-import.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-table-import.ts
@@ -411,13 +411,13 @@ describe("integration/runs/sqlite", () => {
 
       // check the destination
       const userRows = await client.asyncQuery(
-        `SELECT * FROM ${profilesDestinationTableName} ORDER BY id ASC`
+        `SELECT * FROM "${profilesDestinationTableName}" ORDER BY id ASC`
       );
       expect(userRows.length).toBe(10);
       expect(userRows[0].customer_email).toBe("ejervois0@example.com");
 
       const groupRows = await client.asyncQuery(
-        `SELECT * FROM ${groupsDestinationTableName}`
+        `SELECT * FROM "${groupsDestinationTableName}"`
       );
       expect(groupRows.length).toBe(10);
       expect(groupRows[0].group).toBe(group.name);
@@ -532,13 +532,13 @@ describe("integration/runs/sqlite", () => {
 
       // check the destination
       const userRows = await client.asyncQuery(
-        `SELECT * FROM ${profilesDestinationTableName} ORDER BY id ASC`
+        `SELECT * FROM "${profilesDestinationTableName}" ORDER BY id ASC`
       );
       expect(userRows.length).toBe(10);
       expect(userRows[0].customer_email).toBe("ejervois0@example.com");
 
       const groupRows = await client.asyncQuery(
-        `SELECT * FROM ${groupsDestinationTableName}`
+        `SELECT * FROM "${groupsDestinationTableName}"`
       );
       expect(groupRows.length).toBe(10);
       expect(groupRows[0].group).toBe(group.name);

--- a/plugins/@grouparoo/sqlite/__tests__/query-import/import-property.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/query-import/import-property.ts
@@ -58,55 +58,55 @@ describe("sqlite/query/profileProperty", () => {
   afterAll(async () => await afterData());
 
   test("can run a integer query to get a string", async () => {
-    const sql = `SELECT first_name FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT first_name FROM "${usersTableName}" WHERE id = {{ userId }}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a integer query to get a float", async () => {
-    const sql = `SELECT ltv FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT ltv FROM "${usersTableName}" WHERE id = {{ userId }}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a integer query to get a boolean", async () => {
-    const sql = `SELECT ios_app FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT ios_app FROM "${usersTableName}" WHERE id = {{ userId }}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["true"]);
   });
 
   test("can run a integer query to get a date", async () => {
-    const sql = `SELECT stamp FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT stamp FROM "${usersTableName}" WHERE id = {{ userId }}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["2020/02/01 12:13:14"]);
   });
 
   test("can run a string query to get a string", async () => {
-    const sql = `SELECT first_name FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT first_name FROM "${usersTableName}" WHERE email = '{{ email }}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a string query to get a float", async () => {
-    const sql = `SELECT ltv FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT ltv FROM "${usersTableName}" WHERE email = '{{ email }}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a string query to get a boolean", async () => {
-    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT ios_app FROM "${usersTableName}" WHERE email = '{{ email }}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["true"]);
   });
 
   test("can run a string query to get a date", async () => {
-    const sql = `SELECT stamp FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT stamp FROM "${usersTableName}" WHERE email = '{{ email }}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["2020/02/01 12:13:14"]);
   });
 
   test("returns undefined when data is not avilable", async () => {
-    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{ badName }}'`;
+    const sql = `SELECT ios_app FROM "${usersTableName}" WHERE email = '{{ badName }}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(undefined);
   });

--- a/plugins/@grouparoo/sqlite/__tests__/query-import/profiles.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/query-import/profiles.ts
@@ -86,7 +86,7 @@ describe("sqlite/query/profiles", () => {
       where: { key: "userId" },
     });
     const options = {
-      query: `SELECT id FROM ${usersTableName}`,
+      query: `SELECT id FROM "${usersTableName}"`,
       propertyId: userIdProperty.id,
     };
     schedule = await helper.factories.schedule(source, { options });

--- a/plugins/@grouparoo/sqlite/__tests__/utils/data.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/utils/data.ts
@@ -104,7 +104,7 @@ async function fillTable(tableName, fileName) {
   const rows = parse(fs.readFileSync(filePath), { columns: true });
   for (const i in rows) {
     const row = rows[i];
-    const q = `INSERT INTO ${tableName} (${Object.keys(row).join(
+    const q = `INSERT INTO "${tableName}" (${Object.keys(row).join(
       ", "
     )}) VALUES ('${Object.values(row).join("', '")}')`;
 

--- a/plugins/@grouparoo/sqlite/__tests__/utils/data.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/utils/data.ts
@@ -6,14 +6,15 @@ import parse from "csv-parse/lib/sync";
 import { config } from "actionhero";
 
 const workerId = process.env.JEST_WORKER_ID || 1;
-export const usersTableName = `users_${workerId}`;
-export const purchasesTableName = `purchases_${workerId}`;
-export const profilesDestinationTableName = `output_users_${workerId}`;
-export const groupsDestinationTableName = `output_groups_${workerId}`;
+export const usersTableName = `USERS - '${workerId}'`;
+export const usersTableSlug = `users_-__${workerId}_`;
+export const purchasesTableName = `Purchases - '${workerId}'`;
+export const profilesDestinationTableName = `OUTPUT_USERS - '${workerId}'`;
+export const groupsDestinationTableName = `output_groups - '${workerId}'`;
 
 const allTables = {
   [usersTableName]: `
-CREATE TABLE ${usersTableName} (
+CREATE TABLE "${usersTableName}" (
   "id" integer PRIMARY KEY,
   "first_name" text,
   "last_name" text,
@@ -29,7 +30,7 @@ CREATE TABLE ${usersTableName} (
 )
 `,
   [purchasesTableName]: `
-CREATE TABLE ${purchasesTableName} (
+CREATE TABLE "${purchasesTableName}" (
   "id" integer PRIMARY KEY,
   "profile_id" integer,
   "purchase" text,
@@ -39,7 +40,7 @@ CREATE TABLE ${purchasesTableName} (
 )
 `,
   [profilesDestinationTableName]: `
-CREATE TABLE ${profilesDestinationTableName} (
+CREATE TABLE "${profilesDestinationTableName}" (
   "id" integer PRIMARY KEY,
   "customer_email" text,
   "fname" text,
@@ -48,7 +49,7 @@ CREATE TABLE ${profilesDestinationTableName} (
 )
 `,
   [groupsDestinationTableName]: `
-CREATE TABLE ${groupsDestinationTableName}(
+CREATE TABLE "${groupsDestinationTableName}" (
   "id" integer PRIMARY KEY,
   "userId" integer NOT NULL,
   "group" text NOT NULL,
@@ -88,7 +89,7 @@ export async function endClient() {
 }
 async function dropTables() {
   for (const tableName in allTables) {
-    await client.asyncQuery(`DROP TABLE IF EXISTS ${tableName}`);
+    await client.asyncQuery(`DROP TABLE IF EXISTS "${tableName}"`);
   }
 }
 

--- a/plugins/@grouparoo/sqlite/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/export/destinationMappingOptions.ts
@@ -5,7 +5,7 @@ import {
 
 export const destinationMappingOptions: DestinationMappingOptionsMethod =
   async ({ connection, destinationOptions }) => {
-    const query = `SELECT name from pragma_table_info('${destinationOptions.table}')`;
+    const query = `SELECT name from pragma_table_info("${destinationOptions.table}")`;
     const rows = await connection.asyncQuery(query);
 
     const columns: Array<{

--- a/plugins/@grouparoo/sqlite/src/lib/export/destinationOptions.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/export/destinationOptions.ts
@@ -8,7 +8,7 @@ export const destinationOptions: DestinationOptionsMethod = async ({
   destinationOptions,
 }) => {
   async function getColumns(tableName: string) {
-    const query = `SELECT name from pragma_table_info('${tableName}')`;
+    const query = `SELECT name from pragma_table_info("${tableName}")`;
     const colRows = await connection.asyncQuery(query);
     return colRows.map((row) => row.name).sort();
   }

--- a/plugins/@grouparoo/sqlite/src/lib/export/exportProfile.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/export/exportProfile.ts
@@ -37,11 +37,11 @@ export const exportProfile: ExportProfilePluginMethod = async ({
         );
       }
       // delete
-      const query = `DELETE FROM ${table} WHERE ${primaryKey} = ${newProfileProperties[primaryKey]}`;
+      const query = `DELETE FROM "${table}" WHERE ${primaryKey} = ${newProfileProperties[primaryKey]}`;
       validateQuery(query);
       await connection.asyncQuery(query);
     } else if (newProfileProperties[primaryKey]) {
-      const query = `SELECT * FROM ${table} WHERE ${primaryKey} = ${newProfileProperties[primaryKey]}`;
+      const query = `SELECT * FROM "${table}" WHERE ${primaryKey} = ${newProfileProperties[primaryKey]}`;
       validateQuery(query);
       const existingRecords = await connection.asyncQuery(query);
       if (existingRecords.length === 1) {
@@ -51,7 +51,7 @@ export const exportProfile: ExportProfilePluginMethod = async ({
           );
         }
         // update
-        let updateStatement = `UPDATE ${table} SET`;
+        let updateStatement = `UPDATE "${table}" SET`;
         const maxIdx = Object.keys(newProfileProperties).length - 1;
         Object.keys(newProfileProperties).map((key, idx) => {
           updateStatement += ` ${key} = "${newProfileProperties[key]}"`;
@@ -71,7 +71,7 @@ export const exportProfile: ExportProfilePluginMethod = async ({
         );
 
         if (columnsToErase.length > 0) {
-          let eraseStatement = `UPDATE ${table} SET`;
+          let eraseStatement = `UPDATE "${table}" SET`;
           const maxIdx = columnsToErase.length - 1;
           columnsToErase.map((col, idx) => {
             eraseStatement += ` ${col} = NULL`;
@@ -83,7 +83,7 @@ export const exportProfile: ExportProfilePluginMethod = async ({
         }
       } else {
         // delete
-        const deleteQuery = `DELETE FROM ${table} WHERE ${primaryKey} = ${newProfileProperties[primaryKey]}`;
+        const deleteQuery = `DELETE FROM "${table}" WHERE ${primaryKey} = ${newProfileProperties[primaryKey]}`;
         validateQuery(deleteQuery);
         await connection.asyncQuery(deleteQuery);
 
@@ -98,7 +98,7 @@ export const exportProfile: ExportProfilePluginMethod = async ({
     // --- Groups --- //
 
     // delete existing groups
-    const deleteGroupsQuery = `DELETE FROM ${groupsTable} WHERE ${groupForeignKey} = ${newProfileProperties[primaryKey]}`;
+    const deleteGroupsQuery = `DELETE FROM "${groupsTable}" WHERE ${groupForeignKey} = ${newProfileProperties[primaryKey]}`;
     validateQuery(deleteGroupsQuery);
     await connection.asyncQuery(deleteGroupsQuery);
 
@@ -109,7 +109,7 @@ export const exportProfile: ExportProfilePluginMethod = async ({
         data[groupForeignKey] = newProfileProperties[primaryKey];
         data[groupColumnName] = newGroups[i];
 
-        const groupInsertQuery = `INSERT INTO ${groupsTable} (${buildKeyList(
+        const groupInsertQuery = `INSERT INTO "${groupsTable}" (${buildKeyList(
           data
         )}) VALUES (${buildValueList(data)}) ON CONFLICT DO NOTHING`;
         validateQuery(groupInsertQuery);
@@ -139,7 +139,7 @@ const insert = async (
     );
   }
   // insert
-  const query = `INSERT INTO ${table} (${buildKeyList(
+  const query = `INSERT INTO "${table}" (${buildKeyList(
     newProfileProperties
   )}) VALUES (${buildValueList(newProfileProperties)})`;
   validateQuery(query);

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getChangedRowCount.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getChangedRowCount.ts
@@ -7,7 +7,7 @@ export const getChangedRowCount: GetChangedRowCountMethod = async ({
   tableName,
   highWaterMarkCondition,
 }) => {
-  let query = `SELECT COUNT(*) AS __count FROM ${tableName}`;
+  let query = `SELECT COUNT(*) AS __count FROM "${tableName}"`;
 
   if (highWaterMarkCondition) {
     query += ` WHERE ${makeWhereClause(highWaterMarkCondition)}`;

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getChangedRows.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getChangedRows.ts
@@ -20,7 +20,7 @@ export const getChangedRows: GetChangedRowsMethod = async ({
   [key: string]: any;
 }) => {
   // Begin with SELECT statement.
-  let query = `SELECT *, ${highWaterMarkAndSortColumnASC} AS ${highWaterMarkKey} FROM ${tableName}`;
+  let query = `SELECT *, ${highWaterMarkAndSortColumnASC} AS ${highWaterMarkKey} FROM "${tableName}"`;
 
   // Add WHERE clause, if there is a condition for the HWM.
   if (highWaterMarkCondition) {

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getColumns.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getColumns.ts
@@ -39,7 +39,7 @@ export const getColumns: GetColumnDefinitionsMethod = async ({
   connection,
   tableName,
 }) => {
-  const query = `SELECT name, type from pragma_table_info('${tableName}')`;
+  const query = `SELECT name, type from pragma_table_info("${tableName}")`;
   const rows = await connection.asyncQuery(query);
 
   const map: ColumnDefinitionMap = {};

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getPropertyValue.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getPropertyValue.ts
@@ -54,7 +54,7 @@ export const getPropertyValue: GetPropertyValueMethod = async ({
       throw new Error(`${aggregationMethod} is not a known aggregation method`);
   }
 
-  let query = `SELECT ${aggSelect} as __result FROM ${tableName} WHERE`;
+  let query = `SELECT ${aggSelect} as __result FROM "${tableName}" WHERE`;
   let addAnd = false;
 
   for (const condition of matchConditions) {

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getPropertyValues.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getPropertyValues.ts
@@ -65,7 +65,7 @@ export const getPropertyValues: GetPropertyValuesMethod = async ({
       throw new Error(`${aggregationMethod} is not a known aggregation method`);
   }
 
-  let query = `SELECT ${aggSelect} as __result, "${tablePrimaryKeyCol}" as __pk FROM ${tableName} WHERE`;
+  let query = `SELECT ${aggSelect} as __result, "${tablePrimaryKeyCol}" as __pk FROM "${tableName}" WHERE`;
   let addAnd = false;
 
   for (const condition of matchConditions) {

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getSampleRows.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getSampleRows.ts
@@ -7,7 +7,7 @@ export const getSampleRows: GetSampleRowsMethod = async ({
   connection,
   tableName,
 }) => {
-  const query = `SELECT * FROM ${tableName} WHERE id IN (SELECT id FROM ${tableName} ORDER BY RANDOM() LIMIT 10)`;
+  const query = `SELECT * FROM "${tableName}" ORDER BY RANDOM() LIMIT 10);`;
   const out: DataResponseRow[] = await connection.asyncQuery(query);
 
   return out;

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getSampleRows.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getSampleRows.ts
@@ -7,7 +7,7 @@ export const getSampleRows: GetSampleRowsMethod = async ({
   connection,
   tableName,
 }) => {
-  const query = `SELECT * FROM "${tableName}" ORDER BY RANDOM() LIMIT 10);`;
+  const query = `SELECT * FROM "${tableName}" ORDER BY RANDOM() LIMIT 10;`;
   const out: DataResponseRow[] = await connection.asyncQuery(query);
 
   return out;


### PR DESCRIPTION
What I ended up doing here was to use goofy table names when running the specs in this plugin to ensure that we're using quotes where necessary to escape characters in identifiers.

