### PR TITLE
Resque overview page works entirely on polling

### DIFF
--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -150,7 +150,7 @@ export class NavigationList extends OptionallyAuthenticatedAction {
       platformItems.push({
         type: "link",
         title: "Settings",
-        href: "/settings",
+        href: "/settings/core",
       });
 
       platformItems.push({
@@ -192,7 +192,7 @@ export class NavigationList extends OptionallyAuthenticatedAction {
       platformItems.push({
         type: "link",
         title: "Resque",
-        href: "/resque",
+        href: "/resque/overview",
       });
     }
 

--- a/core/src/actions/resque.ts
+++ b/core/src/actions/resque.ts
@@ -72,7 +72,10 @@ export class ResqueResqueDetails extends ResqueActionRead {
   }
 
   async runWithinTransaction() {
-    return { resqueDetails: await task.details() };
+    const resqueDetails = await task.details();
+    const failedCount = await task.failedCount();
+
+    return { resqueDetails, failedCount };
   }
 }
 


### PR DESCRIPTION
This PR changes `/resque/overview` to work entirely on polling.  This way, if the workers are backed up, the page will show accurate data.  