### PR TITLE
Set groups right to ready in config

### DIFF
--- a/core/__tests__/models/group/calculatedGroup.ts
+++ b/core/__tests__/models/group/calculatedGroup.ts
@@ -31,6 +31,7 @@ describe("models/group", () => {
 
     afterEach(async () => {
       await SharedGroupTests.afterEach();
+      process.env.GROUPAROO_RUN_MODE = undefined;
     });
 
     test("an empty calculated group can be created", async () => {
@@ -79,6 +80,15 @@ describe("models/group", () => {
       expect(run.groupMethod).toBe("complete");
 
       await group.reload();
+      expect(group.state).toBe("ready");
+    });
+
+    test("groups with at least one rule are set to ready in config mode", async () => {
+      process.env.GROUPAROO_RUN_MODE = "cli:config";
+      expect(group.state).toBe("draft");
+      await group.setRules([
+        { key: "firstName", match: "nobody", operation: { op: "eq" } },
+      ]);
       expect(group.state).toBe("ready");
     });
 

--- a/core/__tests__/models/group/group.ts
+++ b/core/__tests__/models/group/group.ts
@@ -83,7 +83,7 @@ describe("models/group", () => {
       expect(runs.length).toEqual(1);
       expect(runs[0].state).toEqual("running");
     });
-    test("does not create a group when in config mode", async () => {
+    test("does not create a run when in config mode", async () => {
       process.env.GROUPAROO_RUN_MODE = "cli:config";
 
       const group = await Group.create({

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -262,7 +262,10 @@ export class Group extends LoggedModel<Group> {
     await this.countPotentialMembers(savedRules, null);
 
     if (this.state !== "deleted" && rules.length > 0) {
-      this.state = "initializing";
+      this.state =
+        process.env.GROUPAROO_RUN_MODE === "cli:config"
+          ? "ready"
+          : "initializing";
       this.changed("updatedAt", true);
       await this.save();
       await this.run();


### PR DESCRIPTION
@evantahler This is a quick change, but wanted your input on it. What I'm trying to accomplish is to set a group's `state` to `ready` in config mode when it has at least one rule. Previously they were stuck in `initializing`.

Is this an appropriate change? Would you have gone about it differently?