### PR TITLE
Update nav on group create

### DIFF
--- a/ui/ui-components/pages/group/[id]/rules.tsx
+++ b/ui/ui-components/pages/group/[id]/rules.tsx
@@ -498,6 +498,7 @@ export default function Page(props) {
               onClick={async () => {
                 await updateRules();
                 await getCounts();
+                window.location.reload();
               }}
             >
               Save Rules


### PR DESCRIPTION
Previously: Because there was no redirect after a user adding a group, there was no update in the progress nav bar (on any ui package)

Now: Triggers a  page reload on submission of group setup (which triggers the nav setup bar to update).

There is definitely a more elegant solution that doesn't reload the entire window, but given that there shouldn't be a huge amount of data back and forth on this page it seems ok.