### PR TITLE
`TopLevelGroupRules` start with `grouparoo` prefix

### DIFF
--- a/core/__tests__/models/group/rules/topLevelGroupRules.ts
+++ b/core/__tests__/models/group/rules/topLevelGroupRules.ts
@@ -33,7 +33,7 @@ describe("model/group", () => {
       test("groupRule can be saved without topLevel indicating they have a profileColumn", async () => {
         await group.setRules([
           {
-            key: "id",
+            key: "grouparooId",
             operation: { op: "exists" },
           },
         ]);
@@ -41,7 +41,7 @@ describe("model/group", () => {
         const rules = await group.getRules();
         expect(rules.length).toBe(1);
         expect(rules[0]).toEqual({
-          key: "id",
+          key: "grouparooId",
           topLevel: true,
           type: "string",
           operation: { op: "ne", description: "exists with any value" },
@@ -54,7 +54,7 @@ describe("model/group", () => {
         const groupRule = await GroupRule.findOne({
           where: { groupId: group.id },
         });
-        expect(groupRule.profileColumn).toBe("id");
+        expect(groupRule.profileColumn).toBe("grouparooId");
         expect(groupRule.propertyId).toBe(null);
 
         expect(await group.countPotentialMembers()).toBe(4);
@@ -89,7 +89,7 @@ describe("model/group", () => {
         // OK
         const count = await group.countPotentialMembers([
           {
-            key: "id",
+            key: "grouparooId",
             match: "pro%",
             operation: { op: "like" },
             topLevel: true,
@@ -109,11 +109,11 @@ describe("model/group", () => {
         ).rejects.toThrow(/cannot find type for Property id/);
       });
 
-      describe("id", () => {
+      describe("grouparooId", () => {
         test("exact matches", async () => {
           await group.setRules([
             {
-              key: "id",
+              key: "grouparooId",
               match: mario.id,
               operation: { op: "eq" },
             },
@@ -123,49 +123,53 @@ describe("model/group", () => {
 
         test("partial matches", async () => {
           await group.setRules([
-            { key: "id", match: "pro%", operation: { op: "like" } },
+            { key: "grouparooId", match: "pro%", operation: { op: "like" } },
           ]);
           expect(await group.countPotentialMembers()).toBe(4);
         });
 
         test("multiple rules with same key", async () => {
           await group.setRules([
-            { key: "id", match: "pro%", operation: { op: "like" } },
-            { key: "id", match: "pro_%", operation: { op: "like" } },
+            { key: "grouparooId", match: "pro%", operation: { op: "like" } },
+            { key: "grouparooId", match: "pro_%", operation: { op: "like" } },
           ]);
           expect(await group.countPotentialMembers()).toBe(4);
         });
 
         test("null match", async () => {
           await group.setRules([
-            { key: "id", match: "null", operation: { op: "eq" } },
+            { key: "grouparooId", match: "null", operation: { op: "eq" } },
           ]);
           expect(await group.countPotentialMembers()).toBe(0);
         });
 
         test("not null match", async () => {
           await group.setRules([
-            { key: "id", match: "null", operation: { op: "ne" } },
+            { key: "grouparooId", match: "null", operation: { op: "ne" } },
           ]);
           expect(await group.countPotentialMembers()).toBe(4);
         });
 
         test("exists", async () => {
-          await group.setRules([{ key: "id", operation: { op: "exists" } }]);
+          await group.setRules([
+            { key: "grouparooId", operation: { op: "exists" } },
+          ]);
           expect(await group.countPotentialMembers()).toBe(4);
         });
 
         test("notExists", async () => {
-          await group.setRules([{ key: "id", operation: { op: "notExists" } }]);
+          await group.setRules([
+            { key: "grouparooId", operation: { op: "notExists" } },
+          ]);
           expect(await group.countPotentialMembers()).toBe(0);
         });
       });
 
-      describe("createdAt", () => {
+      describe("grouparooCreatedAt", () => {
         test("exact matches", async () => {
           await group.setRules([
             {
-              key: "createdAt",
+              key: "grouparooCreatedAt",
               match: new Date(0).getTime(),
               operation: { op: "eq" },
             },
@@ -176,7 +180,7 @@ describe("model/group", () => {
         test("comparison matches", async () => {
           await group.setRules([
             {
-              key: "createdAt",
+              key: "grouparooCreatedAt",
               match: new Date(0).getTime(),
               operation: { op: "gt" },
             },
@@ -186,28 +190,36 @@ describe("model/group", () => {
 
         test("null match", async () => {
           await group.setRules([
-            { key: "createdAt", match: "null", operation: { op: "eq" } },
+            {
+              key: "grouparooCreatedAt",
+              match: "null",
+              operation: { op: "eq" },
+            },
           ]);
           expect(await group.countPotentialMembers()).toBe(0);
         });
 
         test("not null match", async () => {
           await group.setRules([
-            { key: "createdAt", match: "null", operation: { op: "ne" } },
+            {
+              key: "grouparooCreatedAt",
+              match: "null",
+              operation: { op: "ne" },
+            },
           ]);
           expect(await group.countPotentialMembers()).toBe(4);
         });
 
         test("exists", async () => {
           await group.setRules([
-            { key: "createdAt", operation: { op: "exists" } },
+            { key: "grouparooCreatedAt", operation: { op: "exists" } },
           ]);
           expect(await group.countPotentialMembers()).toBe(4);
         });
 
         test("notExists", async () => {
           await group.setRules([
-            { key: "createdAt", operation: { op: "notExists" } },
+            { key: "grouparooCreatedAt", operation: { op: "notExists" } },
           ]);
           expect(await group.countPotentialMembers()).toBe(0);
         });
@@ -217,7 +229,7 @@ describe("model/group", () => {
         test("comparison matches (with matches)", async () => {
           await group.setRules([
             {
-              key: "createdAt",
+              key: "grouparooCreatedAt",
               relativeMatchNumber: 2,
               relativeMatchUnit: "days",
               relativeMatchDirection: "subtract",
@@ -230,7 +242,7 @@ describe("model/group", () => {
         test("comparison matches (no matches)", async () => {
           await group.setRules([
             {
-              key: "createdAt",
+              key: "grouparooCreatedAt",
               relativeMatchNumber: 2,
               relativeMatchUnit: "days",
               relativeMatchDirection: "add",

--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -125,7 +125,7 @@ describe("models/property", () => {
     });
 
     test("keys cannot be from the reserved list of keys", async () => {
-      const reservedKeys = ["id", "createdAt", "updatedAt"];
+      const reservedKeys = ["grouparooId", "grouparooCreatedAt"];
       for (const i in reservedKeys) {
         const key = reservedKeys[i];
         await expect(

--- a/core/__tests__/models/run/run.ts
+++ b/core/__tests__/models/run/run.ts
@@ -63,7 +63,9 @@ describe("models/run", () => {
 
       await group.update({ type: "calculated" });
       await group.setRules(
-        group.fromConvenientRules([{ key: "id", operation: { op: "exists" } }])
+        group.fromConvenientRules([
+          { key: "grouparooId", operation: { op: "exists" } },
+        ])
       );
 
       profileA = await helper.factories.profile();

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -19,9 +19,7 @@ import {
 } from "../../../src";
 import path from "path";
 import { api, specHelper } from "actionhero";
-import { Op } from "sequelize";
 import { loadConfigDirectory } from "../../../src/modules/configLoaders";
-import { TopLevelGroupRules } from "../../../src/models/Group";
 
 describe("modules/codeConfig", () => {
   helper.grouparooTestServer({

--- a/core/src/migrations/000073-renameTopLevelGroupRules.ts
+++ b/core/src/migrations/000073-renameTopLevelGroupRules.ts
@@ -1,0 +1,23 @@
+export default {
+  up: async function (migration, DataTypes) {
+    await migration.sequelize.transaction(async () => {
+      await migration.sequelize.query(
+        `UPDATE "groupRules" set "profileColumn" = 'grouparooId' WHERE "profileColumn" = 'id' AND "propertyId" IS NULL;`
+      );
+      await migration.sequelize.query(
+        `UPDATE "groupRules" set "profileColumn" = 'grouparooCreatedAt' WHERE "profileColumn" = 'createdAt' AND "propertyId" IS NULL;`
+      );
+    });
+  },
+
+  down: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.sequelize.query(
+        `UPDATE "groupRules" set "profileColumn" = 'id' WHERE "profileColumn" = 'grouparooId' AND "propertyId" IS NULL;`
+      );
+      await migration.sequelize.query(
+        `UPDATE "groupRules" set "profileColumn" = 'createdAt' WHERE "profileColumn" = 'grouparooCreatedAt' AND "propertyId" IS NULL;`
+      );
+    });
+  },
+};

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -77,8 +77,8 @@ const STATE_TRANSITIONS = [
 ];
 
 export const TopLevelGroupRules = [
-  { key: "id", column: "id", type: "string" },
-  { key: "createdAt", column: "createdAt", type: "date" },
+  { key: "grouparooId", column: "id", type: "string" },
+  { key: "grouparooCreatedAt", column: "createdAt", type: "date" },
 ];
 
 @DefaultScope(() => ({
@@ -525,7 +525,11 @@ export class Group extends LoggedModel<Group> {
         ];
       } else {
         // when we are considering a column on the profiles table
-        const topLevelWhere = {};
+        const topLevelGroupRule = TopLevelGroupRules.find(
+          (tlgr) => tlgr.key === key
+        );
+        if (!topLevelGroupRule)
+          throw new Error(`cannot find TopLevelGroupRule where for key ${key}`);
 
         if (rawValueMatch[Op[operation.op]] && type === "date") {
           rawValueMatch[Op[operation.op]] = new Date(
@@ -533,7 +537,7 @@ export class Group extends LoggedModel<Group> {
           ).getTime();
         }
 
-        topLevelWhere[key] = rawValueMatch;
+        const topLevelWhere = { [topLevelGroupRule.column]: rawValueMatch };
         localWhereGroup[Op.and] = [topLevelWhere];
       }
 

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -26,7 +26,7 @@ import { ProfileProperty } from "./ProfileProperty";
 import { App, SimpleAppOptions } from "./App";
 import { Source, SimpleSourceOptions, SourceMapping } from "./Source";
 import { Option } from "./Option";
-import { Group } from "./Group";
+import { Group, TopLevelGroupRules } from "./Group";
 import { Run } from "./Run";
 import { GroupRule } from "./GroupRule";
 import { PropertyFilter } from "./PropertyFilter";
@@ -569,7 +569,7 @@ export class Property extends LoggedModel<Property> {
 
   @BeforeSave
   static async validateReservedKeys(instance: Property) {
-    const reservedKeys = ["id", "createdAt", "updatedAt"];
+    const reservedKeys = TopLevelGroupRules.map((tlgr) => tlgr.key);
     if (reservedKeys.includes(instance.key)) {
       throw new Error(
         `${instance.key} is a reserved key and cannot be used as a property`


### PR DESCRIPTION
This means that "id" and "updatedAt" are no longer reserved Profile keys.

<img width="1279" alt="Screen Shot 2021-06-24 at 3 30 35 PM" src="https://user-images.githubusercontent.com/303226/123340618-586aa600-d501-11eb-802c-1eb192f9d57c.png">
