### PR TITLE
[Config UI] Don't save mappings for query sources

### DIFF
--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -557,6 +557,12 @@ describe("modules/configWriter", () => {
       expect(config).toBeUndefined();
     });
 
+    test("sources without a mapping will not add mappings to the config object", async () => {
+      const source: Source = await helper.factories.source();
+      const config = await source.getConfigObject();
+      expect(config.mapping).toBeUndefined();
+    });
+
     test("sources will also bring their own schedule", async () => {
       const schedule: Schedule = await helper.factories.schedule(source);
       const config = await source.getConfigObject();

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -297,7 +297,6 @@ export class Source extends LoggedModel<Source> {
     this.app = await this.$get("app");
     const appId = this.app?.getConfigId();
     const options = await this.getOptions(false);
-    const mapping = await MappingHelper.getConfigMapping(this);
 
     if (!appId || !name) return;
 
@@ -307,9 +306,13 @@ export class Source extends LoggedModel<Source> {
       name,
       type,
       appId,
-      mapping,
       options,
     };
+
+    const mapping = await MappingHelper.getConfigMapping(this);
+    if (Object.keys(mapping).length > 0) {
+      configObject.mapping = mapping;
+    }
 
     const setSchedule = async () => {
       if (!this.schedule) return;


### PR DESCRIPTION
Query sources don't need a mapping, but config ui was writing an empty mapping to file, which caused issues when validating the config:

```json
{
  "class": "Source",
  "id": "query",
  "name": "Query",
  "type": "postgres-query-import",
  "appId": "postgres",
  "mapping": {},
  "options": {}
}
```

```
warning: [ config ] error with Source `Query` (query): missing parent id to find a Property 
warning: [ config ] error with Property `ltv` (ltv): source is not ready and property not unique 
```

This PR does not save a `mapping` object to the config file if it's empty.