### PR TITLE
remove warning from source and property pages

### DIFF
--- a/ui/ui-components/pages/property/[id]/edit.tsx
+++ b/ui/ui-components/pages/property/[id]/edit.tsx
@@ -59,11 +59,6 @@ export default function Page(props) {
 
   async function onSubmit(event) {
     event.preventDefault();
-    // if (
-    //   window.confirm(
-    //     "Are you sure?  This will also update all profile properties with this key"
-    //   )
-    // ) {
     setLoading(true);
     const response: Actions.PropertyEdit = await execApi(
       "put",
@@ -83,7 +78,6 @@ export default function Page(props) {
     } else {
       setLoading(false);
     }
-    // }
   }
 
   async function handleDelete() {

--- a/ui/ui-components/pages/property/[id]/edit.tsx
+++ b/ui/ui-components/pages/property/[id]/edit.tsx
@@ -59,31 +59,31 @@ export default function Page(props) {
 
   async function onSubmit(event) {
     event.preventDefault();
-    if (
-      window.confirm(
-        "Are you sure?  This will also update all profile properties with this key"
-      )
-    ) {
-      setLoading(true);
-      const response: Actions.PropertyEdit = await execApi(
-        "put",
-        `/property/${id}`,
-        Object.assign({}, property, { filters: localFilters, state: "ready" })
-      );
-      if (response?.property) {
-        setProperty(response.property);
-        propertiesHandler.set(response.property);
-        if (response.property.state === "ready" && property.state === "draft") {
-          successHandler.set({ message: "Property Created" });
-          router.push(nextPage || "/properties");
-        } else {
-          setLoading(false);
-          successHandler.set({ message: "Property Updated" });
-        }
+    // if (
+    //   window.confirm(
+    //     "Are you sure?  This will also update all profile properties with this key"
+    //   )
+    // ) {
+    setLoading(true);
+    const response: Actions.PropertyEdit = await execApi(
+      "put",
+      `/property/${id}`,
+      Object.assign({}, property, { filters: localFilters, state: "ready" })
+    );
+    if (response?.property) {
+      setProperty(response.property);
+      propertiesHandler.set(response.property);
+      if (response.property.state === "ready" && property.state === "draft") {
+        successHandler.set({ message: "Property Created" });
+        router.push(nextPage || "/properties");
       } else {
         setLoading(false);
+        successHandler.set({ message: "Property Updated" });
       }
+    } else {
+      setLoading(false);
     }
+    // }
   }
 
   async function handleDelete() {

--- a/ui/ui-components/pages/source/[id]/mapping.tsx
+++ b/ui/ui-components/pages/source/[id]/mapping.tsx
@@ -45,34 +45,34 @@ export default function Page(props) {
       return errorHandler.set({ error: "select profile identification" });
     }
 
-    if (confirm("are you sure?")) {
-      setLoading(true);
-      const response: Actions.SourceBootstrapUniqueProperty = await execApi(
-        "post",
-        `/source/${source.id}/bootstrapUniqueProperty`,
-        Object.assign(newProperty, { mappedColumn: newMappingKey })
+    // if (confirm("are you sure?")) {
+    setLoading(true);
+    const response: Actions.SourceBootstrapUniqueProperty = await execApi(
+      "post",
+      `/source/${source.id}/bootstrapUniqueProperty`,
+      Object.assign(newProperty, { mappedColumn: newMappingKey })
+    );
+    if (response?.property) {
+      successHandler.set({ message: "Property created" });
+
+      const prrResponse: Actions.PropertiesList = await execApi(
+        "get",
+        `/properties`,
+        { includeExamples: true, unique: true, state: "ready" }
       );
-      if (response?.property) {
-        successHandler.set({ message: "Property created" });
-
-        const prrResponse: Actions.PropertiesList = await execApi(
-          "get",
-          `/properties`,
-          { includeExamples: true, unique: true, state: "ready" }
-        );
-        if (prrResponse?.properties) {
-          setProperties(prrResponse.properties);
-          setPropertyExamples(prrResponse.examples);
-        }
-
-        setNewMappingValue(response.property.key);
-        document.getElementById(
-          response.property.id
-          // @ts-ignore
-        ).checked = true;
+      if (prrResponse?.properties) {
+        setProperties(prrResponse.properties);
+        setPropertyExamples(prrResponse.examples);
       }
-      setLoading(false);
+
+      setNewMappingValue(response.property.key);
+      document.getElementById(
+        response.property.id
+        // @ts-ignore
+      ).checked = true;
     }
+    setLoading(false);
+    // }
   };
 
   const updateMapping = async (event) => {

--- a/ui/ui-components/pages/source/[id]/mapping.tsx
+++ b/ui/ui-components/pages/source/[id]/mapping.tsx
@@ -45,7 +45,6 @@ export default function Page(props) {
       return errorHandler.set({ error: "select profile identification" });
     }
 
-    // if (confirm("are you sure?")) {
     setLoading(true);
     const response: Actions.SourceBootstrapUniqueProperty = await execApi(
       "post",
@@ -72,7 +71,6 @@ export default function Page(props) {
       ).checked = true;
     }
     setLoading(false);
-    // }
   };
 
   const updateMapping = async (event) => {


### PR DESCRIPTION
- Removed warning from both initial mapping on `source/[id]/mapping` and on the create property pages

"Files changed" tab makes it look more complicated than it is... I just removed the if statement/"are you sure" response.