### PR TITLE
clear `directlyMapped` properties when profile has been removed from the source

### DIFF
--- a/core/__tests__/models/destination/plugins/exportProfile.ts
+++ b/core/__tests__/models/destination/plugins/exportProfile.ts
@@ -191,7 +191,7 @@ describe("models/destination", () => {
 
         const profile = await helper.factories.profile();
         await profile.addOrUpdateProperties({
-          uid: [1001],
+          userId: [1001],
           email: ["newemail@example.com"],
         });
         await groupA.addProfile(profile);
@@ -271,7 +271,7 @@ describe("models/destination", () => {
 
         const profile = await helper.factories.profile();
         await profile.addOrUpdateProperties({
-          uid: [1001],
+          userId: [1001],
           email: ["newemail@example.com"],
         });
         await groupA.addProfile(profile);

--- a/core/__tests__/models/destination/plugins/exportProfile.ts
+++ b/core/__tests__/models/destination/plugins/exportProfile.ts
@@ -191,6 +191,7 @@ describe("models/destination", () => {
 
         const profile = await helper.factories.profile();
         await profile.addOrUpdateProperties({
+          uid: [1001],
           email: ["newemail@example.com"],
         });
         await groupA.addProfile(profile);
@@ -224,7 +225,7 @@ describe("models/destination", () => {
         });
         expect(exportArgs.newProfileProperties).toEqual({
           customer_email: "newemail@example.com",
-          uid: null,
+          uid: 1001,
         });
         expect(exportArgs.oldGroups).toEqual([]);
         expect(exportArgs.newGroups).toEqual(
@@ -248,7 +249,7 @@ describe("models/destination", () => {
         });
         expect(_exports[1].newProfileProperties).toEqual({
           customer_email: "newemail@example.com",
-          uid: null,
+          uid: 1001,
         });
         expect(_exports[1].oldGroups).toEqual([]);
         expect(_exports[1].newGroups).toEqual(
@@ -270,6 +271,7 @@ describe("models/destination", () => {
 
         const profile = await helper.factories.profile();
         await profile.addOrUpdateProperties({
+          uid: [1001],
           email: ["newemail@example.com"],
         });
         await groupA.addProfile(profile);
@@ -303,7 +305,7 @@ describe("models/destination", () => {
         });
         expect(exportArgs.newProfileProperties).toEqual({
           customer_email: "newemail@example.com",
-          uid: null,
+          uid: 1001,
         });
 
         await profile.destroy();

--- a/core/__tests__/models/destination/plugins/exportProfile.ts
+++ b/core/__tests__/models/destination/plugins/exportProfile.ts
@@ -325,7 +325,7 @@ describe("models/destination", () => {
 
         const profile = await helper.factories.profile();
         await profile.addOrUpdateProperties({
-          uid: [1002],
+          userId: [1002],
           email: ["newemail@example.com"],
         });
         await groupA.addProfile(profile);

--- a/core/__tests__/models/destination/plugins/exportProfile.ts
+++ b/core/__tests__/models/destination/plugins/exportProfile.ts
@@ -325,6 +325,7 @@ describe("models/destination", () => {
 
         const profile = await helper.factories.profile();
         await profile.addOrUpdateProperties({
+          uid: [1002],
           email: ["newemail@example.com"],
         });
         await groupA.addProfile(profile);
@@ -340,7 +341,7 @@ describe("models/destination", () => {
 
         expect(exportArgs.newProfileProperties).toEqual({
           customer_email: "newemail@example.com",
-          uid: null,
+          uid: 1002,
         });
 
         await profile.destroy();

--- a/core/__tests__/models/destination/plugins/exportProfiles.ts
+++ b/core/__tests__/models/destination/plugins/exportProfiles.ts
@@ -158,6 +158,7 @@ describe("models/destination", () => {
 
         const profile = await helper.factories.profile();
         await profile.addOrUpdateProperties({
+          userId: [1001],
           email: ["newemail@example.com"],
         });
         await groupA.addProfile(profile);
@@ -201,7 +202,7 @@ describe("models/destination", () => {
         });
         expect(exportArgs.exports[0].newProfileProperties).toEqual({
           customer_email: "newemail@example.com",
-          uid: null,
+          uid: 1001,
         });
         expect(exportArgs.exports[0].oldGroups).toEqual([]);
         expect(exportArgs.exports[0].newGroups).toEqual(
@@ -225,7 +226,7 @@ describe("models/destination", () => {
         });
         expect(_exports[1].newProfileProperties).toEqual({
           customer_email: "newemail@example.com",
-          uid: null,
+          uid: 1001,
         });
         expect(_exports[1].oldGroups).toEqual([]);
         expect(_exports[1].newGroups).toEqual(
@@ -247,6 +248,7 @@ describe("models/destination", () => {
 
         const profile = await helper.factories.profile();
         await profile.addOrUpdateProperties({
+          userId: [1001],
           email: ["newemail@example.com"],
         });
 
@@ -287,7 +289,7 @@ describe("models/destination", () => {
         });
         expect(exportArgs.exports[0].newProfileProperties).toEqual({
           customer_email: "newemail@example.com",
-          uid: null,
+          uid: 1001,
         });
 
         await profile.destroy();

--- a/core/__tests__/models/profile/profile.ts
+++ b/core/__tests__/models/profile/profile.ts
@@ -295,12 +295,8 @@ describe("models/profile", () => {
         expect(newProfile.state).toBe("pending");
         const properties = await newProfile.properties();
         for (const k in properties) {
-          if (k === "userId") {
-            expect(properties[k].state).toEqual("ready");
-          } else {
-            expect(properties[k].state).toEqual("pending");
-            expect(properties[k].startedAt).toBeNull();
-          }
+          expect(properties[k].state).toEqual("pending");
+          expect(properties[k].startedAt).toBeNull();
         }
       });
 
@@ -1071,9 +1067,7 @@ describe("models/profile", () => {
       expect(profileA.state).toBe("pending");
       const properties = await profileA.properties();
       for (const k in properties) {
-        k === "userId"
-          ? expect(properties[k].state).toBe("ready")
-          : expect(properties[k].state).toBe("pending");
+        expect(properties[k].state).toBe("pending");
       }
     });
 

--- a/core/__tests__/modules/plugin.ts
+++ b/core/__tests__/modules/plugin.ts
@@ -340,9 +340,15 @@ describe("modules/plugin", () => {
         );
         expect(peachImport).toBeTruthy();
         expect(marioImport).toBeTruthy();
+        expect(peachImport.data).toEqual({
+          firstName: ["Peach"],
+        });
         expect(peachImport.rawData).toEqual({
           first__name: "Peach",
           last__name: "Toadstool",
+        });
+        expect(marioImport.data).toEqual({
+          firstName: ["Mario"],
         });
         expect(marioImport.rawData).toEqual({
           first__name: "Mario",

--- a/core/__tests__/tasks/profile/checkReady.ts
+++ b/core/__tests__/tasks/profile/checkReady.ts
@@ -3,7 +3,11 @@ import { api, config, task, specHelper } from "actionhero";
 import { Group, plugin, Profile, ProfileProperty } from "../../../src";
 
 describe("tasks/profile:checkReady", () => {
-  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  helper.grouparooTestServer({
+    truncate: true,
+    enableTestPlugin: true,
+    disableTestPluginImport: true,
+  });
   beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
   beforeAll(async () => await helper.factories.properties());
 

--- a/core/__tests__/tasks/profile/export.ts
+++ b/core/__tests__/tasks/profile/export.ts
@@ -227,6 +227,7 @@ describe("tasks/profile:export", () => {
       test("it will append destinationIds from imports", async () => {
         const run = await helper.factories.run();
         const _import = await helper.factories.import(run, {
+          userId: 123,
           email: "bowser@example.com", // create a new profile, not in the group
           firstName: "Bowser",
           lastName: "Koopa",

--- a/core/__tests__/tasks/profileProperty/enqueue.ts
+++ b/core/__tests__/tasks/profileProperty/enqueue.ts
@@ -84,9 +84,7 @@ describe("tasks/profileProperties:enqueue", () => {
           const pendingProfileProperties = await ProfileProperty.findAll({
             where: { state: "pending" },
           });
-          expect(pendingProfileProperties.length).toBe(
-            (propertiesCount - 1) * 2
-          );
+          expect(pendingProfileProperties.length).toBe(propertiesCount * 2);
           for (const p of pendingProfileProperties) {
             expect(p.startedAt).toBe(null);
             await p.update({ startedAt: null });
@@ -103,9 +101,7 @@ describe("tasks/profileProperties:enqueue", () => {
           );
 
           expect(importProfilePropertiesTasks.length).toBe(0);
-          expect(importProfilePropertyTasks.length).toBe(
-            (propertiesCount - 1) * 2
-          );
+          expect(importProfilePropertyTasks.length).toBe(propertiesCount * 2);
 
           for (const p of pendingProfileProperties) {
             await p.reload();
@@ -123,9 +119,7 @@ describe("tasks/profileProperties:enqueue", () => {
           const pendingProfileProperties = await ProfileProperty.findAll({
             where: { state: "pending" },
           });
-          expect(pendingProfileProperties.length).toBe(
-            (propertiesCount - 1) * 2
-          );
+          expect(pendingProfileProperties.length).toBe(propertiesCount * 2);
           for (const p of pendingProfileProperties) {
             expect(p.startedAt).toBe(null);
             await p.update({ startedAt: new Date(0) });
@@ -142,9 +136,7 @@ describe("tasks/profileProperties:enqueue", () => {
           );
 
           expect(importProfilePropertiesTasks.length).toBe(0);
-          expect(importProfilePropertyTasks.length).toBe(
-            (propertiesCount - 1) * 2
-          );
+          expect(importProfilePropertyTasks.length).toBe(propertiesCount * 2);
 
           for (const p of pendingProfileProperties) {
             await p.reload();
@@ -161,9 +153,7 @@ describe("tasks/profileProperties:enqueue", () => {
           const pendingProfileProperties = await ProfileProperty.findAll({
             where: { state: "pending" },
           });
-          expect(pendingProfileProperties.length).toBe(
-            (propertiesCount - 1) * 2
-          );
+          expect(pendingProfileProperties.length).toBe(propertiesCount * 2);
           for (const p of pendingProfileProperties) {
             expect(p.startedAt).toBe(null);
             await p.update({ startedAt: new Date() });
@@ -272,7 +262,7 @@ describe("tasks/profileProperties:enqueue", () => {
           );
 
           expect(importProfilePropertyTasks.length).toBe(0);
-          expect(importProfilePropertiesTasks.length).toBe(propertiesCount - 1);
+          expect(importProfilePropertiesTasks.length).toBe(propertiesCount);
           importProfilePropertiesTasks.forEach((t) =>
             expect(t.args[0].profileIds.length).toBe(1)
           );

--- a/core/src/models/Profile.ts
+++ b/core/src/models/Profile.ts
@@ -96,9 +96,15 @@ export class Profile extends LoggedModel<Profile> {
     properties: {
       [key: string]: Array<string | number | boolean | Date>;
     },
-    toLock = true
+    toLock = true,
+    ignoreMissingProperties = false
   ) {
-    return ProfileOps.addOrUpdateProperties([this], [properties], toLock);
+    return ProfileOps.addOrUpdateProperties(
+      [this],
+      [properties],
+      toLock,
+      ignoreMissingProperties
+    );
   }
 
   async removeProperty(key: string) {

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -330,20 +330,27 @@ export namespace DestinationOps {
       oldGroupNames = mostRecentExport.newGroups;
     }
 
-    for (const k in mapping) {
-      const property = properties.find((r) => r.key === mapping[k]);
-      if (!property) throw new Error(`cannot find rule for ${mapping[k]}`);
-      const { type } = property;
-      mappedNewProfileProperties[k] = {
-        type,
-        rawValue: newProfileProperties[mapping[k]]
-          ? await Promise.all(
-              newProfileProperties[mapping[k]].values.map((v) =>
-                ProfilePropertyOps.buildRawValue(v, type)
+    const directlyMapped = Object.values(newProfileProperties).find(
+      (p) => p.directlyMapped
+    );
+    if (directlyMapped && directlyMapped.values[0] === null) {
+      mappedNewProfileProperties = mappedOldProfileProperties;
+    } else {
+      for (const k in mapping) {
+        const property = properties.find((r) => r.key === mapping[k]);
+        if (!property) throw new Error(`cannot find rule for ${mapping[k]}`);
+        const { type } = property;
+        mappedNewProfileProperties[k] = {
+          type,
+          rawValue: newProfileProperties[mapping[k]]
+            ? await Promise.all(
+                newProfileProperties[mapping[k]].values.map((v) =>
+                  ProfilePropertyOps.buildRawValue(v, type)
+                )
               )
-            )
-          : null,
-      };
+            : null,
+        };
+      }
     }
 
     // Send only the properties from the array that should be sent to the Destination, otherwise send the first entry in the array of profile properties

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -330,28 +330,29 @@ export namespace DestinationOps {
       oldGroupNames = mostRecentExport.newGroups;
     }
 
-    /*
     const directlyMapped = Object.values(newProfileProperties).find(
       (p) => p.directlyMapped
     );
-    if (directlyMapped && directlyMapped.values[0] === null) {
+    if (toDelete && directlyMapped && directlyMapped.values[0] === null) {
+      // We want to be able to delete profiles that have been removed from their source
+      // (new properties would be set to null, so we need the old values to reference them)
       mappedNewProfileProperties = mappedOldProfileProperties;
-    } 
-    */
-    for (const k in mapping) {
-      const property = properties.find((r) => r.key === mapping[k]);
-      if (!property) throw new Error(`cannot find rule for ${mapping[k]}`);
-      const { type } = property;
-      mappedNewProfileProperties[k] = {
-        type,
-        rawValue: newProfileProperties[mapping[k]]
-          ? await Promise.all(
-              newProfileProperties[mapping[k]].values.map((v) =>
-                ProfilePropertyOps.buildRawValue(v, type)
+    } else {
+      for (const k in mapping) {
+        const property = properties.find((r) => r.key === mapping[k]);
+        if (!property) throw new Error(`cannot find rule for ${mapping[k]}`);
+        const { type } = property;
+        mappedNewProfileProperties[k] = {
+          type,
+          rawValue: newProfileProperties[mapping[k]]
+            ? await Promise.all(
+                newProfileProperties[mapping[k]].values.map((v) =>
+                  ProfilePropertyOps.buildRawValue(v, type)
+                )
               )
-            )
-          : null,
-      };
+            : null,
+        };
+      }
     }
 
     // Send only the properties from the array that should be sent to the Destination, otherwise send the first entry in the array of profile properties

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -347,7 +347,7 @@ export namespace DestinationOps {
         mappedNewProfileProperties[k] =
           mappedOldProfileProperties[k] !== undefined
             ? mappedOldProfileProperties[k]
-            : null;
+            : { type, rawValue: null };
       } else {
         mappedNewProfileProperties[k] = {
           type,

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -330,27 +330,28 @@ export namespace DestinationOps {
       oldGroupNames = mostRecentExport.newGroups;
     }
 
+    /*
     const directlyMapped = Object.values(newProfileProperties).find(
       (p) => p.directlyMapped
     );
     if (directlyMapped && directlyMapped.values[0] === null) {
       mappedNewProfileProperties = mappedOldProfileProperties;
-    } else {
-      for (const k in mapping) {
-        const property = properties.find((r) => r.key === mapping[k]);
-        if (!property) throw new Error(`cannot find rule for ${mapping[k]}`);
-        const { type } = property;
-        mappedNewProfileProperties[k] = {
-          type,
-          rawValue: newProfileProperties[mapping[k]]
-            ? await Promise.all(
-                newProfileProperties[mapping[k]].values.map((v) =>
-                  ProfilePropertyOps.buildRawValue(v, type)
-                )
+    } 
+    */
+    for (const k in mapping) {
+      const property = properties.find((r) => r.key === mapping[k]);
+      if (!property) throw new Error(`cannot find rule for ${mapping[k]}`);
+      const { type } = property;
+      mappedNewProfileProperties[k] = {
+        type,
+        rawValue: newProfileProperties[mapping[k]]
+          ? await Promise.all(
+              newProfileProperties[mapping[k]].values.map((v) =>
+                ProfilePropertyOps.buildRawValue(v, type)
               )
-            : null,
-        };
-      }
+            )
+          : null,
+      };
     }
 
     // Send only the properties from the array that should be sent to the Destination, otherwise send the first entry in the array of profile properties

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -663,21 +663,10 @@ export namespace ProfileOps {
     profileIds: string[],
     includeProperties = true
   ) {
-    const nonDirectlyMappedRules = (await Property.findAllWithCache()).filter(
-      (p) => p.directlyMapped === false
-    );
-
-    if (includeProperties && nonDirectlyMappedRules.length > 0) {
+    if (includeProperties) {
       await ProfileProperty.update(
         { state: "pending", startedAt: null },
-        {
-          where: {
-            profileId: { [Op.in]: profileIds },
-            propertyId: {
-              [Op.in]: nonDirectlyMappedRules.map((r) => r.id),
-            },
-          },
-        }
+        { where: { profileId: { [Op.in]: profileIds } } }
       );
     }
 

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -222,7 +222,8 @@ export namespace ProfileOps {
     profileProperties: {
       [key: string]: Array<string | number | boolean | Date> | any;
     }[],
-    toLock = true
+    toLock = true,
+    ignoreMissingProperties = false
   ) {
     if (profiles.length === 0) return;
     if (profiles.length !== profileProperties.length) {
@@ -268,6 +269,7 @@ export namespace ProfileOps {
             properties.find((p) => p.key === key);
 
           if (!property) {
+            if (ignoreMissingProperties) continue;
             throw new Error(`cannot find a property for id or key \`${key}\``);
           }
 
@@ -783,7 +785,6 @@ export namespace ProfileOps {
     profileIds: string[],
     toExport: boolean
   ) {
-    const properties = await Property.findAllWithCache();
     const profiles = await Profile.findAll({
       where: {
         id: { [Op.in]: profileIds },
@@ -794,28 +795,6 @@ export namespace ProfileOps {
       ],
     });
     if (profiles.length === 0) return;
-
-    for (const profile of profiles) {
-      const mergedValues = {};
-      const imports = profile.imports;
-
-      for (const _import of imports.sort(
-        (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
-      )) {
-        const data = _import.data;
-        for (const key in data) {
-          // only if we still have property
-          if (properties.find((r) => r.key === key)) {
-            mergedValues[key] = data[key];
-          }
-        }
-      }
-
-      if (Object.keys(mergedValues).length > 0) {
-        await profile.addOrUpdateProperties(mergedValues);
-        delete profile.profileProperties; // will be reloaded
-      }
-    }
 
     const memberships = await ProfileOps.updateGroupMemberships(profiles);
     const now = new Date();

--- a/core/src/tasks/import/associateProfile.ts
+++ b/core/src/tasks/import/associateProfile.ts
@@ -37,7 +37,7 @@ export class ImportAssociateProfile extends Task {
             if (_import.profileId) return;
 
             const { profile } = await _import.associateProfile();
-
+            await profile.addOrUpdateProperties(_import.data, undefined, true);
             await profile.markPending();
           },
           { write: true }

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -18,7 +18,11 @@ const {
 } = getConfig();
 
 describe("integration/runs/mysql", () => {
-  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  helper.grouparooTestServer({
+    truncate: true,
+    enableTestPlugin: true,
+    disableTestPluginImport: true,
+  });
   beforeAll(async () => await api.resque.queue.connection.redis.flushdb());
   beforeAll(async () => await helper.factories.properties());
 

--- a/plugins/@grouparoo/spec-helper/src/lib/factories/profile.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/factories/profile.ts
@@ -1,3 +1,4 @@
+import faker from "faker";
 import { loadPath } from "../loadPath";
 
 const data = async (props = {}) => {
@@ -9,7 +10,21 @@ const data = async (props = {}) => {
   return Object.assign({}, defaultProps, props);
 };
 
-export default async (props = {}) => {
+export default async (props = {}, properties = {}) => {
   const { Profile } = await import(`@grouparoo/core/${loadPath}`);
-  return Profile.create(await data(props));
+  const profile = await Profile.create(await data(props));
+
+  const { Property } = await import(`@grouparoo/core/${loadPath}`);
+  const allProperties = await Property.findAllWithCache();
+  const directlyMappedProperty = allProperties.find((p) => p.directlyMapped);
+
+  if (directlyMappedProperty) {
+    properties[directlyMappedProperty.key] = faker.datatype.number(99999);
+  }
+
+  await profile.addOrUpdateProperties({
+    ...properties,
+  });
+
+  return profile;
 };


### PR DESCRIPTION
- Allow directlyMapped properties to be cleared
- Send old property values when exporting a deleted profile for one last time
- Move setting import data properties to `associateProfiles` instead of `completeImport`.Setting these properties after everything was imported was setting them to possibly outdated values, and was setting properties that had been cleared by the `importProfileProperty`/`importProfileProperties` tasks, like unique properties from schedules runs.