### PR TITLE
fix typo on ui-components/pages/destinations/new

### DIFF
--- a/ui/ui-components/pages/destination/new/index.tsx
+++ b/ui/ui-components/pages/destination/new/index.tsx
@@ -32,7 +32,7 @@ export default function Page(props) {
     return (
       <>
         <Alert variant="primary">
-          There are no Apps in the ready state yet yet.
+          There are no Apps in the ready state yet.
           <br />
           <br />
           <Button size="sm" href="/apps">


### PR DESCRIPTION
The CTA on `/components/pages/destinations/new` had a typo ("There are no apps in the ready state yet yet").  Now it does not.