### PR TITLE
fix: save and load profile column group rules in code config

### DIFF
--- a/core/__tests__/fixtures/codeConfig/top-level-group-rule/config.js
+++ b/core/__tests__/fixtures/codeConfig/top-level-group-rule/config.js
@@ -1,0 +1,30 @@
+module.exports = async function getConfig() {
+  return [
+    {
+      id: "group_exists",
+      name: "People that exist",
+      class: "Group",
+      type: "calculated",
+      rules: [
+        {
+          propertyId: "grouparooId",
+          operation: { op: "exists" },
+        },
+      ],
+    },
+    {
+      id: "group_recent",
+      name: "People that have been recently added",
+      class: "Group",
+      type: "calculated",
+      rules: [
+        {
+          propertyId: "grouparooCreatedAt",
+          operation: { op: "relative_gt" },
+          relativeMatchNumber: "8",
+          relativeMatchUnit: "days",
+        },
+      ],
+    },
+  ];
+};

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -879,6 +879,73 @@ describe("modules/codeConfig", () => {
     });
   });
 
+  describe("Profile columns in calculated group rules", () => {
+    beforeAll(async () => {
+      api.codeConfig.allowLockedModelChanges = true;
+      const { errors, seenIds } = await loadConfigDirectory(
+        path.join(
+          __dirname,
+          "..",
+          "..",
+          "fixtures",
+          "codeConfig",
+          "top-level-group-rule"
+        )
+      );
+      expect(errors).toEqual([]);
+      expect(seenIds).toEqual({
+        apikey: [],
+        app: [],
+        destination: [],
+        group: ["group_exists", "group_recent"],
+        property: [],
+        schedule: [],
+        source: [],
+        team: [],
+        teammember: [],
+        profile: [],
+      });
+    });
+
+    test("topLevel rules for profile columns are created", async () => {
+      const group = await Group.findById("group_exists");
+      const rules = await group.getRules();
+      expect(rules).toEqual([
+        {
+          key: "grouparooId",
+          match: "null",
+          operation: { description: "is not equal to", op: "ne" },
+          relativeMatchDirection: null,
+          relativeMatchNumber: null,
+          relativeMatchUnit: null,
+          topLevel: true,
+          type: "string",
+        },
+      ]);
+    });
+
+    test("topLevel rules for date profile columns are correctly created", async () => {
+      const group = await Group.findById("group_recent");
+      const rules = await group.getRules();
+      expect(rules).toEqual([
+        {
+          key: "grouparooCreatedAt",
+          match: null,
+          operation: { description: "is after", op: "gt" },
+          relativeMatchDirection: "subtract",
+          relativeMatchNumber: 8,
+          relativeMatchUnit: "days",
+          topLevel: true,
+          type: "date",
+        },
+      ]);
+    });
+
+    afterAll(async () => {
+      await helper.truncate();
+    });
+  });
+
   describe("Dates in calculated group rules", () => {
     beforeAll(async () => {
       api.codeConfig.allowLockedModelChanges = true;

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -769,6 +769,25 @@ describe("modules/configWriter", () => {
       expect(group.getConfigId()).toEqual(group.id);
     });
 
+    test("group rules properly set IDs for profile column properties", async () => {
+      let group: Group = await helper.factories.group({ type: "calculated" });
+      await group.setRules([
+        { key: "grouparooId", match: "nobody", operation: { op: "eq" } },
+      ]);
+
+      const config = await group.getConfigObject();
+      expect(config.rules).toEqual([
+        {
+          propertyId: "grouparooId",
+          match: "nobody",
+          operation: { op: "eq" },
+          relativeMatchDirection: null,
+          relativeMatchNumber: null,
+          relativeMatchUnit: null,
+        },
+      ]);
+    });
+
     test("groups can provide their config objects", async () => {
       const config = await group.getConfigObject();
 

--- a/core/src/actions/groups.ts
+++ b/core/src/actions/groups.ts
@@ -1,7 +1,8 @@
 import { CLS } from "../modules/cls";
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
-import { Group, GROUP_RULE_LIMIT, TopLevelGroupRules } from "../models/Group";
+import { Group, GROUP_RULE_LIMIT } from "../models/Group";
 import { PropertyOpsDictionary } from "../modules/ruleOpsDictionary";
+import { TopLevelGroupRules } from "../modules/topLevelGroupRules";
 import { Profile } from "../models/Profile";
 import { GroupMember } from "../models/GroupMember";
 import { ConfigWriter } from "../modules/configWriter";

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -1,9 +1,11 @@
 import { log } from "actionhero";
 import { PropertyFiltersWithKey } from "../models/Property";
-import { GroupRuleWithKey, TopLevelGroupRules } from "../models/Group";
+import { GroupRuleWithKey } from "../models/Group";
 import { topologicalSort, Graph } from "../modules/topologicalSort";
 import { DestinationSyncMode } from "../models/Destination";
 import { MustacheUtils } from "../modules/mustacheUtils";
+import { TopLevelGroupRules } from "../modules/topLevelGroupRules";
+
 export interface IdsByClass {
   app?: string[];
   source?: string[];

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -1,6 +1,6 @@
 import { log } from "actionhero";
 import { PropertyFiltersWithKey } from "../models/Property";
-import { GroupRuleWithKey } from "../models/Group";
+import { GroupRuleWithKey, TopLevelGroupRules } from "../models/Group";
 import { topologicalSort, Graph } from "../modules/topologicalSort";
 import { DestinationSyncMode } from "../models/Destination";
 import { MustacheUtils } from "../modules/mustacheUtils";
@@ -330,7 +330,14 @@ export async function getParentIds(
       const recordKeys = Object.keys(record);
       for (const j in recordKeys) {
         if (recordKeys[j].match(/.+Id$/)) {
-          prerequisiteIds.push(`property:${record[recordKeys[j]]}`);
+          const value = record[recordKeys[j]];
+
+          // special case: topLevel properties
+          if (TopLevelGroupRules.map((r) => r.key).includes(value)) {
+            continue;
+          }
+
+          prerequisiteIds.push(`property:${value}`);
         }
       }
     }

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -33,6 +33,7 @@ import { GroupOps } from "../modules/ops/group";
 import { ConfigWriter } from "../modules/configWriter";
 import { LockableHelper } from "../modules/lockableHelper";
 import { APIData } from "../modules/apiData";
+import { TopLevelGroupRules } from "../modules/topLevelGroupRules";
 
 export const GROUP_RULE_LIMIT = 10;
 const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -74,11 +75,6 @@ const STATE_TRANSITIONS = [
   { from: "updating", to: "deleted", checks: [] },
   { from: "ready", to: "deleted", checks: [] },
   { from: "deleted", to: "ready", checks: [] },
-];
-
-export const TopLevelGroupRules = [
-  { key: "grouparooId", column: "id", type: "string" },
-  { key: "grouparooCreatedAt", column: "createdAt", type: "date" },
 ];
 
 @DefaultScope(() => ({

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -648,7 +648,7 @@ export class Group extends LoggedModel<Group> {
     for (const rule of convenientRules) {
       const property = await Property.findOneWithCache(rule.key, "key");
       rules.push({
-        propertyId: property.getConfigId(),
+        propertyId: rule.topLevel ? rule.key : property.getConfigId(),
         operation: { op: rule.operation.op },
         match: rule.match,
         relativeMatchNumber: rule.relativeMatchNumber,

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -26,7 +26,7 @@ import { ProfileProperty } from "./ProfileProperty";
 import { App, SimpleAppOptions } from "./App";
 import { Source, SimpleSourceOptions, SourceMapping } from "./Source";
 import { Option } from "./Option";
-import { Group, TopLevelGroupRules } from "./Group";
+import { Group } from "./Group";
 import { Run } from "./Run";
 import { GroupRule } from "./GroupRule";
 import { PropertyFilter } from "./PropertyFilter";
@@ -36,6 +36,7 @@ import { StateMachine } from "../modules/stateMachine";
 import { Mapping } from "./Mapping";
 import { PropertyOps } from "../modules/ops/property";
 import { LockableHelper } from "../modules/lockableHelper";
+import { TopLevelGroupRules } from "../modules/topLevelGroupRules";
 import { APIData } from "../modules/apiData";
 import { CLS } from "../modules/cls";
 

--- a/core/src/modules/configLoaders/group.ts
+++ b/core/src/modules/configLoaders/group.ts
@@ -10,6 +10,7 @@ import { Property } from "../../models/Property";
 import { Op } from "sequelize";
 
 import { ConfigWriter } from "../configWriter";
+import { TopLevelGroupRules } from "../../models/Group";
 
 export async function loadGroup(
   configObject: ConfigurationObject,
@@ -52,13 +53,25 @@ export async function loadGroup(
 
     for (const i in rules) {
       if (rules[i]["propertyId"]) {
-        const property = await Property.findById(rules[i]["propertyId"]);
+        let ruleKey: string, ruleType: string;
+        const topLevelProperty = TopLevelGroupRules.find(
+          (r) => r.key === rules[i]["propertyId"]
+        );
+        if (topLevelProperty) {
+          ruleKey = topLevelProperty.key;
+          ruleType = topLevelProperty.type;
+        } else {
+          const property = await Property.findById(rules[i]["propertyId"]);
+          ruleKey = property.key;
+          ruleType = property.type;
+        }
+
         delete rules[i]["propertyId"];
-        rules[i].key = property.key;
+        rules[i].key = ruleKey;
 
         // if calculating based on a date, parse to unix timestamp
         if (calculatesWithDate.includes(rules[i]["operation"]["op"])) {
-          if (property.type === "date") {
+          if (ruleType === "date") {
             rules[i]["match"] = Date.parse(rules[i]["match"].toString());
           }
         }

--- a/core/src/modules/configLoaders/group.ts
+++ b/core/src/modules/configLoaders/group.ts
@@ -1,3 +1,5 @@
+import { Op } from "sequelize";
+
 import {
   ConfigurationObject,
   getCodeConfigLockKey,
@@ -5,12 +7,10 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { Group } from "../..";
+import { Group } from "../../models/Group";
+import { TopLevelGroupRules } from "../../modules/topLevelGroupRules";
 import { Property } from "../../models/Property";
-import { Op } from "sequelize";
-
 import { ConfigWriter } from "../configWriter";
-import { TopLevelGroupRules } from "../../models/Group";
 
 export async function loadGroup(
   configObject: ConfigurationObject,

--- a/core/src/modules/topLevelGroupRules.ts
+++ b/core/src/modules/topLevelGroupRules.ts
@@ -1,0 +1,4 @@
+export const TopLevelGroupRules = [
+  { key: "grouparooId", column: "id", type: "string" },
+  { key: "grouparooCreatedAt", column: "createdAt", type: "date" },
+];

--- a/ui/ui-components/pages/group/[id]/rules.tsx
+++ b/ui/ui-components/pages/group/[id]/rules.tsx
@@ -93,6 +93,7 @@ export default function Page(props) {
 
     _rules.push({
       key: propertiesAndTopLevelGroupRules[0].key,
+      topLevel: properties.length === 0,
       match: null,
       operation: { op: "exists" },
     });

--- a/ui/ui-components/pages/group/[id]/rules.tsx
+++ b/ui/ui-components/pages/group/[id]/rules.tsx
@@ -92,7 +92,7 @@ export default function Page(props) {
     }
 
     _rules.push({
-      key: properties[0].key,
+      key: propertiesAndTopLevelGroupRules[0].key,
       match: null,
       operation: { op: "exists" },
     });


### PR DESCRIPTION
This PR addresses three issues:
1. An error occurred when trying to add a group rule when no properties had been created. This was due to trying to use the first property as the initial property set on the rule being created. This changes the behavior to also include profile columns, so if there are no properties, the first profile column will be used instead.
2. Group rules that used profile columns (topLevel) could not be saved by config UI .
3. Group rules that used profile columns (topLevel) could not be loaded through code config.