### PR TITLE
Do not retry `profile:completeImport` if not ready

### DIFF
--- a/core/__tests__/tasks/profile/checkReady.ts
+++ b/core/__tests__/tasks/profile/checkReady.ts
@@ -70,7 +70,7 @@ describe("tasks/profile:checkReady", () => {
       expect(peach.state).toBe("pending");
       expect(bowser.state).toBe("pending");
 
-      expect(found.map((t) => t.args[0].profileId).sort()).toEqual(
+      expect(found[0].args[0].profileIds.sort()).toEqual(
         [mario.id, luigi.id].sort() // no toad, no peach, no bowser
       );
 

--- a/core/__tests__/tasks/profile/completeImport.ts
+++ b/core/__tests__/tasks/profile/completeImport.ts
@@ -102,11 +102,12 @@ describe("tasks/profile:completeImport", () => {
 
       const _importA = await helper.factories.import(run, {
         email: "mario@example.com",
-        firstName: "Super",
+        firstName: "Mario",
         noExist: "here",
       });
       const _importB = await helper.factories.import(run, {
         email: "mario@example.com",
+        firstName: "Super",
         lastName: "Mario",
       });
 

--- a/core/__tests__/tasks/profile/export.ts
+++ b/core/__tests__/tasks/profile/export.ts
@@ -316,8 +316,9 @@ describe("tasks/profile:export", () => {
 
           await profile.import();
           await profile.updateGroupMembership();
+
           await specHelper.runTask("profile:completeImport", {
-            profileId: profile.id,
+            profileIds: [profile.id],
           });
 
           // I don't throw, but append the error to the Export

--- a/core/__tests__/tasks/profile/export.ts
+++ b/core/__tests__/tasks/profile/export.ts
@@ -183,6 +183,12 @@ describe("tasks/profile:export", () => {
 
         await ImportWorkflow();
 
+        await profiles[0].reload();
+        const properties = await profiles[0].simplifiedProperties();
+        expect(properties.email).toEqual(["mario@example.com"]);
+        expect(properties.firstName).toEqual(["Super"]);
+        expect(properties.lastName).toEqual(["Mario"]);
+
         const foundExportTasks = await specHelper.findEnqueuedTasks(
           "profile:export"
         );

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -416,8 +416,8 @@ export class Group extends LoggedModel<Group> {
     return GroupOps.removePreviousRunGroupMembers(this, run, limit);
   }
 
-  async updateProfileMembership(profile: Profile) {
-    return GroupOps.updateProfileMembership(this, profile);
+  async updateProfilesMembership(profiles: Profile[]) {
+    return GroupOps.updateProfilesMembership(this, profiles);
   }
 
   async countPotentialMembers(

--- a/core/src/models/GroupMember.ts
+++ b/core/src/models/GroupMember.ts
@@ -118,7 +118,10 @@ export class GroupMember extends Model {
 
   @AfterBulkCreate
   static async logsCreate(instances: GroupMember[]) {
-    const groupIds = [...new Set(instances.map((gm) => gm.groupId))];
+    const groupIds = instances
+      .map((gm) => gm.groupId)
+      .filter(uniqueArrayValues);
+
     for (const groupId of groupIds) {
       const group = await Group.findById(groupId);
       const groupMembers = instances.filter((gm) => gm.groupId === group.id);
@@ -157,8 +160,10 @@ export class GroupMember extends Model {
 
   static async destroyWithLogs(q: { where: WhereAttributeHash }) {
     const instances = await GroupMember.findAll(q);
+    const groupIds = instances
+      .map((gm) => gm.groupId)
+      .filter(uniqueArrayValues);
 
-    const groupIds = [...new Set(instances.map((gm) => gm.groupId))];
     for (const groupId of groupIds) {
       const group = await Group.findById(groupId);
       const groupMembers = instances.filter((gm) => gm.groupId === group.id);
@@ -181,4 +186,8 @@ export class GroupMember extends Model {
 
     await GroupMember.destroy(q);
   }
+}
+
+function uniqueArrayValues(value, index, self) {
+  return self.indexOf(value) === index;
 }

--- a/core/src/models/Profile.ts
+++ b/core/src/models/Profile.ts
@@ -139,17 +139,8 @@ export class Profile extends LoggedModel<Profile> {
   }
 
   async updateGroupMembership() {
-    const results: { [groupId: string]: boolean } = {};
-    const groups = await Group.scope("notDraft").findAll({
-      include: [GroupRule],
-    });
-
-    for (const group of groups) {
-      const belongs = await group.updateProfileMembership(this);
-      results[group.id] = belongs;
-    }
-
-    return results;
+    const data = await ProfileOps.updateGroupMemberships([this]);
+    return data[this.id];
   }
 
   async import(toSave = true, toLock = true) {

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -690,7 +690,7 @@ export namespace ProfileOps {
 
   /**
    * Find profiles that are not ready but whose properties are and make them ready.
-   * Task `profile:completeImport` will be enqueued for each Profile.
+   * Task `profile:completeImport` will then process the profiles.
    */
   export async function makeReady(limit = 100, toExport = true) {
     let profiles: Profile[] = await api.sequelize.query(
@@ -730,10 +730,4 @@ export namespace ProfileOps {
 
     return profiles;
   }
-
-  // function arraysAreEqual(a: Array<any>, b: Array<any>) {
-  //   return (
-  //     a.length === b.length && a.every((value, index) => value === b[index])
-  //   );
-  // }
 }

--- a/core/src/tasks/profile/completeImport.ts
+++ b/core/src/tasks/profile/completeImport.ts
@@ -55,7 +55,7 @@ export class ProfileCompleteImport extends RetryableTask {
 
       if (Object.keys(mergedValues).length > 0) {
         await profile.addOrUpdateProperties(mergedValues);
-        await profile.reload({ include: [ProfileProperty] });
+        delete profile.profileProperties; // will be reloaded
       }
     }
 

--- a/core/src/tasks/profile/completeImport.ts
+++ b/core/src/tasks/profile/completeImport.ts
@@ -43,7 +43,9 @@ export class ProfileCompleteImport extends RetryableTask {
       const mergedValues = {};
       const imports = profile.imports;
 
-      for (const _import of imports) {
+      for (const _import of imports.sort(
+        (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+      )) {
         const data = _import.data;
         for (const key in data) {
           // only if we still have property

--- a/core/src/tasks/profile/completeImport.ts
+++ b/core/src/tasks/profile/completeImport.ts
@@ -33,9 +33,7 @@ export class ProfileCompleteImport extends RetryableTask {
       (p) => p.state !== "ready" // a property may have gone back into the pending state
     );
 
-    if (profile.state !== "ready" || pendingProfileProperty) {
-      return CLS.enqueueTaskIn(config.tasks.timeout + 1, this.name, params);
-    }
+    if (profile.state !== "ready" || pendingProfileProperty) return;
 
     const mergedValues = {};
     const imports = await profile.$get("imports", {


### PR DESCRIPTION
* Do not retry `profile:completeImport` if not ready (solves https://www.pivotaltracker.com/story/show/178560767)
* `profile:completeImport` now handles many profiles at once (speed)
* `GroupMembers` now create logs in bulk when created or destroyed (speed)