### PR TITLE
Make `npm run dev` for `statging-config`

### DIFF
--- a/apps/staging-config/package.json
+++ b/apps/staging-config/package.json
@@ -21,7 +21,7 @@
     "jest": "26.6.3"
   },
   "scripts": {
-    "config": "rm grouparoo_config.sqlite; CONFIG_DATABASE_URL=\"sqlite://grouparoo_config.sqlite\" NEXT_DEVELOPMENT_MODE=true ./node_modules/.bin/grouparoo config",
+    "dev": "rm -f grouparoo_config.sqlite && cd node_modules/@grouparoo/core && DATABASE_URL=\"sqlite://grouparoo_config.sqlite\" NEXT_DEVELOPMENT_MODE=true GROUPAROO_RUN_MODE=\"cli:config\" ./bin/dev",
     "demo": "./node_modules/.bin/grouparoo demo purchases --config"
   },
   "grouparoo": {


### PR DESCRIPTION
Use the normal `./bin/dev` command to run "dev mode" for `apps/staging-config`.  This replaces `npm run config`, which had problems, sometimes, with getting Next into the proper dev mode