### PR TITLE
Use getConfigId() when generating sample profile config files

### DIFF
--- a/core/__tests__/bin/__snapshots__/sync.ts.snap
+++ b/core/__tests__/bin/__snapshots__/sync.ts.snap
@@ -6,6 +6,7 @@ Object {
   "groups": Array [],
   "properties": Object {
     "email": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<String>,
       "createdAt": Any<String>,
       "directlyMapped": false,
@@ -24,6 +25,7 @@ Object {
       ],
     },
     "firstName": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<String>,
       "createdAt": Any<String>,
       "directlyMapped": false,
@@ -42,6 +44,7 @@ Object {
       ],
     },
     "isVIP": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<String>,
       "createdAt": Any<String>,
       "directlyMapped": false,
@@ -60,6 +63,7 @@ Object {
       ],
     },
     "lastLoginAt": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<String>,
       "createdAt": Any<String>,
       "directlyMapped": false,
@@ -78,6 +82,7 @@ Object {
       ],
     },
     "lastName": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<String>,
       "createdAt": Any<String>,
       "directlyMapped": false,
@@ -96,6 +101,7 @@ Object {
       ],
     },
     "ltv": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<String>,
       "createdAt": Any<String>,
       "directlyMapped": false,
@@ -114,6 +120,7 @@ Object {
       ],
     },
     "purchaseAmounts": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<String>,
       "createdAt": Any<String>,
       "directlyMapped": false,
@@ -133,6 +140,7 @@ Object {
       ],
     },
     "purchases": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<String>,
       "createdAt": Any<String>,
       "directlyMapped": false,
@@ -152,6 +160,7 @@ Object {
       ],
     },
     "userId": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<String>,
       "createdAt": Any<String>,
       "directlyMapped": true,

--- a/core/__tests__/models/profile/__snapshots__/snapshot-testing.ts.snap
+++ b/core/__tests__/models/profile/__snapshots__/snapshot-testing.ts.snap
@@ -176,6 +176,7 @@ Object {
   ],
   "properties": Object {
     "email": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -194,6 +195,7 @@ Object {
       ],
     },
     "firstName": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -212,6 +214,7 @@ Object {
       ],
     },
     "isVIP": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -230,6 +233,7 @@ Object {
       ],
     },
     "lastLoginAt": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -248,6 +252,7 @@ Object {
       ],
     },
     "lastName": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -266,6 +271,7 @@ Object {
       ],
     },
     "ltv": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -284,6 +290,7 @@ Object {
       ],
     },
     "purchaseAmounts": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -303,6 +310,7 @@ Object {
       ],
     },
     "purchases": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -322,6 +330,7 @@ Object {
       ],
     },
     "userId": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": true,

--- a/core/__tests__/modules/codeConfig/__snapshots__/snapshotTest.ts.snap
+++ b/core/__tests__/modules/codeConfig/__snapshots__/snapshotTest.ts.snap
@@ -76,6 +76,7 @@ Object {
   ],
   "properties": Object {
     "email": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -94,6 +95,7 @@ Object {
       ],
     },
     "first name": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -112,6 +114,7 @@ Object {
       ],
     },
     "last name": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -130,6 +133,7 @@ Object {
       ],
     },
     "userId": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": true,
@@ -227,6 +231,7 @@ Object {
   ],
   "properties": Object {
     "email": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -245,6 +250,7 @@ Object {
       ],
     },
     "first name": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -263,6 +269,7 @@ Object {
       ],
     },
     "last name": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -281,6 +288,7 @@ Object {
       ],
     },
     "userId": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": true,

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -911,9 +911,12 @@ describe("modules/configWriter", () => {
       expect(options.table).toEqual("my_table_456");
     });
 
+    // --- Profile ---
+
     test("profiles can provide their config objects", async () => {
       const profile: Profile = await helper.factories.profile();
       const properties = { [bootstrapPropertyId]: [12] };
+      const bootstrapProperty = await Property.findByPk(bootstrapPropertyId);
 
       await profile.addOrUpdateProperties({
         ...properties,
@@ -925,7 +928,9 @@ describe("modules/configWriter", () => {
       expect(config).toEqual({
         class: "Profile",
         id: profile.id,
-        properties,
+        properties: {
+          [bootstrapProperty.getConfigId()]: [12],
+        },
       });
     });
 

--- a/core/__tests__/snapshots/__snapshots__/snapshot-testing.ts.snap
+++ b/core/__tests__/snapshots/__snapshots__/snapshot-testing.ts.snap
@@ -176,6 +176,7 @@ Object {
   ],
   "properties": Object {
     "email": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -194,6 +195,7 @@ Object {
       ],
     },
     "firstName": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -212,6 +214,7 @@ Object {
       ],
     },
     "isVIP": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -230,6 +233,7 @@ Object {
       ],
     },
     "lastLoginAt": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -248,6 +252,7 @@ Object {
       ],
     },
     "lastName": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -266,6 +271,7 @@ Object {
       ],
     },
     "ltv": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -284,6 +290,7 @@ Object {
       ],
     },
     "purchaseAmounts": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -303,6 +310,7 @@ Object {
       ],
     },
     "purchases": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": false,
@@ -322,6 +330,7 @@ Object {
       ],
     },
     "userId": Object {
+      "configId": Any<String>,
       "confirmedAt": Any<Date>,
       "createdAt": Any<Date>,
       "directlyMapped": true,

--- a/core/src/actions/properties.ts
+++ b/core/src/actions/properties.ts
@@ -352,6 +352,7 @@ export class PropertyProfilePreview extends AuthenticatedAction {
       id: property.id,
       state: null,
       values: newPropertyValues,
+      configId: property.getConfigId(),
       type: property.type,
       unique: property.unique,
       directlyMapped: property.directlyMapped,

--- a/core/src/models/Profile.ts
+++ b/core/src/models/Profile.ts
@@ -189,7 +189,7 @@ export class Profile extends LoggedModel<Profile> {
     for (const k in properties) {
       const property = properties[k];
       if (property.directlyMapped && property.values.length > 0) {
-        directlyMappedProps[property.id] = property.values;
+        directlyMappedProps[property.configId] = property.values;
       }
     }
 

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -18,6 +18,7 @@ export interface ProfilePropertyType {
     id: ProfileProperty["id"];
     state: ProfileProperty["state"];
     values: Array<string | number | boolean | Date>;
+    configId: ReturnType<Property["getConfigId"]>;
     type: Property["type"];
     unique: Property["unique"];
     directlyMapped: Property["directlyMapped"];
@@ -63,6 +64,7 @@ export namespace ProfileOps {
           id: profileProperties[i].propertyId,
           state: profileProperties[i].state,
           values: [],
+          configId: property.getConfigId(),
           type: property.type,
           unique: property.unique,
           directlyMapped: property.directlyMapped,


### PR DESCRIPTION
This change ensures that, when profiles are added during the same Config UI session as the source and its bootstrap property, profiles can be added back into the system on the next session.