### PR TITLE
Show failure message if there is a reboot problem when installing plugin from ui-config

### DIFF
--- a/core/src/actions/plugins.ts
+++ b/core/src/actions/plugins.ts
@@ -107,6 +107,7 @@ async function safelyRestart() {
     console.log("");
     console.log("*** There was a problem restarting Grouparoo ***");
     console.log(error.message ?? error);
+    console.log("");
     console.log("Please restart the application");
     process.exit(1);
   }


### PR DESCRIPTION
<Table>
<tr>
<td><img width="1490" alt="Screen Shot 2021-06-30 at 12 04 40 PM" src="https://user-images.githubusercontent.com/303226/124017621-cb5d9c00-d99b-11eb-8b93-dab7545b5da0.png">
</td>
<td><img width="1446" alt="Screen Shot 2021-06-30 at 12 05 06 PM" src="https://user-images.githubusercontent.com/303226/124017602-c4cf2480-d99b-11eb-9c76-515c2a6ef32a.png">
</td>
</tr>
</Table>



Related to https://github.com/grouparoo/grouparoo/pull/2003, if we cannot reboot the Grouparoo server after installing a plugin, we now wait 15 seconds and show a message to the user. 