### PR TITLE
Prevent empty string problems when setting Destination data

### DIFF
--- a/ui/ui-components/pages/destination/[id]/data.tsx
+++ b/ui/ui-components/pages/destination/[id]/data.tsx
@@ -138,6 +138,8 @@ export default function Page(props) {
   );
 
   function updateMapping(key, value, oldKey = null) {
+    if (key === "") return;
+
     const _destination = Object.assign({}, destination);
     let destinationMappingKeys = Object.keys(_destination.mapping);
     let insertIndex = destinationMappingKeys.length - 1;
@@ -180,6 +182,8 @@ export default function Page(props) {
     remoteKey,
     oldGroupId = null
   ) {
+    if (remoteKey === "") return;
+
     const _destination = Object.assign({}, destination);
     _destination.destinationGroupMemberships =
       _destination.destinationGroupMemberships.filter(
@@ -194,7 +198,7 @@ export default function Page(props) {
         _destination.destinationGroupMemberships[i] = {
           groupId,
           groupName,
-          remoteKey: remoteKey ? remoteKey : groupName,
+          remoteKey,
         };
         found = true;
       }
@@ -204,7 +208,7 @@ export default function Page(props) {
       _destination.destinationGroupMemberships.push({
         groupId,
         groupName,
-        remoteKey: remoteKey ? remoteKey : groupName,
+        remoteKey,
       });
     }
 

--- a/ui/ui-components/pages/destination/[id]/data.tsx
+++ b/ui/ui-components/pages/destination/[id]/data.tsx
@@ -138,16 +138,14 @@ export default function Page(props) {
   );
 
   function updateMapping(key, value, oldKey = null) {
-    if (key === "") return;
-
     const _destination = Object.assign({}, destination);
     let destinationMappingKeys = Object.keys(_destination.mapping);
     let insertIndex = destinationMappingKeys.length - 1;
 
-    if (oldKey && value) {
+    if (oldKey !== null && oldKey !== undefined && value) {
       insertIndex = destinationMappingKeys.indexOf(oldKey);
       destinationMappingKeys.splice(insertIndex, 1, key);
-    } else if (oldKey) {
+    } else if (oldKey !== null && oldKey !== undefined) {
       insertIndex = destinationMappingKeys.indexOf(oldKey);
       destinationMappingKeys.splice(insertIndex, 1);
     } else {
@@ -182,8 +180,6 @@ export default function Page(props) {
     remoteKey,
     oldGroupId = null
   ) {
-    if (remoteKey === "") return;
-
     const _destination = Object.assign({}, destination);
     _destination.destinationGroupMemberships =
       _destination.destinationGroupMemberships.filter(


### PR DESCRIPTION
Allows the string mappings for a Destination to temporarily become `""` in the UI