### PR TITLE
set mapped column when bootstrapping google sheets property

### DIFF
--- a/plugins/@grouparoo/google-sheets/__tests__/integration/unique-property-bootstrap-options.ts
+++ b/plugins/@grouparoo/google-sheets/__tests__/integration/unique-property-bootstrap-options.ts
@@ -1,0 +1,18 @@
+import { uniquePropertyBootstrapOptions } from "../../src/lib/sheet-import/uniquePropertyBootstrapOptions";
+
+describe("google-sheets/uniquePropertyBootstrapOptions", () => {
+  test("sets column mapping as a default option", async () => {
+    const opts = await uniquePropertyBootstrapOptions({
+      connection: null,
+      app: null,
+      appId: null,
+      appOptions: null,
+      source: null,
+      sourceId: null,
+      sourceOptions: null,
+      mappedColumn: "userId",
+    });
+
+    expect(opts).toEqual({ column: "userId" });
+  });
+});

--- a/plugins/@grouparoo/google-sheets/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/google-sheets/src/initializers/plugin.ts
@@ -6,6 +6,7 @@ import { test } from "../lib/test";
 import { sourcePreview } from "../lib/sheet-import/sourcePreview";
 import { profiles } from "../lib/sheet-import/profiles";
 import { propertyOptions } from "../lib/sheet-import/propertyOptions";
+import { uniquePropertyBootstrapOptions } from "../lib/sheet-import/uniquePropertyBootstrapOptions";
 import { sourceRunPercentComplete } from "../lib/sheet-import/sourceRunPercentComplete";
 
 import {
@@ -74,6 +75,7 @@ export class Plugins extends Initializer {
             sourcePreview,
             profiles,
             sourceRunPercentComplete,
+            uniquePropertyBootstrapOptions,
           },
         },
       ],

--- a/plugins/@grouparoo/google-sheets/src/lib/sheet-import/uniquePropertyBootstrapOptions.ts
+++ b/plugins/@grouparoo/google-sheets/src/lib/sheet-import/uniquePropertyBootstrapOptions.ts
@@ -1,0 +1,6 @@
+import { UniquePropertyBootstrapOptions } from "@grouparoo/core";
+
+export const uniquePropertyBootstrapOptions: UniquePropertyBootstrapOptions =
+  async ({ mappedColumn }) => {
+    return { column: mappedColumn };
+  };


### PR DESCRIPTION
This caused an issue that prevented a property to be bootstrapped through Enterprise/Config UI