### PR TITLE
Don't delete config files if we can't retrieve new objects

### DIFF
--- a/core/src/modules/configWriter.ts
+++ b/core/src/modules/configWriter.ts
@@ -87,10 +87,11 @@ export namespace ConfigWriter {
     // Any models we see before starting would be from existing code config
     // files.
     if (!api.process.started) return;
-
-    await deleteFiles();
-
+    // Get the config objects before deleting any of the current objects. Then,
+    // if we run into an error, we leave what we had before and don't rewrite
+    // the config files until the objects are fixed through the UI.
     const configObjects: WritableConfigObject[] = await getConfigObjects();
+    await deleteFiles();
     await writeFiles(configObjects);
     return configObjects;
   }


### PR DESCRIPTION
This swaps the order of deleting existing config files with retrieving new objects. We were running into an issue where if we hit a snag through Config UI, it could leave you in a state where all the config files are deleted.

This takes the path of waiting to delete until all expected (i.e. _ready_) objects are valid.