### PR TITLE
Remove UI plugins from the `grouparoo.plugins` section in package.json file

### DIFF
--- a/apps/staging-community/package.json
+++ b/apps/staging-community/package.json
@@ -77,8 +77,6 @@
       "@grouparoo/sendgrid",
       "@grouparoo/snowflake",
       "@grouparoo/sqlite",
-      "@grouparoo/ui-config",
-      "@grouparoo/ui-community",
       "@grouparoo/zendesk"
     ]
   }

--- a/apps/staging-config/package.json
+++ b/apps/staging-config/package.json
@@ -29,8 +29,7 @@
     "plugins": [
       "@grouparoo/demo",
       "@grouparoo/postgres",
-      "@grouparoo/sqlite",
-      "@grouparoo/ui-config"
+      "@grouparoo/sqlite"
     ]
   }
 }

--- a/apps/staging-enterprise/package.json
+++ b/apps/staging-enterprise/package.json
@@ -77,8 +77,6 @@
       "@grouparoo/sendgrid",
       "@grouparoo/snowflake",
       "@grouparoo/sqlite",
-      "@grouparoo/ui-enterprise",
-      "@grouparoo/ui-config",
       "@grouparoo/zendesk"
     ]
   }

--- a/cli/src/lib/install.ts
+++ b/cli/src/lib/install.ts
@@ -30,15 +30,12 @@ export default async function Update(pkg: string) {
     process.exit(1);
   }
 
-  const installedPackages = Object.keys(
-    pkgJSONContents?.devDependencies || []
-  ).concat(Object.keys(pkgJSONContents?.dependencies || []));
-
+  const dependencyList = Object.keys(pkgJSONContents?.dependencies || []);
   const availableUiPackages = [
     "@grouparoo/ui-community",
     "@grouparoo/ui-enterprise",
   ];
