### PR TITLE
Remove group calcs in Config UI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,37 +20,37 @@ importers:
 
   apps/staging-community:
     specifiers:
-      '@grouparoo/bigquery': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/csv': 0.4.0-alpha.2
-      '@grouparoo/customerio': 0.4.0-alpha.2
-      '@grouparoo/demo': 0.4.0-alpha.2
-      '@grouparoo/facebook': 0.4.0-alpha.2
-      '@grouparoo/files-s3': 0.4.0-alpha.2
-      '@grouparoo/google-sheets': 0.4.0-alpha.2
-      '@grouparoo/hubspot': 0.4.0-alpha.2
-      '@grouparoo/intercom': 0.4.0-alpha.2
-      '@grouparoo/iterable': 0.4.0-alpha.2
-      '@grouparoo/logger': 0.4.0-alpha.2
-      '@grouparoo/mailchimp': 0.4.0-alpha.2
-      '@grouparoo/marketo': 0.4.0-alpha.2
-      '@grouparoo/mongo': 0.4.0-alpha.2
-      '@grouparoo/mysql': 0.4.0-alpha.2
-      '@grouparoo/onesignal': 0.4.0-alpha.2
-      '@grouparoo/pardot': 0.4.0-alpha.2
-      '@grouparoo/pipedrive': 0.4.0-alpha.2
-      '@grouparoo/postgres': 0.4.0-alpha.2
-      '@grouparoo/redshift': 0.4.0-alpha.2
-      '@grouparoo/sailthru': 0.4.0-alpha.2
-      '@grouparoo/salesforce': 0.4.0-alpha.2
-      '@grouparoo/sendgrid': 0.4.0-alpha.2
-      '@grouparoo/sentry': 0.4.0-alpha.2
-      '@grouparoo/snowflake': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
-      '@grouparoo/sqlite': 0.4.0-alpha.2
-      '@grouparoo/ui-community': 0.4.0-alpha.2
-      '@grouparoo/ui-config': 0.4.0-alpha.2
-      '@grouparoo/zendesk': 0.4.0-alpha.2
+      '@grouparoo/bigquery': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/csv': 0.4.0-alpha.3
+      '@grouparoo/customerio': 0.4.0-alpha.3
+      '@grouparoo/demo': 0.4.0-alpha.3
+      '@grouparoo/facebook': 0.4.0-alpha.3
+      '@grouparoo/files-s3': 0.4.0-alpha.3
+      '@grouparoo/google-sheets': 0.4.0-alpha.3
+      '@grouparoo/hubspot': 0.4.0-alpha.3
+      '@grouparoo/intercom': 0.4.0-alpha.3
+      '@grouparoo/iterable': 0.4.0-alpha.3
+      '@grouparoo/logger': 0.4.0-alpha.3
+      '@grouparoo/mailchimp': 0.4.0-alpha.3
+      '@grouparoo/marketo': 0.4.0-alpha.3
+      '@grouparoo/mongo': 0.4.0-alpha.3
+      '@grouparoo/mysql': 0.4.0-alpha.3
+      '@grouparoo/onesignal': 0.4.0-alpha.3
+      '@grouparoo/pardot': 0.4.0-alpha.3
+      '@grouparoo/pipedrive': 0.4.0-alpha.3
+      '@grouparoo/postgres': 0.4.0-alpha.3
+      '@grouparoo/redshift': 0.4.0-alpha.3
+      '@grouparoo/sailthru': 0.4.0-alpha.3
+      '@grouparoo/salesforce': 0.4.0-alpha.3
+      '@grouparoo/sendgrid': 0.4.0-alpha.3
+      '@grouparoo/sentry': 0.4.0-alpha.3
+      '@grouparoo/snowflake': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
+      '@grouparoo/sqlite': 0.4.0-alpha.3
+      '@grouparoo/ui-community': 0.4.0-alpha.3
+      '@grouparoo/ui-config': 0.4.0-alpha.3
+      '@grouparoo/zendesk': 0.4.0-alpha.3
       jest: 26.6.3
     dependencies:
       '@grouparoo/bigquery': link:../../plugins/@grouparoo/bigquery
