### PR TITLE
Remove `ah-next-plugin` + Next.js v11.0.1

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -37,7 +37,7 @@
     "@types/node": "*",
     "@types/validator": "*",
     "actionhero": "26.0.8",
-    "ah-next-plugin": "0.5.4",
+    "ah-next-plugin": "0.5.5",
     "ah-sequelize-plugin": "3.0.4",
     "bcryptjs": "2.4.3",
     "cls-hooked": "4.2.2",

--- a/core/package.json
+++ b/core/package.json
@@ -37,7 +37,6 @@
     "@types/node": "*",
     "@types/validator": "*",
     "actionhero": "26.0.8",
-    "ah-next-plugin": "0.5.5",
     "ah-sequelize-plugin": "3.0.4",
     "bcryptjs": "2.4.3",
     "cls-hooked": "4.2.2",
@@ -70,6 +69,7 @@
     "sqlite3": "5.0.2",
     "ts-node": "10.0.0",
     "uuid": "8.3.2",
+    "umzug": "v3.0.0-beta.5",
     "validator": "13.6.0",
     "winston": "3.3.3",
     "ws": "7.5.0"
@@ -86,8 +86,7 @@
     "ts-jest": "26.5.6",
     "type-fest": "1.2.1",
     "typedoc": "0.21.0",
-    "typescript": "4.3.4",
-    "umzug": "v3.0.0-beta.5"
+    "typescript": "4.3.4"
   },
   "gitHead": "d87e6adcefcc3e55d671121157b8eda1ae89f22a"
 }

--- a/core/src/actions/next.ts
+++ b/core/src/actions/next.ts
@@ -1,0 +1,20 @@
+import { Action, api } from "actionhero";
+
+export class NextRender extends Action {
+  constructor() {
+    super();
+    this.name = "next:render";
+    this.description = "render react pages via next.js";
+    this.outputExample = {};
+    this.inputs = {};
+    this.logLevel = "debug";
+    this.blockedConnectionTypes = ["websocket", "socket"];
+  }
+
+  async run(data) {
+    if (data.connection.rawConnection.responseHttpCode == 200) {
+      data.toRender = false;
+      return api.next.render(data.connection);
+    }
+  }
+}

--- a/core/src/config/plugins.ts
+++ b/core/src/config/plugins.ts
@@ -23,9 +23,6 @@ export const DEFAULT = {
         "ah-sequelize-plugin": {
           path: getPluginPath("ah-sequelize-plugin"),
         },
-        "ah-next-plugin": {
-          path: getPluginPath("ah-next-plugin"),
-        },
       },
       parentPlugins,
       InjectedPlugins

