### PR TITLE
Options and Mappings support non-unique IDs

### DIFF
--- a/core/__tests__/models/mapping.ts
+++ b/core/__tests__/models/mapping.ts
@@ -46,5 +46,25 @@ describe("models/mapping", () => {
       const mappings = await source.getMapping();
       expect(mappings["bla"]).toBe(userId.key);
     });
+
+    test("a source cannot have 2 mappings with the same remoteKey", async () => {
+      await expect(
+        source.setMapping({ foo: "userId", bar: "userId" })
+      ).rejects.toThrow(/There is already a Mapping for/);
+    });
+
+    test("a source cannot have 2 mappings with the same profileId", async () => {
+      const userId = await Property.findOne({ where: { key: "userId" } });
+
+      await source.setMapping({ foo: "userId" });
+      await expect(
+        Mapping.create({
+          ownerId: source.id,
+          ownerType: "source",
+          propertyId: userId.id,
+          remoteKey: "bar",
+        })
+      ).rejects.toThrow(/There is already a Mapping for/);
+    });
   });
 });

--- a/core/__tests__/models/option.ts
+++ b/core/__tests__/models/option.ts
@@ -257,6 +257,31 @@ describe("models/option", () => {
         expect(appWithOptions.__options[0].value).toBe("foo");
       });
 
+      test("option owners are referenced by the instance type", async () => {
+        const randomOption = await Option.create({
+          ownerId: appWithOptions.id,
+          ownerType: "foo",
+          type: "string",
+          key: "test_default_key",
+          value: "foo",
+        });
+
+        await appWithOptions.setOptions({
+          test_default_key: "newValue",
+        });
+
+        expect((await randomOption.reload()).value).toEqual("foo");
+
+        expect(await appWithOptions.getOptions()).toEqual({
+          test_default_key: "newValue",
+        });
+        await appWithOptions.setOptions({});
+
+        expect((await randomOption.reload()).value).toEqual("foo");
+
+        await randomOption.destroy();
+      });
+
       test("it will use memoized options if they exist", async () => {
         await appWithOptions.setOptions({
           test_default_key: "foo",

--- a/core/src/migrations/000070-speedIndexes.ts
+++ b/core/src/migrations/000070-speedIndexes.ts
@@ -16,16 +16,18 @@ export default {
   },
 
   down: async function (migration) {
-    await migration.removeIndex("imports", ["createdProfile"], {
-      fields: ["createdProfile"],
-    });
+    await migration.sequelize.transaction(async () => {
+      await migration.removeIndex("imports", ["createdProfile"], {
+        fields: ["createdProfile"],
+      });
 
-    await migration.removeIndex("imports", ["exportedAt"], {
-      fields: ["exportedAt"],
-    });
+      await migration.removeIndex("imports", ["exportedAt"], {
+        fields: ["exportedAt"],
+      });
 
-    await migration.removeIndex("profileProperties", ["rawValue"], {
-      fields: ["rawValue"],
+      await migration.removeIndex("profileProperties", ["rawValue"], {
+        fields: ["rawValue"],
+      });
     });
   },
 };

--- a/core/src/migrations/000072-optionAndMappingUniquePerOwnerType.ts
+++ b/core/src/migrations/000072-optionAndMappingUniquePerOwnerType.ts
@@ -1,0 +1,92 @@
+export default {
+  up: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      // -- Options ---
+
+      await migration.removeIndex("options", ["ownerId", "key"], {
+        unique: true,
+        fields: ["ownerId", "key"],
+      });
+      // we need the old name of the key to find the index name
+      await migration.removeIndex("options", ["ownerGuid", "key"], {
+        unique: true,
+        fields: ["ownerGuid", "key"],
+      });
+
+      await migration.addIndex("options", ["ownerId", "ownerType", "key"], {
+        unique: true,
+        fields: ["ownerId", "ownerType", "key"],
+      });
+
+      // -- Mappings ---
+
+      await migration.removeIndex("mappings", ["ownerId", "propertyId"], {
+        unique: true,
+        fields: ["ownerId", "propertyId"],
+      });
+
+      // we need the old name of the key to find the index name
+      await migration.removeIndex(
+        "mappings",
+        ["ownerGuid", "profilePropertyRuleGuid"],
+        {
+          unique: true,
+          fields: ["ownerGuid", "profilePropertyRuleGuid"],
+        }
+      );
+
+      await migration.removeIndex("mappings", ["ownerId", "remoteKey"], {
+        unique: true,
+        fields: ["ownerId", "remoteKey"],
+      });
+
+      // we need the old name of the key to find the index name
+      await migration.removeIndex("mappings", ["ownerGuid", "remoteKey"], {
+        unique: true,
+        fields: ["ownerGuid", "remoteKey"],
+      });
+
+      await migration.addIndex(
+        "mappings",
+        ["ownerId", "ownerType", "propertyId"],
+        {
+          unique: true,
+          fields: ["ownerId", "ownerType", "propertyId"],
+        }
+      );
+
+      await migration.addIndex(
+        "mappings",
+        ["ownerId", "ownerType", "remoteKey"],
+        {
+          unique: true,
+          fields: ["ownerId", "ownerType", "remoteKey"],
+        }
+      );
+    });
+  },
+
+  down: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.removeIndex("options", ["ownerId", "ownerType", "key"], {
+        unique: true,
+        fields: ["ownerId", "ownerType", "key"],
+      });
+
+      await migration.addIndex("options", ["ownerId", "key"], {
+        unique: true,
+        fields: ["ownerId", "key"],
+      });
+
+      await migration.addIndex("mappings", ["ownerId", "propertyId"], {
+        unique: true,
+        fields: ["ownerId", "propertyId"],
+      });
+
+      await migration.addIndex("mappings", ["ownerId", "remoteKey"], {
+        unique: true,
+        fields: ["ownerId", "remoteKey"],
+      });
+    });
+  },
+};