@@ -89,13 +89,13 @@ importers:
 
   apps/staging-config:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/demo': 0.4.0-alpha.2
-      '@grouparoo/postgres': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
-      '@grouparoo/sqlite': 0.4.0-alpha.2
-      '@grouparoo/ui-config': 0.4.0-alpha.2
-      grouparoo: 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/demo': 0.4.0-alpha.3
+      '@grouparoo/postgres': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
+      '@grouparoo/sqlite': 0.4.0-alpha.3
+      '@grouparoo/ui-config': 0.4.0-alpha.3
+      grouparoo: 0.4.0-alpha.3
       jest: 26.6.3
     dependencies:
       '@grouparoo/core': link:../../core
@@ -110,37 +110,37 @@ importers:
 
   apps/staging-enterprise:
     specifiers:
-      '@grouparoo/bigquery': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/csv': 0.4.0-alpha.2
-      '@grouparoo/customerio': 0.4.0-alpha.2
-      '@grouparoo/demo': 0.4.0-alpha.2
-      '@grouparoo/facebook': 0.4.0-alpha.2
-      '@grouparoo/files-s3': 0.4.0-alpha.2
-      '@grouparoo/google-sheets': 0.4.0-alpha.2
-      '@grouparoo/hubspot': 0.4.0-alpha.2
-      '@grouparoo/intercom': 0.4.0-alpha.2
-      '@grouparoo/iterable': 0.4.0-alpha.2
-      '@grouparoo/logger': 0.4.0-alpha.2
-      '@grouparoo/mailchimp': 0.4.0-alpha.2
-      '@grouparoo/marketo': 0.4.0-alpha.2
-      '@grouparoo/mongo': 0.4.0-alpha.2
-      '@grouparoo/mysql': 0.4.0-alpha.2
-      '@grouparoo/onesignal': 0.4.0-alpha.2
-      '@grouparoo/pardot': 0.4.0-alpha.2
-      '@grouparoo/pipedrive': 0.4.0-alpha.2
-      '@grouparoo/postgres': 0.4.0-alpha.2
-      '@grouparoo/redshift': 0.4.0-alpha.2
-      '@grouparoo/sailthru': 0.4.0-alpha.2
-      '@grouparoo/salesforce': 0.4.0-alpha.2
-      '@grouparoo/sendgrid': 0.4.0-alpha.2
-      '@grouparoo/sentry': 0.4.0-alpha.2
-      '@grouparoo/snowflake': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
-      '@grouparoo/sqlite': 0.4.0-alpha.2
-      '@grouparoo/ui-config': 0.4.0-alpha.2
-      '@grouparoo/ui-enterprise': 0.4.0-alpha.2
-      '@grouparoo/zendesk': 0.4.0-alpha.2
+      '@grouparoo/bigquery': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/csv': 0.4.0-alpha.3
+      '@grouparoo/customerio': 0.4.0-alpha.3
+      '@grouparoo/demo': 0.4.0-alpha.3
+      '@grouparoo/facebook': 0.4.0-alpha.3
+      '@grouparoo/files-s3': 0.4.0-alpha.3
+      '@grouparoo/google-sheets': 0.4.0-alpha.3
+      '@grouparoo/hubspot': 0.4.0-alpha.3
+      '@grouparoo/intercom': 0.4.0-alpha.3
+      '@grouparoo/iterable': 0.4.0-alpha.3
+      '@grouparoo/logger': 0.4.0-alpha.3
+      '@grouparoo/mailchimp': 0.4.0-alpha.3
+      '@grouparoo/marketo': 0.4.0-alpha.3
+      '@grouparoo/mongo': 0.4.0-alpha.3
+      '@grouparoo/mysql': 0.4.0-alpha.3
+      '@grouparoo/onesignal': 0.4.0-alpha.3
+      '@grouparoo/pardot': 0.4.0-alpha.3
+      '@grouparoo/pipedrive': 0.4.0-alpha.3
+      '@grouparoo/postgres': 0.4.0-alpha.3
+      '@grouparoo/redshift': 0.4.0-alpha.3
+      '@grouparoo/sailthru': 0.4.0-alpha.3
+      '@grouparoo/salesforce': 0.4.0-alpha.3
+      '@grouparoo/sendgrid': 0.4.0-alpha.3
+      '@grouparoo/sentry': 0.4.0-alpha.3
+      '@grouparoo/snowflake': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
+      '@grouparoo/sqlite': 0.4.0-alpha.3
+      '@grouparoo/ui-config': 0.4.0-alpha.3
+      '@grouparoo/ui-enterprise': 0.4.0-alpha.3
+      '@grouparoo/zendesk': 0.4.0-alpha.3
       jest: 26.6.3
     dependencies:
       '@grouparoo/bigquery': link:../../plugins/@grouparoo/bigquery
