### PR TITLE
Slight sleep when using SQLite if transaction is busy

### DIFF
--- a/core/src/initializers/plugins.ts
+++ b/core/src/initializers/plugins.ts
@@ -1,4 +1,4 @@
-import { Initializer, api, log } from "actionhero";
+import { Initializer, api, log, utils } from "actionhero";
 import { GrouparooPlugin } from "../classes/plugin";
 import { plugin } from "../modules/plugin";
 import { App } from "../models/App";
@@ -89,6 +89,7 @@ export class Plugins extends Initializer {
         const app = await App.findById(id);
         await app.disconnect();
       }
+      await utils.sleep(100);
     });
   }
 

--- a/core/src/modules/cls.ts
+++ b/core/src/modules/cls.ts
@@ -71,14 +71,14 @@ export namespace CLS {
         // this will retry based on the default in the config, but for a priority case,
         // we can say to sleep less each time and retry much more often
         const retry = Object.assign({}, config.sequelize.retry);
-        retry.backoffBase = 1; // retry immediately
+        retry.backoffBase = 100; // retry after 100ms
         retry.backoffExponent = 1; // and don't backoff
         retry.max = 100; // it seems to take half a second or so
         retry.timeout = 30 * 1000; // give the UI 30 seconds total before error
         transOptions.retry = retry;
       } else {
         // give a gap for the UI thread to get access
-        await sleep(1);
+        await sleep(100);
       }
     }
     await api.sequelize.transaction(transOptions, async (t: Transaction) => {

--- a/core/src/modules/cls.ts
+++ b/core/src/modules/cls.ts
@@ -1,4 +1,4 @@
-import { api, task, config } from "actionhero";
+import { api, task, config, utils } from "actionhero";
 import cls from "cls-hooked";
 import { Transaction } from "sequelize";
 
@@ -78,7 +78,7 @@ export namespace CLS {
         transOptions.retry = retry;
       } else {
         // give a gap for the UI thread to get access
-        await sleep(100);
+        await utils.sleep(100);
       }
     }
     await api.sequelize.transaction(transOptions, async (t: Transaction) => {
@@ -134,10 +134,4 @@ export namespace CLS {
   ) {
     await afterCommit(async () => task.enqueueIn(delay, taskName, args, queue));
   }
-}
-
-async function sleep(sleepTime: number) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, sleepTime);
-  });
 }

--- a/core/src/modules/locks.ts
+++ b/core/src/modules/locks.ts
@@ -1,15 +1,9 @@
-import { api } from "actionhero";
+import { api, utils } from "actionhero";
 import * as uuid from "uuid";
 
 const RETRY_SLEEP = 100;
 const MAX_ATTEMPTS = 300;
 const LOCK_DURATION_MS = RETRY_SLEEP * MAX_ATTEMPTS + 1;
-
-async function sleep(sleepTime: number) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, sleepTime);
-  });
-}
 
 export async function waitForLock(
   key: string,
@@ -35,7 +29,7 @@ export async function waitForLock(
   const checkValue = await client.get(lockKey);
 
   if (!set || checkValue !== requestId) {
-    await sleep(sleepTime);
+    await utils.sleep(sleepTime);
     return waitForLock(key, requestId, ttl, attempts, sleepTime);
   }
 

--- a/core/src/tasks/run/tick.ts
+++ b/core/src/tasks/run/tick.ts
@@ -15,7 +15,7 @@ export class RunsTick extends CLSTask {
   }
 
   async runWithinTransaction() {
-    const lastCheck = new Date().getTime() - this.frequency;
+    const lastCheck = new Date().getTime() - Math.max(this.frequency, 1000);
     const runs = await Run.findAll({
       where: { state: "running", updatedAt: { [Op.lt]: lastCheck } },
     });

--- a/plugins/@grouparoo/demo/src/util/shared.ts
+++ b/plugins/@grouparoo/demo/src/util/shared.ts
@@ -21,12 +21,6 @@ export async function prettier(fileOrDirPath) {
   await execSync(`'${pCmd}' --config '${pConfig}' --write '${fileOrDirPath}'`);
 }
 
-export async function sleep(time = 1000) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, time);
-  });
-}
-
 const START_TIME = new Date();
 export const numberOfUsers = 1000;
 export function userCreatedAt(id: any) {


### PR DESCRIPTION
When using slower remote apps and SQLite, it will take longer to acquire use of the single available transaction.  This PR adds a 100ms before retrying when using SQLlite.