### PR TITLE
List `bluebird` as a dependency of `@grouparoo/facebook`

### DIFF
--- a/plugins/@grouparoo/facebook/package.json
+++ b/plugins/@grouparoo/facebook/package.json
@@ -31,6 +31,7 @@
     "@grouparoo/app-templates": "0.4.2-alpha.0",
     "currency-codes": "2.1.0",
     "facebook-nodejs-business-sdk": "10.0.1",
+    "bluebird": "*",
     "iso-3166-1-alpha-2": "1.0.0",
     "js-sha256": "0.9.0"
   },


### PR DESCRIPTION
I explored a number of ways to invalidate more of the node `require.cache`, but none of them were effective.  This might help... but we really need to publish it to test :/