### PR TITLE
Don't boot config server when there are errors

### DIFF
--- a/core/src/initializers/codeConfig.ts
+++ b/core/src/initializers/codeConfig.ts
@@ -29,13 +29,8 @@ export class CodeConfig extends CLSInitializer {
     const configDir = getConfigDir();
     const { errors } = await loadConfigDirectory(configDir);
 
-    if (process.env.GROUPAROO_RUN_MODE === "cli:config") {
-      // boot if there are problems with code config
-      // don't prevent lockedModelChanges
-    } else {
-      if (errors.length > 0) throw new Error("code config error");
-      api.codeConfig.allowLockedModelChanges = false; // after this point in the Actionhero boot lifecycle, locked models cannot be changed
-    }
+    if (errors.length > 0) throw new Error("code config error");
+    api.codeConfig.allowLockedModelChanges = false; // after this point in the Actionhero boot lifecycle, locked models cannot be changed
   }
 
   async stopWithinTransaction() {}


### PR DESCRIPTION
This was a change @evantahler put in place very early in the process, which said that Config UI should be able to boot when there are no errors and that we should not allow locked model changes.

I believe this change to be safe for the following reasons:

1. [We want Config UI boot to fail when there is an error](https://www.pivotaltracker.com/story/show/178545361). This protects us against writing duplicate files and also not having these objects show up in Config when we expect them to be there.
2. As of #1796, locking behaves differently in Config UI. We actually don't want locked model changes, but we're handling the locking such that objects created from files we don't want to write back to (i.e. JS and TS) are the only ones that we're locking.
3. I also don't believe the locking check was doing anything. Even before #1796, I still wasn't able to edit locked records through the UI.