@@ -232,8 +232,8 @@ importers:
 
   core:
     specifiers:
-      '@grouparoo/client-web': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/client-web': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/fs-extra': '*'
       '@types/jest': '*'
       '@types/node': '*'
@@ -253,7 +253,7 @@ importers:
       dotenv: 10.0.0
       fs-extra: 10.0.0
       glob: 7.1.7
-      grouparoo: 0.4.0-alpha.2
+      grouparoo: 0.4.0-alpha.3
       ioredis: 4.27.3
       ioredis-mock: 5.6.0
       isomorphic-fetch: 3.0.0
@@ -345,8 +345,8 @@ importers:
 
   plugins/@grouparoo/app-templates:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       '@types/uuid': '*'
@@ -374,9 +374,9 @@ importers:
   plugins/@grouparoo/bigquery:
     specifiers:
       '@google-cloud/bigquery': 5.6.0
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -406,8 +406,8 @@ importers:
 
   plugins/@grouparoo/csv:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -435,9 +435,9 @@ importers:
 
   plugins/@grouparoo/customerio:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -470,8 +470,8 @@ importers:
 
   plugins/@grouparoo/dbt:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -497,8 +497,8 @@ importers:
 
   plugins/@grouparoo/demo:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -538,9 +538,9 @@ importers:
 
   plugins/@grouparoo/facebook:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -577,7 +577,7 @@ importers:
 
   plugins/@grouparoo/files-local:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -600,7 +600,7 @@ importers:
 
   plugins/@grouparoo/files-s3:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -625,8 +625,8 @@ importers:
 
   plugins/@grouparoo/google-sheets:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -656,9 +656,9 @@ importers:
 
   plugins/@grouparoo/hubspot:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -691,9 +691,9 @@ importers:
 
   plugins/@grouparoo/intercom:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -724,9 +724,9 @@ importers:
 
   plugins/@grouparoo/iterable:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -757,9 +757,9 @@ importers:
 
   plugins/@grouparoo/logger:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -782,9 +782,9 @@ importers:
 
   plugins/@grouparoo/mailchimp:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -815,10 +815,10 @@ importers:
 
   plugins/@grouparoo/marketo:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
       '@grouparoo/node-marketo-rest': 0.7.10
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -848,9 +848,9 @@ importers:
 
   plugins/@grouparoo/mongo:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -879,9 +879,9 @@ importers:
 
   plugins/@grouparoo/mysql:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/mysql': '*'
       '@types/node': '*'
@@ -910,8 +910,8 @@ importers:
 
   plugins/@grouparoo/newrelic:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -935,9 +935,9 @@ importers:
 
   plugins/@grouparoo/onesignal:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -968,9 +968,9 @@ importers:
 
   plugins/@grouparoo/pardot:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -1005,9 +1005,9 @@ importers:
 
   plugins/@grouparoo/pipedrive:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -1038,9 +1038,9 @@ importers:
 
   plugins/@grouparoo/postgres:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       '@types/pg': '*'
@@ -1077,10 +1077,10 @@ importers:
 
   plugins/@grouparoo/redshift:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/postgres': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/postgres': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       '@types/pg': '*'
