### PR TITLE
Destroy Event Models

### DIFF
--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -120,12 +120,6 @@ export class NavigationList extends OptionallyAuthenticatedAction {
       { type: "link", title: "Groups", href: "/groups", icon: "users" },
       {
         type: "link",
-        title: "Events",
-        href: "/events/overview",
-        icon: "stream",
-      },
-      {
-        type: "link",
         title: "Sources",
         href: "/sources",
         icon: "file-import",

--- a/core/src/migrations/000071-removeEvents.ts
+++ b/core/src/migrations/000071-removeEvents.ts
@@ -3,7 +3,7 @@ export default {
     await migration.sequelize.transaction(async () => {
       await migration.dropTable("eventData");
       await migration.dropTable("events");
-      await migration.removeColumnIfExists("profiles", "anonymousId");
+      await migration.removeColumn("profiles", "anonymousId");
       await migration.sequelize.query(
         `DELETE FROM "permissions" WHERE topic = 'event'`
       );

--- a/core/src/migrations/000071-removeEvents.ts
+++ b/core/src/migrations/000071-removeEvents.ts
@@ -3,10 +3,65 @@ export default {
     await migration.sequelize.transaction(async () => {
       await migration.dropTable("eventData");
       await migration.dropTable("events");
-      await migration.removeColumn("profiles", "anonymousId");
+      await migration.removeColumnIfExists("profiles", "anonymousId");
       await migration.sequelize.query(
         `DELETE FROM "permissions" WHERE topic = 'event'`
       );
+
+      const [apps] = await migration.sequelize.query(
+        `SELECT * FROM "apps" WHERE type = 'events'`
+      );
+      for (const app of apps) {
+        const [sources] = await migration.sequelize.query(
+          `SELECT * FROM "sources" WHERE "appId" = '${app.id}'`
+        );
+        for (const source of sources) {
+          const [properties] = await migration.sequelize.query(
+            `SELECT * FROM "properties" WHERE "sourceId" = '${source.id}'`
+          );
+
+          for (const property of properties) {
+            await migration.sequelize.query(
+              `DELETE FROM "runs" WHERE "creatorId" = '${property.id}'`
+            );
+            await migration.sequelize.query(
+              `DELETE FROM "options" WHERE "ownerId" = '${property.id}'`
+            );
+            await migration.sequelize.query(
+              `DELETE FROM "propertyFilters" WHERE "propertyId" = '${property.id}'`
+            );
+            await migration.sequelize.query(
+              `DELETE FROM "profileProperties" WHERE "propertyId" = '${property.id}'`
+            );
+            await migration.sequelize.query(
+              `DELETE FROM "groupRules" WHERE "propertyId" = '${property.id}'`
+            );
+            await migration.sequelize.query(
+              `DELETE FROM "mappings" WHERE "propertyId" = '${property.id}'`
+            );
+            await migration.sequelize.query(
+              `DELETE FROM "properties" WHERE "id" = '${property.id}'`
+            );
+          }
+
+          await migration.sequelize.query(
+            `DELETE FROM "options" WHERE "ownerId" = '${source.id}'`
+          );
+          await migration.sequelize.query(
+            `DELETE FROM "mappings" WHERE "ownerId" = '${source.id}'`
+          );
+          await migration.sequelize.query(
+            `DELETE FROM "sources" WHERE "id" = '${source.id}'`
+          );
+        }
+
+        await migration.sequelize.query(
+          `DELETE FROM "options" WHERE "ownerId" = '${app.id}'`
+        );
+        await migration.sequelize.query(
+          `DELETE FROM "apps" WHERE "id" = '${app.id}'`
+        );
+      }
     });
   },
 

--- a/ui/ui-components/components/log/list.tsx
+++ b/ui/ui-components/components/log/list.tsx
@@ -30,7 +30,6 @@ export default function LogsList(props) {
   let topics = [
     "app",
     "destination",
-    "event",
     "file",
     "group",
     "groupMember",

--- a/ui/ui-components/components/tabs/profile.tsx
+++ b/ui/ui-components/components/tabs/profile.tsx
@@ -7,7 +7,7 @@ export default function ProfileTabs({
 }: {
   profile: Models.ProfileType;
 }) {
-  const tabs = ["edit", "imports", "events", "exports", "logs"];
+  const tabs = ["edit", "imports", "exports", "logs"];
 
   if (process.env.GROUPAROO_UI_EDITION === "config") {
     tabs.splice(tabs.indexOf("imports"), 2);

--- a/ui/ui-components/pages/source/[id]/overview.tsx
+++ b/ui/ui-components/pages/source/[id]/overview.tsx
@@ -240,12 +240,6 @@ export default function Page({
                 source={source}
               />
             )
-          ) : source.connection.name === "events-table-import" ? (
-            <Alert variant="info">
-              A schedule is not needed when using Grouparoo events as a source.
-              Events are automatically processed and linked to profiles as they
-              come in.
-            </Alert>
           ) : (
             <Alert variant="warning">
               Schedule not available for this connection type


### PR DESCRIPTION
This PR exists because https://github.com/grouparoo/grouparoo/pull/1931 removed the code, but not the data. This updates the migration to remove Event:

- Apps
- Sources
- Properties
- Profile Properties

This was tested against a downloaded copy of the staging database.

⚠️ Note: This type of migration has some interesting side effects:

- Deleting Event-based Profile Properties will not update destinations with changes
- Groups which previously used an Event-based Group Rule will just have that rule removed... membership will be updated to match the new Group with the changed rule. It's likely these Group don't make sense any more.
- Destinations which previously used a mapping to an Event-based Property have had that property removed

This PR also removes some missed UI events content.

```
running migrator in /Users/evan/workspace/grouparoo/grouparoo/apps/staging-enterprise

== 000071-removeEvents: migrating =======
000071-removeEvents migrating
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): START TRANSACTION;
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DROP TABLE IF EXISTS "eventData";
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DROP TABLE IF EXISTS "events";
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "permissions" WHERE topic = 'event'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): SELECT * FROM "apps" WHERE type = 'events'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): SELECT * FROM "sources" WHERE "appId" = 'app_d1928d1b-cf8c-4ed1-a27e-197021948986'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): SELECT * FROM "properties" WHERE "sourceId" = 'src_638fae2f-65f9-4746-a0cc-1448c197cf9d'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "runs" WHERE "creatorId" = 'rul_5ba2f1d9-7d53-4772-93c2-02ac96c79b8f'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "options" WHERE "ownerId" = 'rul_5ba2f1d9-7d53-4772-93c2-02ac96c79b8f'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "propertyFilters" WHERE "propertyId" = 'rul_5ba2f1d9-7d53-4772-93c2-02ac96c79b8f'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "profileProperties" WHERE "propertyId" = 'rul_5ba2f1d9-7d53-4772-93c2-02ac96c79b8f'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "groupRules" WHERE "propertyId" = 'rul_5ba2f1d9-7d53-4772-93c2-02ac96c79b8f'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "mappings" WHERE "propertyId" = 'rul_5ba2f1d9-7d53-4772-93c2-02ac96c79b8f'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "properties" WHERE "id" = 'rul_5ba2f1d9-7d53-4772-93c2-02ac96c79b8f'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "runs" WHERE "creatorId" = 'rul_fe857fc7-1cf7-4c9e-9133-1a3bb907b4d5'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "options" WHERE "ownerId" = 'rul_fe857fc7-1cf7-4c9e-9133-1a3bb907b4d5'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "propertyFilters" WHERE "propertyId" = 'rul_fe857fc7-1cf7-4c9e-9133-1a3bb907b4d5'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "profileProperties" WHERE "propertyId" = 'rul_fe857fc7-1cf7-4c9e-9133-1a3bb907b4d5'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "groupRules" WHERE "propertyId" = 'rul_fe857fc7-1cf7-4c9e-9133-1a3bb907b4d5'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "mappings" WHERE "propertyId" = 'rul_fe857fc7-1cf7-4c9e-9133-1a3bb907b4d5'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "properties" WHERE "id" = 'rul_fe857fc7-1cf7-4c9e-9133-1a3bb907b4d5'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "options" WHERE "ownerId" = 'src_638fae2f-65f9-4746-a0cc-1448c197cf9d'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "mappings" WHERE "ownerId" = 'src_638fae2f-65f9-4746-a0cc-1448c197cf9d'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "sources" WHERE "id" = 'src_638fae2f-65f9-4746-a0cc-1448c197cf9d'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "options" WHERE "ownerId" = 'app_d1928d1b-cf8c-4ed1-a27e-197021948986'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): DELETE FROM "apps" WHERE "id" = 'app_d1928d1b-cf8c-4ed1-a27e-197021948986'
Executing (5c59da7c-fdae-4bbd-95de-38466ba32573): COMMIT;
== 000071-removeEvents: migrated (0.023s)

000071-removeEvents migrated
✅ Done
```
