### PR TITLE
Support locked cluster-name Setting when initializing first Team

### DIFF
--- a/core/__tests__/actions/settings.ts
+++ b/core/__tests__/actions/settings.ts
@@ -7,22 +7,31 @@ describe("actions/settings", () => {
 
   helper.grouparooTestServer({ truncate: true, resetSettings: true });
 
-  beforeAll(async () => {
-    await specHelper.runAction("team:initialize", {
-      firstName: "Mario",
-      lastName: "Mario",
-      password: "P@ssw0rd!",
-      email: "mario@example.com",
+  describe("settings", () => {
+    test("unauthenticated users can view the cluster name setting", async () => {
+      const { setting } = await specHelper.runAction(
+        "setting:view:core:cluster-name"
+      );
+
+      expect(setting.locked).toBe(null);
+      expect(setting.value).toBe("My Grouparoo Cluster");
     });
-
-    connection = await specHelper.buildConnection();
-
-    await Setting.truncate();
   });
 
   describe("reader signed in", () => {
     let csrfToken;
     let id;
+
+    beforeAll(async () => {
+      await specHelper.runAction("team:initialize", {
+        firstName: "Mario",
+        lastName: "Mario",
+        password: "P@ssw0rd!",
+        email: "mario@example.com",
+      });
+
+      connection = await specHelper.buildConnection();
+    });
 
     beforeAll(async () => {
       await Setting.truncate();

--- a/core/src/actions/settings.ts
+++ b/core/src/actions/settings.ts
@@ -30,6 +30,25 @@ export class SettingsList extends AuthenticatedAction {
   }
 }
 
+// only this setting can be shown without being authenticated
+export class SettingCoreClusterName extends OptionallyAuthenticatedAction {
+  constructor() {
+    super();
+    this.name = "setting:view:core:cluster-name";
+    this.description = "get the value for the cluster name setting";
+    this.outputExample = {};
+    this.permission = { topic: "system", mode: "read" };
+  }
+
+  async runWithinTransaction() {
+    const clusterNameSetting = await Setting.findOne({
+      where: { pluginName: "core", key: "cluster-name" },
+    });
+
+    return { setting: await clusterNameSetting.apiData() };
+  }
+}
+
 export class SettingEdit extends AuthenticatedAction {
   constructor() {
     super();

--- a/core/src/actions/teams.ts
+++ b/core/src/actions/teams.ts
@@ -1,4 +1,4 @@
-import { api, env } from "actionhero";
+import { api } from "actionhero";
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { CLSAction } from "../classes/actions/clsAction";
 import { Team } from "../models/Team";
@@ -53,11 +53,9 @@ export class TeamInitialize extends CLSAction {
       const clusterNameSetting = await Setting.findOne({
         where: { pluginName: "core", key: "cluster-name" },
       });
-      const nodeEnv = env || "development";
-      const clusterName = `${params.companyName} - ${
-        nodeEnv.charAt(0).toUpperCase() + nodeEnv.slice(1)
-      }`; // the cluster name would be `Grouparoo - Development`
-      await clusterNameSetting.update({ value: clusterName });
+      if (!clusterNameSetting.locked) {
+        await clusterNameSetting.update({ value: params.companyName });
+      }
     }
 
     return {

--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -51,6 +51,7 @@ export const DEFAULT = {
         { path: "/v:apiVersion/profile/:profileId/logs", action: "logs:list" },
         { path: "/v:apiVersion/account", action: "account:view" },
         { path: "/v:apiVersion/settings", action: "settings:list" },
+        { path: "/v:apiVersion/setting/core/cluster-name", action: "setting:view:core:cluster-name" },
         { path: "/v:apiVersion/apps", action: "apps:list" },
         { path: "/v:apiVersion/sources", action: "sources:list" },
         { path: "/v:apiVersion/source/:id/connectionOptions", action: "source:connectionOptions" },

--- a/ui/ui-components/pages/team/initialize.tsx
+++ b/ui/ui-components/pages/team/initialize.tsx
@@ -14,6 +14,7 @@ export default function TeamInitializePage(props) {
   const { execApi } = useApi(props, errorHandler);
   const { handleSubmit, register } = useForm();
   const [loading, setLoading] = useState(false);
+  const setting: Actions.SettingCoreClusterName["setting"] = props.setting;
 
   async function onSubmit(data) {
     setLoading(true);
@@ -65,8 +66,8 @@ export default function TeamInitializePage(props) {
                 required
                 type="text"
                 name="companyName"
-                placeholder=""
-                disabled={loading}
+                placeholder={setting.locked ? setting.value : ""}
+                disabled={loading || setting.locked ? true : false}
                 ref={register}
               />
               <Form.Control.Feedback type="invalid">
@@ -171,3 +172,9 @@ export default function TeamInitializePage(props) {
     </>
   );
 }
+
+TeamInitializePage.getInitialProps = async (ctx) => {
+  const { execApi } = useApi(ctx);
+  const { setting } = await execApi("get", `/setting/core/cluster-name`);
+  return { setting };
+};

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -229,6 +229,7 @@ import {
 import {
   SettingEdit,
   SettingsList,
+  SettingCoreClusterName,
 } from "@grouparoo/core/src/actions/settings";
 import {
   SetupStepEdit,
@@ -649,6 +650,9 @@ export namespace Actions {
   >;
   export type SettingsList = AsyncReturnType<
     typeof SettingsList.prototype.runWithinTransaction
+  >;
+  export type SettingCoreClusterName = AsyncReturnType<
+    typeof SettingCoreClusterName.prototype.runWithinTransaction
   >;
 
   export type SetupStepEdit = AsyncReturnType<


### PR DESCRIPTION
If the `core:cluster-name` setting has already been set by code config, this PR:
* grays out the setting on the `/team/initialize` page by adding a public API route to read just the cluster name setting for unauthenticated users
* ignores any value that attempts to to update the locked setting
* Updates the format of the cluster name generated on `/team/initialize` to not include the NODE_ENV, to better match how code config handles it

<img width="1496" alt="Screen Shot 2021-07-14 at 3 37 56 PM" src="https://user-images.githubusercontent.com/303226/125702693-c34fb4a8-1b53-4cc3-956c-2476c9b66fa5.png">