@@ -1106,9 +1106,9 @@ importers:
 
   plugins/@grouparoo/sailthru:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -1139,9 +1139,9 @@ importers:
 
   plugins/@grouparoo/salesforce:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -1172,9 +1172,9 @@ importers:
 
   plugins/@grouparoo/sendgrid:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@sendgrid/client': 7.4.3
       '@types/jest': '*'
       '@types/node': '*'
@@ -1205,8 +1205,8 @@ importers:
 
   plugins/@grouparoo/sentry:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@sentry/node': 6.5.0
       '@sentry/tracing': 6.5.0
       '@types/jest': '*'
@@ -1232,9 +1232,9 @@ importers:
 
   plugins/@grouparoo/snowflake:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -1267,7 +1267,7 @@ importers:
 
   plugins/@grouparoo/spec-helper:
     specifiers:
-      '@grouparoo/core': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
       '@types/faker': '*'
       '@types/jest': '*'
       '@types/node': '*'
@@ -1302,9 +1302,9 @@ importers:
 
   plugins/@grouparoo/sqlite:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       '@types/pg': '*'
@@ -1337,9 +1337,9 @@ importers:
 
   plugins/@grouparoo/zendesk:
     specifiers:
-      '@grouparoo/app-templates': 0.4.0-alpha.2
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/app-templates': 0.4.0-alpha.3
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.6
@@ -1374,9 +1374,9 @@ importers:
       '@fortawesome/free-brands-svg-icons': 5.15.3
       '@fortawesome/free-solid-svg-icons': 5.15.3
       '@fortawesome/react-fontawesome': 0.1.14
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
-      '@grouparoo/ui-components': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
+      '@grouparoo/ui-components': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1459,8 +1459,8 @@ importers:
       '@fortawesome/free-brands-svg-icons': 5.15.3
       '@fortawesome/free-solid-svg-icons': 5.15.3
       '@fortawesome/react-fontawesome': 0.1.14
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1543,9 +1543,9 @@ importers:
       '@fortawesome/free-brands-svg-icons': 5.15.3
       '@fortawesome/free-solid-svg-icons': 5.15.3
       '@fortawesome/react-fontawesome': 0.1.14
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
-      '@grouparoo/ui-components': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
+      '@grouparoo/ui-components': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1630,9 +1630,9 @@ importers:
       '@fortawesome/free-brands-svg-icons': 5.15.3
       '@fortawesome/free-solid-svg-icons': 5.15.3
       '@fortawesome/react-fontawesome': 0.1.14
-      '@grouparoo/core': 0.4.0-alpha.2
-      '@grouparoo/spec-helper': 0.4.0-alpha.2
-      '@grouparoo/ui-components': 0.4.0-alpha.2
+      '@grouparoo/core': 0.4.0-alpha.3
+      '@grouparoo/spec-helper': 0.4.0-alpha.3
+      '@grouparoo/ui-components': 0.4.0-alpha.3
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -14449,7 +14449,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3
+      jest: 26.6.3_ts-node@10.0.0
       jest-util: 26.6.2
       json5: 2.2.0
       lodash: 4.17.21

--- a/ui/ui-components/pages/destination/[id]/data.tsx
+++ b/ui/ui-components/pages/destination/[id]/data.tsx
@@ -301,7 +301,10 @@ export default function Page(props) {
                       })
                       .map((group) => (
                         <option key={`grp-${group.id}`} value={group.id}>
-                          {group.name} ({group.profilesCount} members)
+                          {group.name}
+                          {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                            <>&nbsp;{group.profilesCount} members</>
+                          )}
                         </option>
                       ))}
                   </Form.Control>

