### PR TITLE
Using env vars for secret values in Config UI

### DIFF
--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -426,6 +426,17 @@ describe("modules/configWriter", () => {
       expect(config).toBeUndefined();
     });
 
+    test("apps don't transform env vars", async () => {
+      process.env.GROUPAROO_OPTION__APP__CONFIG_WRITER_ENV_VAR = "my_file_123";
+      const app: App = await helper.factories.app({
+        options: { fileId: "CONFIG_WRITER_ENV_VAR" },
+      });
+      const config = await app.getConfigObject();
+      expect(config.options.fileId).toEqual("CONFIG_WRITER_ENV_VAR");
+      const options = await app.getOptions();
+      expect(options.fileId).toEqual("my_file_123");
+    });
+
     test("sources can provide their config objects", async () => {
       const config = await source.getConfigObject();
 
@@ -477,6 +488,16 @@ describe("modules/configWriter", () => {
         options,
       });
       expect(config[1]).toEqual(scheduleConfig);
+    });
+
+    test("sources don't transform env vars", async () => {
+      process.env.GROUPAROO_OPTION__SOURCE__CONFIG_WRITER_ENV_VAR =
+        "my_table_123";
+      await source.setOptions({ table: "CONFIG_WRITER_ENV_VAR" });
+      const config = await source.getConfigObject();
+      expect(config.options.table).toEqual("CONFIG_WRITER_ENV_VAR");
+      const options = await source.getOptions();
+      expect(options.table).toEqual("my_table_123");
     });
 
     test("schedules can provide their config objects", async () => {
@@ -537,6 +558,20 @@ describe("modules/configWriter", () => {
         mapping,
         options,
       });
+    });
+
+    test("schedules don't transform env vars", async () => {
+      process.env.GROUPAROO_OPTION__SCHEDULE__CONFIG_WRITER_ENV_VAR =
+        faker.database.column();
+      const schedule: Schedule = await helper.factories.schedule(source, {
+        options: { maxColumn: "CONFIG_WRITER_ENV_VAR" },
+      });
+      const config = await schedule.getConfigObject();
+      expect(config.options.maxColumn).toEqual("CONFIG_WRITER_ENV_VAR");
+      const options = await schedule.getOptions();
+      expect(options.maxColumn).toEqual(
+        process.env.GROUPAROO_OPTION__SCHEDULE__CONFIG_WRITER_ENV_VAR
+      );
     });
 
     test("properties can provide their config objects", async () => {
@@ -603,6 +638,18 @@ describe("modules/configWriter", () => {
       });
     });
 
