### PR TITLE
fix: set scope on model options

### DIFF
--- a/core/__tests__/models/app/app.ts
+++ b/core/__tests__/models/app/app.ts
@@ -197,6 +197,37 @@ describe("models/app", () => {
       );
     });
 
+    test("__options only includes options for apps", async () => {
+      const app = await App.create({
+        id: "myAppId",
+        name: "test app",
+        type: "test-plugin-app",
+      });
+
+      await Option.create({
+        ownerId: app.id,
+        ownerType: "app",
+        key: "fileId",
+        value: "users",
+        type: "string",
+      });
+
+      await Option.create({
+        ownerId: app.id,
+        ownerType: "source",
+        key: "someOtherProperty",
+        value: "someValue",
+        type: "string",
+      });
+
+      const options = await app.$get("__options");
+      expect(options.length).toBe(1);
+      expect(options[0].ownerType).toBe("app");
+      expect(options[0].key).toBe("fileId");
+
+      await app.destroy();
+    });
+
     test("adding the wrong options for the app produces an error", async () => {
       const app = await App.create({
         name: "test app",

--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -151,6 +151,39 @@ describe("models/destination", () => {
       await group.destroy();
     });
 
+    test("deleting a destination does not delete options for other models with the same id", async () => {
+      destination = await Destination.create({
+        name: "some destination",
+        type: "test-plugin-export",
+        appId: app.id,
+      });
+
+      await destination.setOptions({ table: "table" });
+
+      const foreignOption = await Option.create({
+        ownerId: destination.id,
+        ownerType: "other",
+        key: "someKey",
+        value: "someValue",
+        type: "string",
+      });
+
+      let count = await Option.count({
+        where: { ownerId: destination.id },
+      });
+      expect(count).toBe(2);
+
+      await destination.destroy();
+      const options = await Option.findAll({
+        where: { ownerId: destination.id },
+      });
+      expect(options.length).toBe(1);
+      expect(options[0].ownerType).toBe("other");
+      expect(options[0].key).toBe("someKey");
+
+      await foreignOption.destroy();
+    });
+
     test("destinations can retrieve related export totals", async () => {
       destination = await Destination.create({
         name: "bye destination",

--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -291,6 +291,38 @@ describe("models/destination", () => {
         );
       });
 
+      test("__options only includes options for destinations", async () => {
+        const destination = await Destination.create({
+          id: "myDestinationId",
+          type: "test-plugin-export",
+          name: "test property",
+          appId: app.id,
+        });
+
+        await Option.create({
+          ownerId: destination.id,
+          ownerType: "destination",
+          key: "table",
+          value: "users",
+          type: "string",
+        });
+
+        await Option.create({
+          ownerId: destination.id,
+          ownerType: "app",
+          key: "someOtherProperty",
+          value: "someValue",
+          type: "string",
+        });
+
+        const options = await destination.$get("__options");
+        expect(options.length).toBe(1);
+        expect(options[0].ownerType).toBe("destination");
+        expect(options[0].key).toBe("table");
+
+        await destination.destroy();
+      });
+
       test("options must match the app options (extra options needed by connection)", async () => {
         destination = new Destination({
           name: "incoming destination - too many options",

--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -509,6 +509,46 @@ describe("models/property", () => {
     expect(optionsCount).toBe(0);
   });
 
+  test("deleting a property does not delete options for other models with the same id", async () => {
+    const source = await helper.factories.source();
+    await source.setOptions({ table: "some table" });
+    await source.setMapping({ id: "userId" });
+    await source.update({ state: "ready" });
+
+    const property = await Property.create({
+      sourceId: source.id,
+      key: "thing",
+      type: "string",
+      unique: false,
+    });
+
+    await property.setOptions({ column: "abc" });
+
+    const foreignOption = await Option.create({
+      ownerId: property.id,
+      ownerType: "other",
+      key: "someKey",
+      value: "someValue",
+      type: "string",
+    });
+
+    let count = await Option.count({
+      where: { ownerId: property.id },
+    });
+    expect(count).toBe(2);
+
+    await property.destroy();
+    const options = await Option.findAll({
+      where: { ownerId: property.id },
+    });
+    expect(options.length).toBe(1);
+    expect(options[0].ownerType).toBe("other");
+    expect(options[0].key).toBe("someKey");
+
+    await foreignOption.destroy();
+    await source.destroy();
+  });
+
   describe("directlyMapping", () => {
     let userIdProperty: Property;
     let emailProperty: Property;

--- a/core/__tests__/models/schedule.ts
+++ b/core/__tests__/models/schedule.ts
@@ -140,6 +140,38 @@ describe("models/schedule", () => {
         await schedule.destroy();
       });
 
+      test("__options only includes options for schedules", async () => {
+        const schedule = await Schedule.create({
+          id: "myScheduleId",
+          type: "test-plugin-import",
+          name: "test schedule",
+          sourceId: source.id,
+        });
+
+        await Option.create({
+          ownerId: schedule.id,
+          ownerType: "schedule",
+          key: "maxColumn",
+          value: "abc",
+          type: "string",
+        });
+
+        await Option.create({
+          ownerId: schedule.id,
+          ownerType: "source",
+          key: "someOtherProperty",
+          value: "someValue",
+          type: "string",
+        });
+
+        const options = await schedule.$get("__options");
+        expect(options.length).toBe(1);
+        expect(options[0].ownerType).toBe("schedule");
+        expect(options[0].key).toBe("maxColumn");
+
+        await schedule.destroy();
+      });
+
       test("recurring schedules require a recurring frequency > 1 minute", async () => {
         const schedule = await helper.factories.schedule();
         await expect(

--- a/core/__tests__/models/source.ts
+++ b/core/__tests__/models/source.ts
@@ -223,6 +223,38 @@ describe("models/source", () => {
       await source.destroy();
     });
 
+    test("__options only includes options for sources", async () => {
+      const source = await Source.create({
+        id: "mySourceId",
+        type: "test-plugin-import",
+        name: "test source",
+        appId: app.id,
+      });
+
+      await Option.create({
+        ownerId: source.id,
+        ownerType: "source",
+        key: "table",
+        value: "users",
+        type: "string",
+      });
+
+      await Option.create({
+        ownerId: source.id,
+        ownerType: "app",
+        key: "someOtherProperty",
+        value: "someValue",
+        type: "string",
+      });
+
+      const options = await source.$get("__options");
+      expect(options.length).toBe(1);
+      expect(options[0].ownerType).toBe("source");
+      expect(options[0].key).toBe("table");
+
+      await source.destroy();
+    });
+
     test("options can be set and retrieved", async () => {
       const source = await Source.create({
         type: "test-plugin-import",

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -82,7 +82,10 @@ export class App extends LoggedModel<App> {
   @Column(DataType.ENUM(...STATES))
   state: typeof STATES[number];
 
-  @HasMany(() => Option, "ownerId")
+  @HasMany(() => Option, {
+    foreignKey: "ownerId",
+    scope: { ownerType: "app" },
+  })
   __options: Option[]; // the underscores are needed as "options" is an internal method on sequelize instances
 
   @HasMany(() => Source)

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -368,6 +368,7 @@ export class App extends LoggedModel<App> {
     return Option.destroy({
       where: {
         ownerId: instance.id,
+        ownerType: "app",
       },
     });
   }

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -685,7 +685,7 @@ export class Destination extends LoggedModel<Destination> {
   @AfterDestroy
   static async destroyDestinationOptions(instance: Destination) {
     return Option.destroy({
-      where: { ownerId: instance.id },
+      where: { ownerId: instance.id, ownerType: "destination" },
     });
   }
 

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -170,7 +170,10 @@ export class Destination extends LoggedModel<Destination> {
   @HasMany(() => Mapping)
   mappings: Mapping[];
 
-  @HasMany(() => Option, "ownerId")
+  @HasMany(() => Option, {
+    foreignKey: "ownerId",
+    scope: { ownerType: "destination" },
+  })
   __options: Option[]; // the underscores are needed as "options" is an internal method on sequelize instances
 
   @HasMany(() => Export)

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -648,7 +648,7 @@ export class Property extends LoggedModel<Property> {
   @AfterDestroy
   static async destroyOptions(instance: Property) {
     await Option.destroy({
-      where: { ownerId: instance.id },
+      where: { ownerId: instance.id, ownerType: "property" },
     });
   }
 

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -191,7 +191,10 @@ export class Property extends LoggedModel<Property> {
   @BelongsTo(() => Source)
   source: Source;
 
-  @HasMany(() => Option, "ownerId")
+  @HasMany(() => Option, {
+    foreignKey: "ownerId",
+    scope: { ownerType: "property" },
+  })
   __options: Option[]; // the underscores are needed as "options" is an internal method on sequelize instances
 
   @HasMany(() => PropertyFilter)

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -312,7 +312,9 @@ export class Schedule extends LoggedModel<Schedule> {
 
   @AfterDestroy
   static async destroyAppOptions(instance: Schedule) {
-    return Option.destroy({ where: { ownerId: instance.id } });
+    return Option.destroy({
+      where: { ownerId: instance.id, ownerType: "schedule" },
+    });
   }
 
   @AfterDestroy

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -108,7 +108,10 @@ export class Schedule extends LoggedModel<Schedule> {
   @Column
   recurringFrequency: number;
 
-  @HasMany(() => Option, "ownerId")
+  @HasMany(() => Option, {
+    foreignKey: "ownerId",
+    scope: { ownerType: "schedule" },
+  })
   __options: Option[]; // the underscores are needed as "options" is an internal method on sequelize instances
 
   @BelongsTo(() => Source)

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -418,7 +418,7 @@ export class Source extends LoggedModel<Source> {
   @AfterDestroy
   static async destroyOptions(instance: Source) {
     return Option.destroy({
-      where: { ownerId: instance.id },
+      where: { ownerId: instance.id, ownerType: "source" },
     });
   }
 

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -105,7 +105,10 @@ export class Source extends LoggedModel<Source> {
   @HasMany(() => Property)
   properties: Property[];
 
-  @HasMany(() => Option, "ownerId")
+  @HasMany(() => Option, {
+    foreignKey: "ownerId",
+    scope: { ownerType: "source" },
+  })
   __options: Option[]; // the underscores are needed as "options" is an internal method on sequelize instances
 
   async getOptions(sourceFromEnvironment = true) {


### PR DESCRIPTION
Because we now support having different types of models with the same ID, this could create an issue where getting the options of one model included those of another that had the same ID. This adds a scope on the HasMany association to limit results for only the model in question.

We were also deleting options for all models with the same id.