### PR TITLE
End validation if error is `instanceof Sequelize.DatabaseError`

### DIFF
--- a/core/__tests__/actions/apiKey.ts
+++ b/core/__tests__/actions/apiKey.ts
@@ -106,6 +106,7 @@ describe("actions/apiKeys", () => {
         code: "AUTHORIZATION_ERROR",
         fields: [],
         message: 'Not authorized for mode "read" on topic "apiKey"',
+        sql: null,
       });
     });
 

--- a/core/__tests__/integration/errors.ts
+++ b/core/__tests__/integration/errors.ts
@@ -26,7 +26,7 @@ describe("errors", () => {
     csrfToken = sessionResponse.csrfToken;
   });
 
-  test("trying to create a team with the same name produces a readable error message, code, and fields", async () => {
+  test("trying to create a team with the same name produces a readable error message, code, and fields + the sql query", async () => {
     connection.params = {
       csrfToken,
       name: "new team",
@@ -46,6 +46,7 @@ describe("errors", () => {
       message: "name must be unique",
       code: "unique violation",
       fields: ["name"],
+      sql: 'INSERT INTO "teams" ("id","name","permissionAllRead","permissionAllWrite","createdAt","updatedAt") VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id","name","locked","permissionAllRead","permissionAllWrite","createdAt","updatedAt";',
     });
   });
 });

--- a/core/src/config/errors.ts
+++ b/core/src/config/errors.ts
@@ -152,6 +152,7 @@ export function GrouparooErrorSerializer(error) {
   let message = "";
   let code = error.code || undefined;
   let fields = [];
+  let sql = error.sql || null;
 
   if (error.errors) {
     // a Sequelize Error https://sequelize.org/master/identifiers.html#errors
@@ -169,5 +170,5 @@ export function GrouparooErrorSerializer(error) {
     message = `${error}`;
   }
 
-  return { message, code, fields };
+  return { message, code, fields, sql };
 }

--- a/core/src/config/errors.ts
+++ b/core/src/config/errors.ts
@@ -154,9 +154,10 @@ export function GrouparooErrorSerializer(error) {
   let fields = [];
 
   if (error.errors) {
-    // a Sequelize Error https://sequelize.readthedocs.io/en/latest/api/errors
+    // a Sequelize Error https://sequelize.org/master/identifiers.html#errors
     const selectedError = error.errors[0];
     message = selectedError.message;
+
     if (!code) code = selectedError.type;
     if (error.fields)
       fields = Array.isArray(error.fields)

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -295,10 +295,6 @@ export async function processConfigObjects(
 
       log(error?.stack || error, "debug");
 
-      // if (errorMessage.includes("current transaction is aborted")) {
-      //   log(errorMessage, "warning");
-      //   throw new Error(`Cannot validate additional objects.`);
-      // } else
       if (fields.length === 0) {
         log(errorMessage, "warning");
         continue;

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -269,7 +269,7 @@ export async function processConfigObjects(
       }
     } catch (error) {
       // Normally, we can can keep going after an error and keep checking the other config objects
-      // but, there's some types of errors (like unique key duplicates and casting incorrect types) which pollute the transaction and we need to stop
+      // but, there's some types of errors (like unique key duplicates) which pollute or abort the transaction and we need to stop
 
       const { message, fields } = GrouparooErrorSerializer(error);
 


### PR DESCRIPTION
Checks if error message includes 'transaction aborted' and will stop trying to validate other configs if so.

Also updated the link to the sequelize docs