+    test("properties don't transform env vars", async () => {
+      process.env.GROUPAROO_OPTION__PROPERTY__CONFIG_WRITER_ENV_VAR =
+        faker.database.column();
+      await property.setOptions({ column: "CONFIG_WRITER_ENV_VAR" });
+      const config = await property.getConfigObject();
+      expect(config.options.column).toEqual("CONFIG_WRITER_ENV_VAR");
+      const options = await property.getOptions();
+      expect(options.column).toEqual(
+        process.env.GROUPAROO_OPTION__PROPERTY__CONFIG_WRITER_ENV_VAR
+      );
+    });
+
     test("groups without a name will not provide a config object", async () => {
       group.name = undefined;
       const config = await group.getConfigObject();
@@ -658,6 +705,19 @@ describe("modules/configWriter", () => {
       destination.name = undefined;
       const config = await destination.getConfigObject();
       expect(config).toBeUndefined();
+    });
+
+    test("destinations don't transform env vars", async () => {
+      process.env.GROUPAROO_OPTION__DESTINATION__CONFIG_WRITER_ENV_VAR =
+        "my_table_456";
+      const destination: Destination = await helper.factories.destination(
+        undefined,
+        { groupId: group.id, options: { table: "CONFIG_WRITER_ENV_VAR" } }
+      );
+      const config = await destination.getConfigObject();
+      expect(config.options.table).toEqual("CONFIG_WRITER_ENV_VAR");
+      const options = await destination.getOptions();
+      expect(options.table).toEqual("my_table_456");
     });
 
     test("profiles can provide their config objects", async () => {

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -68,13 +68,13 @@ describe("modules/configWriter", () => {
       await App.destroy({ truncate: true });
     });
 
-    test.skip("provides a url-friendly path from the name in the object", async () => {
+    test("provides a url-friendly path from the name in the object", async () => {
       const app: App = await helper.factories.app({ name: "HELLO @#$ WORLD" });
       const configObject = await app.getConfigObject();
       const res = ConfigWriter.generateFilePath(configObject);
       expect(res).toEqual("hello_world.json");
     });
-    test.skip("adds a prefix, if specified", async () => {
+    test("adds a prefix, if specified", async () => {
       const app: App = await helper.factories.app({ name: "HELLO @#$ WORLD" });
       const configObject = await app.getConfigObject();
       const res = ConfigWriter.generateFilePath(configObject, "apps");
@@ -94,7 +94,7 @@ describe("modules/configWriter", () => {
       for (let file of files) fs.rmSync(file);
     });
 
-    test.skip("does nothing unless in cli:config mode", async () => {
+    test("does nothing unless in cli:config mode", async () => {
       const app: App = await helper.factories.app();
       const appFilePath = path.join(
         configDir,
@@ -112,7 +112,7 @@ describe("modules/configWriter", () => {
       expect(files).toEqual([appFilePath]);
     });
 
-    test.skip("writes a file for each object", async () => {
+    test("writes a file for each object", async () => {
       const app: App = await helper.factories.app();
       const source: Source = await helper.factories.source(app);
       await source.setOptions({ table: "test-table-04" });
@@ -139,7 +139,7 @@ describe("modules/configWriter", () => {
       expect(appConfig).toEqual(await app.getConfigObject());
     });
 
-    test.skip("does not write objects that are locked", async () => {
+    test("does not write objects that are locked", async () => {
       const app: App = await helper.factories.app();
       await app.update({ locked: "config:test" });
       await ConfigWriter.run();
@@ -147,7 +147,7 @@ describe("modules/configWriter", () => {
       expect(files).toEqual([]);
     });
 
-    test.skip("deletes an object's file after the record is deleted", async () => {
+    test("deletes an object's file after the record is deleted", async () => {
       const app: App = await helper.factories.app();
       await ConfigWriter.run();
       let files = glob.sync(configFilePattern);
@@ -161,7 +161,7 @@ describe("modules/configWriter", () => {
       expect(files).toEqual([]);
     });
 
-    test.skip("does not delete or duplicate locked (JS) files", async () => {
+    test("does not delete or duplicate locked (JS) files", async () => {
       const app: App = await helper.factories.app();
       await app.update({ locked: "config:test" });
       const configObject = await app.getConfigObject();
@@ -201,7 +201,7 @@ describe("modules/configWriter", () => {
       ConfigWriter.resetConfigFileCache();
     });
 
-    test.skip("stores a cache of config objects", async () => {
+    test("stores a cache of config objects", async () => {
       const configObject = await app.getConfigObject();
       const absFilePath = path.join(
         configDir,
@@ -218,7 +218,7 @@ describe("modules/configWriter", () => {
       expect(cache[0].objects[0]).toEqual(configObject);
     });
 
-    test.skip("does not store locked files", async () => {
+    test("does not store locked files", async () => {
       const configObject = await app.getConfigObject();
       const absFilePath = path.join(configDir, `apps/${app.getConfigId()}.js`);
       const res = await ConfigWriter.cacheConfigFile({
@@ -231,7 +231,7 @@ describe("modules/configWriter", () => {
       expect(cache.length).toEqual(0);
     });
 
-    test.skip("is reset-able", async () => {
+    test("is reset-able", async () => {
       const configObject = await app.getConfigObject();
       const absFilePath = path.join(
         configDir,
@@ -257,7 +257,7 @@ describe("modules/configWriter", () => {
         configObject = await app.getConfigObject();
       });
 
-      test.skip('returns "config:writer" for JS files (LOCKED)', async () => {
+      test('returns "config:writer" for JS files (LOCKED)', async () => {
         process.env.GROUPAROO_RUN_MODE = "cli:config";
         const absFilePath = path.join(
           configDir,
@@ -270,7 +270,7 @@ describe("modules/configWriter", () => {
         expect(ConfigWriter.getLockKey(configObject)).toEqual("config:writer");
         process.env.GROUPAROO_RUN_MODE = undefined;
       });
-      test.skip("returns null for JSON files (UNLOCKED)", async () => {
+      test("returns null for JSON files (UNLOCKED)", async () => {
         process.env.GROUPAROO_RUN_MODE = "cli:config";
         const absFilePath = path.join(
           configDir,
@@ -283,7 +283,7 @@ describe("modules/configWriter", () => {
         expect(ConfigWriter.getLockKey(configObject)).toEqual(null);
         process.env.GROUPAROO_RUN_MODE = undefined;
       });
-      test.skip('returns "code:config" when in start mode', async () => {
+      test('returns "code:config" when in start mode', async () => {
         process.env.GROUPAROO_RUN_MODE = "cli:start";
         expect(ConfigWriter.getLockKey(configObject)).toEqual("config:code");
         process.env.GROUPAROO_RUN_MODE = undefined;
@@ -300,11 +300,11 @@ describe("modules/configWriter", () => {
       await Property.destroy({ truncate: true });
     });
 
-    test.skip("returns an empty array when there are no objects", async () => {
+    test("returns an empty array when there are no objects", async () => {
       const configObjects = await ConfigWriter.getConfigObjects();
       expect(configObjects).toEqual([]);
     });
-    test.skip("skips objects without an id", async () => {
+    test("skips objects without an id", async () => {
       let app: App = await helper.factories.app();
       let configObjects = await ConfigWriter.getConfigObjects();
       expect(configObjects).toEqual([
@@ -318,7 +318,7 @@ describe("modules/configWriter", () => {
       configObjects = await ConfigWriter.getConfigObjects();
       expect(configObjects).toEqual([]);
     });
-    test.skip("lists the formatted config objects, ready to be written", async () => {
+    test("lists the formatted config objects, ready to be written", async () => {
       const app: App = await helper.factories.app();
       const source: Source = await helper.factories.source(app);
       await source.setOptions({ table: "test-table-03" });
@@ -402,7 +402,7 @@ describe("modules/configWriter", () => {
       await Group.destroy({ truncate: true });
     });
 
-    test.skip("apps can provide their config objects", async () => {
+    test("apps can provide their config objects", async () => {
       const app: App = await helper.factories.app();
       const config = await app.getConfigObject();
 
@@ -420,13 +420,13 @@ describe("modules/configWriter", () => {
       });
     });
 
-    test.skip("apps without a name will not provide a config object", async () => {
+    test("apps without a name will not provide a config object", async () => {
       const app: App = await helper.factories.app({ name: undefined });
       const config = await app.getConfigObject();
       expect(config).toBeUndefined();
     });
 
-    test.skip("sources can provide their config objects", async () => {
+    test("sources can provide their config objects", async () => {
       const config = await source.getConfigObject();
 
       expect(config.id).toBeTruthy();
@@ -448,7 +448,7 @@ describe("modules/configWriter", () => {
       });
     });
 
-    test.skip("sources without a name will not provide a config object", async () => {
+    test("sources without a name will not provide a config object", async () => {
       const source: Source = await helper.factories.source(undefined, {
         name: undefined,
       });
@@ -456,7 +456,7 @@ describe("modules/configWriter", () => {
       expect(config).toBeUndefined();
     });
 
-    test.skip("sources will also bring their own schedule", async () => {
+    test("sources will also bring their own schedule", async () => {
       const schedule: Schedule = await helper.factories.schedule(source);
       const config = await source.getConfigObject();
       const scheduleConfig = await schedule.getConfigObject();
@@ -479,7 +479,7 @@ describe("modules/configWriter", () => {
       expect(config[1]).toEqual(scheduleConfig);
     });
 
-    test.skip("schedules can provide their config objects", async () => {
+    test("schedules can provide their config objects", async () => {
       const schedule: Schedule = await helper.factories.schedule(source);
       const config = await schedule.getConfigObject();
 
@@ -500,7 +500,7 @@ describe("modules/configWriter", () => {
       });
     });
 
-    test.skip("schedules without a name will not provide a config object", async () => {
+    test("schedules without a name will not provide a config object", async () => {
       const schedule: Schedule = await helper.factories.schedule(source);
       schedule.name = undefined;
       // There's no need to save here because getConfigObject is reading the
@@ -509,7 +509,7 @@ describe("modules/configWriter", () => {
       expect(config).toBeUndefined();
     });
 
-    test.skip("sources with a nameless schedule provide a single object", async () => {
+    test("sources with a nameless schedule provide a single object", async () => {
       const source = await helper.factories.source();
       await source.setOptions({ table: "test-table-05" });
       await source.bootstrapUniqueProperty("uId05", "integer", "id", "uid05");
@@ -539,7 +539,7 @@ describe("modules/configWriter", () => {
       });
     });
 
-    test.skip("properties can provide their config objects", async () => {
+    test("properties can provide their config objects", async () => {
       const filterObj = { key: "id", match: "0", op: "greater than" };
       await property.setFilters([filterObj]);
 
@@ -572,13 +572,13 @@ describe("modules/configWriter", () => {
       });
     });
 
-    test.skip("properties without a name will not provide a config object", async () => {
+    test("properties without a name will not provide a config object", async () => {
       property.key = undefined;
       const config = await property.getConfigObject();
       expect(config).toBeUndefined();
     });
 
-    test.skip("groups can provide their config objects", async () => {
+    test("groups can provide their config objects", async () => {
       const config = await group.getConfigObject();
 
       expect(config.id).toBeTruthy();
@@ -603,13 +603,13 @@ describe("modules/configWriter", () => {
       });
     });
 
-    test.skip("groups without a name will not provide a config object", async () => {
+    test("groups without a name will not provide a config object", async () => {
       group.name = undefined;
       const config = await group.getConfigObject();
       expect(config).toBeUndefined();
     });
 
-    test.skip("destinations can provide their config objects", async () => {
+    test("destinations can provide their config objects", async () => {
       const destination: Destination = await helper.factories.destination(
         undefined,
         { groupId: group.id }
@@ -650,7 +650,7 @@ describe("modules/configWriter", () => {
       });
     });
 
-    test.skip("destinations without a name will not provide a config object", async () => {
+    test("destinations without a name will not provide a config object", async () => {
       const destination: Destination = await helper.factories.destination(
         undefined,
         { groupId: group.id }
@@ -660,7 +660,7 @@ describe("modules/configWriter", () => {
       expect(config).toBeUndefined();
     });
 
-    test.skip("profiles can provide their config objects", async () => {
+    test("profiles can provide their config objects", async () => {
       const profile: Profile = await helper.factories.profile();
       const properties = { [bootstrapPropertyId]: [12] };
 

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -238,7 +238,7 @@ export class App extends LoggedModel<App> {
   async getConfigObject() {
     const { type, name } = this;
 
-    const options = await this.getOptions();
+    const options = await this.getOptions(false);
 
     if (!name) return;
 

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -557,7 +557,7 @@ export class Destination extends LoggedModel<Destination> {
       dgms.map((dgm) => [dgm.remoteKey, dgm.group.getConfigId()])
     );
 
-    const options = await this.getOptions();
+    const options = await this.getOptions(false);
     const mapping = await MappingHelper.getConfigMapping(this);
 
     if (!name || !appId) return;

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -389,7 +389,7 @@ export class Property extends LoggedModel<Property> {
 
     this.source = await this.$get("source");
     const sourceId = this.source?.getConfigId();
-    const options = await this.getOptions();
+    const options = await this.getOptions(false);
     const filters = await this.getFilters();
 
     if (!key || !sourceId) return;

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -195,7 +195,7 @@ export class Schedule extends LoggedModel<Schedule> {
 
     if (!sourceId || !name) return;
 
-    const options = await this.getOptions();
+    const options = await this.getOptions(false);
     return {
       class: "Schedule",
       id: this.getConfigId(),

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -296,7 +296,7 @@ export class Source extends LoggedModel<Source> {
 
     this.app = await this.$get("app");
     const appId = this.app?.getConfigId();
-    const options = await this.getOptions();
+    const options = await this.getOptions(false);
     const mapping = await MappingHelper.getConfigMapping(this);
 
     if (!appId || !name) return;

--- a/ui/ui-components/pages/app/[id]/edit.tsx
+++ b/ui/ui-components/pages/app/[id]/edit.tsx
@@ -174,9 +174,22 @@ export default function Page(props) {
               {typeOptions.length > 0 ? (
                 <>
                   <hr />
-                  <strong>Options for a {app.type} app</strong>
-                  <br />
-                  <br />
+                  <p>
+                    <strong>Options for a {app.type} app</strong>
+                    {process.env.GROUPAROO_UI_EDITION === "config" && (
+                      <>
+                        <br />
+                        You can use environment variables for secret values.{" "}
+                        <a
+                          target="_blank"
+                          href="https://www.grouparoo.com/docs/support/secrets"
+                        >
+                          Learn more
+                        </a>
+                        .
+                      </>
+                    )}
+                  </p>
 
                   {typeOptions.map((opt) => {
                     return (


### PR DESCRIPTION
While secrets worked when _loading_ config files on boot, they were being retrieved and written back to file using their resolved values. This PR introduces the functionality to write the env variable **keys** to file, along with new specs to test that functionality. The behavior is now in place for five of the writable models, though it will likely only apply to apps.

This also brings a note to the app edit page when in Config mode to note how to work with secret values by linking to our documentation.