--- a/ui/ui-components/pages/group/[id]/edit.tsx
+++ b/ui/ui-components/pages/group/[id]/edit.tsx
@@ -167,7 +167,8 @@ export default function Page(props) {
             </fieldset>
           </Form>
         </Col>
-        {group.type === "calculated" ? (
+        {group.type === "calculated" &&
+        process.env.GROUPAROO_UI_EDITION !== "config" ? (
           <Col>
             <p>
               {group.calculatedAt ? (

--- a/ui/ui-components/pages/group/[id]/rules.tsx
+++ b/ui/ui-components/pages/group/[id]/rules.tsx
@@ -160,12 +160,14 @@ export default function Page(props) {
       <GroupTabs group={group} />
       <h1>{group.name} - Rules</h1>
       <StateBadge state={group.state} /> <LockedBadge object={group} />
-      <p>
-        Total Profiles in this group: &nbsp;
-        <Badge style={{ fontSize: 16 }} variant="info">
-          {countPotentialMembers}
-        </Badge>
-      </p>
+      {process.env.GROUPAROO_UI_EDITION !== "config" && (
+        <p>
+          Total Profiles in this group: &nbsp;
+          <Badge style={{ fontSize: 16 }} variant="info">
+            {countPotentialMembers}
+          </Badge>
+        </p>
+      )}
       <p>
         Define the profile properties that you want to segment by. Profiles in
         this Group will match <Badge variant="success">{group.matchType}</Badge>{" "}
@@ -183,9 +185,11 @@ export default function Page(props) {
                 <th>
                   <strong>Operation</strong>
                 </th>
-                <th>
-                  <strong># of Profiles</strong>
-                </th>
+                {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                  <th>
+                    <strong># of Profiles</strong>
+                  </th>
+                )}
                 <th>&nbsp;</th>
               </tr>
             </thead>
@@ -440,9 +444,11 @@ export default function Page(props) {
                       </Form.Group>
                     </td>
 
-                    <td>
-                      <Badge variant="info">{componentCounts[idx]}</Badge>
-                    </td>
+                    {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                      <td>
+                        <Badge variant="info">{componentCounts[idx]}</Badge>
+                      </td>
+                    )}
 
                     <td>
                       <Button
@@ -469,16 +475,18 @@ export default function Page(props) {
             Add Rule
           </Button>
           &nbsp;
-          <LoadingButton
-            disabled={loading}
-            variant="outline-dark"
-            size="sm"
-            onClick={async () => {
-              await getCounts(false);
-            }}
-          >
-            Count Potential Group Members
-          </LoadingButton>
+          {process.env.GROUPAROO_UI_EDITION !== "config" && (
+            <LoadingButton
+              disabled={loading}
+              variant="outline-dark"
+              size="sm"
+              onClick={async () => {
+                await getCounts(false);
+              }}
+            >
+              Count Potential Group Members
+            </LoadingButton>
+          )}
           <br />
           <br />{" "}
           {group.locked ? (

--- a/ui/ui-components/pages/groups.tsx
+++ b/ui/ui-components/pages/groups.tsx
@@ -64,9 +64,11 @@ export default function Page(props) {
           <tr>
             <th>Name</th>
             <th>Type</th>
-            <th>Profiles</th>
+            {process.env.GROUPAROO_UI_EDITION !== "config" && <th>Profiles</th>}
             <th>State</th>
-            <th>Calculated At</th>
+            {process.env.GROUPAROO_UI_EDITION !== "config" && (
+              <th>Calculated At</th>
+            )}
             <th>Created At</th>
             <th>Updated At</th>
           </tr>
@@ -93,17 +95,21 @@ export default function Page(props) {
                   )}
                 </td>
                 <td>{group.type}</td>
-                <td>{group.profilesCount}</td>
+                {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                  <td>{group.profilesCount}</td>
+                )}
                 <td>
                   <StateBadge state={group.state} />
                 </td>
-                <td>
-                  {group.calculatedAt ? (
-                    <Moment fromNow>{group.calculatedAt}</Moment>
-                  ) : (
-                    "Never"
-                  )}
-                </td>
+                {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                  <td>
+                    {group.calculatedAt ? (
+                      <Moment fromNow>{group.calculatedAt}</Moment>
+                    ) : (
+                      "Never"
+                    )}
+                  </td>
+                )}
                 <td>
                   <Moment fromNow>{group.createdAt}</Moment>
                 </td>


### PR DESCRIPTION
Removes the following in the Config UI:

* \# of Profiles column
* Button to Count potential group members
* "Total Profiles in this group: #" line
* number of group members in destinations
* List view. remove calculatedAt and Profiles columns
* Edit View:  "never updated" and "Next Member Calculation"  