--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -77,7 +77,8 @@ export const DEFAULT = {
         { path: "/v:apiVersion/file/:id", action: "file:view" },
         { path: "/v:apiVersion/notifications", action: "notifications:list" },
         { path: "/v:apiVersion/notification/:id", action: "notification:view" },
-        { path: "/v:apiVersion/object/:id", action: "object:find" }
+        { path: "/v:apiVersion/object/:id", action: "object:find" },
+        { path: "/", action: "next:render", matchTrailingPathParts: true }
       ],
 
       post: [

--- a/core/src/initializers/next.ts
+++ b/core/src/initializers/next.ts
@@ -1,0 +1,72 @@
+import path from "path";
+import fs from "fs";
+import { Initializer, Connection, api, log, config } from "actionhero";
+
+declare module "actionhero" {
+  export interface Api {
+    next: {
+      app?: any;
+      render?: (Connection) => void;
+      handle?: (req, res) => void;
+    };
+  }
+}
+
+export class Next extends Initializer {
+  constructor() {
+    super();
+    this.loadPriority = 1000;
+    this.startPriority = 899;
+    this.stopPriority = 101;
+    this.name = "next";
+  }
+
+  async initialize() {
+    api.next = {
+      render: async (connection: Connection) => {
+        if (connection.type !== "web") {
+          throw new Error('Connections for next.js apps must be of type "web"');
+        }
+        const { req, res } = connection.rawConnection;
+        return api.next.handle(req, res);
+      },
+    };
+  }
+
+  async start() {
+    if (config.servers.web.enabled !== true) return;
+
+    if (!config.next.enabled) {
+      log("next disabled");
+      return;
+    }
+
+    if (config.next.dev) {
+      log("Running next in development mode...");
+    }
+
+    // We don't want to statically import next until we know we need it. It loads a lot and has problems in test mode
+    // We also don't want next to be part of grouparoo/core, but to come from the UI plugins (could be locally installed or hoisted)
+    const nextWithinPluginPath = path.join(
+      config.general.paths.next[0],
+      "node_modules",
+      "next"
+    );
+    const next = await import(
+      fs.existsSync(nextWithinPluginPath) ? nextWithinPluginPath : "next"
+    );
+
+    api.next.app = next.default({
+      dev: config.next.dev,
+      quiet: config.next.quiet,
+      dir: config.general.paths.next[0],
+    });
+
+    api.next.handle = api.next.app.getRequestHandler();
+    await api.next.app.prepare();
+  }
+
+  async stop() {
+    if (api.next.app) await api.next.app.close();
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,7 +218,7 @@ importers:
       '@types/pluralize': 0.0.29
       '@types/validator': '*'
       actionhero: 26.0.8
-      ah-next-plugin: 0.5.4
+      ah-next-plugin: 0.5.5
       ah-sequelize-plugin: 3.0.4
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
@@ -268,7 +268,7 @@ importers:
       '@types/node': 15.12.4
       '@types/validator': 13.1.4
       actionhero: 26.0.8
-      ah-next-plugin: 0.5.4_actionhero@26.0.8
+      ah-next-plugin: 0.5.5_actionhero@26.0.8
       ah-sequelize-plugin: 3.0.4_acb0c81dd9e61036fa300bedbdac0d70
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
@@ -3976,14 +3976,14 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ah-next-plugin/0.5.4_actionhero@26.0.8:
-    resolution: {integrity: sha512-/vnQLhzF05c7qMogauIpWpP+8ab+wPGhcSlOMJxZXZtAMYh1jkYb/FrExJeixgNhsU3efrpxaCLy1PHrNpWr5w==}
+  /ah-next-plugin/0.5.5_actionhero@26.0.8:
+    resolution: {integrity: sha512-CQl/CCe7Wb3HZbnOXbokBpqI8ue+EHskMecxZBTBg090TYRcdDez+o8Jw4hKFmLVu4aLtBSN/ZyLzaz65fWRtw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       actionhero: '>=22'
-      next: ^9.x || ^10.x || ^11.x
-      react: ^16.6.0 || ^17
-      react-dom: ^16.6.0 || ^17
+      next: '>=9.0.0'
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
     dependencies:
       actionhero: 26.0.8
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,7 +218,6 @@ importers:
       '@types/pluralize': 0.0.29
       '@types/validator': '*'
       actionhero: 26.0.8
-      ah-next-plugin: 0.5.5
       ah-sequelize-plugin: 3.0.4
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
@@ -268,7 +267,6 @@ importers:
       '@types/node': 15.12.4
       '@types/validator': 13.1.4
       actionhero: 26.0.8
-      ah-next-plugin: 0.5.5_actionhero@26.0.8
       ah-sequelize-plugin: 3.0.4_acb0c81dd9e61036fa300bedbdac0d70
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
@@ -300,6 +298,7 @@ importers:
       sequelize-typescript: 2.1.0_fb0aa51423eb8f834cee16adf8b2a5f5
       sqlite3: 5.0.2
       ts-node: 10.0.0_83f53b0a0c5616d3fa00ed4e30b9ce1b
+      umzug: 3.0.0-beta.5
       uuid: 8.3.2
       validator: 13.6.0
       winston: 3.3.3
@@ -317,7 +316,6 @@ importers:
       type-fest: 1.2.1
       typedoc: 0.21.0_typescript@4.3.4
       typescript: 4.3.4
-      umzug: 3.0.0-beta.5
 
   plugins/@grouparoo/app-templates:
     specifiers:
@@ -3976,18 +3974,6 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ah-next-plugin/0.5.5_actionhero@26.0.8:
-    resolution: {integrity: sha512-CQl/CCe7Wb3HZbnOXbokBpqI8ue+EHskMecxZBTBg090TYRcdDez+o8Jw4hKFmLVu4aLtBSN/ZyLzaz65fWRtw==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      actionhero: '>=22'
-      next: '>=9.0.0'
-      react: '>=16.6.0'
-      react-dom: '>=16.6.0'
-    dependencies:
-      actionhero: 26.0.8
-    dev: false
-
   /ah-sequelize-plugin/3.0.4_acb0c81dd9e61036fa300bedbdac0d70:
     resolution: {integrity: sha512-vLxIF5AbwHJ0dy4kO+tzUFBb7pue2r7m1tNMikmXJj0PXc/U9Jml04+tFy0Y02rveU6JbYoUx16K/3LuwGrpOA==}
     engines: {node: '>=8.0.0'}
@@ -4013,6 +3999,7 @@ packages:
   /alpha-sort/3.1.0:
     resolution: {integrity: sha512-mRMFzTqMpyGsMUN/rytVErIFQ0nNtMQdyxop09082hTVYbfK2rts7E1XpTExaEyxKT5JZimdA7zGgVQMVgOfXA==}
     engines: {node: '>=8'}
+    dev: false
 
   /amdefine/1.0.1:
     resolution: {integrity: sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=}
@@ -6865,12 +6852,14 @@ packages:
     dependencies:
       minimatch: 3.0.4
       rimraf: 2.7.1
+    dev: false
 
   /fs-jetpack/3.2.0:
     resolution: {integrity: sha512-LMUQxf85b3y/IuQZM9gz7bPMH60Y+NpulmHdhv8nHvgu6daYd7DiSZJSgiHKk1h6vfv1VCOqpdJcR+ThO7sFVA==}
     dependencies:
       minimatch: 3.0.4
       rimraf: 2.7.1
+    dev: false
 
   /fs-minipass/1.2.7:
     resolution: {integrity: sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==}
@@ -7458,6 +7447,7 @@ packages:
     dependencies:
       is-stream: 2.0.0
       type-fest: 0.8.1
+    dev: false
 
   /he/1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
@@ -13391,6 +13381,7 @@ packages:
     dependencies:
       arrify: 2.0.1
       dot-prop: 5.3.0
+    dev: false
 
   /source-map-resolve/0.5.3:
     resolution: {integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==}
@@ -14142,6 +14133,7 @@ packages:
       fs-jetpack: 3.2.0
       hasha: 5.2.2
       sort-on: 4.1.1
+    dev: false
 
   /touch/3.1.0:
     resolution: {integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==}
@@ -14401,6 +14393,7 @@ packages:
       p-each-series: 2.2.0
       p-map: 4.0.0
       tory: 0.4.4
+    dev: false
 
   /unbox-primitive/1.0.1:
     resolution: {integrity: sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1367,7 +1367,7 @@ importers:
       jest-environment-webdriver: 0.2.0
       md5: 2.3.0
       moment: 2.29.1
-      next: 11.0.0
+      next: 11.0.1
       node-sass: 5.0.0
       nprogress: 0.2.0
       pluralize: 8.0.0
@@ -1397,7 +1397,7 @@ importers:
       dotenv: 10.0.0
       md5: 2.3.0
       moment: 2.29.1
-      next: 11.0.0_a4e6f4c02e68e8550fe63d9569225a89
+      next: 11.0.1_a4e6f4c02e68e8550fe63d9569225a89
       node-sass: 5.0.0
       nprogress: 0.2.0
       pluralize: 8.0.0
@@ -1451,7 +1451,7 @@ importers:
       jest-mock-axios: 4.4.0
       md5: 2.3.0
       moment: 2.29.1
-      next: 11.0.0
+      next: 11.0.1
       node-sass: 5.0.0
       nprogress: 0.2.0
       pluralize: 8.0.0
@@ -1491,7 +1491,7 @@ importers:
       jest-mock-axios: 4.4.0
       md5: 2.3.0
       moment: 2.29.1
-      next: 11.0.0_a4e6f4c02e68e8550fe63d9569225a89
+      next: 11.0.1_a4e6f4c02e68e8550fe63d9569225a89
       node-sass: 5.0.0
       nprogress: 0.2.0
       pluralize: 8.0.0
@@ -1535,7 +1535,7 @@ importers:
       jest-environment-webdriver: 0.2.0
       md5: 2.3.0
       moment: 2.29.1
-      next: 11.0.0
+      next: 11.0.1
       node-sass: 5.0.0
       nprogress: 0.2.0
       pluralize: 8.0.0
@@ -1566,7 +1566,7 @@ importers:
       dotenv: 10.0.0
       md5: 2.3.0
       moment: 2.29.1
-      next: 11.0.0_a4e6f4c02e68e8550fe63d9569225a89
+      next: 11.0.1_a4e6f4c02e68e8550fe63d9569225a89
       node-sass: 5.0.0
       nprogress: 0.2.0
       pluralize: 8.0.0
@@ -1621,7 +1621,7 @@ importers:
       jest-environment-webdriver: 0.2.0
       md5: 2.3.0
       moment: 2.29.1
-      next: 11.0.0
+      next: 11.0.1
       node-sass: 5.0.0
       nprogress: 0.2.0
       pluralize: 8.0.0
@@ -1651,7 +1651,7 @@ importers:
       dotenv: 10.0.0
       md5: 2.3.0
       moment: 2.29.1
-      next: 11.0.0_a4e6f4c02e68e8550fe63d9569225a89
+      next: 11.0.1_a4e6f4c02e68e8550fe63d9569225a89
       node-sass: 5.0.0
       nprogress: 0.2.0
       pluralize: 8.0.0
@@ -3161,14 +3161,14 @@ packages:
       newrelic: 7.5.0
     dev: false
 
-  /@next/env/11.0.0:
-    resolution: {integrity: sha512-VKpmDvTYeCpEQjREg3J4pCmVs/QjEzoLmkM8shGFK6e9AmFd0G9QXOL8HGA8qKhy/XmNb7dHeMqrcMiBua4OgA==}
+  /@next/env/11.0.1:
+    resolution: {integrity: sha512-yZfKh2U6R9tEYyNUrs2V3SBvCMufkJ07xMH5uWy8wqcl5gAXoEw6A/1LDqwX3j7pUutF9d1ZxpdGDA3Uag+aQQ==}
 
-  /@next/polyfill-module/11.0.0:
-    resolution: {integrity: sha512-gydtFzRqsT549U8+sY8382I/f4HFcelD8gdUGnAofQJa/jEU1jkxmjCHC8tmEiyeMLidl7iDZgchfSCpmMzzUg==}
+  /@next/polyfill-module/11.0.1:
+    resolution: {integrity: sha512-Cjs7rrKCg4CF4Jhri8PCKlBXhszTfOQNl9AjzdNy4K5jXFyxyoSzuX2rK4IuoyE+yGp5A3XJCBEmOQ4xbUp9Mg==}
 
-  /@next/react-dev-overlay/11.0.0_react-dom@17.0.2+react@17.0.2:
-    resolution: {integrity: sha512-q+Wp+eStEMThe77zxdeJ/nbuODkHR6P+/dfUqYXZSqbLf6x5c5xwLBauwwVbkCYFZpAlDuL8Jk8QSAH1OsqC2w==}
+  /@next/react-dev-overlay/11.0.1_react-dom@17.0.2+react@17.0.2:
+    resolution: {integrity: sha512-lvUjMVpLsgzADs9Q8wtC5LNqvfdN+M0BDMSrqr04EDWAyyX0vURHC9hkvLbyEYWyh+WW32pwjKBXdkMnJhoqMg==}
     peerDependencies:
       react: ^17.0.2
       react-dom: ^17.0.2
@@ -3187,8 +3187,8 @@ packages:
       stacktrace-parser: 0.1.10
       strip-ansi: 6.0.0
 
-  /@next/react-refresh-utils/11.0.0_react-refresh@0.8.3:
-    resolution: {integrity: sha512-hi5eY+KBn4QGtUv7VL2OptdM33fI2hxhd7+omOFmAK+S0hDWhg1uqHqqGJk0W1IfqlWEzzL10WvTJDPRAtDugQ==}
+  /@next/react-refresh-utils/11.0.1_react-refresh@0.8.3:
+    resolution: {integrity: sha512-K347DM6Z7gBSE+TfUaTTceWvbj0B6iNAsFZXbFZOlfg3uyz2sbKpzPYYFocCc27yjLaS8OfR8DEdS2mZXi8Saw==}
     peerDependencies:
       react-refresh: 0.8.3
       webpack: ^4 || ^5
@@ -4748,7 +4748,7 @@ packages:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
     dependencies:
       base64-js: 1.5.1
-      ieee754: 1.1.13
+      ieee754: 1.2.1
       isarray: 1.0.0
 
   /buffer/5.6.0:
@@ -7672,6 +7672,7 @@ packages:
 
   /ieee754/1.1.13:
     resolution: {integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==}
+    dev: false
 
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -10407,8 +10408,8 @@ packages:
       - supports-color
     dev: false
 
-  /next/11.0.0_a4e6f4c02e68e8550fe63d9569225a89:
-    resolution: {integrity: sha512-1OA0ccCTwVtdLats/1v7ReiBVx+Akya0UVhHo9IBr8ZkpDI3/SGNcaruJBp5agy8ROF97VDKkZamoUXxRB9NUA==}
+  /next/11.0.1_a4e6f4c02e68e8550fe63d9569225a89:
+    resolution: {integrity: sha512-yR7be7asNbvpVNpi6xxEg28wZ7Gqmj1nOt0sABH9qORmF3+pms2KZ7Cng33oK5nqPIzEEFJD0pp2PCe3/ueMIg==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     peerDependencies:
@@ -10427,10 +10428,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.12.5
       '@hapi/accept': 5.0.2
-      '@next/env': 11.0.0
-      '@next/polyfill-module': 11.0.0
-      '@next/react-dev-overlay': 11.0.0_react-dom@17.0.2+react@17.0.2
-      '@next/react-refresh-utils': 11.0.0_react-refresh@0.8.3
+      '@next/env': 11.0.1
+      '@next/polyfill-module': 11.0.1
+      '@next/react-dev-overlay': 11.0.1_react-dom@17.0.2+react@17.0.2
+      '@next/react-refresh-utils': 11.0.1_react-refresh@0.8.3
       assert: 2.0.0
       ast-types: 0.13.2
       browserify-zlib: 0.2.0

--- a/ui/ui-community/next-env.d.ts
+++ b/ui/ui-community/next-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />

--- a/ui/ui-community/package.json
+++ b/ui/ui-community/package.json
@@ -39,7 +39,7 @@
     "dotenv": "10.0.0",
     "md5": "2.3.0",
     "moment": "2.29.1",
-    "next": "11.0.0",
+    "next": "11.0.1",
     "node-sass": "5.0.0",
     "nprogress": "0.2.0",
     "pluralize": "8.0.0",

--- a/ui/ui-components/package.json
+++ b/ui/ui-components/package.json
@@ -46,7 +46,7 @@
     "jest-mock-axios": "4.4.0",
     "md5": "2.3.0",
     "moment": "2.29.1",
-    "next": "11.0.0",
+    "next": "11.0.1",
     "node-sass": "5.0.0",
     "nprogress": "0.2.0",
     "pluralize": "8.0.0",

--- a/ui/ui-config/next-env.d.ts
+++ b/ui/ui-config/next-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />

--- a/ui/ui-config/package.json
+++ b/ui/ui-config/package.json
@@ -40,7 +40,7 @@
     "dotenv": "10.0.0",
     "md5": "2.3.0",
     "moment": "2.29.1",
-    "next": "11.0.0",
+    "next": "11.0.1",
     "node-sass": "5.0.0",
     "nprogress": "0.2.0",
     "pluralize": "8.0.0",

--- a/ui/ui-enterprise/next-env.d.ts
+++ b/ui/ui-enterprise/next-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />

--- a/ui/ui-enterprise/package.json
+++ b/ui/ui-enterprise/package.json
@@ -39,7 +39,7 @@
     "dotenv": "10.0.0",
     "md5": "2.3.0",
     "moment": "2.29.1",
-    "next": "11.0.0",
+    "next": "11.0.1",
     "node-sass": "5.0.0",
     "nprogress": "0.2.0",
     "pluralize": "8.0.0",


### PR DESCRIPTION
This PR "vendors" and modifies `ah-next-plugin` so we can dynamically load next from within a UI plugin (if present).  This means that next no longer is a peerDependency of core (or `ah-next-plugin`), so only one exact version should be installed. 