### PR TITLE
Update the pnpm lockfile as part publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
         default: "alpha"
 
 jobs:
-  build:
+  publish:
     env:
       RELEASE_TYPE: alpha
     runs-on: ubuntu-latest
@@ -37,3 +37,23 @@ jobs:
         env:
           GITHUB_AUTH: ${{ secrets.GH_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  update-lockfile:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'grouparoo/grouparoo' }}
+    needs: publish
+    steps:
+      - uses: actions/checkout@master
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+      - name: Update PNPM lockfile
+        run: |
+          cd tools/merger && ./lockfile
+      - uses: stefanzweifel/git-auto-commit-action@v4.1.2
+        with:
+          commit_message: Updating lockfile [ci skip]
+          commit_user_name: Grouparoo Bot
+          commit_user_email: hello@grouparoo.com
+          commit_author: Grouparoo Bot <hello@grouparoo.com>
+          branch: ${{ github.head_ref }}

--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build:
+  update-branch:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'grouparoo/grouparoo' }}
     steps:

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build:
+  update-lockfile:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'grouparoo/grouparoo' }}
     steps:


### PR DESCRIPTION
Since the commits we use to bump the version include `[ci skip]` (which we still want to do), the other github actions won't be triggered.  However, since the version's have been updated, we do want to rebuild the pnpm lockfile, or else many new PRs will try to update this file.

This PR copies over the steps from the `update-lockfile` action into the `publish` action