### PR TITLE
Fix autofocus for config sign in

### DIFF
--- a/ui/ui-config/pages/session/sign-in.tsx
+++ b/ui/ui-config/pages/session/sign-in.tsx
@@ -80,7 +80,6 @@ export default function SignInPage(props) {
                 <Form.Label>Email Address</Form.Label>
                 <Form.Control
                   disabled={loading}
-                  autoFocus
                   required
                   name="email"
                   type="email"


### PR DESCRIPTION
Note that this only works when navigating to the sign in page via Next's router.