### PR TITLE
ConfigWriter.generateId() throws an error when it can't build a valid id

### DIFF
--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -74,8 +74,10 @@ describe("modules/configWriter", () => {
     test("it returns undefined when name is an empty string", () => {
       expect(ConfigWriter.generateId("")).toBeUndefined();
     });
-    test("it returns undefined when name does not have url-friendly characters", () => {
-      expect(ConfigWriter.generateId("!")).toBeUndefined();
+    test("it throws an error when name does not have url-friendly characters", () => {
+      expect(() => {
+        ConfigWriter.generateId("!");
+      }).toThrow("Could not generate ID from name.");
     });
     test("it preserves hyphens", () => {
       expect(ConfigWriter.generateId("hello-world")).toEqual("hello-world");
@@ -348,7 +350,7 @@ describe("modules/configWriter", () => {
           object: await app.getConfigObject(),
         },
       ]);
-      app.name = "$";
+      app.name = "";
       await app.save();
       configObjects = await ConfigWriter.getConfigObjects();
       expect(configObjects).toEqual([]);
@@ -632,7 +634,9 @@ describe("modules/configWriter", () => {
         { key: "firstName05" },
         { column: "firstName05" }
       );
-      await helper.factories.schedule(source, { name: "!" });
+      const schedule: Schedule = await helper.factories.schedule(source);
+      await schedule.update({ name: "" }, { hooks: false });
+
       const config = await source.getConfigObject();
 
       const { name, type } = source;

--- a/core/src/modules/configWriter.ts
+++ b/core/src/modules/configWriter.ts
@@ -53,7 +53,7 @@ export namespace ConfigWriter {
   // ---------------------------------------- | Helpers
 
   export function generateId(name, separator: string = "_"): string {
-    if (!name) return;
+    if (!name || name.length === 0) return;
     const id = name
       .toLowerCase()
       // replace bad characters with a space
@@ -64,7 +64,7 @@ export namespace ConfigWriter {
       .replace(/[ ]/g, separator)
       // replace multiple word separators with an underscore
       .replace(/[\-_ ][\-_ ]+/g, separator);
-    if (id.length === 0) return;
+    if (id.length === 0) throw new Error("Could not generate ID from name.");
     return id;
   }
 


### PR DESCRIPTION
The `generateId()` method will throw an error when given some string for which it can't generate a valid ID value. However, when given an empty value, it will simply return `undefined`. This protects us from throwing an error when trying to build config objects for records that don't have a name-like value available yet.

IOW the following conditions exist:

- The typical workflow remains the same.
- Naming an item something like "$", where the `id` would be empty will throw and error: `Could not generate ID from name.`
- Naming one item "Post" and another "$Post" (where there would be a clash in `id` values) does not throw an error. It will only create the last one it grabs (and that _may_ not be consistent). 