-  const existingUiPackage = installedPackages.find((p) =>
+  const existingUiPackage = dependencyList.find((p) =>
     availableUiPackages.includes(p)
   );
 

--- a/cli/src/lib/install.ts
+++ b/cli/src/lib/install.ts
@@ -24,18 +24,32 @@ export default async function Update(pkg: string) {
   let plugins: string[] = pkgJSONContents?.grouparoo?.plugins;
 
   if (!plugins) {
-    logger.fail("There is no `grouparoo` section in this package.json.");
+    logger.fail(
+      "There is no `grouparoo.plugins` section in this package.json."
+    );
     process.exit(1);
   }
 
-  if (pkg && pkg?.match("@grouparoo/ui-")) {
-    const existingUIPackage = plugins.find((p) => p.match(/@grouparoo\/ui.*/));
-    if (existingUIPackage) {
-      logger.fail(
-        "There is already a ui package in this project. Uninstall the existing ui package before adding another."
-      );
-      process.exit(1);
-    }
+  const installedPackages = Object.keys(
+    pkgJSONContents?.devDependencies || []
+  ).concat(Object.keys(pkgJSONContents?.dependencies || []));
+
+  const availableUiPackages = [
+    "@grouparoo/ui-community",
+    "@grouparoo/ui-enterprise",
+  ];
+  const existingUiPackage = installedPackages.find((p) =>
+    availableUiPackages.includes(p)
+  );
+
+  const isUiPackage =
+    availableUiPackages.filter((p) => pkg?.includes(p)).length > 0;
+  const isConfigUiPackage = pkg?.includes("@grouparoo/ui-config");
+  if (existingUiPackage && isUiPackage) {
+    logger.fail(
+      "There is already a ui package in this project. Uninstall the existing ui package before adding another."
+    );
+    process.exit(1);
   }
 
   if (pkg && !(await isGrouparooPlugin(pkg))) {
@@ -43,13 +57,13 @@ export default async function Update(pkg: string) {
     process.exit(1);
   }
 
-  await NPM.install(logger, workDir, pkg);
+  await NPM.install(logger, workDir, pkg, true, "error", isConfigUiPackage);
 
   // reload after npm install
   pkgJSONContents = readPackageJSON(packageFile);
   plugins = pkgJSONContents?.grouparoo?.plugins;
 
-  if (pkg) {
+  if (pkg && !isConfigUiPackage && !isUiPackage) {
     let cleanedPackageName =
       pkg.split("@").length === 3 ? "@" + pkg.split("@")[1] : pkg.split("@")[0];
     if (!plugins.includes(cleanedPackageName)) {

--- a/cli/src/utils/npm.ts
+++ b/cli/src/utils/npm.ts
@@ -15,7 +15,7 @@ export namespace NPM {
   ) {
     let args = ["install"];
 
-    if (devDependency) args.push("-D");
+    if (devDependency) args.push("--save-dev");
 
     const npmCheck = await spawnPromise(NPM, ["--version"]);
     const npmVersion = npmCheck.stdout.trim();

--- a/cli/src/utils/npm.ts
+++ b/cli/src/utils/npm.ts
@@ -10,9 +10,12 @@ export namespace NPM {
     workDir: string,
     pkg?: string,
     exact = true,
-    npm_config_loglevel = "error"
+    npm_config_loglevel = "error",
+    devDependency = false
   ) {
-    const args = ["install"];
+    let args = ["install"];
+
+    if (devDependency) args.push("-D");
 
     const npmCheck = await spawnPromise(NPM, ["--version"]);
     const npmVersion = npmCheck.stdout.trim();

--- a/cli/templates/package.json
+++ b/cli/templates/package.json
@@ -16,8 +16,6 @@
     "start": "cd node_modules/@grouparoo/core && ./bin/start"
   },
   "grouparoo": {
-    "plugins": [
-      "@grouparoo/ui-community"
-    ]
+    "plugins": []
   }
 }

--- a/core/src/utils/pluginDetails.js
+++ b/core/src/utils/pluginDetails.js
@@ -63,60 +63,74 @@ function getPluginManifest() {
   manifest.parent = { grouparoo: parentPkg.grouparoo, path: parentPath };
 
   // plugins
-  if (manifest.parent.grouparoo && manifest.parent.grouparoo.plugins) {
-    for (const i in manifest.parent.grouparoo.plugins) {
-      const pluginName = manifest.parent.grouparoo.plugins[i];
+  let pluginNames = [...(manifest?.parent?.grouparoo?.plugins || [])];
 
-      if (pluginName === "@grouparoo/core") continue;
+  const availableUiPlugins = [
+    "@grouparoo/ui-enterprise",
+    "@grouparoo/ui-community",
+    "@grouparoo/ui-config",
+  ];
 
-      let pluginPath = "";
-      try {
-        pluginPath = require.resolve(pluginName);
-      } catch {
-        pluginPath = path.join(parentPath, "node_modules", pluginName);
-        if (!fs.existsSync(pluginPath)) {
-          pluginPath = path.join(
-            grouparooMonorepoApp
-              ? path.join(
-                  __dirname,
-                  "..",
-                  "..",
-                  "..",
-                  "apps",
-                  grouparooMonorepoApp
-                )
-              : path.join(__dirname, "..", "..", "..", "..", "..", ".."),
-            "node_modules",
-            pluginName
-          );
-        }
-      }
+  const installedPackages = Object.keys(
+    parentPkg?.devDependencies || []
+  ).concat(Object.keys(parentPkg?.dependencies || []));
 
-      pluginPath = fs.realpathSync(pluginPath);
-      const pluginPkg = readPackageJson(path.join(pluginPath, "package.json"));
+  for (let availableUiPlugin of availableUiPlugins) {
+    if (installedPackages.includes(availableUiPlugin)) {
+      pluginNames.push(availableUiPlugin);
+    }
+  }
 
-      if (pluginPkg.name) {
-        manifest.plugins.push({
-          name: pluginPkg.name,
-          version: pluginPkg.version,
-          license: pluginPkg.license,
-          url:
-            pluginPkg.url ||
-            (pluginPkg.repository && pluginPkg.repository.url
-              ? pluginPkg.repository.url
-              : null) ||
-            pluginPkg.homepage,
-          path: pluginPath,
-          grouparoo: pluginPkg.grouparoo || null,
-        });
+  for (const pluginName of pluginNames) {
+    if (pluginName === "@grouparoo/core") continue;
+
+    let pluginPath = "";
+    try {
+      pluginPath = require.resolve(pluginName);
+    } catch {
+      pluginPath = path.join(parentPath, "node_modules", pluginName);
+      if (!fs.existsSync(pluginPath)) {
+        pluginPath = path.join(
+          grouparooMonorepoApp
+            ? path.join(
+                __dirname,
+                "..",
+                "..",
+                "..",
+                "apps",
+                grouparooMonorepoApp
+              )
+            : path.join(__dirname, "..", "..", "..", "..", "..", ".."),
+          "node_modules",
+          pluginName
+        );
       }
     }
 
-    manifest.plugins.sort((a, b) => {
-      if (a.name > b.name) return 1;
-      if (a.name < b.name) return -1;
-    });
+    pluginPath = fs.realpathSync(pluginPath);
+    const pluginPkg = readPackageJson(path.join(pluginPath, "package.json"));
+
+    if (pluginPkg.name) {
+      manifest.plugins.push({
+        name: pluginPkg.name,
+        version: pluginPkg.version,
+        license: pluginPkg.license,
+        url:
+          pluginPkg.url ||
+          (pluginPkg.repository && pluginPkg.repository.url
+            ? pluginPkg.repository.url
+            : null) ||
+          pluginPkg.homepage,
+        path: pluginPath,
+        grouparoo: pluginPkg.grouparoo || null,
+      });
+    }
   }
+
+  manifest.plugins.sort((a, b) => {
+    if (a.name > b.name) return 1;
+    if (a.name < b.name) return -1;
+  });
 
   return manifest;
 }

--- a/core/src/utils/pluginDetails.js
+++ b/core/src/utils/pluginDetails.js
@@ -81,6 +81,8 @@ function getPluginManifest() {
     }
   }
 
+  pluginNames = [...new Set(pluginNames)];
+
   for (const pluginName of pluginNames) {
     if (pluginName === "@grouparoo/core") continue;
 

--- a/core/src/utils/pluginDetails.js
+++ b/core/src/utils/pluginDetails.js
@@ -110,6 +110,9 @@ function getPluginManifest() {
     }
 
     pluginPath = fs.realpathSync(pluginPath);
+
+    if (!fs.existsSync(pluginPath)) continue;
+
     const pluginPkg = readPackageJson(path.join(pluginPath, "package.json"));
 
     if (pluginPkg.name) {


### PR DESCRIPTION
Makes the following changes:

- UI plugins are loaded automatically if they are installed. They do not have to be in the `grouparoo.plugins` array.
- `grouparoo install` will install ui-config as a dev dependency.
- `grouparoo install` does not add ui-config, ui-community, or ui-enterprise to the `grouparoo.plugins` array.
- Fix an issue with the conflict error on `grouparoo install`. Now it will only fail if trying to install ui-community or ui-enterprise when one or the other has been installed. The error logic ignores ui-config.
- Removes duplicates from `grouparoo.plugins` (on the fly, it doesn't actually make changes to package.json).

This one is weird to test. I did all of the testing manually.