### PR TITLE
next.js wildcard route should be injected last in start lifecycle step

### DIFF
--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -77,8 +77,7 @@ export const DEFAULT = {
         { path: "/v:apiVersion/file/:id", action: "file:view" },
         { path: "/v:apiVersion/notifications", action: "notifications:list" },
         { path: "/v:apiVersion/notification/:id", action: "notification:view" },
-        { path: "/v:apiVersion/object/:id", action: "object:find" },
-        { path: "/", action: "next:render", matchTrailingPathParts: true }
+        { path: "/v:apiVersion/object/:id", action: "object:find" }
       ],
 
       post: [

--- a/core/src/initializers/next.ts
+++ b/core/src/initializers/next.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import fs from "fs";
-import { Initializer, Connection, api, log, config } from "actionhero";
+import { Initializer, Connection, api, log, config, route } from "actionhero";
 
 declare module "actionhero" {
   export interface Api {
@@ -15,10 +15,10 @@ declare module "actionhero" {
 export class Next extends Initializer {
   constructor() {
     super();
+    this.name = "next";
     this.loadPriority = 1000;
     this.startPriority = 899;
     this.stopPriority = 101;
-    this.name = "next";
   }
 
   async initialize() {
@@ -64,6 +64,10 @@ export class Next extends Initializer {
 
     api.next.handle = api.next.app.getRequestHandler();
     await api.next.app.prepare();
+
+    if (config.servers.web.enabled === true) {
+      route.registerRoute("get", "/", "next:render", null, true);
+    }
   }
 
   async stop() {

--- a/core/src/initializers/resque.ts
+++ b/core/src/initializers/resque.ts
@@ -6,6 +6,7 @@ export class ResqueInitializer extends Initializer {
   constructor() {
     super();
     this.name = `@grouparoo/resque`;
+    this.loadPriority = 1000;
   }
 
   async initialize() {


### PR DESCRIPTION
Fixes a bug which prevented all resque API routes from being exposed