### PR TITLE
Relax error throwing for `profileProperties:enqueue` task

### DIFF
--- a/core/src/tasks/import/associateProfiles.ts
+++ b/core/src/tasks/import/associateProfiles.ts
@@ -1,4 +1,3 @@
-import { log } from "actionhero";
 import { plugin } from "../../modules/plugin";
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { ImportOps } from "../../modules/ops/import";
@@ -27,9 +26,5 @@ export class ImportAssociateProfiles extends CLSTask {
       limit,
       delayMs
     );
-
-    if (imports.length > 0) {
-      log(`enqueued ${imports.length} imports for association`);
-    }
   }
 }


### PR DESCRIPTION
This PR relaxes error handling for the `profileProperties:enqueue` task.  We will log errors which occur, but not throw. 

This PR also increases the number of times `RetryableTask` will retry when `NODE_ENV=development` to 3 (from 1). 