### PR TITLE
Hide setup bar if complete

### DIFF
--- a/core/__tests__/actions/setupSteps.ts
+++ b/core/__tests__/actions/setupSteps.ts
@@ -35,10 +35,6 @@ describe("actions/setupSteps", () => {
         { complete: false },
         { where: { complete: true } }
       );
-      const setting = await Setting.findOne({
-        where: { key: "display-startup-steps" },
-      });
-      await setting.update({ value: true });
     });
 
     test("a reader can list setupSteps", async () => {

--- a/core/__tests__/actions/setupSteps.ts
+++ b/core/__tests__/actions/setupSteps.ts
@@ -45,7 +45,7 @@ describe("actions/setupSteps", () => {
       connection.params = {
         csrfToken,
       };
-      const { error, setupSteps, toDisplay } = await specHelper.runAction(
+      const { error, setupSteps } = await specHelper.runAction(
         "setupSteps:list",
         connection
       );
@@ -70,26 +70,8 @@ describe("actions/setupSteps", () => {
       expect(setupSteps[0].outcome).toBe(null);
       expect(setupSteps[0].skipped).toBe(false);
       expect(setupSteps[0].complete).toBe(false);
-      expect(toDisplay).toBe(true);
 
       id = setupSteps[0].id;
-    });
-
-    test("toDisplay is false when the setting is disabled", async () => {
-      const setting = await Setting.findOne({
-        where: { key: "display-startup-steps" },
-      });
-      await setting.update({ value: false });
-
-      connection.params = {
-        csrfToken,
-      };
-      const { toDisplay } = await specHelper.runAction(
-        "setupSteps:list",
-        connection
-      );
-
-      expect(toDisplay).toBe(false);
     });
 
     test("setupSteps can be completed outside of the action and re-calculated when viewed", async () => {

--- a/core/src/actions/setupSteps.ts
+++ b/core/src/actions/setupSteps.ts
@@ -30,14 +30,7 @@ export class SetupStepsList extends AuthenticatedAction {
       await setupSteps[i].performCheck();
       responseSetupSteps.push(await setupSteps[i].apiData());
     }
-
-    const setting = await Setting.findOne({
-      where: { key: "display-startup-steps" },
-    });
-
-    const toDisplay = setting.value === "true";
-
-    return { toDisplay, setupSteps: responseSetupSteps };
+    return { setupSteps: responseSetupSteps };
   }
 }
 

--- a/core/src/initializers/settings.ts
+++ b/core/src/initializers/settings.ts
@@ -179,14 +179,6 @@ export class Plugins extends CLSInitializer {
 
     const interfaceSettings: SettingsListItem[] = [
       {
-        key: "display-startup-steps",
-        title: "Display Startup Steps",
-        defaultValue: "true",
-        description:
-          "Should Grouparoo display the Setup Steps to all Team Members?  You can always visit /setup to see your setup steps.",
-        type: "boolean",
-      },
-      {
         key: "status-calculation-frequency-seconds",
         title: "Status Calculation Frequency Seconds",
         defaultValue: "10",

--- a/ui/ui-components/components/icons.ts
+++ b/ui/ui-components/components/icons.ts
@@ -2,34 +2,35 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 
 // Add new Icons you want to use in the Grouparoo app here
 import {
+  faAddressCard,
   faCaretSquareRight,
   faCaretSquareLeft,
-  faHome,
-  faUser,
-  faAddressCard,
-  faUsers,
-  faFileImport,
-  faFileExport,
-  faTerminal,
-  faStream,
   faExchangeAlt,
+  faFileExport,
+  faFileImport,
+  faHome,
+  faStream,
+  faTerminal,
   faThLarge,
+  faTimes,
+  faUser,
+  faUsers,
 } from "@fortawesome/free-solid-svg-icons";
 
 import { faSlack } from "@fortawesome/free-brands-svg-icons";
 
 library.add(
+  faAddressCard,
   faCaretSquareRight,
   faCaretSquareLeft,
-  faHome,
-  faUser,
-  faAddressCard,
-  faUsers,
-  faFileImport,
-  faFileExport,
-  faTerminal,
-  faSlack,
-  faStream,
   faExchangeAlt,
-  faThLarge
+  faFileExport,
+  faFileImport,
+  faHome,
+  faStream,
+  faTerminal,
+  faThLarge,
+  faTimes,
+  faUser,
+  faUsers
 );

--- a/ui/ui-components/components/icons.ts
+++ b/ui/ui-components/components/icons.ts
@@ -27,6 +27,7 @@ library.add(
   faFileExport,
   faFileImport,
   faHome,
+  faSlack,
   faStream,
   faTerminal,
   faThLarge,

--- a/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
+++ b/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
@@ -57,7 +57,19 @@ export default function SetupStepsNavProgressBar({
     (100 * completeStepsCount) / totalStepsCount
   );
 
-  if (!shouldDisplay || percentComplete === 100) return null;
+  if (!shouldDisplay) return null;
+
+  if (isOnBoardingComplete) {
+    return (
+      <Row className="pt-1 px-4">
+        <Col>
+          <Link href="/setup">
+            <a>{isOnBoardingComplete ? "Setup Complete 🎉" : "Get Started:"}</a>
+          </Link>
+        </Col>
+      </Row>
+    );
+  }
 
   return (
     <div

--- a/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
+++ b/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
@@ -26,7 +26,7 @@ export default function SetupStepsNavProgressBar({
         getSetupSteps
       );
     };
-  }, [!shouldDisplay]);
+  }, []);
 
   async function getSetupSteps(newUrl?: string) {
     if (router.pathname.match(/^\/session\//)) return;
@@ -64,7 +64,7 @@ export default function SetupStepsNavProgressBar({
       <Row className="pt-1 px-4">
         <Col>
           <Link href="/setup">
-            <a>{isOnBoardingComplete ? "Setup Complete 🎉" : "Get Started:"}</a>
+            <a>Get Started:</a>
           </Link>
         </Col>
       </Row>

--- a/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
+++ b/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
@@ -1,16 +1,23 @@
 import { useEffect, useState } from "react";
 import { Models } from "../../utils/apiData";
-import { ProgressBar, Row, Col } from "react-bootstrap";
+import { ProgressBar, Row, Col, Button } from "react-bootstrap";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import {
+  FontAwesomeIcon,
+  FontAwesomeIconProps,
+} from "@fortawesome/react-fontawesome";
 import { Actions } from "../../utils/apiData";
 
 export default function SetupStepsNavProgressBar({
   execApi,
   setupStepHandler,
+  successHandler,
 }) {
   const [steps, setSteps] = useState<Models.SetupStepType[]>([]);
   const [shouldDisplay, setShouldDisplay] = useState(false);
+  const [initialOnBoardingState, setInitialOnBoardingState] = useState(null);
+  const [hideCard, setHideCard] = useState(null);
   const router = useRouter();
 
   useEffect(() => {
@@ -40,7 +47,6 @@ export default function SetupStepsNavProgressBar({
 
     if (setupSteps) {
       setShouldDisplay(toDisplay);
-
       setSteps(setupSteps);
     }
   }
@@ -49,6 +55,7 @@ export default function SetupStepsNavProgressBar({
   const isOnBoardingComplete = steps.every(
     (step) => step.complete || step.skipped
   );
+
   const totalStepsCount = steps.length;
   const completeStepsCount = steps.filter(
     (step) => step.complete || step.skipped
@@ -57,19 +64,29 @@ export default function SetupStepsNavProgressBar({
     (100 * completeStepsCount) / totalStepsCount
   );
 
-  if (!shouldDisplay) return null;
+  let onBoardingState = percentComplete === 100 ? "complete" : "incomplete";
 
-  if (isOnBoardingComplete) {
-    return (
-      <Row className="pt-1 px-4">
-        <Col>
-          <Link href="/setup">
-            <a>Get Started:</a>
-          </Link>
-        </Col>
-      </Row>
-    );
+  if (initialOnBoardingState === null && !isNaN(percentComplete)) {
+    console.log(`done: ${percentComplete}`);
+    setInitialOnBoardingState(onBoardingState);
   }
+
+  useEffect(() => {
+    console.log(`was: ${initialOnBoardingState} now: ${onBoardingState}`);
+    if (
+      initialOnBoardingState === "incomplete" &&
+      onBoardingState === "complete"
+    ) {
+      console.log("done!!!");
+    }
+  }, [percentComplete]);
+
+  if (
+    !shouldDisplay ||
+    initialOnBoardingState === "complete" ||
+    hideCard === true
+  )
+    return null;
 
   return (
     <div
@@ -78,6 +95,24 @@ export default function SetupStepsNavProgressBar({
         backgroundColor: "var(--grouparoo-background-blue)",
       }}
     >
+      {initialOnBoardingState === "incomplete" &&
+      onBoardingState === "complete" ? (
+        <Row>
+          <Col className="d-flex justify-content-end mr-1 text-light">
+            {" "}
+            <Button
+              variant="link"
+              className="p-0 m-0 text-light"
+              onClick={() => {
+                setHideCard(true);
+              }}
+            >
+              <FontAwesomeIcon icon="times" size="xs" />
+            </Button>
+          </Col>
+        </Row>
+      ) : null}
+
       <Row
         className="px-3"
         style={{

--- a/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
+++ b/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Models } from "../../utils/apiData";
-import { ProgressBar } from "react-bootstrap";
+import { ProgressBar, Row, Col } from "react-bootstrap";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { Actions } from "../../utils/apiData";
@@ -26,7 +26,7 @@ export default function SetupStepsNavProgressBar({
         getSetupSteps
       );
     };
-  }, []);
+  }, [!shouldDisplay]);
 
   async function getSetupSteps(newUrl?: string) {
     if (router.pathname.match(/^\/session\//)) return;
@@ -40,6 +40,7 @@ export default function SetupStepsNavProgressBar({
 
     if (setupSteps) {
       setShouldDisplay(toDisplay);
+
       setSteps(setupSteps);
     }
   }
@@ -56,38 +57,42 @@ export default function SetupStepsNavProgressBar({
     (100 * completeStepsCount) / totalStepsCount
   );
 
-  if (!shouldDisplay) return null;
+  if (!shouldDisplay || percentComplete === 100) return null;
 
   return (
     <div
+      className="m-2 px-1 pb-3 pt-1 rounded"
       style={{
         backgroundColor: "var(--grouparoo-background-blue)",
-        width: "100%",
-        padding: 20,
-        marginTop: 10,
       }}
     >
-      <div
+      <Row
+        className="px-3"
         style={{
           fontSize: 18,
-          paddingLeft: 0,
           color: "var(--secondary)",
         }}
       >
-        <Link href="/setup">
-          <a>{isOnBoardingComplete ? "Setup Complete 🎉" : "Get Started:"}</a>
-        </Link>
-      </div>
-      <div
-        style={{
-          paddingLeft: 0,
-          paddingBottom: 10,
-          color: "var(--secondary)",
-        }}
-      >
-        {activeStep?.title}
-      </div>
-      <ProgressBar now={percentComplete} />
+        <Col>
+          <Link href="/setup">
+            <a>{isOnBoardingComplete ? "Setup Complete 🎉" : "Get Started:"}</a>
+          </Link>
+        </Col>
+      </Row>
+      <Row className="px-3">
+        <Col>
+          <div
+            style={{
+              paddingLeft: 0,
+              paddingBottom: 10,
+              color: "var(--secondary)",
+            }}
+          >
+            {activeStep?.title}
+          </div>
+          <ProgressBar now={percentComplete} />
+        </Col>
+      </Row>
     </div>
   );
 }

--- a/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
+++ b/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
@@ -12,9 +12,10 @@ export default function SetupStepsNavProgressBar({
 }) {
   const [steps, setSteps] = useState<Models.SetupStepType[]>([]);
   const [shouldDisplay, setShouldDisplay] = useState(false);
-  const [initialOnBoardingState, setInitialOnBoardingState] = useState(null);
+  const [initialOnBoardingState, setInitialOnBoardingState] =
+    useState<boolean>(null);
   //because shouldDisplay is set on every Setup Step call, track if a user manually hides setup steps separately
-  const [hideCard, setHideCard] = useState(null);
+  const [hideCard, setHideCard] = useState<boolean>(null);
   const router = useRouter();
 
   useEffect(() => {
@@ -60,18 +61,14 @@ export default function SetupStepsNavProgressBar({
     (100 * completeStepsCount) / totalStepsCount
   );
 
-  let onBoardingState = percentComplete === 100 ? "complete" : "incomplete";
+  let onBoardingState = percentComplete === 100 ? true : false;
 
   //make sure we've waited until percentComplete calculates to set initialOnBoardingState
   if (initialOnBoardingState === null && !isNaN(percentComplete)) {
     setInitialOnBoardingState(onBoardingState);
   }
 
-  if (
-    !shouldDisplay ||
-    initialOnBoardingState === "complete" ||
-    hideCard === true
-  )
+  if (!shouldDisplay || initialOnBoardingState === true || hideCard === true)
     return null;
 
   return (
@@ -81,8 +78,7 @@ export default function SetupStepsNavProgressBar({
         backgroundColor: "var(--grouparoo-background-blue)",
       }}
     >
-      {initialOnBoardingState === "incomplete" &&
-      onBoardingState === "complete" ? (
+      {initialOnBoardingState === false && onBoardingState === true ? (
         <Row>
           <Col className="d-flex justify-content-end mr-1 text-light">
             {" "}

--- a/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
+++ b/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
@@ -11,7 +11,6 @@ export default function SetupStepsNavProgressBar({
   setupStepHandler,
 }) {
   const [steps, setSteps] = useState<Models.SetupStepType[]>([]);
-  const [shouldDisplay, setShouldDisplay] = useState(false);
   const [initialOnBoardingState, setInitialOnBoardingState] =
     useState<boolean>(null);
   //because shouldDisplay is set on every Setup Step call, track if a user manually hides setup steps separately
@@ -38,13 +37,12 @@ export default function SetupStepsNavProgressBar({
     if (newUrl && newUrl.match(/^\/session\//)) return;
     if (newUrl && newUrl === "/") return;
 
-    const { setupSteps, toDisplay }: Actions.SetupStepsList = await execApi(
+    const { setupSteps }: Actions.SetupStepsList = await execApi(
       "get",
       `/setupSteps`
     );
 
     if (setupSteps) {
-      setShouldDisplay(toDisplay);
       setSteps(setupSteps);
     }
   }
@@ -68,7 +66,12 @@ export default function SetupStepsNavProgressBar({
     setInitialOnBoardingState(onBoardingState);
   }
 
-  if (!shouldDisplay || initialOnBoardingState === true || hideCard === true)
+  //if we haven't figured out initial state yet, or the initial state is complete, or someone chooses to... hide the card
+  if (
+    initialOnBoardingState === null ||
+    initialOnBoardingState === true ||
+    hideCard === true
+  )
     return null;
 
   return (

--- a/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
+++ b/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
@@ -3,20 +3,17 @@ import { Models } from "../../utils/apiData";
 import { ProgressBar, Row, Col, Button } from "react-bootstrap";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import {
-  FontAwesomeIcon,
-  FontAwesomeIconProps,
-} from "@fortawesome/react-fontawesome";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Actions } from "../../utils/apiData";
 
 export default function SetupStepsNavProgressBar({
   execApi,
   setupStepHandler,
-  successHandler,
 }) {
   const [steps, setSteps] = useState<Models.SetupStepType[]>([]);
   const [shouldDisplay, setShouldDisplay] = useState(false);
   const [initialOnBoardingState, setInitialOnBoardingState] = useState(null);
+  //because shouldDisplay is set on every Setup Step call, track if a user manually hides setup steps separately
   const [hideCard, setHideCard] = useState(null);
   const router = useRouter();
 
@@ -55,7 +52,6 @@ export default function SetupStepsNavProgressBar({
   const isOnBoardingComplete = steps.every(
     (step) => step.complete || step.skipped
   );
-
   const totalStepsCount = steps.length;
   const completeStepsCount = steps.filter(
     (step) => step.complete || step.skipped
@@ -66,20 +62,10 @@ export default function SetupStepsNavProgressBar({
 
   let onBoardingState = percentComplete === 100 ? "complete" : "incomplete";
 
+  //make sure we've waited until percentComplete calculates to set initialOnBoardingState
   if (initialOnBoardingState === null && !isNaN(percentComplete)) {
-    console.log(`done: ${percentComplete}`);
     setInitialOnBoardingState(onBoardingState);
   }
-
-  useEffect(() => {
-    console.log(`was: ${initialOnBoardingState} now: ${onBoardingState}`);
-    if (
-      initialOnBoardingState === "incomplete" &&
-      onBoardingState === "complete"
-    ) {
-      console.log("done!!!");
-    }
-  }, [percentComplete]);
 
   if (
     !shouldDisplay ||

--- a/ui/ui-components/components/session/signIn.tsx
+++ b/ui/ui-components/components/session/signIn.tsx
@@ -36,9 +36,9 @@ export default function SignInForm(props) {
       if (nextPage) {
         router.push(nextPage.toString());
       } else {
-        const { setupSteps, toDisplay } = await getSetupSteps();
+        const { setupSteps } = await getSetupSteps();
         const isSetupComplete = setupSteps.every((step) => step.complete);
-        if (isSetupComplete || !toDisplay) {
+        if (isSetupComplete) {
           router.push("/dashboard");
         } else {
           router.push("/setup");
@@ -48,11 +48,11 @@ export default function SignInForm(props) {
   };
 
   async function getSetupSteps() {
-    const { setupSteps, toDisplay }: Actions.SetupStepsList = await execApi(
+    const { setupSteps }: Actions.SetupStepsList = await execApi(
       "get",
       `/setupSteps`
     );
-    return { setupSteps, toDisplay };
+    return { setupSteps };
   }
 
   return (

--- a/ui/ui-components/pages/setup.tsx
+++ b/ui/ui-components/pages/setup.tsx
@@ -56,10 +56,6 @@ export default function Page(props) {
             Community
           </a>
           <br />
-          <br />
-          {process.env.GROUPAROO_UI_EDITION === "config" ? null : (
-            <HideSetupButton />
-          )}
         </Alert>
       )}
 
@@ -89,14 +85,6 @@ export default function Page(props) {
       </Row>
 
       <br />
-
-      {process.env.GROUPAROO_UI_EDITION === "config" ? null : (
-        <Row>
-          <Col style={{ textAlign: "center" }}>
-            <HideSetupButton /> <br /> <br />
-          </Col>
-        </Row>
-      )}
     </>
   );
 }
@@ -106,13 +94,3 @@ Page.getInitialProps = async (ctx) => {
   const { setupSteps } = await execApi("get", `/setupSteps`);
   return { setupSteps };
 };
-
-function HideSetupButton() {
-  return (
-    <Link href="/settings/interface">
-      <a>
-        Hide this Setup Guide for everyone in your organization via settings
-      </a>
-    </Link>
-  );
-}

--- a/ui/ui-config/pages/session/sign-in.tsx
+++ b/ui/ui-config/pages/session/sign-in.tsx
@@ -28,9 +28,9 @@ export default function SignInPage(props) {
       if (nextPage) {
         router.push(nextPage.toString());
       } else {
-        const { setupSteps, toDisplay } = await getSetupSteps();
+        const { setupSteps } = await getSetupSteps();
         const isSetupComplete = setupSteps.every((step) => step.complete);
-        if (isSetupComplete || !toDisplay) {
+        if (isSetupComplete) {
           router.push("/profiles");
         } else {
           router.push("/setup");
@@ -40,11 +40,11 @@ export default function SignInPage(props) {
   };
 
   async function getSetupSteps() {
-    const { setupSteps, toDisplay }: Actions.SetupStepsList = await execApi(
+    const { setupSteps }: Actions.SetupStepsList = await execApi(
       "get",
       `/setupSteps`
     );
-    return { setupSteps, toDisplay };
+    return { setupSteps };
   }
 
   return (


### PR DESCRIPTION
Open to other suggestions here!

The original story in tracker called for removing the component entirely if completed, but after discussion it sounded like we want the option to minimize instead.

Tried going with always hiding, but then user doesn't get any confirmation that they've completed the steps (OR they get it every time they reopen the app or refresh the page).  Using an accordion component to minimize, it's still a heavy visual element and sticks out a lot.

Went with showing a small success message always that also links to the `/setup` page if they want to refer back to the steps, docs, etc. later.

The updated UI on all three UI packages looks like this if a user has completed the steps:
![Screen Shot 2021-07-06 at 11 20 23 AM](https://user-images.githubusercontent.com/63751206/124648819-90041700-de4c-11eb-8ca4-c4bee18d9bad.png)

At one point in fiddling with things, I switched the style to appear more like a card and not bleed into the rest of the page.  I like it better but have zero strong feelings about it if we want it changed back.

![Screen Shot 2021-07-06 at 11 25 07 AM](https://user-images.githubusercontent.com/63751206/124649046-d6f20c80-de4c-11eb-93ac-c65a1d18e72d.png)