### PR TITLE
Show restart message when facebook plugin fails to install

### DIFF
--- a/core/src/actions/plugins.ts
+++ b/core/src/actions/plugins.ts
@@ -69,10 +69,7 @@ export class PluginInstall extends AuthenticatedAction {
     // Return if did not ask to restart
     if (!params.restart) return { success: response.success };
     // Otherwise, return, then restart the server.
-    setTimeout(() => {
-      clearPluginConfigCache();
-      api.process.restart();
-    }, restartSleepTime);
+    setTimeout(() => safelyRestart(), restartSleepTime);
     return { success: response.success, checkIn: restartSleepTime * 4 };
   }
 }
@@ -97,11 +94,21 @@ export class PluginUninstall extends AuthenticatedAction {
     // Return if did not ask to restart
     if (!params.restart) return { success: response.success };
     // Otherwise, return, then restart the server.
-    setTimeout(() => {
-      clearPluginConfigCache();
-      api.process.restart();
-    }, restartSleepTime);
+    setTimeout(() => safelyRestart(), restartSleepTime);
     return { success: response.success, checkIn: restartSleepTime * 4 };
+  }
+}
+
+async function safelyRestart() {
+  try {
+    clearPluginConfigCache();
+    await api.process.restart();
+  } catch (error) {
+    console.log("");
+    console.log("*** There was a problem restarting Grouparoo ***");
+    console.log(error.message ?? error);
+    console.log("Please restart the application");
+    process.exit(1);
   }
 }
 

--- a/plugins/@grouparoo/facebook/package.json
+++ b/plugins/@grouparoo/facebook/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@grouparoo/app-templates": "0.4.2-alpha.1",
-    "bluebird": "*",
     "currency-codes": "2.1.0",
     "facebook-nodejs-business-sdk": "10.0.1",
     "iso-3166-1-alpha-2": "1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,7 +518,6 @@ importers:
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 26.0.8
-      bluebird: '*'
       currency-codes: 2.1.0
       dotenv: 10.0.0
       facebook-nodejs-business-sdk: 10.0.1
@@ -532,7 +531,6 @@ importers:
       typescript: 4.3.4
     dependencies:
       '@grouparoo/app-templates': link:../app-templates
-      bluebird: 3.7.2
       currency-codes: 2.1.0
       facebook-nodejs-business-sdk: 10.0.1
       iso-3166-1-alpha-2: 1.0.0
@@ -14228,7 +14226,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.6.3_ts-node@10.0.0
+      jest: 26.6.3
       jest-util: 26.6.2
       json5: 2.2.0
       lodash: 4.17.21


### PR DESCRIPTION
Due to `facebook-nodejs-business-sdk`'s dynamic reliance on the bluebird plugin, we cannot properly restart Grouparoo/Actionhero as this plugin is installed.  This is the only plugin with this problem.   To that end, we now just show a better error message:

```
notice: stopping process...
notice: Stopping server: web
notice: Stopping server: websocket
notice: *** @grouparoo/core Stopped ***

*** There was a problem restarting Grouparoo ***
Cannot find module 'bluebird'
Require stack:
- /private/tmp/grouparoo-test/node_modules/request-promise/lib/rp.js
- /private/tmp/grouparoo-test/node_modules/facebook-nodejs-business-sdk/dist/cjs.js
- /private/tmp/grouparoo-test/node_modules/@grouparoo/facebook/dist/lib/connect.js
- /private/tmp/grouparoo-test/node_modules/@grouparoo/facebook/dist/lib/test.js
- /private/tmp/grouparoo-test/node_modules/@grouparoo/facebook/dist/initializers/plugin.js
- /private/tmp/grouparoo-test/node_modules/actionhero/dist/classes/process.js
- /private/tmp/grouparoo-test/node_modules/actionhero/dist/index.js
- /Users/evan/workspace/grouparoo/grouparoo/cli/dist/utils/loadLocalCommands.js
- /Users/evan/workspace/grouparoo/grouparoo/cli/dist/grouparoo.js
Please restart the application
```

Getting the install + hot reload working would require forking `facebook-nodejs-business-sdk`. 