### PR TITLE
Add a first setup step in config mode that is always true

### DIFF
--- a/core/__tests__/models/setupStep.ts
+++ b/core/__tests__/models/setupStep.ts
@@ -9,6 +9,10 @@ describe("models/setupStep", () => {
     resetSettings: true,
   });
 
+  afterEach(async () => {
+    process.env.GROUPAROO_RUN_MODE = undefined;
+  });
+
   test("setupSteps will be created when the server boots", async () => {
     const setupSteps = await SetupStep.findAll({
       order: [["position", "asc"]],
@@ -20,15 +24,25 @@ describe("models/setupStep", () => {
   });
 
   test("setupSteps can return the related title and description", async () => {
-    const setupStep = await await SetupStep.findOne({ where: { position: 1 } });
+    const setupStep = await SetupStep.findOne({ where: { position: 1 } });
     expect(setupStep.getTitle()).toEqual(
-      SetupStepOps.setupStepDescriptions.filter((ssd) => ssd.position === 1)[0]
-        .title
+      SetupStepOps.setupStepDescriptions().filter(
+        (ssd) => ssd.position === 1
+      )[0].title
     );
     expect(setupStep.getDescription()).toEqual(
-      SetupStepOps.setupStepDescriptions.filter((ssd) => ssd.position === 1)[0]
-        .description
+      SetupStepOps.setupStepDescriptions().filter(
+        (ssd) => ssd.position === 1
+      )[0].description
     );
+  });
+
+  test("setupSteps ops returns config versions when in config mode", async () => {
+    let setupSteps = SetupStepOps.setupStepDescriptions();
+    expect(setupSteps[0].key).toEqual("name_your_grouparoo_instance");
+    process.env.GROUPAROO_RUN_MODE = "cli:config";
+    setupSteps = SetupStepOps.setupStepDescriptions();
+    expect(setupSteps[0].key).toEqual("install_grouparoo");
   });
 
   test("setup steps have unique keys", async () => {

--- a/core/src/initializers/setupSteps.ts
+++ b/core/src/initializers/setupSteps.ts
@@ -13,8 +13,11 @@ export class OnboardingSteps extends CLSInitializer {
 
   async startWithinTransaction() {
     // insert or update the setup steps we want
-    for (const i in SetupStepOps.setupStepDescriptions) {
-      const ssd = SetupStepOps.setupStepDescriptions[i];
+    const setupSteps =
+      process.env.GROUPAROO_RUN_MODE === "cli:config"
+        ? SetupStepOps.configSetupStepDescriptions
+        : SetupStepOps.setupStepDescriptions;
+    for (const ssd of setupSteps) {
       const onboardingStep = await SetupStep.findOne({
         where: { key: ssd.key },
       });
@@ -35,7 +38,7 @@ export class OnboardingSteps extends CLSInitializer {
     await SetupStep.destroy({
       where: {
         key: {
-          [Op.notIn]: SetupStepOps.setupStepDescriptions.map((ssd) => ssd.key),
+          [Op.notIn]: setupSteps.map((ssd) => ssd.key),
         },
       },
     });

--- a/core/src/initializers/setupSteps.ts
+++ b/core/src/initializers/setupSteps.ts
@@ -13,10 +13,7 @@ export class OnboardingSteps extends CLSInitializer {
 
   async startWithinTransaction() {
     // insert or update the setup steps we want
-    const setupSteps =
-      process.env.GROUPAROO_RUN_MODE === "cli:config"
-        ? SetupStepOps.configSetupStepDescriptions
-        : SetupStepOps.setupStepDescriptions;
+    const setupSteps = SetupStepOps.setupStepDescriptions();
     for (const ssd of setupSteps) {
       const onboardingStep = await SetupStep.findOne({
         where: { key: ssd.key },

--- a/core/src/models/SetupStep.ts
+++ b/core/src/models/SetupStep.ts
@@ -112,9 +112,11 @@ export class SetupStep extends LoggedModel<SetupStep> {
   }
 
   getSetupStepDescription() {
-    const ssdFilteredArray = SetupStepOps.setupStepDescriptions.filter(
-      (ssd) => ssd.key === this.key
-    );
+    const setupSteps =
+      process.env.GROUPAROO_RUN_MODE === "cli:config"
+        ? SetupStepOps.configSetupStepDescriptions
+        : SetupStepOps.setupStepDescriptions;
+    const ssdFilteredArray = setupSteps.filter((ssd) => ssd.key === this.key);
 
     if (ssdFilteredArray.length === 1) return ssdFilteredArray[0];
 

--- a/core/src/models/SetupStep.ts
+++ b/core/src/models/SetupStep.ts
@@ -112,10 +112,7 @@ export class SetupStep extends LoggedModel<SetupStep> {
   }
 
   getSetupStepDescription() {
-    const setupSteps =
-      process.env.GROUPAROO_RUN_MODE === "cli:config"
-        ? SetupStepOps.configSetupStepDescriptions
-        : SetupStepOps.setupStepDescriptions;
+    const setupSteps = SetupStepOps.setupStepDescriptions();
     const ssdFilteredArray = setupSteps.filter((ssd) => ssd.key === this.key);
 
     if (ssdFilteredArray.length === 1) return ssdFilteredArray[0];

--- a/core/src/modules/ops/setupSteps.ts
+++ b/core/src/modules/ops/setupSteps.ts
@@ -151,65 +151,41 @@ export namespace SetupStepOps {
     },
   };
 
-  export const setupStepDescriptions: Array<setupStepDescription> = [
-    {
-      ...allSetupStepDescriptions.name_your_grouparoo_instance,
-      position: 1,
-    },
-    {
-      ...allSetupStepDescriptions.add_an_app,
-      position: 2,
-    },
-    {
-      ...allSetupStepDescriptions.create_a_source,
-      position: 3,
-    },
-    {
-      ...allSetupStepDescriptions.create_a_unique_profile_property,
-      position: 4,
-    },
-    {
-      ...allSetupStepDescriptions.create_a_schedule,
-      position: 5,
-    },
-    {
-      ...allSetupStepDescriptions.create_a_group,
-      position: 6,
-    },
-    {
-      ...allSetupStepDescriptions.create_a_destination,
-      position: 7,
-    },
-  ];
+  export const setupStepDescriptions = (): Array<setupStepDescription> => {
+    const firstStep =
+      process.env.GROUPAROO_RUN_MODE === "cli:config"
+        ? { ...allSetupStepDescriptions.install_grouparoo }
+        : { ...allSetupStepDescriptions.name_your_grouparoo_instance };
 
-  export const configSetupStepDescriptions: Array<setupStepDescription> = [
-    {
-      ...allSetupStepDescriptions.install_grouparoo,
-      position: 1,
-    },
-    {
-      ...allSetupStepDescriptions.add_an_app,
-      position: 2,
-    },
-    {
-      ...allSetupStepDescriptions.create_a_source,
-      position: 3,
-    },
-    {
-      ...allSetupStepDescriptions.create_a_unique_profile_property,
-      position: 4,
-    },
-    {
-      ...allSetupStepDescriptions.create_a_schedule,
-      position: 5,
-    },
-    {
-      ...allSetupStepDescriptions.create_a_group,
-      position: 6,
-    },
-    {
-      ...allSetupStepDescriptions.create_a_destination,
-      position: 7,
-    },
-  ];
+    return [
+      {
+        ...firstStep,
+        position: 1,
+      },
+      {
+        ...allSetupStepDescriptions.add_an_app,
+        position: 2,
+      },
+      {
+        ...allSetupStepDescriptions.create_a_source,
+        position: 3,
+      },
+      {
+        ...allSetupStepDescriptions.create_a_unique_profile_property,
+        position: 4,
+      },
+      {
+        ...allSetupStepDescriptions.create_a_schedule,
+        position: 5,
+      },
+      {
+        ...allSetupStepDescriptions.create_a_group,
+        position: 6,
+      },
+      {
+        ...allSetupStepDescriptions.create_a_destination,
+        position: 7,
+      },
+    ];
+  };
 }

--- a/core/src/modules/ops/setupSteps.ts
+++ b/core/src/modules/ops/setupSteps.ts
@@ -15,7 +15,7 @@ const configURL = "https://www.grouparoo.com/docs/config";
 
 export namespace SetupStepOps {
   export type setupStepDescription = {
-    position: number;
+    position?: number;
     key: string;
     title: string;
     description: string;
@@ -27,9 +27,20 @@ export namespace SetupStepOps {
     outcome?: () => Promise<string>;
   };
 
-  export const setupStepDescriptions: Array<setupStepDescription> = [
-    {
-      position: 1,
+  const allSetupStepDescriptions: { [key: string]: setupStepDescription } = {
+    install_grouparoo: {
+      key: "install_grouparoo",
+      title: "Install Grouparoo",
+      description: "Install the Grouparoo package.",
+      href: undefined,
+      cta: undefined,
+      showCtaOnCommunity: false,
+      helpLink: `https://www.grouparoo.com/docs/installation`,
+      check: async () => {
+        return true;
+      },
+    },
+    name_your_grouparoo_instance: {
       key: "name_your_grouparoo_instance",
       title: "Name your Grouparoo Instance",
       description: "Give your Grouparoo cluster a name.",
@@ -42,8 +53,7 @@ export namespace SetupStepOps {
         return setting.value !== setting.defaultValue;
       },
     },
-    {
-      position: 2,
+    add_an_app: {
       key: "add_an_app",
       title: "Add an App",
       description:
@@ -56,8 +66,7 @@ export namespace SetupStepOps {
         return count > 0;
       },
     },
-    {
-      position: 3,
+    create_a_source: {
       key: "create_a_source",
       title: "Create a Source",
       description:
@@ -70,8 +79,7 @@ export namespace SetupStepOps {
         return count > 0;
       },
     },
-    {
-      position: 4,
+    create_a_unique_profile_property: {
       key: "create_a_unique_profile_property",
       title: "Create a Unique Profile Property",
       description:
@@ -90,8 +98,7 @@ export namespace SetupStepOps {
         return `${count} Profiles created`;
       },
     },
-    {
-      position: 5,
+    create_a_schedule: {
       key: "create_a_schedule",
       title: "Create a Schedule",
       description:
@@ -108,8 +115,7 @@ export namespace SetupStepOps {
         return `${count} Runs created`;
       },
     },
-    {
-      position: 6,
+    create_a_group: {
       key: "create_a_group",
       title: "Create a Group",
       description:
@@ -126,8 +132,7 @@ export namespace SetupStepOps {
         return `${count} Group Memberships created`;
       },
     },
-    {
-      position: 7,
+    create_a_destination: {
       key: "create_a_destination",
       title: "Create a Destination",
       description:
@@ -143,6 +148,68 @@ export namespace SetupStepOps {
         const count = await Export.count();
         return `${count} Profiles exported to a Destination`;
       },
+    },
+  };
+
+  export const setupStepDescriptions: Array<setupStepDescription> = [
+    {
+      ...allSetupStepDescriptions.name_your_grouparoo_instance,
+      position: 1,
+    },
+    {
+      ...allSetupStepDescriptions.add_an_app,
+      position: 2,
+    },
+    {
+      ...allSetupStepDescriptions.create_a_source,
+      position: 3,
+    },
+    {
+      ...allSetupStepDescriptions.create_a_unique_profile_property,
+      position: 4,
+    },
+    {
+      ...allSetupStepDescriptions.create_a_schedule,
+      position: 5,
+    },
+    {
+      ...allSetupStepDescriptions.create_a_group,
+      position: 6,
+    },
+    {
+      ...allSetupStepDescriptions.create_a_destination,
+      position: 7,
+    },
+  ];
+
+  export const configSetupStepDescriptions: Array<setupStepDescription> = [
+    {
+      ...allSetupStepDescriptions.install_grouparoo,
+      position: 1,
+    },
+    {
+      ...allSetupStepDescriptions.add_an_app,
+      position: 2,
+    },
+    {
+      ...allSetupStepDescriptions.create_a_source,
+      position: 3,
+    },
+    {
+      ...allSetupStepDescriptions.create_a_unique_profile_property,
+      position: 4,
+    },
+    {
+      ...allSetupStepDescriptions.create_a_schedule,
+      position: 5,
+    },
+    {
+      ...allSetupStepDescriptions.create_a_group,
+      position: 6,
+    },
+    {
+      ...allSetupStepDescriptions.create_a_destination,
+      position: 7,
     },
   ];
 }

--- a/ui/ui-components/components/setupSteps/setupStepCard.tsx
+++ b/ui/ui-components/components/setupSteps/setupStepCard.tsx
@@ -71,12 +71,13 @@ export default function SetupStepCard({
                       Learn More
                     </Button>
                     &nbsp;&nbsp;
-                    {process.env.GROUPAROO_UI_EDITION !== "community" ||
-                    step.showCtaOnCommunity ? (
-                      <Button size="sm" href={step.href}>
-                        {step.cta}
-                      </Button>
-                    ) : null}
+                    {(process.env.GROUPAROO_UI_EDITION !== "community" ||
+                      step.showCtaOnCommunity) &&
+                      step.cta && (
+                        <Button size="sm" href={step.href}>
+                          {step.cta}
+                        </Button>
+                      )}
                   </Col>
                   {process.env.GROUPAROO_UI_EDITION === "config" ? null : (
                     <Col md={6} style={{ textAlign: "right" }}>


### PR DESCRIPTION
This was a quick iteration on a workflow bug we found. Suggested solution [here](https://www.pivotaltracker.com/story/show/178546753/comments/224915857).

Based on the way I approached this, it is a little weird to test because we have to _start_ the server in a particular mode to test that we have the right steps. Would you suggest I go about this differently, or can you think of an easy way to test that isn't creating a whole new spec?