### PR TITLE
"Import and Export" button will Export Profile to Destinations that it should be removed from

### DIFF
--- a/core/__tests__/models/profile/profile.ts
+++ b/core/__tests__/models/profile/profile.ts
@@ -11,7 +11,6 @@ import {
   Log,
 } from "../../../src";
 import { ProfileOps } from "../../../src/modules/ops/profile";
-import { api, specHelper } from "actionhero";
 
 function simpleProfileValues(complexProfileValues): { [key: string]: any } {
   const keys = Object.keys(complexProfileValues);

--- a/core/__tests__/models/profile/sync.ts
+++ b/core/__tests__/models/profile/sync.ts
@@ -1,0 +1,257 @@
+import { helper } from "@grouparoo/spec-helper";
+import {
+  Profile,
+  Group,
+  Destination,
+  Export,
+  GrouparooPlugin,
+  ProfileProperty,
+} from "../../../src";
+import { api } from "actionhero";
+
+function simpleProfileValues(complexProfileValues): { [key: string]: any } {
+  const keys = Object.keys(complexProfileValues);
+  const simpleProfileProperties = {};
+  keys.forEach((key) => {
+    simpleProfileProperties[key] = complexProfileValues[key].values;
+  });
+  return simpleProfileProperties;
+}
+
+describe("profile sync", () => {
+  let profile: Profile;
+  let group: Group;
+  let destination: Destination;
+
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
+  beforeAll(async () => {
+    await helper.factories.properties();
+  });
+
+  afterEach(async () => {
+    await Profile.truncate();
+    await ProfileProperty.truncate();
+    await Group.truncate();
+    await Destination.truncate();
+    await Export.truncate();
+  });
+
+  beforeEach(async () => {
+    profile = await helper.factories.profile();
+    group = await helper.factories.group();
+    await group.update({ type: "calculated" });
+    destination = await helper.factories.destination();
+  });
+
+  test("syncing a profile will import properties", async () => {
+    let properties = await profile.properties();
+    expect(simpleProfileValues(properties)).toEqual(
+      expect.objectContaining({
+        firstName: [null],
+        isVIP: [null],
+        lastName: [null],
+        ltv: [null],
+      })
+    );
+
+    await profile.sync();
+
+    properties = await profile.properties();
+    expect(simpleProfileValues(properties)).toEqual(
+      expect.objectContaining({
+        firstName: ["Mario"],
+        isVIP: [true],
+        lastName: ["Mario"],
+        ltv: [100],
+      })
+    );
+  });
+
+  test("syncing a profile will update group membership", async () => {
+    let groups = await profile.$get("groups");
+    expect(groups).toEqual([]);
+
+    await group.setRules([
+      { key: "firstName", match: "Mario", operation: { op: "eq" } },
+    ]);
+    await group.update({ state: "ready" });
+
+    await profile.sync();
+
+    groups = await profile.$get("groups");
+    expect(groups.length).toEqual(1);
+    expect(groups[0].name).toEqual(group.name);
+  });
+
+  describe("with destination tracking group", () => {
+    beforeEach(async () => {
+      await group.setRules([
+        { key: "firstName", match: "Mario", operation: { op: "eq" } },
+      ]);
+      await group.update({ state: "ready" });
+      await destination.trackGroup(group);
+    });
+
+    test("syncing will create exports", async () => {
+      const createdExports = await profile.sync();
+      const foundExports = await profile.$get("exports");
+
+      expect(createdExports.length).toBe(1);
+      expect(foundExports.length).toBe(1);
+    });
+
+    test("optionally exports can be predicted but not saved", async () => {
+      const createdExports = await profile.sync(undefined, false);
+      const foundExports = await profile.$get("exports");
+
+      expect(createdExports.length).toBe(1);
+      expect(foundExports.length).toBe(0);
+    });
+
+    test("exports will be forced by default", async () => {
+      await profile.sync();
+      const createdExports = await profile.sync();
+      expect(createdExports.length).toBe(1);
+      expect(createdExports[0].force).toBe(true);
+      expect(createdExports[0].hasChanges).toBe(true);
+    });
+
+    test("optionally a sync will not force the export", async () => {
+      await profile.sync();
+      const createdExports = await profile.sync(false);
+      expect(createdExports.length).toBe(1);
+      expect(createdExports[0].force).toBe(false);
+      expect(createdExports[0].hasChanges).toBe(false);
+    });
+
+    describe("toDelete exports", () => {
+      let otherGroup: Group;
+      let otherDestination: Destination;
+
+      beforeEach(async () => {
+        otherGroup = await helper.factories.group();
+        await otherGroup.update({ type: "calculated" });
+        await otherGroup.setRules([
+          { key: "grouparooId", match: "pro%", operation: { op: "like" } },
+        ]);
+        otherDestination = await helper.factories.destination();
+        await otherDestination.trackGroup(otherGroup);
+      });
+
+      test("profile sync will create a toDelete export if the group's rules remove it from the group", async () => {
+        // add to both groups initially
+        await profile.sync();
+        let groups = await profile.$get("groups");
+        expect(groups.length).toBe(2);
+
+        // change the rules
+        await group.setRules([
+          { key: "firstName", match: "Luigi", operation: { op: "eq" } },
+        ]);
+
+        // test
+        let exports = await profile.sync();
+        groups = await profile.$get("groups");
+        expect(groups.length).toBe(1);
+        expect(groups[0].id).toBe(otherGroup.id);
+        expect(exports.length).toBe(2);
+        const destinationExport = exports.find(
+          (e) => e.destinationId === destination.id
+        );
+        const otherDestinationExport = exports.find(
+          (e) => e.destinationId === otherDestination.id
+        );
+        expect(destinationExport.toDelete).toBe(true);
+        expect(otherDestinationExport.toDelete).toBe(false);
+
+        // sync again and ensure that there is only one export next time
+        exports = await profile.sync();
+        expect(exports.length).toBe(1);
+        expect(exports[0].destinationId).toBe(otherDestination.id);
+
+        // reset
+        await group.setRules([
+          { key: "firstName", match: "Mario", operation: { op: "eq" } },
+        ]);
+      });
+
+      test("profile sync will create a toDelete export if the profile's properties remove it from the group", async () => {
+        // add to both groups initially
+        await profile.sync();
+
+        let groups = await profile.$get("groups");
+        expect(groups.length).toBe(2);
+
+        // find and hack the plugin
+        const testPlugin: GrouparooPlugin = api.plugins.plugins.find(
+          (a) => a.name === "@grouparoo/test-plugin"
+        );
+        const testPluginConnection = testPlugin.connections.find(
+          (c) => c.name === "test-plugin-import"
+        );
+        const originalMethod = testPluginConnection.methods.profileProperty;
+        testPluginConnection.methods.profileProperty = async ({ property }) => {
+          const data = {
+            firstName: ["Luigi"],
+          };
+
+          return data[property.key];
+        };
+
+        // test
+        let exports = await profile.sync();
+        groups = await profile.$get("groups");
+        expect(groups.length).toBe(1);
+        expect(groups[0].id).toBe(otherGroup.id);
+        expect(exports.length).toBe(2);
+        const destinationExport = exports.find(
+          (e) => e.destinationId === destination.id
+        );
+        const otherDestinationExport = exports.find(
+          (e) => e.destinationId === otherDestination.id
+        );
+        expect(destinationExport.toDelete).toBe(true);
+        expect(otherDestinationExport.toDelete).toBe(false);
+
+        // sync again and ensure that there is only one export next time
+        exports = await profile.sync();
+        expect(exports.length).toBe(1);
+        expect(exports[0].destinationId).toBe(otherDestination.id);
+
+        // reset the plugin
+        testPluginConnection.methods.profileProperty = originalMethod;
+      });
+
+      test("profile sync will create a toDelete export if destination had untracked the group but not yet run", async () => {
+        // add to both groups initially
+        await profile.sync();
+        let groups = await profile.$get("groups");
+        expect(groups.length).toBe(2);
+
+        // change the destination
+        await destination.unTrackGroup();
+
+        // test
+        let exports = await profile.sync();
+        expect(exports.length).toBe(2);
+        const destinationExport = exports.find(
+          (e) => e.destinationId === destination.id
+        );
+        const otherDestinationExport = exports.find(
+          (e) => e.destinationId === otherDestination.id
+        );
+        expect(destinationExport.toDelete).toBe(true);
+        expect(otherDestinationExport.toDelete).toBe(false);
+
+        // sync again and ensure that there is only one export next time
+        exports = await profile.sync();
+        expect(exports.length).toBe(1);
+        expect(exports[0].destinationId).toBe(otherDestination.id);
+
+        // reset
+        await destination.trackGroup(group);
+      });
+    });
+  });
+});

--- a/core/src/actions/profiles.ts
+++ b/core/src/actions/profiles.ts
@@ -178,13 +178,11 @@ export class ProfileEdit extends AuthenticatedAction {
   async runWithinTransaction({ params }) {
     const profile = await Profile.findById(params.id);
 
-    const oldGroups = await profile.$get("groups");
-
     await profile.update(params);
     await profile.addOrUpdateProperties(params.properties);
     await profile.removeProperties(params.removedProperties);
 
-    await profile.sync(false, oldGroups);
+    await profile.sync(false);
 
     const groups = await profile.$get("groups");
 

--- a/core/src/models/Profile.ts
+++ b/core/src/models/Profile.ts
@@ -118,19 +118,17 @@ export class Profile extends LoggedModel<Profile> {
     await this.reload();
   }
 
-  async sync(force = true, oldGroupsOverride?: Group[], toExport = true) {
-    return ProfileOps.sync(this, force, oldGroupsOverride, toExport);
+  async sync(force = true, toExport = true) {
+    return ProfileOps.sync(this, force, toExport);
   }
 
   async snapshot(saveExports = false) {
-    await this.sync(undefined, undefined, false); // import the profile and recalculate groups; skip exports here
-
+    const exports = await this.sync(undefined, saveExports);
     const properties = await this.properties();
     const groups = await this.$get("groups", { include: [GroupRule] });
     const groupApiData = (
       await Promise.all(groups.map((g) => g.apiData()))
     ).sort((a, b) => (a.name > b.name ? 1 : -1));
-    const exports = await this.export(true, [], saveExports);
     const exportsApiData = (
       await Promise.all(exports.map((e) => e.apiData(false)))
     ).sort((a, b) => (a.destinationName > b.destinationName ? 1 : -1));

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -470,13 +470,13 @@ export namespace ProfileOps {
   export async function _export(
     profile: Profile,
     force = false,
-    oldGroupsOverride: Group[] = [],
+    oldGroups: Group[] = [],
     saveExports = true
   ) {
     const groups = await profile.$get("groups");
 
     const destinations = await Destination.destinationsForGroups([
-      ...oldGroupsOverride,
+      ...oldGroups,
       ...groups,
     ]);
 
@@ -525,19 +525,14 @@ export namespace ProfileOps {
   /**
    * Fully Import and Export a profile
    */
-  export async function sync(
-    profile: Profile,
-    force = true,
-    oldGroupsOverride?: Group[],
-    toExport = true
-  ) {
-    const oldGroups = oldGroupsOverride ?? (await profile.$get("groups"));
+  export async function sync(profile: Profile, force = true, toExport = true) {
+    const oldGroups = await profile.$get("groups");
 
     await profile.markPending();
     await profile.import();
     await profile.updateGroupMembership();
     await profile.update({ state: "ready" });
-    await ProfileOps._export(profile, force, oldGroups, toExport);
+    return ProfileOps._export(profile, force, oldGroups, toExport);
   }
 
   /**


### PR DESCRIPTION
This PR ensures that calling `profile.sync()` will create exports for when Profiles are removed from Destinations... not just when they are added.   There are 3 ways that a Profile might Leave a Destination:

1. The Profile's Properties have changed
2. The Group's defintion has changed
3. The Destination no longer tracks a Group that the Profile is in

1 and 2 happen in-line to the `profile.sync()` call, so we know the Group membership has changed.  3 requires that we look though old Exports for the profile and include those destinations in the check.