### PR TITLE
Human IDs, Part 2

### DIFF
--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -402,6 +402,19 @@ describe("modules/configWriter", () => {
       await Group.destroy({ truncate: true });
     });
 
+    // --- App ---
+
+    test("apps should only humanize their ID if it matches default pattern", async () => {
+      let app: App = await helper.factories.app();
+      expect(app.getConfigId()).toEqual(ConfigWriter.generateId(app.name));
+      expect(app.getConfigId()).not.toEqual(app.id);
+
+      app = await helper.factories.app({ id: "hello-world" });
+      expect(app.id).toEqual("hello-world");
+      expect(app.getConfigId()).not.toEqual(ConfigWriter.generateId(app.name));
+      expect(app.getConfigId()).toEqual(app.id);
+    });
+
     test("apps can provide their config objects", async () => {
       const app: App = await helper.factories.app();
       const config = await app.getConfigObject();
@@ -435,6 +448,23 @@ describe("modules/configWriter", () => {
       expect(config.options.fileId).toEqual("CONFIG_WRITER_ENV_VAR");
       const options = await app.getOptions();
       expect(options.fileId).toEqual("my_file_123");
+    });
+
+    // --- Source ---
+
+    test("sources should only humanize their ID if it matches default pattern", async () => {
+      let source: Source = await helper.factories.source();
+      expect(source.getConfigId()).toEqual(
+        ConfigWriter.generateId(source.name)
+      );
+      expect(source.getConfigId()).not.toEqual(source.id);
+
+      source = await helper.factories.source(undefined, { id: "hello-world" });
+      expect(source.id).toEqual("hello-world");
+      expect(source.getConfigId()).not.toEqual(
+        ConfigWriter.generateId(source.name)
+      );
+      expect(source.getConfigId()).toEqual(source.id);
     });
 
     test("sources can provide their config objects", async () => {
@@ -498,6 +528,27 @@ describe("modules/configWriter", () => {
       expect(config.options.table).toEqual("CONFIG_WRITER_ENV_VAR");
       const options = await source.getOptions();
       expect(options.table).toEqual("my_table_123");
+    });
+
+    // --- Schedule ---
+
+    test("schedules should only humanize their ID if it matches default pattern", async () => {
+      let schedule: Schedule = await helper.factories.schedule(source);
+      expect(schedule.getConfigId()).toEqual(
+        ConfigWriter.generateId(schedule.name)
+      );
+      expect(schedule.getConfigId()).not.toEqual(schedule.id);
+      await schedule.destroy();
+      await source.reload();
+
+      schedule = await helper.factories.schedule(source, {
+        id: "hello-world",
+      });
+      expect(schedule.id).toEqual("hello-world");
+      expect(schedule.getConfigId()).not.toEqual(
+        ConfigWriter.generateId(schedule.name)
+      );
+      expect(schedule.getConfigId()).toEqual(schedule.id);
     });
 
     test("schedules can provide their config objects", async () => {
@@ -574,6 +625,34 @@ describe("modules/configWriter", () => {
       );
     });
 
+    // --- Property ---
+
+    test("properties should only humanize their ID if it matches default pattern", async () => {
+      let property: Property = await helper.factories.property(
+        source,
+        { key: faker.lorem.word() },
+        { column: faker.database.column() }
+      );
+      expect(property.getConfigId()).toEqual(
+        ConfigWriter.generateId(property.key)
+      );
+      expect(property.getConfigId()).not.toEqual(property.id);
+
+      property = await helper.factories.property(
+        source,
+        {
+          id: "hello-world",
+          key: faker.lorem.word(),
+        },
+        { column: faker.database.column() }
+      );
+      expect(property.id).toEqual("hello-world");
+      expect(property.getConfigId()).not.toEqual(
+        ConfigWriter.generateId(property.key)
+      );
+      expect(property.getConfigId()).toEqual(property.id);
+    });
+
     test("properties can provide their config objects", async () => {
       const filterObj = { key: "id", match: "0", op: "greater than" };
       await property.setFilters([filterObj]);
@@ -611,6 +690,21 @@ describe("modules/configWriter", () => {
       property.key = undefined;
       const config = await property.getConfigObject();
       expect(config).toBeUndefined();
+    });
+
+    // --- Group ---
+
+    test("groups should only humanize their ID if it matches default pattern", async () => {
+      let group: Group = await helper.factories.group();
+      expect(group.getConfigId()).toEqual(ConfigWriter.generateId(group.name));
+      expect(group.getConfigId()).not.toEqual(group.id);
+
+      group = await helper.factories.group({ id: "hello-world" });
+      expect(group.id).toEqual("hello-world");
+      expect(group.getConfigId()).not.toEqual(
+        ConfigWriter.generateId(group.name)
+      );
+      expect(group.getConfigId()).toEqual(group.id);
     });
 
     test("groups can provide their config objects", async () => {
@@ -654,6 +748,25 @@ describe("modules/configWriter", () => {
       group.name = undefined;
       const config = await group.getConfigObject();
       expect(config).toBeUndefined();
+    });
+
+    // --- Destination ---
+
+    test("destinations should only humanize their ID if it matches default pattern", async () => {
+      let destination: Destination = await helper.factories.destination();
+      expect(destination.getConfigId()).toEqual(
+        ConfigWriter.generateId(destination.name)
+      );
+      expect(destination.getConfigId()).not.toEqual(destination.id);
+
+      destination = await helper.factories.destination(undefined, {
+        id: "hello-world",
+      });
+      expect(destination.id).toEqual("hello-world");
+      expect(destination.getConfigId()).not.toEqual(
+        ConfigWriter.generateId(destination.name)
+      );
+      expect(destination.getConfigId()).toEqual(destination.id);
     });
 
     test("destinations can provide their config objects", async () => {

--- a/core/src/classes/loggedModel.ts
+++ b/core/src/classes/loggedModel.ts
@@ -11,6 +11,7 @@ import {
   Length,
   BeforeBulkCreate,
 } from "sequelize-typescript";
+import validator from "validator";
 import * as uuid from "uuid";
 import { Log } from "../models/Log";
 import { config, chatRoom } from "actionhero";
@@ -137,6 +138,11 @@ export abstract class LoggedModel<T> extends Model {
     }
 
     return message;
+  }
+
+  idIsDefault(): boolean {
+    const uuid = this.id.split("_").pop();
+    return this.id.startsWith(`${this.idPrefix()}_`) && validator.isUUID(uuid);
   }
 
   abstract apiData(): Promise<{ [key: string]: any }>;

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -232,7 +232,7 @@ export class App extends LoggedModel<App> {
   }
 
   getConfigId() {
-    return ConfigWriter.generateId(this.name);
+    return this.idIsDefault() ? ConfigWriter.generateId(this.name) : this.id;
   }
 
   async getConfigObject() {

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -539,7 +539,7 @@ export class Destination extends LoggedModel<Destination> {
   }
 
   getConfigId() {
-    return ConfigWriter.generateId(this.name);
+    return this.idIsDefault() ? ConfigWriter.generateId(this.name) : this.id;
   }
 
   async getConfigObject() {

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -627,7 +627,7 @@ export class Group extends LoggedModel<Group> {
   }
 
   getConfigId() {
-    return ConfigWriter.generateId(this.name);
+    return this.idIsDefault() ? ConfigWriter.generateId(this.name) : this.id;
   }
 
   async getConfigObject() {

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -381,7 +381,7 @@ export class Property extends LoggedModel<Property> {
   }
 
   getConfigId() {
-    return ConfigWriter.generateId(this.key);
+    return this.idIsDefault() ? ConfigWriter.generateId(this.key) : this.id;
   }
 
   async getConfigObject() {

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -184,7 +184,7 @@ export class Schedule extends LoggedModel<Schedule> {
   }
 
   getConfigId() {
-    return ConfigWriter.generateId(this.name);
+    return this.idIsDefault() ? ConfigWriter.generateId(this.name) : this.id;
   }
 
   async getConfigObject() {

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -288,7 +288,7 @@ export class Source extends LoggedModel<Source> {
   }
 
   getConfigId() {
-    return ConfigWriter.generateId(this.name);
+    return this.idIsDefault() ? ConfigWriter.generateId(this.name) : this.id;
   }
 
   async getConfigObject() {

--- a/core/src/modules/configWriter.ts
+++ b/core/src/modules/configWriter.ts
@@ -71,8 +71,7 @@ export namespace ConfigWriter {
     object: ConfigurationObject,
     prefix?: string
   ): string {
-    const name = Array.isArray(object) ? object[0].name : object.name;
-    let filePath = `${generateId(name)}.json`;
+    let filePath = `${object.id}.json`;
     if (prefix) filePath = `${prefix}/${filePath}`;
     return filePath;
   }


### PR DESCRIPTION
This is a continuation of #1895. That story was rejected because the `id` would be updated every time. So whenever a `name` (or `key`) would change, the file would change locations.

Logged Model now makes an inference as to whether its `id` follows the default structure or not. The writable models use this method to determine if they should use the `id` value from the database or slugify their human property.

Through this process I also found that the config writer was using the `name` property on the config object to generate the filename. Now we assume that the `id` was generated properly and use it directly to name the file.