### PR TITLE
check type on newUrl before matching

### DIFF
--- a/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
+++ b/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
@@ -34,8 +34,9 @@ export default function SetupStepsNavProgressBar({
 
   async function getSetupSteps(newUrl?: string) {
     if (router.pathname.match(/^\/session\//)) return;
-    if (newUrl && newUrl.match(/^\/session\//)) return;
-    if (newUrl && newUrl === "/") return;
+    if (newUrl && typeof newUrl === "string" && newUrl.match(/^\/session\//))
+      return;
+    if (newUrl && typeof newUrl === "string" && newUrl === "/") return;
 
     const response: Actions.SetupStepsList = await execApi(
       "get",


### PR DESCRIPTION
Previously, trying to skip a step would cause an error: `newUrl.match is not a funciton`.

`newUrl.match is not a function` error was due to newUrl sometimes not being a string depending where it was called from.  We only want to check matches on strings.