### PR TITLE
fix: source with directlyMapped property can be destroyed

### DIFF
--- a/core/src/tasks/source/destroy.ts
+++ b/core/src/tasks/source/destroy.ts
@@ -25,25 +25,12 @@ export class SourceDestroy extends CLSTask {
 
     // check if we still have properties
     try {
-      await Source.ensureNotInUse(source, true);
+      await Source.ensureNotInUse(source);
     } catch (error) {
       if (error.message.match(/cannot delete a source that has a property/)) {
         return; // check back later
       }
       throw error;
-    }
-
-    const directlyMappedProperty = await Property.scope(null).findOne({
-      where: { sourceId: source.id, directlyMapped: true },
-    });
-
-    if (directlyMappedProperty) {
-      //@ts-ignore
-      await directlyMappedProperty.destroy({ hooks: false });
-      await Property.stopRuns(directlyMappedProperty);
-      await Property.destroyOptions(directlyMappedProperty);
-      await Property.destroyPropertyFilters(directlyMappedProperty);
-      await Property.destroyProfileProperties(directlyMappedProperty);
     }
 
     // no properties, let's delete it


### PR DESCRIPTION
Previously, deleting a source with a directlyMapped property threw an error saying that it still had a property, and trying to delete the property threw an error saying that it was being used in a mapping. This change allows these to be deleted by deleting the directlyMapped property along with the source, like code config was doing.