### PR TITLE
Add "Create Sample Profiles" to setup steps in config

### DIFF
--- a/core/__tests__/models/setupStep.ts
+++ b/core/__tests__/models/setupStep.ts
@@ -37,12 +37,19 @@ describe("models/setupStep", () => {
     );
   });
 
-  test("setupSteps ops returns config versions when in config mode", async () => {
-    let setupSteps = SetupStepOps.setupStepDescriptions();
+  test("setupSteps ops returns standard versions when not in config mode", async () => {
+    const setupSteps = SetupStepOps.setupStepDescriptions();
     expect(setupSteps[0].key).toEqual("name_your_grouparoo_instance");
+    expect(setupSteps[5].key).toEqual("create_a_group");
+    expect(setupSteps[6].key).toEqual("create_a_destination");
+  });
+
+  test("setupSteps ops returns config versions when in config mode", async () => {
     process.env.GROUPAROO_RUN_MODE = "cli:config";
-    setupSteps = SetupStepOps.setupStepDescriptions();
+    const setupSteps = SetupStepOps.setupStepDescriptions();
     expect(setupSteps[0].key).toEqual("install_grouparoo");
+    expect(setupSteps[5].key).toEqual("create_a_sample_profile");
+    expect(setupSteps[6].key).toEqual("create_a_group");
   });
 
   test("setup steps have unique keys", async () => {

--- a/core/src/modules/ops/setupSteps.ts
+++ b/core/src/modules/ops/setupSteps.ts
@@ -115,6 +115,19 @@ export namespace SetupStepOps {
         return `${count} Runs created`;
       },
     },
+    create_a_sample_profile: {
+      key: "create_a_sample_profile",
+      title: "Create a Sample Profile",
+      description:
+        "Create a Sample Profile so you can validate your configuration is importing the correct data. These Profiles will allow you to test Group building and your Destination settings and mappings.",
+      href: "/profile/new",
+      cta: "Add a Sample Profile",
+      helpLink: `${configURL}/profiles`,
+      check: async () => {
+        const count = await Profile.count();
+        return count > 0;
+      },
+    },
     create_a_group: {
       key: "create_a_group",
       title: "Create a Group",
@@ -152,40 +165,75 @@ export namespace SetupStepOps {
   };
 
   export const setupStepDescriptions = (): Array<setupStepDescription> => {
-    const firstStep =
+    const setupSteps =
       process.env.GROUPAROO_RUN_MODE === "cli:config"
-        ? { ...allSetupStepDescriptions.install_grouparoo }
-        : { ...allSetupStepDescriptions.name_your_grouparoo_instance };
+        ? [
+            {
+              ...allSetupStepDescriptions.install_grouparoo,
+              position: 1,
+            },
+            {
+              ...allSetupStepDescriptions.add_an_app,
+              position: 2,
+            },
+            {
+              ...allSetupStepDescriptions.create_a_source,
+              position: 3,
+            },
+            {
+              ...allSetupStepDescriptions.create_a_unique_profile_property,
+              position: 4,
+            },
+            {
+              ...allSetupStepDescriptions.create_a_schedule,
+              position: 5,
+            },
+            {
+              ...allSetupStepDescriptions.create_a_sample_profile,
+              position: 6,
+            },
 
-    return [
-      {
-        ...firstStep,
-        position: 1,
-      },
-      {
-        ...allSetupStepDescriptions.add_an_app,
-        position: 2,
-      },
-      {
-        ...allSetupStepDescriptions.create_a_source,
-        position: 3,
-      },
-      {
-        ...allSetupStepDescriptions.create_a_unique_profile_property,
-        position: 4,
-      },
-      {
-        ...allSetupStepDescriptions.create_a_schedule,
-        position: 5,
-      },
-      {
-        ...allSetupStepDescriptions.create_a_group,
-        position: 6,
-      },
-      {
-        ...allSetupStepDescriptions.create_a_destination,
-        position: 7,
-      },
-    ];
+            {
+              ...allSetupStepDescriptions.create_a_group,
+              position: 7,
+            },
+            {
+              ...allSetupStepDescriptions.create_a_destination,
+              position: 8,
+            },
+          ]
+        : [
+            {
+              ...allSetupStepDescriptions.name_your_grouparoo_instance,
+              position: 1,
+            },
+            {
+              ...allSetupStepDescriptions.add_an_app,
+              position: 2,
+            },
+            {
+              ...allSetupStepDescriptions.create_a_source,
+              position: 3,
+            },
+            {
+              ...allSetupStepDescriptions.create_a_unique_profile_property,
+              position: 4,
+            },
+            {
+              ...allSetupStepDescriptions.create_a_schedule,
+              position: 5,
+            },
+
+            {
+              ...allSetupStepDescriptions.create_a_group,
+              position: 6,
+            },
+            {
+              ...allSetupStepDescriptions.create_a_destination,
+              position: 7,
+            },
+          ];
+
+    return setupSteps;
   };
 }


### PR DESCRIPTION
**Do not merge until UI Config docs are up.** 

The "Learn More" link in the new setup steps is based on those docs.

Added setting up sample profiles as a step for UI-Config only.

Because there are now multiple differences between UI config setup steps and all other setup steps now, I separated them out rather than complicating the logic.