### PR TITLE
redirect to app edit after plugin install

### DIFF
--- a/ui/ui-config/pages/app/new.tsx
+++ b/ui/ui-config/pages/app/new.tsx
@@ -130,6 +130,14 @@ export default function Page(props) {
       await timeout(response.checkIn);
       await waitForServer();
 
+      //we only want the plugin type, not the '@grouparoo/'
+      const pluginName = plugin.plugin.name.substring(11);
+      const newApp: Actions.AppCreate = await execApi("post", `/app`, {
+        type: pluginName,
+      });
+      if (newApp?.app) {
+        return router.push("/app/[id]/edit", `/app/${newApp.app.id}/edit`);
+      }
       await resetPluginsAndApps();
       setLoading(false);
       setInstallingMessage(false);


### PR DESCRIPTION
After installing a Plugin, an App instance is created users are redirected to `/app/[id]/edit` upon server restart.