--- a/core/src/models/Mapping.ts
+++ b/core/src/models/Mapping.ts
@@ -75,12 +75,13 @@ export class Mapping extends LoggedModel<Mapping> {
       where: {
         id: { [Op.ne]: instance.id },
         ownerId: instance.ownerId,
+        ownerType: instance.ownerType,
         propertyId: instance.propertyId,
       },
     });
     if (existing) {
       throw new Error(
-        `There is already a Mapping for ${instance.ownerId} and ${instance.propertyId}`
+        `There is already a Mapping for ${instance.ownerId} (${instance.ownerType}) and ${instance.propertyId}`
       );
     }
   }
@@ -91,12 +92,13 @@ export class Mapping extends LoggedModel<Mapping> {
       where: {
         id: { [Op.ne]: instance.id },
         ownerId: instance.ownerId,
+        ownerType: instance.ownerType,
         remoteKey: instance.remoteKey,
       },
     });
     if (existing) {
       throw new Error(
-        `There is already a Mapping for to ${instance.ownerId} and ${instance.remoteKey}`
+        `There is already a Mapping for to ${instance.ownerId} (${instance.ownerType}) and ${instance.remoteKey}`
       );
     }
   }

--- a/core/src/models/Option.ts
+++ b/core/src/models/Option.ts
@@ -88,12 +88,13 @@ export class Option extends LoggedModel<Option> {
       where: {
         id: { [Op.ne]: instance.id },
         ownerId: instance.ownerId,
+        ownerType: instance.ownerType,
         key: instance.key,
       },
     });
     if (existing) {
       throw new Error(
-        `There is already a Option for ${instance.ownerId} and ${instance.key}`
+        `There is already a Option for ${instance.ownerId} (${instance.ownerType}) and ${instance.key}`
       );
     }
   }

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -39,7 +39,7 @@ export namespace OptionHelper {
     const options =
       instance.__options ??
       (await Option.findAll({
-        where: { ownerId: instance.id },
+        where: { ownerId: instance.id, ownerType: modelName(instance) },
       }));
 
     if (!instance.__options) instance.__options = options;
@@ -96,7 +96,7 @@ export namespace OptionHelper {
     await LockableHelper.beforeUpdateOptions(instance, hasChanges);
 
     await Option.destroy({
-      where: { ownerId: instance.id },
+      where: { ownerId: instance.id, ownerType: modelName(instance) },
     });
 
     const newOptions: Option[] = [];


### PR DESCRIPTION
Now that IDs are not globally unique (https://github.com/grouparoo/grouparoo/pull/1937), the OptionHelper and Mapping Helper need to be more careful, checking `ownerType` as well as `ownerId`. 

This PR updates those helpers, validations, and unique indexes accordingly.