### PR TITLE
Better protect `status#get` from old-format status samples

### DIFF
--- a/core/__tests__/modules/status.ts
+++ b/core/__tests__/modules/status.ts
@@ -86,6 +86,17 @@ describe("modules/status", () => {
       await redis.set(`${cachePrefix}:undefined`, undefined);
       await redis.set(`${cachePrefix}:null`, null);
       await redis.set(`${cachePrefix}:not-json`, "{a:1");
+      await redis.set(
+        `${cachePrefix}:old-format-1`,
+        JSON.stringify({ timestamp: new Date().getTime(), thing: "stuff" })
+      );
+      await redis.set(
+        `${cachePrefix}:old-format-2`,
+        JSON.stringify({
+          timestamp: new Date().getTime(),
+          metric: { collection: "foo" },
+        })
+      );
 
       const foundMetrics = await Status.get(); // does not throw
       expect(foundMetrics["test"]["test"].length).toBe(1);

--- a/core/src/modules/status.ts
+++ b/core/src/modules/status.ts
@@ -63,7 +63,14 @@ export namespace Status {
         } catch {}
         return parsed;
       })
-      .filter((v) => v && v.timestamp);
+      .filter(
+        (sample) =>
+          sample &&
+          sample.timestamp &&
+          sample.metric &&
+          sample.metric.topic &&
+          sample.metric.collection
+      );
 
     const response: StatusGetResponse = {};
 


### PR DESCRIPTION
When upgrading to v0.4, there are likely old status samples in your redis database in the old sample format.  This problem will fix itself after ~1.5 hours as the old samples expire in redis, but this PR better guards against trying to load and display samples in the old format