### PR TITLE
Periodically confirm that profiles still exist in the source

### DIFF
--- a/core/__tests__/actions/schedules.ts
+++ b/core/__tests__/actions/schedules.ts
@@ -45,6 +45,7 @@ describe("actions/schedules", () => {
         type: "test-plugin-import",
         sourceId: source.id,
         recurring: false,
+        confirmProfiles: true,
       };
       const { error, schedule } = await specHelper.runAction(
         "schedule:create",
@@ -53,6 +54,7 @@ describe("actions/schedules", () => {
       expect(error).toBeUndefined();
       expect(schedule.id).toBeTruthy();
       expect(schedule.name).toBe("test schedule");
+      expect(schedule.confirmProfiles).toBe(true);
 
       id = schedule.id;
     });
@@ -77,6 +79,7 @@ describe("actions/schedules", () => {
           csrfToken,
           id,
           name: "new schedule name",
+          confirmProfiles: false,
         };
         const { error, schedule } = await specHelper.runAction(
           "schedule:edit",
@@ -86,6 +89,7 @@ describe("actions/schedules", () => {
         expect(schedule.id).toBeTruthy();
         expect(schedule.name).toBe("new schedule name");
         expect(schedule.state).toBe("draft");
+        expect(schedule.confirmProfiles).toBe(false);
       });
 
       test("an administrator can view a schedule", async () => {

--- a/core/__tests__/fixtures/codeConfig/bootstrapped-property-in-source/config.js
+++ b/core/__tests__/fixtures/codeConfig/bootstrapped-property-in-source/config.js
@@ -47,6 +47,7 @@ module.exports = async function getConfig() {
       sourceId: "users_table", // sourceId -> `users_table`
       recurring: true,
       recurringFrequency: 1000 * 60 * 15, // 15 minutes in ms
+      confirmProfiles: true,
       options: {
         maxColumn: "updated_at",
       },

--- a/core/__tests__/fixtures/codeConfig/initial/config.js
+++ b/core/__tests__/fixtures/codeConfig/initial/config.js
@@ -39,6 +39,7 @@ module.exports = async function getConfig() {
       sourceId: "users_table", // sourceId -> `users_table`
       recurring: true,
       recurringFrequency: 1000 * 60 * 15, // 15 minutes in ms
+      confirmProfiles: true,
       options: {
         maxColumn: "updated_at",
       },

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -126,6 +126,7 @@ describe("modules/codeConfig", () => {
         expect(schedules[0].name).toBe("Users Table Schedule");
         expect(schedules[0].state).toBe("ready");
         expect(schedules[0].recurring).toBe(true);
+        expect(schedules[0].confirmProfiles).toBe(true);
         expect(schedules[0].recurringFrequency).toBe(900000);
         expect(schedules[0].locked).toBe("config:code");
       });

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -625,7 +625,7 @@ describe("modules/configWriter", () => {
 
       expect(config.id).toBeTruthy();
 
-      const { name, recurring, recurringFrequency } = schedule;
+      const { name, recurring, recurringFrequency, confirmProfiles } = schedule;
       const options = await schedule.$get("__options");
       expect(options.length).toEqual(1);
 
@@ -636,6 +636,7 @@ describe("modules/configWriter", () => {
         sourceId: source.getConfigId(),
         recurring,
         recurringFrequency,
+        confirmProfiles,
         options: Object.fromEntries(options.map((o) => [o.key, o.value])),
         filters: [
           {

--- a/core/__tests__/tasks/profile/confirm.ts
+++ b/core/__tests__/tasks/profile/confirm.ts
@@ -1,0 +1,306 @@
+import { helper } from "@grouparoo/spec-helper";
+import Moment from "moment";
+import { api, task, specHelper } from "actionhero";
+import {
+  Import,
+  plugin,
+  Profile,
+  ProfileProperty,
+  Schedule,
+  Source,
+} from "../../../src";
+
+describe("tasks/profiles:confirm", () => {
+  helper.grouparooTestServer({
+    truncate: true,
+    enableTestPlugin: true,
+    disableTestPluginImport: true,
+  });
+  beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
+  beforeAll(async () => await helper.factories.properties());
+
+  afterEach(async () => {
+    await plugin.updateSetting("core", "runs-profile-batch-size", 100);
+    await plugin.updateSetting("core", "confirm-profiles-days", 7);
+  });
+
+  test("can be enqueued", async () => {
+    await task.enqueue("profiles:confirm", {});
+    const found = await specHelper.findEnqueuedTasks("profiles:confirm");
+    expect(found.length).toEqual(1);
+  });
+
+  test("creates imports and marks profiles pending if they haven't been confirmed in a while", async () => {
+    const staleProfile: Profile = await helper.factories.profile();
+    const recentProfile: Profile = await helper.factories.profile();
+
+    await ProfileProperty.update(
+      {
+        state: "ready",
+        confirmedAt: Moment().subtract(10, "days").toDate(),
+      },
+      {
+        where: {
+          profileId: staleProfile.id,
+        },
+      }
+    );
+
+    await ProfileProperty.update(
+      {
+        state: "ready",
+        confirmedAt: Moment().subtract(6, "days").toDate(),
+      },
+      {
+        where: {
+          profileId: recentProfile.id,
+        },
+      }
+    );
+
+    await Profile.update(
+      { state: "ready" },
+      {
+        where: {
+          id: [staleProfile.id, recentProfile.id],
+        },
+      }
+    );
+
+    const count = await specHelper.runTask("profiles:confirm", {});
+    expect(count).toBe(1);
+
+    await staleProfile.reload();
+    await recentProfile.reload();
+
+    expect(staleProfile.state).toBe("pending");
+    expect(recentProfile.state).toBe("ready"); // dont need to confirm
+
+    const staleProfileProperties = await ProfileProperty.findAll({
+      where: {
+        state: "pending",
+        profileId: staleProfile.id,
+      },
+    });
+    expect(staleProfileProperties.length).toBe(9);
+
+    const recentProfileProperties = await ProfileProperty.findAll({
+      where: {
+        state: "ready",
+        profileId: recentProfile.id,
+      },
+    });
+    expect(recentProfileProperties.length).toBe(9);
+
+    const imports = await Import.findAll({
+      where: { profileId: [staleProfile.id, recentProfile.id] },
+    });
+
+    expect(imports.length).toBe(1);
+    expect(imports[0].profileId).toBe(staleProfile.id);
+    expect(imports[0].creatorType).toBe("task");
+    expect(imports[0].creatorId).toBe("profiles:confirm");
+
+    await staleProfile.destroy();
+    await recentProfile.destroy();
+  });
+
+  test("the amount of days can be configured", async () => {
+    await plugin.updateSetting("core", "confirm-profiles-days", 5);
+
+    const profile: Profile = await helper.factories.profile();
+    await ProfileProperty.update(
+      {
+        state: "ready",
+        confirmedAt: Moment().subtract(6, "days").toDate(),
+      },
+      {
+        where: {
+          profileId: profile.id,
+        },
+      }
+    );
+    await profile.update({ state: "ready" });
+
+    const count = await specHelper.runTask("profiles:confirm", {});
+    expect(count).toBe(1);
+
+    await profile.reload();
+    expect(profile.state).toBe("pending");
+
+    const imports = await Import.findAll({
+      where: {
+        profileId: profile.id,
+        creatorType: "task",
+        creatorId: "profiles:confirm",
+      },
+    });
+    expect(imports.length).toBe(1);
+
+    await profile.destroy();
+  });
+
+  test("can disable confirming profiles by setting days to 0", async () => {
+    await plugin.updateSetting("core", "confirm-profiles-days", 0);
+
+    const profile: Profile = await helper.factories.profile();
+    await ProfileProperty.update(
+      {
+        state: "ready",
+        confirmedAt: Moment().subtract(6, "days").toDate(),
+      },
+      {
+        where: {
+          profileId: profile.id,
+        },
+      }
+    );
+    await profile.update({ state: "ready" });
+
+    const count = await specHelper.runTask("profiles:confirm", {});
+    expect(count).toBe(0);
+
+    await profile.reload();
+    expect(profile.state).toBe("ready");
+
+    const imports = await Import.findAll({
+      where: {
+        profileId: profile.id,
+        creatorType: "task",
+        creatorId: "profiles:confirm",
+      },
+    });
+    expect(imports.length).toBe(0);
+
+    await profile.destroy();
+  });
+
+  test("creates imports for profiles that haven't been confirmed if the schedule has run and it's marked as confirmProfiles=true", async () => {
+    await plugin.updateSetting("core", "confirm-profiles-days", 0);
+
+    const source = await Source.findOne();
+    const schedule: Schedule = await helper.factories.schedule(source, {
+      confirmProfiles: true,
+    });
+    await helper.factories.run(schedule, {
+      state: "complete",
+      completedAt: new Date(),
+    });
+
+    const profile: Profile = await helper.factories.profile();
+    await ProfileProperty.update(
+      {
+        state: "ready",
+        confirmedAt: Moment().subtract(1, "days").toDate(),
+      },
+      {
+        where: {
+          profileId: profile.id,
+        },
+      }
+    );
+    await profile.update({ state: "ready" });
+
+    const count = await specHelper.runTask("profiles:confirm", {});
+    expect(count).toBe(1);
+
+    await profile.reload();
+    expect(profile.state).toBe("pending");
+
+    const imports = await Import.findAll({
+      where: {
+        profileId: profile.id,
+        creatorType: "task",
+        creatorId: "profiles:confirm",
+      },
+    });
+    expect(imports.length).toBe(1);
+
+    await profile.destroy();
+    await schedule.destroy();
+  });
+
+  test("does not create imports for profiles that haven't been confirmed if the schedule has run and it's marked as confirmProfiles=false", async () => {
+    await plugin.updateSetting("core", "confirm-profiles-days", 0);
+
+    const source = await Source.findOne();
+    const schedule: Schedule = await helper.factories.schedule(source, {
+      confirmProfiles: false,
+    });
+    await helper.factories.run(schedule, {
+      state: "complete",
+      completedAt: new Date(),
+    });
+
+    const profile: Profile = await helper.factories.profile();
+    await ProfileProperty.update(
+      {
+        state: "ready",
+        confirmedAt: Moment().subtract(1, "days").toDate(),
+      },
+      {
+        where: {
+          profileId: profile.id,
+        },
+      }
+    );
+    await profile.update({ state: "ready" });
+
+    const count = await specHelper.runTask("profiles:confirm", {});
+    expect(count).toBe(0);
+
+    await profile.reload();
+    expect(profile.state).toBe("ready");
+
+    const imports = await Import.findAll({
+      where: {
+        profileId: profile.id,
+        creatorType: "task",
+        creatorId: "profiles:confirm",
+      },
+    });
+    expect(imports.length).toBe(0);
+
+    await profile.destroy();
+    await schedule.destroy();
+  });
+
+  test("only processes profiles up to the batch size", async () => {
+    await plugin.updateSetting("core", "runs-profile-batch-size", 2);
+
+    const profile1: Profile = await helper.factories.profile();
+    const profile2: Profile = await helper.factories.profile();
+    const profile3: Profile = await helper.factories.profile();
+
+    await ProfileProperty.update(
+      {
+        state: "ready",
+        confirmedAt: Moment().subtract(10, "days").toDate(),
+      },
+      {
+        where: {
+          profileId: [profile1.id, profile2.id, profile3.id],
+        },
+      }
+    );
+
+    await Profile.update(
+      { state: "ready" },
+      {
+        where: {
+          id: [profile1.id, profile2.id, profile3.id],
+        },
+      }
+    );
+
+    const count = await specHelper.runTask("profiles:confirm", {});
+    expect(count).toBe(2);
+
+    await profile1.reload();
+    await profile2.reload();
+    await profile3.reload();
+
+    const states = [profile1.state, profile2.state, profile3.state].sort();
+    expect(states).toEqual(["pending", "pending", "ready"]);
+  });
+});

--- a/core/__tests__/tasks/profile/confirm.ts
+++ b/core/__tests__/tasks/profile/confirm.ts
@@ -6,6 +6,7 @@ import {
   plugin,
   Profile,
   ProfileProperty,
+  Run,
   Schedule,
   Source,
 } from "../../../src";
@@ -182,7 +183,7 @@ describe("tasks/profiles:confirm", () => {
     const schedule: Schedule = await helper.factories.schedule(source, {
       confirmProfiles: true,
     });
-    await helper.factories.run(schedule, {
+    const run: Run = await helper.factories.run(schedule, {
       state: "complete",
       completedAt: new Date(),
     });
@@ -210,8 +211,8 @@ describe("tasks/profiles:confirm", () => {
     const imports = await Import.findAll({
       where: {
         profileId: profile.id,
-        creatorType: "task",
-        creatorId: "profiles:confirm",
+        creatorType: "run",
+        creatorId: run.id,
       },
     });
     expect(imports.length).toBe(1);
@@ -227,7 +228,7 @@ describe("tasks/profiles:confirm", () => {
     const schedule: Schedule = await helper.factories.schedule(source, {
       confirmProfiles: false,
     });
-    await helper.factories.run(schedule, {
+    const run: Run = await helper.factories.run(schedule, {
       state: "complete",
       completedAt: new Date(),
     });
@@ -255,8 +256,8 @@ describe("tasks/profiles:confirm", () => {
     const imports = await Import.findAll({
       where: {
         profileId: profile.id,
-        creatorType: "task",
-        creatorId: "profiles:confirm",
+        creatorType: "run",
+        creatorId: run.id,
       },
     });
     expect(imports.length).toBe(0);

--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -76,6 +76,7 @@ export class ScheduleCreate extends AuthenticatedAction {
       name: { required: false },
       sourceId: { required: true },
       recurring: { required: true },
+      confirmProfiles: { required: false },
       state: { required: false },
       options: { required: false },
       recurringFrequency: { required: true, default: 0 },
@@ -89,6 +90,7 @@ export class ScheduleCreate extends AuthenticatedAction {
       sourceId: params.sourceId,
       recurring: params.recurring,
       recurringFrequency: params.recurringFrequency,
+      confirmProfiles: params.confirmProfiles,
     });
 
     if (params.options) await schedule.setOptions(params.options);

--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -116,6 +116,7 @@ export class ScheduleEdit extends AuthenticatedAction {
       name: { required: false },
       sourceId: { required: false },
       recurring: { required: false },
+      confirmProfiles: { required: false },
       state: { required: false },
       options: { required: false },
       recurringFrequency: { required: false },
@@ -136,7 +137,11 @@ export class ScheduleEdit extends AuthenticatedAction {
     if (params.options) await schedule.setOptions(params.options);
     if (params.filters) await schedule.setFilters(params.filters);
 
-    await schedule.update({ state: params.state, name: params.name });
+    await schedule.update({
+      state: params.state,
+      name: params.name,
+      confirmProfiles: params.confirmProfiles,
+    });
 
     await ConfigWriter.run();
 

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -35,6 +35,7 @@ export interface ConfigurationObject {
   unique?: boolean;
   isArray?: boolean;
   rules?: GroupRuleWithKey[];
+  confirmProfiles?: boolean;
   recurring?: boolean;
   recurringFrequency?: number;
   groupId?: string;

--- a/core/src/initializers/settings.ts
+++ b/core/src/initializers/settings.ts
@@ -148,7 +148,7 @@ export class Plugins extends CLSInitializer {
         title: "Confirm Profile Existence Days",
         defaultValue: 7,
         description:
-          "How many days should we wait before creating an import for a profile that hasn't been seen in a while to confirm they still exist in the source?",
+          "How often should Grouparoo check that a Profile still exists in your Source, deleting the Profile if it has been removed? Setting to `0` will disable this check.",
         type: "number",
       },
       {

--- a/core/src/initializers/settings.ts
+++ b/core/src/initializers/settings.ts
@@ -144,6 +144,14 @@ export class Plugins extends CLSInitializer {
         type: "string",
       },
       {
+        key: "confirm-profiles-days",
+        title: "Confirm Profile Existence Days",
+        defaultValue: 7,
+        description:
+          "How many days should we wait before creating an import for a profile that hasn't been seen in a while to confirm they still exist in the source?",
+        type: "number",
+      },
+      {
         key: "sweeper-delete-old-runs-days",
         title: "Sweeper: Delete Old Runs Days",
         defaultValue: 31,

--- a/core/src/migrations/000077-addScheduleConfirmProfiles.ts
+++ b/core/src/migrations/000077-addScheduleConfirmProfiles.ts
@@ -1,0 +1,15 @@
+export default {
+  up: async function (migration, DataTypes) {
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("schedules", "confirmProfiles", {
+        type: DataTypes.BOOLEAN,
+      });
+    });
+  },
+
+  down: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("schedules", "confirmProfiles");
+    });
+  },
+};

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -112,6 +112,11 @@ export class Schedule extends LoggedModel<Schedule> {
   @Column
   recurringFrequency: number;
 
+  @AllowNull(false)
+  @Default(false)
+  @Column
+  confirmProfiles: boolean;
+
   @HasMany(() => Option, {
     foreignKey: "ownerId",
     scope: { ownerType: "schedule" },
@@ -123,6 +128,12 @@ export class Schedule extends LoggedModel<Schedule> {
     scope: { ownerType: "schedule" },
   })
   filters: Filter[];
+
+  @HasMany(() => Run, {
+    foreignKey: "creatorId",
+    scope: { creatorType: "schedule" },
+  })
+  runs: Run[];
 
   @BelongsTo(() => Source)
   source: Source;
@@ -183,6 +194,7 @@ export class Schedule extends LoggedModel<Schedule> {
       sourceId: this.sourceId,
       recurring: this.recurring,
       locked: this.locked,
+      confirmProfiles: this.confirmProfiles,
       options,
       filters,
       recurringFrequency: this.recurringFrequency,

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -226,7 +226,7 @@ export class Schedule extends LoggedModel<Schedule> {
   }
 
   async getConfigObject() {
-    const { name, recurring, recurringFrequency } = this;
+    const { name, recurring, recurringFrequency, confirmProfiles } = this;
 
     this.source = await this.$get("source");
     const sourceId = this.source?.getConfigId();
@@ -243,6 +243,7 @@ export class Schedule extends LoggedModel<Schedule> {
       sourceId,
       recurring,
       recurringFrequency,
+      confirmProfiles,
       options,
       filters,
     };

--- a/core/src/modules/configLoaders/schedule.ts
+++ b/core/src/modules/configLoaders/schedule.ts
@@ -38,6 +38,7 @@ export async function loadSchedule(
     name: configObject.name,
     recurring: configObject.recurring,
     recurringFrequency: configObject.recurringFrequency,
+    confirmProfiles: configObject.confirmProfiles,
   });
 
   await schedule.setOptions(extractNonNullParts(configObject, "options"));

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -756,7 +756,7 @@ export namespace ProfileOps {
         oldProfileProperties,
         oldGroupIds,
         creatorType: "task",
-        creatorId: this.name,
+        creatorId: "profiles:confirm",
       });
     }
 

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -708,6 +708,65 @@ export namespace ProfileOps {
   }
 
   /**
+   * Import profiles whose directlyMapped property has not been confirmed after a certain date.
+   */
+  export async function confirmExistence(
+    limit: number,
+    fromDate: Date,
+    sourceId?: string
+  ) {
+    const properties = await Property.findAllWithCache();
+    const directlyMapped = properties.filter(
+      (p) => p.directlyMapped && (!sourceId || sourceId === p.sourceId)
+    );
+
+    const profiles = await Profile.findAll({
+      limit,
+      where: { state: "ready" },
+      include: [
+        GroupMember,
+        {
+          model: ProfileProperty,
+          required: true,
+          where: {
+            state: "ready",
+            confirmedAt: {
+              [Op.lt]: fromDate,
+            },
+            rawValue: {
+              [Op.ne]: null,
+            },
+            propertyId: directlyMapped.map((p) => p.id),
+          },
+        },
+      ],
+    });
+
+    const now = new Date();
+
+    const bulkImports = [];
+    for (const profile of profiles) {
+      delete profile.profileProperties; // get all profile properties
+      const oldProfileProperties = await profile.simplifiedProperties();
+      const oldGroupIds = profile.groupMembers.map((gm) => gm.groupId);
+
+      bulkImports.push({
+        profileId: profile.id,
+        profileAssociatedAt: now,
+        oldProfileProperties,
+        oldGroupIds,
+        creatorType: "task",
+        creatorId: this.name,
+      });
+    }
+
+    await Import.bulkCreate(bulkImports);
+    await markPendingByIds(profiles.map((p) => p.id));
+
+    return profiles.length;
+  }
+
+  /**
    * Merge 2 Profiles, favoring the first Profile
    */
   export async function merge(profile: Profile, otherProfile: Profile) {

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -14,6 +14,7 @@ import { ProfilePropertyOps } from "./profileProperty";
 import { GroupRule } from "../../models/GroupRule";
 import { Import } from "../../models/Import";
 import { plugin } from "../plugin";
+import { Run } from "../../models/Run";
 
 export interface ProfilePropertyType {
   [key: string]: {
@@ -713,7 +714,8 @@ export namespace ProfileOps {
   export async function confirmExistence(
     limit: number,
     fromDate: Date,
-    sourceId?: string
+    sourceId?: string,
+    run?: Run
   ) {
     const properties = await Property.findAllWithCache();
     const directlyMapped = properties.filter(
@@ -743,8 +745,12 @@ export namespace ProfileOps {
     });
 
     const now = new Date();
-
     const bulkImports = [];
+
+    const creatorInfo = run
+      ? { creatorType: "run", creatorId: run.id }
+      : { creatorType: "task", creatorId: "profiles:confirm" };
+
     for (const profile of profiles) {
       delete profile.profileProperties; // get all profile properties
       const oldProfileProperties = await profile.simplifiedProperties();
@@ -755,8 +761,7 @@ export namespace ProfileOps {
         profileAssociatedAt: now,
         oldProfileProperties,
         oldGroupIds,
-        creatorType: "task",
-        creatorId: "profiles:confirm",
+        ...creatorInfo,
       });
     }
 

--- a/core/src/tasks/profile/confirm.ts
+++ b/core/src/tasks/profile/confirm.ts
@@ -12,14 +12,13 @@ import { ProfileOps } from "../../modules/ops/profile";
 import { GroupMember } from "../../models/GroupMember";
 import { Import } from "../../models/Import";
 
-export class ProfilePropertiesEnqueue extends CLSTask {
+export class ProfilesConfirm extends CLSTask {
   constructor() {
     super();
-    this.name = "profileProperties:confirm";
-    this.description =
-      "Confirm that directlyMapped profile properties still exist";
+    this.name = "profiles:confirm";
+    this.description = "Confirm that profiles still exist in the source";
     this.frequency = 1000 * 30;
-    this.queue = "profileProperties";
+    this.queue = "profiles";
     this.inputs = {};
   }
 

--- a/core/src/tasks/profile/confirm.ts
+++ b/core/src/tasks/profile/confirm.ts
@@ -48,8 +48,10 @@ export class ProfilesConfirm extends CLSTask {
       );
     }
 
-    const nextConfirmAt = Moment().subtract(confirmDays, "days").toDate();
-    count += await ProfileOps.confirmExistence(limit - count, nextConfirmAt);
+    if (confirmDays > 0) {
+      const nextConfirmAt = Moment().subtract(confirmDays, "days").toDate();
+      count += await ProfileOps.confirmExistence(limit - count, nextConfirmAt);
+    }
 
     // re-enqueue if there is more to do
     if (count > 0) await CLS.enqueueTask(this.name, {});

--- a/core/src/tasks/profile/confirm.ts
+++ b/core/src/tasks/profile/confirm.ts
@@ -41,6 +41,12 @@ export class ProfilesConfirm extends CLSTask {
 
     for (const schedule of schedules) {
       const latestRun = schedule.runs[0];
+      const pendingImports = await latestRun.$count("imports", {
+        where: { profileAssociatedAt: null },
+      });
+
+      if (pendingImports !== 0) continue;
+
       count += await ProfileOps.confirmExistence(
         limit - count,
         latestRun.completedAt,

--- a/core/src/tasks/profile/confirm.ts
+++ b/core/src/tasks/profile/confirm.ts
@@ -40,11 +40,12 @@ export class ProfilesConfirm extends CLSTask {
     });
 
     for (const schedule of schedules) {
-      const latestRunAt = schedule.runs[0].completedAt;
+      const latestRun = schedule.runs[0];
       count += await ProfileOps.confirmExistence(
         limit - count,
-        latestRunAt,
-        schedule.sourceId
+        latestRun.completedAt,
+        schedule.sourceId,
+        latestRun
       );
     }
 

--- a/core/src/tasks/profile/confirm.ts
+++ b/core/src/tasks/profile/confirm.ts
@@ -1,16 +1,10 @@
-import { Op } from "sequelize";
 import Moment from "moment";
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { CLS } from "../../modules/cls";
-import { Property } from "../../models/Property";
 import { plugin } from "../../modules/plugin";
-import { ProfileProperty } from "../../models/ProfileProperty";
-import { Profile } from "../../models/Profile";
 import { Schedule } from "../../models/Schedule";
 import { Run } from "../../models/Run";
 import { ProfileOps } from "../../modules/ops/profile";
-import { GroupMember } from "../../models/GroupMember";
-import { Import } from "../../models/Import";
 
 export class ProfilesConfirm extends CLSTask {
   constructor() {
@@ -20,62 +14,6 @@ export class ProfilesConfirm extends CLSTask {
     this.frequency = 1000 * 30;
     this.queue = "profiles";
     this.inputs = {};
-  }
-
-  async confirmProfileProperties(
-    limit: number,
-    fromDate: Date,
-    sourceId?: string
-  ) {
-    const properties = await Property.findAllWithCache();
-    const directlyMapped = properties.filter(
-      (p) => p.directlyMapped && (!sourceId || sourceId === p.sourceId)
-    );
-
-    const profiles = await Profile.findAll({
-      limit,
-      where: { state: "ready" },
-      include: [
-        GroupMember,
-        {
-          model: ProfileProperty,
-          required: true,
-          where: {
-            state: "ready",
-            confirmedAt: {
-              [Op.lt]: fromDate,
-            },
-            rawValue: {
-              [Op.ne]: null,
-            },
-            propertyId: directlyMapped.map((p) => p.id),
-          },
-        },
-      ],
-    });
-
-    const now = new Date();
-
-    const bulkImports = [];
-    for (const profile of profiles) {
-      delete profile.profileProperties; // get all profile properties
-      const oldProfileProperties = await profile.simplifiedProperties();
-      const oldGroupIds = profile.groupMembers.map((gm) => gm.groupId);
-
-      bulkImports.push({
-        profileId: profile.id,
-        profileAssociatedAt: now,
-        oldProfileProperties,
-        oldGroupIds,
-        creatorType: "task",
-        creatorId: this.name,
-      });
-    }
-
-    await Import.bulkCreate(bulkImports);
-    await ProfileOps.markPendingByIds(profiles.map((p) => p.id));
-
-    return profiles.length;
   }
 
   async runWithinTransaction() {
@@ -105,16 +43,16 @@ export class ProfilesConfirm extends CLSTask {
 
     for (const schedule of schedules) {
       const latestRunAt = schedule.runs[0].completedAt;
-      count += await this.confirmProfileProperties(
+      count += await ProfileOps.confirmExistence(
         limit - count,
         latestRunAt,
         schedule.sourceId
       );
     }
 
-    const days = 1;
+    const days = 1; // TODO make a setting
     const nextConfirmAt = Moment().subtract(days, "days").toDate();
-    count += await this.confirmProfileProperties(limit - count, nextConfirmAt);
+    count += await ProfileOps.confirmExistence(limit - count, nextConfirmAt);
 
     // re-enqueue if there is more to do
     if (count > 0) await CLS.enqueueTask(this.name, {});

--- a/core/src/tasks/profile/confirm.ts
+++ b/core/src/tasks/profile/confirm.ts
@@ -18,12 +18,10 @@ export class ProfilesConfirm extends CLSTask {
 
   async runWithinTransaction() {
     const limit = parseInt(
-      (
-        await plugin.readSetting(
-          "core",
-          "imports-profile-properties-batch-size"
-        )
-      ).value
+      (await plugin.readSetting("core", "runs-profile-batch-size")).value
+    );
+    const confirmDays = parseInt(
+      (await plugin.readSetting("core", "confirm-profiles-days")).value
     );
 
     let count = 0;
@@ -50,8 +48,7 @@ export class ProfilesConfirm extends CLSTask {
       );
     }
 
-    const days = 1; // TODO make a setting
-    const nextConfirmAt = Moment().subtract(days, "days").toDate();
+    const nextConfirmAt = Moment().subtract(confirmDays, "days").toDate();
     count += await ProfileOps.confirmExistence(limit - count, nextConfirmAt);
 
     // re-enqueue if there is more to do

--- a/core/src/tasks/profileProperty/confirm.ts
+++ b/core/src/tasks/profileProperty/confirm.ts
@@ -1,0 +1,111 @@
+import { Op } from "sequelize";
+import Moment from "moment";
+import { CLSTask } from "../../classes/tasks/clsTask";
+import { CLS } from "../../modules/cls";
+import { Property } from "../../models/Property";
+import { plugin } from "../../modules/plugin";
+import { ProfileProperty } from "../../models/ProfileProperty";
+import { Profile } from "../../models/Profile";
+import { Schedule } from "../../models/Schedule";
+import { Run } from "../../models/Run";
+
+export class ProfilePropertiesEnqueue extends CLSTask {
+  constructor() {
+    super();
+    this.name = "profileProperties:confirm";
+    this.description =
+      "Confirm that directlymapped profile properties still exist";
+    this.frequency = 1000 * 10;
+    this.queue = "profileProperties";
+    this.inputs = {};
+  }
+
+  async confirmProfileProperties(
+    limit: number,
+    fromDate: Date,
+    sourceId?: string
+  ) {
+    const properties = await Property.findAllWithCache();
+    const directlyMapped = properties.filter(
+      (p) => p.directlyMapped && (!sourceId || sourceId === p.sourceId)
+    );
+
+    const { count, rows: profileProperties } =
+      await ProfileProperty.findAndCountAll({
+        limit,
+        where: {
+          state: "ready",
+          confirmedAt: {
+            [Op.lt]: fromDate,
+          },
+          rawValue: {
+            [Op.ne]: null,
+          },
+          propertyId: directlyMapped.map((p) => p.id),
+        },
+      });
+
+    await ProfileProperty.update(
+      {
+        state: "pending",
+      },
+      {
+        where: {
+          id: profileProperties.map((p) => p.id),
+        },
+      }
+    );
+
+    const profileIds = profileProperties.map((p) => p.profileId);
+    await Profile.update({ state: "pending" }, { where: { id: profileIds } });
+
+    return count;
+  }
+
+  async runWithinTransaction() {
+    const limit = parseInt(
+      (
+        await plugin.readSetting(
+          "core",
+          "imports-profile-properties-batch-size"
+        )
+      ).value
+    );
+
+    let count = 0;
+
+    const schedules = await Schedule.findAll({
+      where: { confirmProfiles: true },
+      include: [
+        {
+          model: Run,
+          limit: 1,
+          where: { state: "complete" },
+          order: [["completedAt", "desc"]],
+          required: true,
+        },
+      ],
+    });
+
+    for (const schedule of schedules) {
+      const latestRunAt = schedule.runs[0].completedAt;
+      count += await this.confirmProfileProperties(
+        limit,
+        latestRunAt,
+        schedule.sourceId
+      );
+    }
+
+    // const days = 1;
+
+    // const ts = Moment().add(days, "days").toDate();
+    // confirmProfileProperties(ts)
+
+    // const delayMs = 1 * 24 * 60 * 60 * 1000; // 1 day (for testing)
+
+    // re-enqueue if there is more to do
+    if (count > 0) await CLS.enqueueTask(this.name, {});
+
+    return count;
+  }
+}

--- a/ui/ui-components/pages/import/[id]/edit.tsx
+++ b/ui/ui-components/pages/import/[id]/edit.tsx
@@ -16,13 +16,6 @@ export default function Page(props) {
     _import,
   }: { groups: Models.GroupType[]; _import: Models.ImportType } = props;
 
-  function groupName(groupId) {
-    const group = groups.filter((g) => g.id === groupId)[0];
-    if (group) {
-      return group.name;
-    }
-  }
-
   const errorMetadata = _import.errorMetadata
     ? JSON.parse(_import.errorMetadata)
     : {};
@@ -42,14 +35,13 @@ export default function Page(props) {
           <h2>Details</h2>
           <p>
             Creator:{" "}
-            <Link href={`/object/${_import.creatorId}`} prefetch={false}>
-              <a>
-                {_import.creatorType === "group"
-                  ? `"${groupName(_import.creatorId)}"`
-                  : null}{" "}
-                {_import.creatorId}
-              </a>
-            </Link>
+            {_import.creatorType === "run" ? (
+              <Link href="/run/[id]/edit" as={`/run/${_import.creatorId}/edit`}>
+                <a>{_import.creatorId}</a>
+              </Link>
+            ) : (
+              _import.creatorId
+            )}
             <br />
             Profile:{" "}
             <Link

--- a/ui/ui-components/pages/source/[id]/schedule.tsx
+++ b/ui/ui-components/pages/source/[id]/schedule.tsx
@@ -155,6 +155,15 @@ export default function Page(props) {
         <fieldset disabled={schedule.locked !== null}>
           <Row>
             <Col>
+              <Form.Group controlId="confirmProfiles">
+                <Form.Check
+                  type="checkbox"
+                  label="Confirm that profiles exist when running schedule?"
+                  disabled={loading}
+                  checked={schedule.confirmProfiles}
+                  onChange={(e) => update(e)}
+                />
+              </Form.Group>
               <Form.Group controlId="recurring">
                 <Form.Check
                   type="checkbox"


### PR DESCRIPTION
- [x] Confirm after schedule runs (if option is selected) - for sources that want to delete profiles every time the schedule runs (full table)
- [x] Confirm at a set frequency - for sources with large amounts of profiles that work off a high watermark, so this can be done less frequently
  - [x] Setting to configure how often we confirm
- [x] Mark all properties pending (to clear everything else out and correctly remove from groups if needed) 
- [x] Create imports - we're marking everything pending so there could be unrelated changes in other properties. Make imports so we can track these changes.
- [x] Testing

(?) Do we need a run for these imports? What kind of run would it be? Who would be its creator?

### New option on schedules:
Is this name too long?
![image](https://user-images.githubusercontent.com/4368928/126668248-22fb25f3-993b-431c-9a6c-ca143250f5a2.png)
