### PR TITLE
Rename `profile.properties()` to `profile.getProperties()`

### DIFF
--- a/core/__tests__/actions/properties.ts
+++ b/core/__tests__/actions/properties.ts
@@ -349,7 +349,7 @@ describe("actions/properties", () => {
       const _profile = await helper.factories.profile();
       await _profile.addOrUpdateProperties({ userId: [1001] });
 
-      const originalProperties = _profile.properties();
+      const originalProperties = _profile.getProperties();
       expect(originalProperties["email"]).toBeFalsy();
 
       connection.params = {

--- a/core/__tests__/integration/runs/internalRun.ts
+++ b/core/__tests__/integration/runs/internalRun.ts
@@ -131,7 +131,7 @@ describe("integration/runs/internalRun", () => {
       });
 
       // both new properties are marked as pending
-      const properties = await profile.properties();
+      const properties = await profile.getProperties();
       expect(properties.userId.state).toBe("ready");
       expect(properties.email.state).toBe("ready");
       expect(properties.firstName.state).toBe("pending");

--- a/core/__tests__/models/profile/profile.ts
+++ b/core/__tests__/models/profile/profile.ts
@@ -185,7 +185,7 @@ describe("models/profile", () => {
       expect(responseB.isNew).toBe(false);
 
       const profile = responseB.profile;
-      const properties = await profile.properties();
+      const properties = await profile.getProperties();
       expect(properties.email.values).toEqual(["koopa@example.com"]);
       expect(properties.userId.values).toEqual([99]);
       expect(properties.house.values).toEqual([null]);
@@ -193,7 +193,7 @@ describe("models/profile", () => {
     });
 
     test("properties will include the value, type, unique, and timestamps", async () => {
-      const properties = await toad.properties();
+      const properties = await toad.getProperties();
       expect(properties.email.type).toBe("email");
       expect(properties.email.unique).toBe(true);
       expect(properties.email.values[0]).toBe("toad@example.com");
@@ -273,7 +273,7 @@ describe("models/profile", () => {
 
       test("creating a profile creates null profile properties", async () => {
         const newProfile = await Profile.create();
-        const properties = await newProfile.properties();
+        const properties = await newProfile.getProperties();
         expect(Object.keys(properties).length).toBe(5);
         for (const k in properties) {
           expect(properties[k].values).toEqual([null]);
@@ -293,7 +293,7 @@ describe("models/profile", () => {
         await newProfile.reload();
 
         expect(newProfile.state).toBe("pending");
-        const properties = await newProfile.properties();
+        const properties = await newProfile.getProperties();
         for (const k in properties) {
           if (k === "userId") {
             expect(properties[k].state).toEqual("ready");
@@ -306,7 +306,7 @@ describe("models/profile", () => {
 
       test("it can add a new profile property when the schema is prepared", async () => {
         await profile.addOrUpdateProperties({ email: ["luigi@example.com"] });
-        const properties = await profile.properties();
+        const properties = await profile.getProperties();
         expect(simpleProfileValues(properties)).toEqual({
           email: ["luigi@example.com"],
           firstName: [null],
@@ -323,7 +323,7 @@ describe("models/profile", () => {
         );
 
         await profile.addOrUpdateProperties({ email: ["luigi@example.com"] });
-        const properties = await profile.properties();
+        const properties = await profile.getProperties();
         expect(properties.email.state).toBe("ready");
         expect(properties.firstName.state).toBe("pending");
       });
@@ -356,7 +356,7 @@ describe("models/profile", () => {
           await profile.addOrUpdateProperties({
             email: ["new-email@example.com"],
           });
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(properties.email.valueChangedAt.getTime()).toBeGreaterThan(
             start
           );
@@ -370,7 +370,7 @@ describe("models/profile", () => {
           await profile.addOrUpdateProperties({
             email: ["new-email@example.com"],
           });
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(properties.email.valueChangedAt.getTime()).toBeLessThan(start);
           expect(properties.email.confirmedAt.getTime()).toBeGreaterThan(start);
         });
@@ -386,7 +386,7 @@ describe("models/profile", () => {
           await profile.addOrUpdateProperties({
             email: ["new-email@example.com"],
           });
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(properties.email.stateChangedAt.getTime()).toBeGreaterThan(
             start
           );
@@ -418,7 +418,7 @@ describe("models/profile", () => {
           await profile.addOrUpdateProperties({
             purchases: ["hat"],
           });
-          let properties = await profile.properties();
+          let properties = await profile.getProperties();
           expect(properties.purchases.valueChangedAt.getTime()).toBeGreaterThan(
             start
           );
@@ -430,7 +430,7 @@ describe("models/profile", () => {
           await profile.addOrUpdateProperties({
             purchases: ["hat", "mushroom"],
           });
-          properties = await profile.properties();
+          properties = await profile.getProperties();
           expect(properties.purchases.valueChangedAt.getTime()).toBeGreaterThan(
             firstChangeAt
           );
@@ -443,7 +443,7 @@ describe("models/profile", () => {
           await profile.addOrUpdateProperties({
             purchases: ["hat", "mushroom"],
           });
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(properties.purchases.valueChangedAt.getTime()).toBeLessThan(
             start
           );
@@ -463,7 +463,7 @@ describe("models/profile", () => {
           await profile.addOrUpdateProperties({
             purchases: ["hat", "mushroom"],
           });
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(properties.purchases.stateChangedAt.getTime()).toBeGreaterThan(
             start
           );
@@ -480,7 +480,7 @@ describe("models/profile", () => {
             userId: [123],
           });
 
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(simpleProfileValues(properties)).toEqual({
             email: ["luigi@example.com"],
             firstName: ["Luigi"],
@@ -501,7 +501,7 @@ describe("models/profile", () => {
           await profile.addOrUpdateProperties({
             email: ["luigi-again@example.com"],
           });
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(simpleProfileValues(properties)).toEqual({
             email: ["luigi-again@example.com"],
             firstName: ["Luigi"],
@@ -513,14 +513,14 @@ describe("models/profile", () => {
 
         test("it will ignore the property _meta, as it is reserved", async () => {
           await profile.addOrUpdateProperties({ _meta: ["bla"] });
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(simpleProfileValues(properties)._meta).toBeFalsy();
           expect(simpleProfileValues(properties).firstName).toEqual(["Luigi"]);
         });
 
         test("it can remove an existing property", async () => {
           await profile.removeProperty("email");
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(properties["email"]).toBeUndefined();
           expect(simpleProfileValues(properties)).toEqual({
             firstName: ["Luigi"],
@@ -531,16 +531,16 @@ describe("models/profile", () => {
         });
 
         test("no problems arise when re-adding a deleted property", async () => {
-          let properties = await profile.properties();
+          let properties = await profile.getProperties();
           expect(properties.email).toBeUndefined();
           await profile.addOrUpdateProperties({ email: ["luigi@example.com"] });
-          properties = await profile.properties();
+          properties = await profile.getProperties();
           expect(properties.email.values).toEqual(["luigi@example.com"]);
         });
 
         test("it will not raise when trying to remove a non-existent property", async () => {
           await profile.removeProperty("funky");
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(simpleProfileValues(properties)).toEqual({
             email: ["luigi@example.com"],
             firstName: ["Luigi"],
@@ -552,7 +552,7 @@ describe("models/profile", () => {
 
         test("profile properties can be addded by key", async () => {
           await profile.addOrUpdateProperties({ email: ["luigi@example.com"] });
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(simpleProfileValues(properties).email).toEqual([
             "luigi@example.com",
           ]);
@@ -566,7 +566,7 @@ describe("models/profile", () => {
             [emailProperty.id]: ["luigi@example.com"],
           });
 
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(simpleProfileValues(properties).email).toEqual([
             "luigi@example.com",
           ]);
@@ -587,7 +587,7 @@ describe("models/profile", () => {
             { hooks: false } // we need to skip validations
           );
 
-          const properties = await profile.properties(); // does not throw
+          const properties = await profile.getProperties(); // does not throw
           expect(Object.keys(properties).length).toBe(5);
 
           await expect(profileProperty.reload()).rejects.toThrow(
@@ -635,7 +635,7 @@ describe("models/profile", () => {
             userId: [123],
             purchases: ["star", "mushroom", "mushroom", "go kart"],
           });
-          const properties = await profile.properties();
+          const properties = await profile.getProperties();
           expect(simpleProfileValues(properties)).toEqual({
             email: ["luigi@example.com"],
             firstName: ["Luigi"],
@@ -651,14 +651,14 @@ describe("models/profile", () => {
             email: ["luigi@example.com"],
             purchases: ["star", "mushroom", "mushroom", "go kart"],
           });
-          const firstProperties = await profile.properties();
+          const firstProperties = await profile.getProperties();
           const firstUpdate = firstProperties.purchases.updatedAt;
 
           await profile.addOrUpdateProperties({
             email: ["luigi@example.com"],
             purchases: ["star", "mushroom", "mushroom", "go kart"],
           });
-          const secondProperties = await profile.properties();
+          const secondProperties = await profile.getProperties();
           expect(
             secondProperties.purchases.updatedAt.getTime()
           ).toBeGreaterThanOrEqual(firstUpdate.getTime());
@@ -669,7 +669,7 @@ describe("models/profile", () => {
             email: ["luigi@example.com"],
             purchases: ["star", "mushroom", "mushroom", "go kart"],
           });
-          const firstProperties = await profile.properties();
+          const firstProperties = await profile.getProperties();
           const firstUpdate = firstProperties.purchases.updatedAt;
 
           await helper.sleep(1000);
@@ -678,7 +678,7 @@ describe("models/profile", () => {
             email: ["luigi@example.com"],
             purchases: ["go kart"],
           });
-          const secondProperties = await profile.properties();
+          const secondProperties = await profile.getProperties();
           expect(
             secondProperties.purchases.updatedAt.getTime()
           ).toBeGreaterThan(firstUpdate.getTime());
@@ -898,7 +898,7 @@ describe("models/profile", () => {
       const profile = await Profile.create();
       await profile.addOrUpdateProperties({ userId: [1001] });
       await profile.addOrUpdateProperties({ email: ["peach@example.com"] });
-      let properties = await profile.properties();
+      let properties = await profile.getProperties();
       expect(simpleProfileValues(properties)).toEqual({
         userId: [1001],
         email: ["peach@example.com"],
@@ -912,7 +912,7 @@ describe("models/profile", () => {
       };
       await profile.import();
 
-      properties = await profile.properties();
+      properties = await profile.getProperties();
       expect(simpleProfileValues(properties)).toEqual({
         userId: [1001],
         email: ["peach@example.com"],
@@ -927,7 +927,7 @@ describe("models/profile", () => {
         email: ["bowser@example.com"],
         color: ["green"],
       });
-      let properties = await profile.properties();
+      let properties = await profile.getProperties();
       expect(Object.keys(properties).sort()).toEqual([
         "color",
         "email",
@@ -942,7 +942,7 @@ describe("models/profile", () => {
 
       await profile.import();
 
-      properties = await profile.properties();
+      properties = await profile.getProperties();
       expect(simpleProfileValues(properties)).toEqual({
         userId: [1003],
         email: ["bowser@example.com"],
@@ -955,7 +955,7 @@ describe("models/profile", () => {
     test("after importing, all missing properties will have created a null profile property", async () => {
       const profile = await Profile.create();
       await profile.addOrUpdateProperties({ userId: [1002] });
-      let properties = await profile.properties();
+      let properties = await profile.getProperties();
       expect(Object.keys(properties).sort()).toEqual([
         "color",
         "email",
@@ -968,7 +968,7 @@ describe("models/profile", () => {
       };
       await profile.import();
 
-      properties = await profile.properties();
+      properties = await profile.getProperties();
       expect(simpleProfileValues(properties)).toEqual({
         userId: [1002],
         email: [null],
@@ -1003,8 +1003,8 @@ describe("models/profile", () => {
     });
 
     test("the profiles both have properties", async () => {
-      const propertiesA = await profileA.properties();
-      const propertiesB = await profileB.properties();
+      const propertiesA = await profileA.getProperties();
+      const propertiesB = await profileB.getProperties();
       expect(Object.keys(propertiesA).length).toBe(9);
       expect(Object.keys(propertiesB).length).toBe(9);
     });
@@ -1020,8 +1020,8 @@ describe("models/profile", () => {
         email: ["new-email@example.com"],
       });
 
-      const propertiesA = await profileA.properties();
-      const propertiesB = await profileB.properties();
+      const propertiesA = await profileA.getProperties();
+      const propertiesB = await profileB.getProperties();
 
       expect(propertiesA.email.values).toEqual(["new-email@example.com"]);
       expect(propertiesA.userId.values).toBeTruthy();
@@ -1046,14 +1046,14 @@ describe("models/profile", () => {
     test("merging profiles moved the properties", async () => {
       await ProfileOps.merge(profileA, profileB);
 
-      const propertiesA = await profileA.properties();
-      const propertiesB = await profileB.properties();
+      const propertiesA = await profileA.getProperties();
+      const propertiesB = await profileB.getProperties();
       expect(Object.keys(propertiesA).length).toBe(9);
       expect(Object.keys(propertiesB).length).toBe(0);
     });
 
     test("the merged profile kept the newer non-null properties", async () => {
-      const properties = await profileA.properties();
+      const properties = await profileA.getProperties();
       expect(properties.email.values).toEqual(["new-email@example.com"]);
       expect(properties.userId.values).toEqual([100]);
       expect(properties.firstName.values).toEqual(["fname"]);
@@ -1062,14 +1062,14 @@ describe("models/profile", () => {
 
     test("the merged profiles should have only kept the array properties of the newest profile property", async () => {
       // we can't be sure of the array-order for the combined profiles.  A re-import should be deterministic too
-      const propertiesA = await profileA.properties();
+      const propertiesA = await profileA.getProperties();
       expect(propertiesA.purchases.values).toEqual(["shoe"]);
     });
 
     test("the merged profile is pending", async () => {
       await profileA.reload();
       expect(profileA.state).toBe("pending");
-      const properties = await profileA.properties();
+      const properties = await profileA.getProperties();
       for (const k in properties) {
         k === "userId"
           ? expect(properties[k].state).toBe("ready")

--- a/core/__tests__/models/profile/sync.ts
+++ b/core/__tests__/models/profile/sync.ts
@@ -45,7 +45,7 @@ describe("profile sync", () => {
   });
 
   test("syncing a profile will import properties", async () => {
-    let properties = await profile.properties();
+    let properties = await profile.getProperties();
     expect(simpleProfileValues(properties)).toEqual(
       expect.objectContaining({
         firstName: [null],
@@ -57,7 +57,7 @@ describe("profile sync", () => {
 
     await profile.sync();
 
-    properties = await profile.properties();
+    properties = await profile.getProperties();
     expect(simpleProfileValues(properties)).toEqual(
       expect.objectContaining({
         firstName: ["Mario"],

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -1071,7 +1071,7 @@ describe("modules/codeConfig", () => {
         expect(john.id).toBe("profile_john");
         expect(john.state).toBe("pending");
 
-        const johnProps = await john.properties();
+        const johnProps = await john.getProperties();
         expect(johnProps.userId.state).toBe("ready");
         expect(johnProps.userId.values).toEqual([20]);
         expect(johnProps.email.state).toBe("pending");
@@ -1081,7 +1081,7 @@ describe("modules/codeConfig", () => {
         expect(matthew.id).toBe("profile_matthew");
         expect(matthew.state).toBe("pending");
 
-        const matthewProps = await matthew.properties();
+        const matthewProps = await matthew.getProperties();
         expect(matthewProps.userId.state).toBe("ready");
         expect(matthewProps.userId.values).toEqual([100]);
         expect(matthewProps.email.state).toBe("pending");

--- a/core/__tests__/modules/groupExport.ts
+++ b/core/__tests__/modules/groupExport.ts
@@ -92,7 +92,7 @@ describe("modules/groupExport", () => {
       let lastLoginAt: Date;
 
       // mario
-      let properties = await mario.properties();
+      let properties = await mario.getProperties();
       expect(rows[0].id).toBe(mario.id);
       expect(parseInt(rows[0].createdAt)).toBeGreaterThan(0);
       expect(rows[0]["email"]).toBe(properties.email.values[0]);
@@ -103,7 +103,7 @@ describe("modules/groupExport", () => {
       );
 
       // luigi
-      properties = await luigi.properties();
+      properties = await luigi.getProperties();
       expect(rows[1].id).toBe(luigi.id);
       expect(parseInt(rows[1].createdAt)).toBeGreaterThan(0);
       expect(rows[1]["email"]).toBe(properties.email.values[0]);
@@ -114,7 +114,7 @@ describe("modules/groupExport", () => {
       );
 
       // peach
-      properties = await peach.properties();
+      properties = await peach.getProperties();
       expect(rows[2].id).toBe(peach.id);
       expect(parseInt(rows[2].createdAt)).toBeGreaterThan(0);
       expect(rows[2]["email"]).toBe(properties.email.values[0]);
@@ -125,7 +125,7 @@ describe("modules/groupExport", () => {
       );
 
       // toad
-      properties = await toad.properties();
+      properties = await toad.getProperties();
       expect(rows[3].id).toBe(toad.id);
       expect(parseInt(rows[3].createdAt)).toBeGreaterThan(0);
       expect(rows[3]["email"]).toBe(properties.email.values[0]);
@@ -139,7 +139,7 @@ describe("modules/groupExport", () => {
     describe("array properties", () => {
       test("array properties are flattened into a comma-delimited list in a single CSV column", async () => {
         await mario.addOrUpdateProperties({ purchases: ["hat", "shell"] });
-        const properties = await mario.properties();
+        const properties = await mario.getProperties();
         expect(properties.purchases.values).toEqual(["hat", "shell"]);
 
         const { filename } = await groupExportToCSV(group, 1);

--- a/core/__tests__/tasks/profileProperty/importProfileProperties.ts
+++ b/core/__tests__/tasks/profileProperty/importProfileProperties.ts
@@ -215,7 +215,7 @@ describe("tasks/profileProperty:importProfileProperties", () => {
         });
       }
 
-      const profileProperties = await profileA.properties();
+      const profileProperties = await profileA.getProperties();
       expect(profileProperties.firstName.values).toEqual(["Mario"]);
       expect(profileProperties.lastName.values).toEqual(["Mario"]);
 

--- a/core/__tests__/tasks/profileProperty/sweep.ts
+++ b/core/__tests__/tasks/profileProperty/sweep.ts
@@ -35,12 +35,12 @@ describe("tasks/profileProperties:sweep", () => {
     );
 
     // other profiles' properties are OK
-    const marioProperties = await mario.properties();
+    const marioProperties = await mario.getProperties();
     expect(marioProperties["email"].values).toEqual(["mario@example.com"]);
   });
 
   test("a profile property with a missing property", async () => {
-    const luigi = await helper.factories.profile();
+    const luigi: Profile = await helper.factories.profile();
     await luigi.addOrUpdateProperties({
       firstName: ["Luigi"],
       lastName: ["Mario"],
@@ -66,7 +66,7 @@ describe("tasks/profileProperties:sweep", () => {
     );
 
     // Luigi's other properties are OK
-    const luigiProperties = await luigi.properties();
+    const luigiProperties = await luigi.getProperties();
     expect(luigiProperties["email"].values).toEqual(["luigi@example.com"]);
   });
 });

--- a/core/src/models/Profile.ts
+++ b/core/src/models/Profile.ts
@@ -67,7 +67,7 @@ export class Profile extends LoggedModel<Profile> {
   exports: Export[];
 
   async apiData() {
-    const properties = await this.properties();
+    const properties = await this.getProperties();
 
     return {
       id: this.id,
@@ -78,12 +78,12 @@ export class Profile extends LoggedModel<Profile> {
     };
   }
 
-  async properties() {
-    return ProfileOps.properties(this);
+  async getProperties() {
+    return ProfileOps.getProperties(this);
   }
 
   async simplifiedProperties() {
-    const properties = await this.properties();
+    const properties = await this.getProperties();
     const simpleProperties: {
       [key: string]: Array<string | boolean | number | Date>;
     } = {};
@@ -124,7 +124,7 @@ export class Profile extends LoggedModel<Profile> {
 
   async snapshot(saveExports = false) {
     const exports = await this.sync(undefined, saveExports);
-    const properties = await this.properties();
+    const properties = await this.getProperties();
     const groups = await this.$get("groups", { include: [GroupRule] });
     const groupApiData = (
       await Promise.all(groups.map((g) => g.apiData()))
@@ -168,7 +168,7 @@ export class Profile extends LoggedModel<Profile> {
   }
 
   async validateProfilePropertiesAreReady() {
-    const properties = await this.properties();
+    const properties = await this.getProperties();
     for (const k in properties) {
       if (properties[k].state !== "ready") {
         throw new Error(
@@ -179,7 +179,7 @@ export class Profile extends LoggedModel<Profile> {
   }
 
   async getConfigObject() {
-    const properties = await this.properties();
+    const properties = await this.getProperties();
     const directlyMappedProps: {
       [key: string]: Array<string | boolean | number | Date>;
     } = {};

--- a/core/src/modules/groupExport.ts
+++ b/core/src/modules/groupExport.ts
@@ -33,7 +33,7 @@ export async function groupExportToCSV(group: Group, limit = 1000) {
   }
 
   async function buildCsvRowFromProperty(profile: Profile) {
-    const properties = await profile.properties();
+    const properties = await profile.getProperties();
     const simpleProperties = {};
     for (const key in properties) {
       simpleProperties[key] =

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -97,7 +97,7 @@ export namespace DestinationOps {
       [groupId: string]: string;
     }
   ) {
-    const profileProperties = await profile.properties();
+    const profileProperties = await profile.getProperties();
     const mappingKeys = Object.keys(mapping);
     const mappedProfileProperties = {};
     const destinationMappingOptions =
@@ -309,7 +309,7 @@ export namespace DestinationOps {
       toDelete = true;
     }
 
-    let newProfileProperties = await profile.properties();
+    let newProfileProperties = await profile.getProperties();
 
     // New and old properties and groups are in the context of this destination and what it has currently been sent
     // If there is not a mostRecentExport, both old groups and old profile properties are an empty collection

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -39,7 +39,7 @@ export namespace ProfileOps {
   /**
    * Get the Properties of this Profile
    */
-  export async function properties(profile: Profile) {
+  export async function getProperties(profile: Profile) {
     const profileProperties =
       profile.profileProperties ||
       (await ProfileProperty.scope(null).findAll({
@@ -402,7 +402,7 @@ export namespace ProfileOps {
     const now = new Date();
 
     for (const profile of profiles) {
-      const profileProperties = await profile.properties();
+      const profileProperties = await profile.getProperties();
 
       for (const key in properties) {
         const property = properties[key];
@@ -700,8 +700,8 @@ export namespace ProfileOps {
 
     try {
       // transfer properties, keeping the newest values
-      const properties = await profile.properties();
-      const otherProperties = await otherProfile.properties();
+      const properties = await profile.getProperties();
+      const otherProperties = await otherProfile.getProperties();
       const newProperties = {};
       for (const key in otherProperties) {
         if (

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -116,7 +116,7 @@ export namespace SourceOps {
     if (Object.values(sourceMapping).length > 0) {
       const propertyMappingKey = Object.values(sourceMapping)[0];
       const profileProperties =
-        preloadedArgs.profileProperties || (await profile.properties());
+        preloadedArgs.profileProperties || (await profile.getProperties());
       if (!profileProperties[propertyMappingKey]) {
         return;
       }
@@ -246,7 +246,7 @@ export namespace SourceOps {
       where: { state: "ready" },
     });
 
-    const profileProperties = await profile.properties();
+    const profileProperties = await profile.getProperties();
     const app = await source.$get("app", { scope: null, include: [Option] });
     const appOptions = await app.getOptions();
     const connection = await app.getConnection();

--- a/core/src/modules/plugin.ts
+++ b/core/src/modules/plugin.ts
@@ -330,7 +330,7 @@ export namespace plugin {
       updatedAt: expandDates(profile.updatedAt),
     };
 
-    const properties = await profile.properties();
+    const properties = await profile.getProperties();
 
     for (const key in properties) {
       data[key] =

--- a/core/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/src/tasks/profileProperty/importProfileProperty.ts
@@ -37,7 +37,7 @@ export class ImportProfileProperty extends RetryableTask {
 
     const property = await Property.findOneWithCache(params.propertyId);
     if (!property) return;
-    const profileProperties = await profile.properties();
+    const profileProperties = await profile.getProperties();
     const source = await property.$get("source", {
       scope: null,
       include: [Option, Mapping],

--- a/plugins/@grouparoo/app-templates/src/source/table/profileProperties.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/profileProperties.ts
@@ -47,7 +47,7 @@ export const getProfileProperties: GetProfilePropertiesMethod = ({
     const primaryKeysHash: { [pk: string]: string[] } = {};
 
     for (const i in profiles) {
-      const properties = await profiles[i].properties();
+      const properties = await profiles[i].getProperties();
       if (
         properties[tableMappingCol]?.values.length > 0 &&
         properties[tableMappingCol].values[0] // not null or undefined

--- a/plugins/@grouparoo/app-templates/src/source/table/profileProperty.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/profileProperty.ts
@@ -49,14 +49,14 @@ export const getProfileProperty: GetProfilePropertyMethod = ({
       aggregationMethod === AggregationMethod.Exact
     ) {
       const tableMappingCol: string = Object.values(sourceMapping)[0];
-      const profileProperties = await profile.properties();
+      const profileProperties = await profile.getProperties();
       // if no property or no values, bail
       if (!profileProperties[tableMappingCol]?.values.length) {
         return undefined;
       }
     }
 
-    const profileData = await profile.properties();
+    const profileData = await profile.getProperties();
     const isArray = !!property.isArray;
 
     if (!profileData.hasOwnProperty(profilePropertyMatch)) {

--- a/plugins/@grouparoo/csv/__tests__/integration/csv-file.ts
+++ b/plugins/@grouparoo/csv/__tests__/integration/csv-file.ts
@@ -286,7 +286,7 @@ describe("integration/runs/csv/file", () => {
         })
       ).profileId;
       const profile = await Profile.findOne({ where: { id: profileId } });
-      const properties = await profile.properties();
+      const properties = await profile.getProperties();
       expect(properties.userId.values).toEqual([1]);
       expect(properties.email.values).toEqual(["ejervois0@example.com"]);
     });

--- a/plugins/@grouparoo/csv/__tests__/integration/csv-remote.ts
+++ b/plugins/@grouparoo/csv/__tests__/integration/csv-remote.ts
@@ -267,7 +267,7 @@ describe("integration/runs/csv/remote", () => {
         })
       ).profileId;
       const profile = await Profile.findOne({ where: { id: profileId } });
-      const properties = await profile.properties();
+      const properties = await profile.getProperties();
       expect(properties.userId.values).toEqual([1]);
       expect(properties.email.values).toEqual(["ejervois0@example.com"]);
     });

--- a/plugins/@grouparoo/csv/src/lib/file-import/profileProperties.ts
+++ b/plugins/@grouparoo/csv/src/lib/file-import/profileProperties.ts
@@ -17,7 +17,7 @@ export const profileProperties: ProfilePropertiesPluginMethod = async ({
   const primaryKeysHash: { [pk: string]: string } = {};
 
   for (const i in profiles) {
-    const properties = await profiles[i].properties();
+    const properties = await profiles[i].getProperties();
     if (
       properties[tableMappingCol]?.values.length > 0 &&
       properties[tableMappingCol].values[0] // not null or undefined

--- a/plugins/@grouparoo/csv/src/lib/remote-import/profileProperties.ts
+++ b/plugins/@grouparoo/csv/src/lib/remote-import/profileProperties.ts
@@ -18,7 +18,7 @@ export const profileProperties: ProfilePropertiesPluginMethod = async ({
   const primaryKeysHash: { [pk: string]: string } = {};
 
   for (const i in profiles) {
-    const properties = await profiles[i].properties();
+    const properties = await profiles[i].getProperties();
     if (
       properties[tableMappingCol]?.values.length > 0 &&
       properties[tableMappingCol].values[0] // not null or undefined

--- a/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
+++ b/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
@@ -320,7 +320,7 @@ describe("integration/runs/google-sheets", () => {
         })
       ).profileId;
       const profile = await Profile.findOne({ where: { id: profileId } });
-      const properties = await profile.properties();
+      const properties = await profile.getProperties();
       expect(properties.userId.values).toEqual([1]);
       expect(properties.email.values).toEqual(["ejervois0@example.com"]);
     });

--- a/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-import.ts
+++ b/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-import.ts
@@ -331,7 +331,7 @@ describe("integration/runs/mailchimp-import", () => {
         })
       ).profileId;
       const profile = await Profile.findOne({ where: { id: profileId } });
-      const properties = await profile.properties();
+      const properties = await profile.getProperties();
       expect(properties.userId.values).toEqual([1]);
       expect(properties.email.values).toEqual(["xejervois0@grouparoo.com"]);
     });

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-query-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-query-import.ts
@@ -134,7 +134,7 @@ describe("integration/runs/mysql", () => {
         await profile.reload();
 
         expect(profile.id).toBeTruthy();
-        const properties = await profile.properties();
+        const properties = await profile.getProperties();
         expect(properties.email.values[0]).toMatch(/.*@example.com/);
         i++;
       }

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -432,7 +432,7 @@ describe("integration/runs/mysql", () => {
       })
     ).profileId;
     const profile = await Profile.findOne({ where: { id: profileId } });
-    const properties = await profile.properties();
+    const properties = await profile.getProperties();
     expect(properties.userId.values).toEqual([1]);
     expect(properties.email.values).toEqual(["ejervois0@example.com"]);
   });

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-query-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-query-import.ts
@@ -132,7 +132,7 @@ describe("integration/runs/postgres", () => {
         await profile.reload();
 
         expect(profile.id).toBeTruthy();
-        const properties = await profile.properties();
+        const properties = await profile.getProperties();
         expect(properties.email.values[0]).toMatch(/.*@example.com/);
         i++;
       }

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
@@ -427,7 +427,7 @@ describe("integration/runs/postgres", () => {
       })
     ).profileId;
     const profile = await Profile.findOne({ where: { id: profileId } });
-    const properties = await profile.properties();
+    const properties = await profile.getProperties();
     expect(properties.userId.values).toEqual([1]);
     expect(properties.email.values).toEqual(["ejervois0@example.com"]);
   });

--- a/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-query-import.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-query-import.ts
@@ -132,7 +132,7 @@ describe("integration/runs/sqlite", () => {
         await profile.reload();
 
         expect(profile.id).toBeTruthy();
-        const properties = await profile.properties();
+        const properties = await profile.getProperties();
         expect(properties.email.values[0]).toMatch(/.*@example.com/);
         i++;
       }

--- a/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-table-import.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-table-import.ts
@@ -431,7 +431,7 @@ describe("integration/runs/sqlite", () => {
       })
     ).profileId;
     const profile = await Profile.findOne({ where: { id: profileId } });
-    const properties = await profile.properties();
+    const properties = await profile.getProperties();
     expect(properties.userId.values).toEqual([1]);
     expect(properties.email.values).toEqual(["ejervois0@example.com"]);
   });


### PR DESCRIPTION
To reduce confusion, `profile.properties()` is renamed to `profile.getProperties()` to match other getters, and not hint that `properties` is an attribute of the model. 