### PR TITLE
add option to keep old property value if it's no longer found

### DIFF
--- a/core/__tests__/actions/properties.ts
+++ b/core/__tests__/actions/properties.ts
@@ -336,6 +336,7 @@ describe("actions/properties", () => {
         csrfToken,
         id,
         unique: true,
+        keepValueIfNotFound: true,
       };
       const { error, property } = await specHelper.runAction(
         "property:edit",
@@ -343,6 +344,7 @@ describe("actions/properties", () => {
       );
       expect(error).toBeUndefined();
       expect(property.unique).toBe(true);
+      expect(property.keepValueIfNotFound).toBe(true);
     });
 
     test("an administrator can see a profile preview of a property", async () => {

--- a/core/__tests__/fixtures/codeConfig/bootstrapped-property-in-source/config.js
+++ b/core/__tests__/fixtures/codeConfig/bootstrapped-property-in-source/config.js
@@ -59,6 +59,7 @@ module.exports = async function getConfig() {
       type: "email",
       unique: true,
       isArray: false,
+      keepValueIfNotFound: true,
       sourceId: "users_table", // sourceId -> `users_table`
       options: {
         column: "email",

--- a/core/__tests__/fixtures/codeConfig/initial/config.js
+++ b/core/__tests__/fixtures/codeConfig/initial/config.js
@@ -67,6 +67,7 @@ module.exports = async function getConfig() {
       type: "email",
       unique: true,
       isArray: false,
+      keepValueIfNotFound: true,
       sourceId: "users_table", // sourceId -> `users_table`
       options: {
         column: "email",

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -157,6 +157,12 @@ describe("modules/codeConfig", () => {
           "config:code",
           "config:code",
         ]);
+        expect(rules.map((r) => r.keepValueIfNotFound).sort()).toEqual([
+          false,
+          false,
+          false,
+          true,
+        ]);
 
         const options = await Promise.all(rules.map((r) => r.getOptions()));
         expect(options.map((o) => o.column).sort()).toEqual([

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -738,7 +738,8 @@ describe("modules/configWriter", () => {
       const config = await property.getConfigObject();
       expect(config.id).toBeTruthy();
 
-      const { key, type, unique, identifying, isArray } = property;
+      const { key, type, unique, identifying, isArray, keepValueIfNotFound } =
+        property;
 
       const options = await property.$get("__options");
       expect(options.length).toEqual(1);
@@ -752,6 +753,7 @@ describe("modules/configWriter", () => {
         unique,
         identifying,
         isArray,
+        keepValueIfNotFound,
         options: Object.fromEntries(options.map((o) => [o.key, o.value])),
         filters: [
           {

--- a/core/__tests__/tasks/profileProperty/importProfileProperties.ts
+++ b/core/__tests__/tasks/profileProperty/importProfileProperties.ts
@@ -140,6 +140,46 @@ describe("tasks/profileProperty:importProfileProperties", () => {
       spy.mockRestore();
     });
 
+    test("will keep old value if the profile property no longer exists and is marked as keepValueIfNotFound=true", async () => {
+      const spy = jest
+        .spyOn(testPluginConnection.methods, "profileProperties")
+        .mockImplementation(() => undefined);
+
+      const profile: Profile = await helper.factories.profile();
+      await profile.addOrUpdateProperties({
+        userId: [99],
+        email: ["someoldemail@example.com"],
+      });
+      const profileProperty = await ProfileProperty.findOne({
+        where: { rawValue: "99" },
+      });
+      await profileProperty.update({ state: "pending" });
+
+      await Property.update(
+        { keepValueIfNotFound: true },
+        { where: { key: "email" } }
+      );
+
+      await specHelper.runTask("profileProperty:importProfileProperties", {
+        profileIds: [profile.id],
+        propertyId: profileProperty.propertyId,
+      });
+
+      // new value and state
+      await profileProperty.reload();
+      expect(profileProperty.state).toBe("ready");
+      expect(profileProperty.rawValue).toBe(null);
+      await profile.destroy();
+
+      // reset property
+      await Property.update(
+        { keepValueIfNotFound: false },
+        { where: { key: "email" } }
+      );
+
+      spy.mockRestore();
+    });
+
     test("will not import profile properties that have pending dependencies", async () => {
       const userIdProperty = await Property.findOne({
         where: { key: "userId" },

--- a/core/__tests__/tasks/profileProperty/importProfileProperty.ts
+++ b/core/__tests__/tasks/profileProperty/importProfileProperty.ts
@@ -102,6 +102,57 @@ describe("tasks/profileProperty:importProfileProperty", () => {
       expect(profileProperty.rawValue).toBe(null);
 
       spy.mockRestore();
+
+      await profile.destroy();
+    });
+
+    test("will keep old value if the profile property no longer exists and is marked as keepValueIfNotFound=true", async () => {
+      const testPlugin: GrouparooPlugin = api.plugins.plugins.find(
+        (a) => a.name === "@grouparoo/test-plugin"
+      );
+
+      let testPluginConnection = testPlugin.connections.find(
+        (c) => c.name === "test-plugin-import"
+      );
+
+      const spy = jest
+        .spyOn(testPluginConnection.methods, "profileProperty")
+        .mockImplementation(() => undefined);
+
+      const profile: Profile = await helper.factories.profile();
+      await profile.addOrUpdateProperties({
+        userId: [99],
+        email: ["someoldemail@example.com"],
+      });
+      const profileProperty = await ProfileProperty.findOne({
+        where: { rawValue: "someoldemail@example.com", profileId: profile.id },
+      });
+      await profileProperty.update({ state: "pending" });
+
+      await Property.update(
+        { keepValueIfNotFound: true },
+        { where: { key: "email" } }
+      );
+
+      await specHelper.runTask("profileProperty:importProfileProperty", {
+        profileId: profile.id,
+        propertyId: profileProperty.propertyId,
+      });
+
+      // new value and state
+      await profileProperty.reload();
+      expect(profileProperty.state).toBe("ready");
+      expect(profileProperty.rawValue).toBe("someoldemail@example.com");
+
+      spy.mockRestore();
+
+      // reset property
+      await Property.update(
+        { keepValueIfNotFound: false },
+        { where: { key: "email" } }
+      );
+
+      await profile.destroy();
     });
 
     test("will not import profile properties that have pending dependencies", async () => {

--- a/core/src/actions/properties.ts
+++ b/core/src/actions/properties.ts
@@ -144,6 +144,7 @@ export class PropertyCreate extends AuthenticatedAction {
       sourceId: { required: false },
       options: { required: false },
       filters: { required: false },
+      keepValueIfNotFound: { required: false },
     };
   }
 
@@ -154,6 +155,7 @@ export class PropertyCreate extends AuthenticatedAction {
       unique: params.unique,
       isArray: params.isArray,
       sourceId: params.sourceId,
+      keepValueIfNotFound: params.keepValueIfNotFound,
     });
     if (params.options) await property.setOptions(params.options);
     if (params.filters) await property.setFilters(params.filters);
@@ -185,6 +187,7 @@ export class PropertyEdit extends AuthenticatedAction {
       sourceId: { required: false },
       options: { required: false },
       filters: { required: false },
+      keepValueIfNotFound: { required: false },
     };
   }
 

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -34,6 +34,7 @@ export interface ConfigurationObject {
   identifying?: boolean;
   unique?: boolean;
   isArray?: boolean;
+  keepValueIfNotFound?: boolean;
   rules?: GroupRuleWithKey[];
   recurring?: boolean;
   recurringFrequency?: number;

--- a/core/src/migrations/000078-propertyKeepValueIfNotFound.ts
+++ b/core/src/migrations/000078-propertyKeepValueIfNotFound.ts
@@ -1,0 +1,15 @@
+export default {
+  up: async function (migration, DataTypes) {
+    await migration.sequelize.transaction(async () => {
+      await migration.addColumn("properties", "keepValueIfNotFound", {
+        type: DataTypes.BOOLEAN,
+      });
+    });
+  },
+
+  down: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.removeColumn("properties", "keepValueIfNotFound");
+    });
+  },
+};

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -182,6 +182,11 @@ export class Property extends LoggedModel<Property> {
   @Column
   isArray: boolean;
 
+  @AllowNull(false)
+  @Default(false)
+  @Column
+  keepValueIfNotFound: boolean;
+
   @BelongsTo(() => Source)
   source: Source;
 
@@ -305,6 +310,7 @@ export class Property extends LoggedModel<Property> {
       unique: this.unique,
       identifying: this.identifying,
       directlyMapped: this.directlyMapped,
+      keepValueIfNotFound: this.keepValueIfNotFound,
       locked: this.locked,
       options,
       filters,

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -325,7 +325,8 @@ export class Property extends LoggedModel<Property> {
   }
 
   async getConfigObject() {
-    const { key, type, unique, identifying, isArray } = this;
+    const { key, type, unique, identifying, isArray, keepValueIfNotFound } =
+      this;
 
     this.source = await this.$get("source");
     const sourceId = this.source?.getConfigId();
@@ -343,6 +344,7 @@ export class Property extends LoggedModel<Property> {
       unique,
       identifying,
       isArray,
+      keepValueIfNotFound,
       options,
       filters,
     };

--- a/core/src/modules/configLoaders/property.ts
+++ b/core/src/modules/configLoaders/property.ts
@@ -48,6 +48,7 @@ export async function loadProperty(
     key: configObject.key || configObject.name,
     unique: configObject.unique,
     isArray: configObject.isArray,
+    keepValueIfNotFound: configObject.keepValueIfNotFound,
     locked: ConfigWriter.getLockKey(configObject),
   });
 

--- a/core/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/src/tasks/profileProperty/importProfileProperties.ts
@@ -122,7 +122,7 @@ export class ImportProfileProperties extends RetryableTask {
     await ProfileProperty.update(
       {
         state: "ready",
-        rawValue: null,
+        rawValue: property.keepValueIfNotFound ? undefined : null,
         stateChangedAt: new Date(),
         confirmedAt: new Date(),
       },

--- a/core/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/src/tasks/profileProperty/importProfileProperty.ts
@@ -79,7 +79,7 @@ export class ImportProfileProperty extends RetryableTask {
       await ProfileProperty.update(
         {
           state: "ready",
-          rawValue: null,
+          rawValue: property.keepValueIfNotFound ? undefined : null,
           stateChangedAt: new Date(),
           confirmedAt: new Date(),
         },

--- a/ui/ui-components/pages/property/[id]/edit.tsx
+++ b/ui/ui-components/pages/property/[id]/edit.tsx
@@ -261,6 +261,15 @@ export default function Page(props) {
                   disabled={loading}
                 />
               </Form.Group>
+              <Form.Group controlId="keepValueIfNotFound">
+                <Form.Check
+                  type="checkbox"
+                  label="Keep value if not found?"
+                  checked={property.keepValueIfNotFound}
+                  onChange={(e) => update(e)}
+                  disabled={loading}
+                />
+              </Form.Group>
               <Form.Group controlId="sourceId">
                 <Form.Label>Property Source</Form.Label>
                 <Form.Control as="select" disabled value={source.id}>


### PR DESCRIPTION
Open to suggestions on a better name for this option!

Once both this and #2070 is merged, we can probably optimize the `profiles:confirm` task to ignore properties that have this set to `true`.