### PR TITLE
Continue to use ENV string when re-setting option with ObfuscatedPasswordString

### DIFF
--- a/core/__tests__/models/option.ts
+++ b/core/__tests__/models/option.ts
@@ -171,8 +171,18 @@ describe("models/option", () => {
 
       test("options can be set from an environment variable but not stored in the database", async () => {
         await OptionHelper.setOptions(app, { fileId: "TEST_OPTION" });
-        const options = await app.getOptions();
-        expect(options.fileId).toBe("abc123");
+        expect(await app.getOptions(true)).toEqual({ fileId: "abc123" });
+        expect(await app.getOptions(false)).toEqual({ fileId: "TEST_OPTION" });
+      });
+
+      test("options remain set with ENV re-set withObfuscatedPasswordString ", async () => {
+        await OptionHelper.setOptions(app, { fileId: "TEST_OPTION" });
+        expect(await app.getOptions(false)).toEqual({ fileId: "TEST_OPTION" });
+        // shouldn't change value in DB from ENV
+        await OptionHelper.setOptions(app, {
+          fileId: ObfuscatedPasswordString,
+        });
+        expect(await app.getOptions(false)).toEqual({ fileId: "TEST_OPTION" });
       });
     });
 

--- a/core/__tests__/models/option.ts
+++ b/core/__tests__/models/option.ts
@@ -182,6 +182,7 @@ describe("models/option", () => {
         await OptionHelper.setOptions(app, {
           fileId: ObfuscatedPasswordString,
         });
+        expect(await app.getOptions(true)).toEqual({ fileId: "abc123" });
         expect(await app.getOptions(false)).toEqual({ fileId: "TEST_OPTION" });
       });
     });

--- a/core/__tests__/models/option.ts
+++ b/core/__tests__/models/option.ts
@@ -185,6 +185,14 @@ describe("models/option", () => {
         expect(await app.getOptions(true)).toEqual({ fileId: "abc123" });
         expect(await app.getOptions(false)).toEqual({ fileId: "TEST_OPTION" });
       });
+
+      test("if the real value was set when previously an ENV string was used, use the ENV sting", async () => {
+        await OptionHelper.setOptions(app, { fileId: "TEST_OPTION" });
+        expect(await app.getOptions(false)).toEqual({ fileId: "TEST_OPTION" });
+        await OptionHelper.setOptions(app, { fileId: "abc123" });
+        expect(await app.getOptions(true)).toEqual({ fileId: "abc123" });
+        expect(await app.getOptions(false)).toEqual({ fileId: "TEST_OPTION" });
+      });
     });
 
     describe("default option values", () => {

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -73,16 +73,30 @@ export namespace OptionHelper {
     );
 
     await validateOptions(instance, sanitizedOptions, null);
-    const oldOptions = await getOptions(instance, false);
+    const oldOptionsWithoutEnv = await getOptions(instance, false);
+    const oldOptionsWithEnv = await getOptions(instance, true);
+
+    // If we had previously used an ENV string, and the value was returned, assume we meant to use the ENV
+    // This is helpful for some UI options types (list) which really render the value
+    for (const key in sanitizedOptions) {
+      if (
+        oldOptionsWithoutEnv[key] !== undefined &&
+        oldOptionsWithoutEnv[key] !== oldOptionsWithEnv[key] &&
+        sanitizedOptions[key] === oldOptionsWithEnv[key]
+      ) {
+        sanitizedOptions[key] = oldOptionsWithoutEnv[key];
+      }
+    }
+
     let hasChanges = false;
 
-    for (const i in oldOptions) {
-      if (oldOptions[i] !== sanitizedOptions[i]) {
+    for (const key in oldOptionsWithoutEnv) {
+      if (oldOptionsWithoutEnv[key] !== sanitizedOptions[key]) {
         hasChanges = true;
       }
     }
-    for (const i in sanitizedOptions) {
-      if (oldOptions[i] !== sanitizedOptions[i]) {
+    for (const key in sanitizedOptions) {
+      if (oldOptionsWithoutEnv[key] !== sanitizedOptions[key]) {
         hasChanges = true;
       }
     }

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -65,11 +65,11 @@ export namespace OptionHelper {
     options: SimpleOptions
   ) {
     delete instance.__options;
-    let sanitizedOptions = Object.assign({}, options);
 
-    sanitizedOptions = await replaceObfuscatedPasswords(
+    const sanitizedOptions = await replaceObfuscatedPasswords(
       instance,
-      sanitizedOptions
+      options,
+      false
     );
 
     await validateOptions(instance, sanitizedOptions, null);
@@ -429,21 +429,25 @@ export namespace OptionHelper {
 
   export async function replaceObfuscatedPasswords(
     instance: Source | Destination | Schedule | Property | App,
-    options?: SimpleOptions
+    options?: SimpleOptions,
+    sourceFromEnvironment = true
   ) {
     let sanitizedOptions: SimpleOptions = Object.assign({}, options);
-    const optionsFromDatabase = await getOptions(instance, true, false);
 
+    const optionsFromDatabase = await getOptions(
+      instance,
+      sourceFromEnvironment,
+      false
+    );
     if (Object.keys(sanitizedOptions).length === 0) {
       sanitizedOptions = optionsFromDatabase;
     }
 
-    let optionsKeys = Object.keys(sanitizedOptions);
-    optionsKeys.forEach((option) => {
-      if (sanitizedOptions[option] === ObfuscatedPasswordString) {
-        sanitizedOptions[option] = optionsFromDatabase[option];
+    for (const key of Object.keys(sanitizedOptions)) {
+      if (sanitizedOptions[key] === ObfuscatedPasswordString) {
+        sanitizedOptions[key] = optionsFromDatabase[key];
       }
-    });
+    }
 
     return sanitizedOptions;
   }


### PR DESCRIPTION
This PR fixes bugs in the behavior of the Option Helper in 2 ways:

Assume your Grouparoo instance has the environment variable `GROUPAROO_OPTION__APP__MAILCHIMP_PASSWORD="passw0rd"`, and you wish to use the [environment variable secret](https://www.grouparoo.com/docs/support/secrets) string `MAILCHIMP_PASSWORD` to safely store your options:

* If an Option value was previously set to an ENV string (`MAILCHIMP_PASSWORD`), the next time a user viewed a UI form with this option they would be sent the value `__obfuscated` so the protected data would not be sent.  However, if the form was re-saved again, the real value (`"passw0rd"`) would be saved into the database, not the ENV string (`MAILCHIMP_PASSWORD`).  This is now fixed. 
* If the user sends back a string value (`"passw0rd"`) in an Option form when they previously had used an ENV string (`MAILCHIMP_PASSWORD`), and the value is the same value that the ENV string resolves too, we assume the user still wants to use the ENV string and not the string value.  This is helpful in cases where the UI renderers a previously set ENV value string in the UI for non-password protected or obfuscated forms (eg: a list). 

In both cases, these incorrect string option value (vs the expected ENV string) was then also transfered to any config files when using `@grouparoo/ui-config`