### PR TITLE
Sort Sources when importing a Profile all at once

### DIFF
--- a/core/__tests__/actions/sources.ts
+++ b/core/__tests__/actions/sources.ts
@@ -1,7 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { specHelper } from "actionhero";
-import { Op } from "sequelize";
-import { ProfileProperty, Property, Option, Source, App } from "../../src";
+import { Option, Source, App } from "../../src";
 
 describe("actions/sources", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -135,7 +134,7 @@ describe("actions/sources", () => {
 
     test("a source with no options will see an empty preview", async () => {
       const options = await Option.findAll({ where: { ownerId: id } });
-      await Promise.all(options.map((o) => o.destroy()));
+      for (const option of options) await option.destroy();
 
       connection.params = {
         csrfToken,

--- a/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
+++ b/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
@@ -491,7 +491,7 @@ describe("models/destination", () => {
           email: ["mario@example.com"],
           userId: [1],
           firstName: ["mario"],
-          lastName: ["luigi"],
+          lastName: ["mario"],
         });
 
         group = await helper.factories.group();

--- a/core/__tests__/models/profile/profile.ts
+++ b/core/__tests__/models/profile/profile.ts
@@ -786,7 +786,7 @@ describe("models/profile", () => {
 
     afterAll(async () => {
       const members = await group.$get("groupMembers");
-      await Promise.all(members.map((m) => m.destroy()));
+      for (const m of members) await m.destroy();
       await group.destroy();
       await source.setMapping({});
       await Property.truncate();

--- a/core/__tests__/models/profile/snapshot-testing.ts
+++ b/core/__tests__/models/profile/snapshot-testing.ts
@@ -82,7 +82,8 @@ describe("test grouparoo profiles", () => {
 
     test("groups match the snapshot", async () => {
       const groups = await profile.$get("groups");
-      const groupApiData = await Promise.all(groups.map((g) => g.apiData()));
+      let groupApiData = [];
+      for (const g of groups) groupApiData.push(await g.apiData());
 
       expect(groupApiData.length).toEqual(1);
 
@@ -96,9 +97,8 @@ describe("test grouparoo profiles", () => {
 
     test("potential exports match the snapshot", async () => {
       const _exports = await profile.export(true, [], false);
-      const exportApiData = await Promise.all(
-        _exports.map((e) => e.apiData(false))
-      );
+      const exportApiData = [];
+      for (const e of _exports) exportApiData.push(await e.apiData(false));
       expect(exportApiData.length).toEqual(1);
 
       expect(exportApiData[0]).toMatchSnapshot({
@@ -106,6 +106,7 @@ describe("test grouparoo profiles", () => {
         startedAt: expect.any(Number),
         sendAt: expect.any(Number),
         state: "pending",
+        destinationName: "test destination",
         newProfileProperties: expect.objectContaining({
           email: expect.stringMatching(/@example.com/),
           "primary-id": expect.any(Number),

--- a/core/__tests__/models/source/sortByDependencies.ts
+++ b/core/__tests__/models/source/sortByDependencies.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { Source, App, Property, Mapping } from "../../../src";
+import { Source, App, Property, Mapping, Profile } from "../../../src";
 import { SourceOps } from "../../../src/modules/ops/source";
 
 describe("models/source/sortByDependencies", () => {
@@ -99,5 +99,12 @@ describe("models/source/sortByDependencies", () => {
       purchasesTable.id,
       productsTable.id,
     ]);
+  });
+
+  test("a Profile can be imported with chained sources", async () => {
+    const profile: Profile = await helper.factories.profile();
+    await profile.import();
+    const properties = await profile.getProperties();
+    expect(properties.product_name.values[0]).toBeTruthy();
   });
 });

--- a/core/__tests__/models/source/sortByDependencies.ts
+++ b/core/__tests__/models/source/sortByDependencies.ts
@@ -1,0 +1,103 @@
+import { helper } from "@grouparoo/spec-helper";
+import { Source, App, Property, Mapping } from "../../../src";
+import { SourceOps } from "../../../src/modules/ops/source";
+
+describe("models/source/sortByDependencies", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  let app: App;
+  let usersTable: Source;
+  let purchasesTable: Source;
+  let productsTable: Source;
+
+  let emailProperty: Property;
+  let purchaseProductIdProperty: Property;
+  let purchasedProductNameProperty: Property;
+
+  beforeAll(async () => {
+    app = await helper.factories.app();
+
+    usersTable = await Source.create({
+      type: "test-plugin-import",
+      name: "users table",
+      appId: app.id,
+    });
+    await usersTable.setOptions({ table: "users" });
+    await usersTable.bootstrapUniqueProperty("userId", "integer", "id");
+    await usersTable.setMapping({ id: "userId" });
+    await usersTable.update({ state: "ready" });
+
+    emailProperty = await helper.factories.property(
+      usersTable,
+      { key: "email", type: "email" },
+      { column: "email" }
+    );
+
+    purchasesTable = await Source.create({
+      type: "test-plugin-import",
+      name: "purchases table",
+      appId: app.id,
+    });
+    await purchasesTable.setOptions({ table: "purchases" });
+    await purchasesTable.setMapping({ user_id: "userId" });
+    await purchasesTable.update({ state: "ready" });
+
+    purchaseProductIdProperty = await helper.factories.property(
+      purchasesTable,
+      { key: "product_id", type: "integer" },
+      { column: "id" }
+    );
+
+    productsTable = await Source.create({
+      type: "test-plugin-import",
+      name: "products table",
+      appId: app.id,
+    });
+    await productsTable.setOptions({ table: "products" });
+    await productsTable.setMapping({ id: "product_id" });
+    await productsTable.update({ state: "ready" });
+
+    purchasedProductNameProperty = await helper.factories.property(
+      productsTable,
+      { key: "product_name", type: "string" },
+      { column: "name" }
+    );
+  });
+
+  beforeEach(async () => {
+    usersTable = await usersTable.reload({ include: [Mapping, Property] });
+    purchasesTable = await purchasesTable.reload({
+      include: [Mapping, Property],
+    });
+    productsTable = await productsTable.reload({
+      include: [Mapping, Property],
+    });
+  });
+
+  test("it sorts when sources provided in order", async () => {
+    const sortedSources = SourceOps.sortByDependencies([
+      usersTable,
+      purchasesTable,
+      productsTable,
+    ]);
+
+    expect(sortedSources.map((s) => s.id)).toEqual([
+      usersTable.id,
+      purchasesTable.id,
+      productsTable.id,
+    ]);
+  });
+
+  test("it sorts when sources provided out of order", async () => {
+    const sortedSources = SourceOps.sortByDependencies([
+      productsTable,
+      usersTable,
+      purchasesTable,
+    ]);
+
+    expect(sortedSources.map((s) => s.id)).toEqual([
+      usersTable.id,
+      purchasesTable.id,
+      productsTable.id,
+    ]);
+  });
+});

--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -10,9 +10,9 @@ import {
   Option,
   ProfileProperty,
   Destination,
-} from "../../src";
+} from "../../../src";
 import { Op } from "sequelize";
-import { SourceOps } from "../../src/modules/ops/source";
+import { SourceOps } from "../../../src/modules/ops/source";
 
 describe("models/source", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });

--- a/core/__tests__/modules/groupExport.ts
+++ b/core/__tests__/modules/groupExport.ts
@@ -72,7 +72,7 @@ describe("modules/groupExport", () => {
       "a group's profiles can be exported and create a run",
       async () => {
         const profiles = [mario, luigi, toad, peach];
-        await Promise.all(profiles.map((profile) => group.addProfile(profile)));
+        for (const p of profiles) await group.addProfile(p);
 
         const response = await groupExportToCSV(group, 1);
         filename = response.filename;

--- a/core/__tests__/tasks/group/destroy.ts
+++ b/core/__tests__/tasks/group/destroy.ts
@@ -184,9 +184,8 @@ describe("tasks/group:destroy", () => {
       await group.setRules([
         { key: "lastName", match: "Mario", operation: { op: "eq" } },
       ]);
-      await Promise.all(
-        [mario, luigi].map(async (p) => p.updateGroupMembership())
-      );
+      await mario.updateGroupMembership();
+      await luigi.updateGroupMembership();
 
       groupMemberCount = await group.$count("groupMembers");
       expect(groupMemberCount).toBe(2);

--- a/core/__tests__/tasks/group/run.ts
+++ b/core/__tests__/tasks/group/run.ts
@@ -132,9 +132,10 @@ describe("tasks/group:run", () => {
 
       // complete pending imports
       await ImportWorkflow();
-      await Promise.all(
-        [mario, luigi, peach, toad].map(async (p) => p.updateGroupMembership())
-      );
+      await mario.updateGroupMembership();
+      await luigi.updateGroupMembership();
+      await peach.updateGroupMembership();
+      await toad.updateGroupMembership();
 
       await specHelper.runTask("group:run", { runId: run.id }); // run is complete, mark group as ready
 
@@ -197,9 +198,10 @@ describe("tasks/group:run", () => {
         [peach, toad].map((p) => p.id).sort()
       );
 
-      await Promise.all(
-        [mario, luigi, peach, toad].map(async (p) => p.updateGroupMembership())
-      );
+      await mario.updateGroupMembership();
+      await luigi.updateGroupMembership();
+      await peach.updateGroupMembership();
+      await toad.updateGroupMembership();
 
       await specHelper.runTask("group:run", { runId: run.id }); // run is complete, mark group as ready
 

--- a/core/__tests__/utils/prepareSharedGroupTest.ts
+++ b/core/__tests__/utils/prepareSharedGroupTest.ts
@@ -106,7 +106,7 @@ export namespace SharedGroupTests {
       groupId: group.id,
     });
     const members = await group.$get("groupMembers");
-    await Promise.all(members.map((m) => m.destroy()));
+    for (const m of members) await m.destroy();
     await group.destroy();
     await run.destroy();
     await Import.truncate();

--- a/core/src/actions/apiKeys.ts
+++ b/core/src/actions/apiKeys.ts
@@ -24,9 +24,7 @@ export class ApiKeysList extends AuthenticatedAction {
 
     return {
       total,
-      apiKeys: await Promise.all(
-        apiKeys.map(async (apiKey) => apiKey.apiData())
-      ),
+      apiKeys: await Promise.all(apiKeys.map((apiKey) => apiKey.apiData())),
     };
   }
 }

--- a/core/src/actions/destinations.ts
+++ b/core/src/actions/destinations.ts
@@ -50,9 +50,7 @@ export class DestinationsList extends AuthenticatedAction {
 
     return {
       total,
-      destinations: await Promise.all(
-        destinations.map(async (conn) => conn.apiData())
-      ),
+      destinations: await Promise.all(destinations.map((d) => d.apiData())),
     };
   }
 }

--- a/core/src/actions/files.ts
+++ b/core/src/actions/files.ts
@@ -39,7 +39,7 @@ export class FilesList extends AuthenticatedAction {
 
     return {
       total,
-      files: await Promise.all(files.map(async (f) => f.apiData())),
+      files: await Promise.all(files.map((f) => f.apiData())),
     };
   }
 }

--- a/core/src/actions/groups.ts
+++ b/core/src/actions/groups.ts
@@ -44,7 +44,7 @@ export class GroupsList extends AuthenticatedAction {
 
     return {
       total,
-      groups: await Promise.all(groups.map(async (g) => g.apiData())),
+      groups: await Promise.all(groups.map((g) => g.apiData())),
     };
   }
 }

--- a/core/src/actions/logs.ts
+++ b/core/src/actions/logs.ts
@@ -51,6 +51,9 @@ export class LogsList extends AuthenticatedAction {
     const total = await Log.count(search);
     const logs = await Log.findAll(search);
 
-    return { total, logs: await Promise.all(logs.map((log) => log.apiData())) };
+    return {
+      total,
+      logs: await Promise.all(logs.map((log) => log.apiData())),
+    };
   }
 }

--- a/core/src/actions/runs.ts
+++ b/core/src/actions/runs.ts
@@ -54,7 +54,7 @@ export class RunsList extends AuthenticatedAction {
     const runs = await Run.scope(null).findAll(search);
 
     return {
-      runs: await Promise.all(runs.map(async (run) => run.apiData())),
+      runs: await Promise.all(runs.map((run) => run.apiData())),
       total: await Run.scope(null).count({ where }),
     };
   }

--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -39,9 +39,7 @@ export class SchedulesList extends AuthenticatedAction {
 
     return {
       total,
-      schedules: await Promise.all(
-        schedules.map(async (conn) => conn.apiData())
-      ),
+      schedules: await Promise.all(schedules.map((conn) => conn.apiData())),
     };
   }
 }

--- a/core/src/actions/settings.ts
+++ b/core/src/actions/settings.ts
@@ -25,7 +25,7 @@ export class SettingsList extends AuthenticatedAction {
   async runWithinTransaction({ params }) {
     const setting = await Setting.findAll({ order: params.order });
     return {
-      settings: await Promise.all(setting.map(async (s) => await s.apiData())),
+      settings: await Promise.all(setting.map((s) => s.apiData())),
     };
   }
 }

--- a/core/src/actions/sources.ts
+++ b/core/src/actions/sources.ts
@@ -43,9 +43,7 @@ export class SourcesList extends AuthenticatedAction {
 
     return {
       total,
-      sources: await Promise.all(
-        sources.map(async (source) => source.apiData())
-      ),
+      sources: await Promise.all(sources.map((source) => source.apiData())),
     };
   }
 }

--- a/core/src/actions/teamMembers.ts
+++ b/core/src/actions/teamMembers.ts
@@ -27,9 +27,7 @@ export class TeamMembersList extends AuthenticatedAction {
     });
 
     return {
-      teamMembers: await Promise.all(
-        teamMembers.map(async (tem) => tem.apiData())
-      ),
+      teamMembers: await Promise.all(teamMembers.map((tem) => tem.apiData())),
     };
   }
 }

--- a/core/src/actions/teams.ts
+++ b/core/src/actions/teams.ts
@@ -78,7 +78,7 @@ export class TeamsList extends AuthenticatedAction {
   async runWithinTransaction() {
     const teams = await Team.findAll();
     return {
-      teams: await Promise.all(teams.map(async (team) => team.apiData())),
+      teams: await Promise.all(teams.map((team) => team.apiData())),
     };
   }
 }
@@ -170,9 +170,7 @@ export class TeamView extends AuthenticatedAction {
     return {
       team: await team.apiData(),
       teamMembers: await Promise.all(
-        team.teamMembers.map(async (mem) => {
-          return await mem.apiData();
-        })
+        team.teamMembers.map((mem) => mem.apiData())
       ),
     };
   }

--- a/core/src/models/ApiKey.ts
+++ b/core/src/models/ApiKey.ts
@@ -13,7 +13,6 @@ import {
 import * as UUID from "uuid";
 import { LoggedModel } from "../classes/loggedModel";
 import { Permission, PermissionTopics } from "./Permission";
-import { AsyncReturnType } from "type-fest";
 import { LockableHelper } from "../modules/lockableHelper";
 import { APIData } from "../modules/apiData";
 
@@ -61,8 +60,9 @@ export class ApiKey extends LoggedModel<ApiKey> {
     const permissions = await this.$get("permissions", {
       order: [["topic", "asc"]],
     });
-    const permissionsApiData: AsyncReturnType<Permission["apiData"]>[] =
-      await Promise.all(permissions.map((prm) => prm.apiData()));
+    const permissionsApiData = await Promise.all(
+      permissions.map((prm) => prm.apiData())
+    );
 
     return {
       id: this.id,

--- a/core/src/models/Team.ts
+++ b/core/src/models/Team.ts
@@ -13,7 +13,6 @@ import { api } from "actionhero";
 import { LoggedModel } from "../classes/loggedModel";
 import { TeamMember } from "./TeamMember";
 import { Permission, PermissionTopics } from "./Permission";
-import { AsyncReturnType } from "type-fest";
 import { LockableHelper } from "../modules/lockableHelper";
 import { APIData } from "../modules/apiData";
 
@@ -51,8 +50,9 @@ export class Team extends LoggedModel<Team> {
     const permissions = await this.$get("permissions", {
       order: [["topic", "asc"]],
     });
-    const permissionsApiData: AsyncReturnType<Permission["apiData"]>[] =
-      await Promise.all(permissions.map((prm) => prm.apiData()));
+    const permissionsApiData = await Promise.all(
+      permissions.map((prm) => prm.apiData())
+    );
 
     return {
       id: this.id,

--- a/core/src/modules/ops/export.ts
+++ b/core/src/modules/ops/export.ts
@@ -122,18 +122,16 @@ export namespace ExportOps {
         );
       } else {
         // the plugin has a per-profile exportProfile method
-        await Promise.all(
-          _exports.map((_export) =>
-            CLS.enqueueTask(
-              "export:send",
-              {
-                destinationId: destination.id,
-                exportId: _export.id,
-              },
-              `exports:${app.type}`
-            )
-          )
-        );
+        for (const _export of _exports) {
+          await CLS.enqueueTask(
+            "export:send",
+            {
+              destinationId: destination.id,
+              exportId: _export.id,
+            },
+            `exports:${app.type}`
+          );
+        }
       }
     }
 

--- a/core/src/modules/ops/exportProcessor.ts
+++ b/core/src/modules/ops/exportProcessor.ts
@@ -52,17 +52,13 @@ export namespace ExportProcessorOps {
 
       const app = await destination.$get("app", { scope: null });
 
-      await Promise.all(
-        exportProcessors.map((processor) =>
-          CLS.enqueueTask(
-            "export:process",
-            {
-              exportProcessorId: processor.id,
-            },
-            `exports:${app.type}`
-          )
-        )
-      );
+      for (const processor of exportProcessors) {
+        await CLS.enqueueTask(
+          "export:process",
+          { exportProcessorId: processor.id },
+          `exports:${app.type}`
+        );
+      }
     }
 
     return exportProcessors.length;

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -461,6 +461,13 @@ export namespace ProfileOps {
       let hash = {};
       const sources = await Source.findAll({ where: { state: "ready" } });
       const excludeSourceIds = [];
+
+      // for (const source of sources) {
+      //   const { canImport, properties } = await source.import(profile);
+      //   if (!canImport) excludeSourceIds.push(source.id);
+      //   await addOrUpdateProperties([profile], [properties], false);
+      // }
+
       await Promise.all(
         sources.map((source) =>
           source.import(profile).then(({ canImport, properties }) => {

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -469,6 +469,7 @@ export namespace ProfileOps {
       for (const source of sortedSources) {
         const { canImport, properties } = await source.import(profile);
         if (!canImport) excludeSourceIds.push(source.id);
+        // We need to save each property as it is loaded so it can be used as a mapping for the next source
         if (toSave) await addOrUpdateProperties([profile], [properties], false);
       }
 

--- a/core/src/modules/ops/profileProperty.ts
+++ b/core/src/modules/ops/profileProperty.ts
@@ -120,19 +120,17 @@ export namespace ProfilePropertyOps {
         : null;
 
       if (method === "ProfileProperties") {
-        await CLS.enqueueTask(`profileProperty:import${method}`, {
+        await CLS.enqueueTask(`profileProperty:importProfileProperties`, {
           propertyId: property.id,
           profileIds: pendingProfileProperties.map((ppp) => ppp.profileId),
         });
       } else if (method === "ProfileProperty") {
-        await Promise.all(
-          pendingProfileProperties.map((ppp) =>
-            CLS.enqueueTask(`profileProperty:import${method}`, {
-              propertyId: property.id,
-              profileId: ppp.profileId,
-            })
-          )
-        );
+        for (const ppp of pendingProfileProperties) {
+          await CLS.enqueueTask(`profileProperty:importProfileProperty`, {
+            propertyId: property.id,
+            profileId: ppp.profileId,
+          });
+        }
       } else {
         // Schedule sources don't import properties on-demand, keep old value
         await ProfileProperty.update(

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -303,6 +303,29 @@ export namespace SourceOps {
   }
 
   /**
+   * Sorts an array of Sources by their dependencies.
+   * Be sure to eager-load Mappings and Properties
+   */
+  export function sortByDependencies(sources: Source[]) {
+    sources.sort((a, b) => {
+      const AProvides = a.properties.map((p) => p.id);
+      const ADependsOn = a.mappings.map((m) => m.propertyId);
+      const BProvides = b.properties.map((p) => p.id);
+      const BDependsOn = b.mappings.map((m) => m.propertyId);
+
+      if (ADependsOn.find((v) => BProvides.includes(v))) {
+        return 1;
+      } else if (BDependsOn.find((v) => AProvides.includes(v))) {
+        return -1;
+      } else {
+        return 0;
+      }
+    });
+
+    return sources;
+  }
+
+  /**
    * This method is used to bootstrap a new source which requires a Property for a mapping, when the rule doesn't yet exist.
    */
   export async function bootstrapUniqueProperty(

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -242,7 +242,7 @@ export namespace SourceOps {
    */
   export async function _import(source: Source, profile: Profile) {
     const hash = {};
-    const rules = await source.$get("properties", {
+    const properties = await source.$get("properties", {
       where: { state: "ready" },
     });
 
@@ -277,13 +277,15 @@ export namespace SourceOps {
       };
     }
 
-    await Promise.all(
-      rules.map((rule) =>
-        source
-          .importProfileProperty(profile, rule, null, null, preloadedArgs)
-          .then((response) => (hash[rule.id] = response))
-      )
-    );
+    for (const property of properties) {
+      hash[property.id] = await source.importProfileProperty(
+        profile,
+        property,
+        null,
+        null,
+        preloadedArgs
+      );
+    }
 
     // remove null and undefined as we cannot set that value
     const hashKeys = Object.keys(hash);

--- a/core/src/modules/plugins.ts
+++ b/core/src/modules/plugins.ts
@@ -51,30 +51,29 @@ export namespace Plugins {
       },
     ].concat(pluginManifest.plugins);
 
-    const pluginResponse: PluginWithVersions[] = await Promise.all(
-      plugins.map(async (plugin) => {
-        let latestVersion = "unknown";
+    const pluginResponse: PluginWithVersions[] = [];
+    for (const plugin of plugins) {
+      let latestVersion = "unknown";
 
-        try {
-          const manifest = await getLatestNPMVersion(plugin);
-          latestVersion = manifest.version;
-        } catch (error) {
-          log(error.toString(), "info");
-        }
+      try {
+        const manifest = await getLatestNPMVersion(plugin);
+        latestVersion = manifest.version;
+      } catch (error) {
+        log(error.toString(), "info");
+      }
 
-        return {
-          name: plugin.name,
-          currentVersion: plugin.version,
-          license: plugin.license,
-          url: plugin.url,
-          latestVersion,
-          upToDate:
-            latestVersion === "unknown"
-              ? true
-              : compareVersions(plugin.version, latestVersion) >= 0,
-        };
-      })
-    );
+      pluginResponse.push({
+        name: plugin.name,
+        currentVersion: plugin.version,
+        license: plugin.license,
+        url: plugin.url,
+        latestVersion,
+        upToDate:
+          latestVersion === "unknown"
+            ? true
+            : compareVersions(plugin.version, latestVersion) >= 0,
+      });
+    }
 
     return pluginResponse;
   }

--- a/core/src/tasks/group/updateCalculatedGroups.ts
+++ b/core/src/tasks/group/updateCalculatedGroups.ts
@@ -44,6 +44,8 @@ export class GroupsUpdateCalculatedGroups extends CLSTask {
       }
     }
 
-    await Promise.all(groupsToRun.map((group) => group.run()));
+    for (const group of groupsToRun) {
+      await group.run();
+    }
   }
 }

--- a/core/src/tasks/profile/export.ts
+++ b/core/src/tasks/profile/export.ts
@@ -93,7 +93,10 @@ export class ProfileExport extends RetryableTask {
       }
     } catch (error) {
       if (env !== "test") log(`[EXPORT ERROR] ${error}`, "alert");
-      await Promise.all(imports.map((e) => e.setError(error, this.name)));
+
+      for (const i of imports) {
+        await i.setError(error, this.name);
+      }
     }
   }
 }

--- a/core/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/src/tasks/profileProperty/importProfileProperties.ts
@@ -91,14 +91,13 @@ export class ImportProfileProperties extends RetryableTask {
       );
     } catch (error) {
       // if something goes wrong with the batch import, fall-back to per-profile/property imports
-      await Promise.all(
-        profilesToImport.map((profile) => {
-          CLS.enqueueTask("profileProperty:importProfileProperty", {
-            profileId: profile.id,
-            propertyId: property.id,
-          });
-        })
-      );
+      for (const profile of profilesToImport) {
+        await CLS.enqueueTask("profileProperty:importProfileProperty", {
+          profileId: profile.id,
+          propertyId: property.id,
+        });
+      }
+
       return log(error, "error");
     }
 

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -145,12 +145,9 @@ export namespace helper {
   }
 
   export async function truncate() {
-    await Promise.all(
-      models.map(async (model) => {
-        // @ts-ignore
-        return model.truncate();
-      })
-    );
+    for (const model of models) {
+      await model.truncate();
+    }
 
     const { cache, api } = await import("actionhero");
     await cache.destroy("properties:all");


### PR DESCRIPTION
This PR now properly loads the the Profile Properties from all Sources in order when fully importing a Profile.  
This PR also fixes up some confusing `Promise.all` code in favor of for loops.

TODO:
- [x] use topological sort
- [x] test new method