### PR TITLE
Destroy before ending run

### DIFF
--- a/core/__tests__/modules/status.ts
+++ b/core/__tests__/modules/status.ts
@@ -111,6 +111,20 @@ describe("modules/status", () => {
 
       const foundMetrics = await Status.get();
       expect(foundMetrics).toEqual({
+        Destination: {
+          deleted: [
+            {
+              metric: {
+                aggregation: "count",
+                collection: "deleted",
+                count: 0,
+                topic: "Destination",
+              },
+              timestamp: expect.any(Number),
+            },
+          ],
+        },
+
         Export: {
           pending: [
             {
@@ -125,6 +139,17 @@ describe("modules/status", () => {
           ],
         },
         Group: {
+          deleted: [
+            {
+              metric: {
+                aggregation: "count",
+                collection: "deleted",
+                count: 0,
+                topic: "Group",
+              },
+              timestamp: expect.any(Number),
+            },
+          ],
           totals: [
             {
               metric: {
@@ -187,6 +212,19 @@ describe("modules/status", () => {
             },
           ],
         },
+        Property: {
+          deleted: [
+            {
+              metric: {
+                aggregation: "count",
+                collection: "deleted",
+                count: 0,
+                topic: "Property",
+              },
+              timestamp: expect.any(Number),
+            },
+          ],
+        },
         Run: {
           pending: [
             {
@@ -215,6 +253,17 @@ describe("modules/status", () => {
           ],
         },
         Source: {
+          deleted: [
+            {
+              metric: {
+                aggregation: "count",
+                collection: "deleted",
+                count: 0,
+                topic: "Source",
+              },
+              timestamp: expect.any(Number),
+            },
+          ],
           nextRun: [
             {
               metric: {

--- a/core/__tests__/tasks/source/destroy.ts
+++ b/core/__tests__/tasks/source/destroy.ts
@@ -101,7 +101,7 @@ describe("tasks/source:destroy", () => {
       );
     });
 
-    test("will destroy its directly mapped property", async () => {
+    test("will destroy its directly mapped property if not used elsewhere", async () => {
       const source: Source = await helper.factories.source();
       const myUserIdProp = await source.bootstrapUniqueProperty(
         "myUserId",

--- a/core/src/bin/status.ts
+++ b/core/src/bin/status.ts
@@ -56,6 +56,7 @@ export class StatusCLI extends CLI {
 
       const pendingItems = [];
       const pendingRuns = [];
+      const pendingDeletions = [];
 
       for (const topic in samples) {
         for (const collection in samples[topic]) {
@@ -65,6 +66,10 @@ export class StatusCLI extends CLI {
             pendingItems.push({
               [metric.topic]: [metric.count],
             });
+          }
+
+          if (metric.collection === "deleted") {
+            pendingDeletions.push({ [metric.topic]: [metric.count] });
           }
 
           if (
@@ -92,6 +97,13 @@ export class StatusCLI extends CLI {
         {
           header: "Active Runs",
           status: pendingRuns.reduce((s, arr) => Object.assign(s, arr), {}),
+        },
+        {
+          header: "Pending Deletions",
+          status: pendingDeletions.reduce(
+            (s, arr) => Object.assign(s, arr),
+            {}
+          ),
         },
       ];
 

--- a/core/src/modules/status.ts
+++ b/core/src/modules/status.ts
@@ -45,6 +45,12 @@ export namespace Status {
     async () => StatusReporters.Pending.pendingProfiles(),
     async () => StatusReporters.Pending.pendingRuns(),
 
+    //things waiting to be deleted
+    async () => StatusReporters.Deleted.deletedDestinations(),
+    async () => StatusReporters.Deleted.deletedGroups(),
+    async () => StatusReporters.Deleted.deletedProperties(),
+    async () => StatusReporters.Deleted.deletedSources(),
+
     // additional things
     async () => StatusReporters.Groups.byNewestMember(),
     async () => StatusReporters.Sources.nextRuns(),

--- a/core/src/modules/statusReporters.ts
+++ b/core/src/modules/statusReporters.ts
@@ -323,6 +323,57 @@ export namespace StatusReporters {
     }
   }
 
+  export namespace Deleted {
+    export async function deletedGroups(): Promise<StatusMetric> {
+      return {
+        collection: "deleted",
+        topic: "Group",
+        aggregation: "count",
+        count: await Group.count({
+          where: { state: "deleted" },
+        }),
+      };
+    }
+
+    export async function deletedDestinations(): Promise<StatusMetric> {
+      return {
+        collection: "deleted",
+        topic: "Destination",
+        aggregation: "count",
+        count: await Destination.count({
+          where: { state: "deleted" },
+        }),
+      };
+    }
+
+    export async function deletedProperties(): Promise<StatusMetric> {
+      return {
+        collection: "deleted",
+        topic: "Property",
+        aggregation: "count",
+        count: await Property.count({ where: { state: "deleted" } }),
+      };
+    }
+
+    export async function deletedSources(): Promise<StatusMetric> {
+      return {
+        collection: "deleted",
+        topic: "Source",
+        aggregation: "count",
+        count: await Source.count({ where: { state: "deleted" } }),
+      };
+    }
+  }
+
+  export async function deletedApps(): Promise<StatusMetric> {
+    return {
+      collection: "deleted",
+      topic: "App",
+      aggregation: "count",
+      count: await App.count({ where: { state: "deleted" } }),
+    };
+  }
+
   export namespace Groups {
     export async function byNewestMember() {
       const metrics: StatusMetric[] = [];

--- a/core/src/tasks/source/destroy.ts
+++ b/core/src/tasks/source/destroy.ts
@@ -33,6 +33,16 @@ export class SourceDestroy extends CLSTask {
       throw error;
     }
 
+    // check if the property is directly mapped
+    try {
+      await Source.ensureDirectlyMappedPropertyNotInUse(source);
+    } catch (error) {
+      if (error.message.match(/cannot delete property/)) {
+        return; // check back later
+      }
+      throw error;
+    }
+
     // no properties, let's delete it
     await source.destroy();
   }

--- a/core/src/tasks/system/status/status.ts
+++ b/core/src/tasks/system/status/status.ts
@@ -37,8 +37,13 @@ export class StatusTask extends CLSTask {
 
       const complete = await this.checkForComplete(samples);
       if (runMode === "cli:run" && complete) {
+        await task.enqueue("destroy", {});
+
         await this.logFinalSummary();
-        await this.stopServer(toStop);
+
+        const samples = await this.getSamples();
+        const complete = await this.checkForComplete(samples);
+        if (complete) await this.stopServer(toStop);
       }
 
       await this.updateTaskFrequency();

--- a/core/src/tasks/system/status/status.ts
+++ b/core/src/tasks/system/status/status.ts
@@ -70,7 +70,7 @@ export class StatusTask extends CLSTask {
       }
     }
 
-    if (pendingCollections < 4) return false; // not every model has been checked yet (PENDING: profile, runs, import, export; DELETED: group, destination, property, source, app)
+    if (pendingCollections < 4) return false; // not every required model has been checked yet (PENDING: profile, runs, import, export)
     return pendingItems > 0 ? false : true;
   }
 

--- a/core/src/tasks/system/status/status.ts
+++ b/core/src/tasks/system/status/status.ts
@@ -126,7 +126,7 @@ export class StatusTask extends CLSTask {
           });
         }
 
-        if (latestMetric.collection === "deleted") {
+        if (latestMetric.collection === "deleted" && latestMetric.count > 0) {
           pendingDeletions.push({
             [latestMetric.topic]: [latestMetric.count],
           });

--- a/core/src/tasks/system/status/status.ts
+++ b/core/src/tasks/system/status/status.ts
@@ -36,14 +36,11 @@ export class StatusTask extends CLSTask {
       if (runMode === "cli:run") this.logSamples(samples);
 
       const complete = await this.checkForComplete(samples);
-      if (runMode === "cli:run" && complete) {
-        await task.enqueue("destroy", {});
 
+      if (runMode === "cli:run" && complete) {
         await this.logFinalSummary();
 
-        const samples = await this.getSamples();
-        const complete = await this.checkForComplete(samples);
-        if (complete) await this.stopServer(toStop);
+        await this.stopServer(toStop);
       }
 
       await this.updateTaskFrequency();
@@ -63,14 +60,17 @@ export class StatusTask extends CLSTask {
       for (const collection in samples[topic]) {
         const metrics = samples[topic][collection];
         const { metric } = metrics[metrics.length - 1];
-        if (metric.collection === "pending") {
+        if (
+          metric.collection === "pending" ||
+          metric.collection === "deleted"
+        ) {
           pendingItems += metric.count;
           pendingCollections++;
         }
       }
     }
 
-    if (pendingCollections < 4) return false; // not every model has been checked yet (profile, runs, import, export)
+    if (pendingCollections < 4) return false; // not every model has been checked yet (PENDING: profile, runs, import, export; DELETED: group, destination, property, source, app)
     return pendingItems > 0 ? false : true;
   }
 

--- a/core/src/tasks/system/status/status.ts
+++ b/core/src/tasks/system/status/status.ts
@@ -97,6 +97,7 @@ export class StatusTask extends CLSTask {
     const totalItems = [];
     const pendingItems = [];
     const pendingRuns = [];
+    const pendingDeletions = [];
 
     const pendingCollection = samples["Run"]
       ? samples["Run"]["pending"]
@@ -121,6 +122,12 @@ export class StatusTask extends CLSTask {
 
         if (latestMetric.collection === "pending") {
           pendingItems.push({
+            [latestMetric.topic]: [latestMetric.count],
+          });
+        }
+
+        if (latestMetric.collection === "deleted") {
+          pendingDeletions.push({
             [latestMetric.topic]: [latestMetric.count],
           });
         }
@@ -164,6 +171,12 @@ export class StatusTask extends CLSTask {
       logItems.push({
         header: "Active Runs",
         status: pendingRuns.reduce((s, arr) => Object.assign(s, arr), {}),
+      });
+    }
+    if (pendingDeletions.length > 0) {
+      logItems.push({
+        header: "Pending Deletions",
+        status: pendingDeletions.reduce((s, arr) => Object.assign(s, arr), {}),
       });
     }
 


### PR DESCRIPTION
Previously, `roo run` could end with rows in a deleted state.

This PR 
(a) adds a check for pending deletions
(b) adds pending deletions to the status reports
(c) processes the deletions (destroys the rows marked as deleted) before allowing the process to shutdown.

Thanks to @pedroslopez for helping me out with how our `destroy` tasks recur.