### PR TITLE
Type UI Event Dispatchers

### DIFF
--- a/ui/ui-components/__tests__/components/setupStepsNavProgressBar.tsx
+++ b/ui/ui-components/__tests__/components/setupStepsNavProgressBar.tsx
@@ -3,9 +3,10 @@ import Component from "../../components/navigation/setupStepsNavProgressBar";
 import mockAxios from "jest-mock-axios";
 import { Actions } from "../../utils/apiData";
 import { useApi } from "../../hooks/useApi";
+import { EventDispatcher } from "../../utils/eventDispatcher";
 
 const useRouter = jest.spyOn(require("next/router"), "useRouter");
-const mockSetupStepHandler = { subscribe: () => {}, unsubscribe: () => {} };
+const mockSetupStepHandler = new EventDispatcher<any>();
 
 describe("setupStepsNavProgressBar", () => {
   describe("hidden", () => {

--- a/ui/ui-components/classes/grouparooPluginPage.ts
+++ b/ui/ui-components/classes/grouparooPluginPage.ts
@@ -1,10 +1,12 @@
 import { Component } from "react";
 import { Client } from "../client/client";
+import { ErrorHandler } from "../utils/errorHandler";
+import { SuccessHandler } from "../utils/successHandler";
 
 export interface GrouparooPluginPageProps {
   query: any;
-  errorHandler: any;
-  successHandler: any;
+  errorHandler: ErrorHandler;
+  successHandler: SuccessHandler;
 }
 
 export interface GrouparooPluginPageState {

--- a/ui/ui-components/client/client.ts
+++ b/ui/ui-components/client/client.ts
@@ -1,6 +1,7 @@
 import Axios, { AxiosRequestConfig, Method } from "axios";
 import { isBrowser } from "../utils/isBrowser";
 import PackageJSON from "../package.json";
+import { UploadHandler } from "../utils/uploadHandler";
 
 interface ClientCacheObject {
   locked: boolean;
@@ -103,7 +104,7 @@ export class Client {
     path,
     data: AxiosRequestConfig["data"] = {},
     useCache = true,
-    uploadHandler?,
+    uploadHandler?: UploadHandler,
     req?,
     res?
   ) {

--- a/ui/ui-components/components/alerts/error.tsx
+++ b/ui/ui-components/components/alerts/error.tsx
@@ -1,7 +1,12 @@
 import { useState, useEffect } from "react";
 import { Alert } from "react-bootstrap";
+import { ErrorHandler } from "../../utils/errorHandler";
 
-export default function ErrorAlert({ errorHandler }) {
+export default function ErrorAlert({
+  errorHandler,
+}: {
+  errorHandler: ErrorHandler;
+}) {
   const [errorMessage, setErrorMessage] = useState(null);
   const [secondsToShow] = useState(1000 * 4);
   const [show, setShow] = useState(false);
@@ -12,7 +17,7 @@ export default function ErrorAlert({ errorHandler }) {
 
     return () => {
       clearTimeout(timer);
-      errorHandler.unsubscribe("error-alert", subscription.bind(this));
+      errorHandler.unsubscribe("error-alert");
     };
   }, []);
 

--- a/ui/ui-components/components/alerts/success.tsx
+++ b/ui/ui-components/components/alerts/success.tsx
@@ -1,7 +1,12 @@
 import { useState, useEffect } from "react";
 import { Alert } from "react-bootstrap";
+import { SuccessHandler } from "../../utils/successHandler";
 
-export default function SuccessAlert({ successHandler }) {
+export default function SuccessAlert({
+  successHandler,
+}: {
+  successHandler: SuccessHandler;
+}) {
   const [message, setMessage] = useState("");
   const [secondsToShow] = useState(1000 * 4);
   const [show, setShow] = useState(false);
@@ -12,7 +17,7 @@ export default function SuccessAlert({ successHandler }) {
 
     return () => {
       clearTimeout(timer);
-      successHandler.unsubscribe("success-alert", subscription.bind(this));
+      successHandler.unsubscribe("success-alert");
     };
   }, []);
 

--- a/ui/ui-components/components/destination/profilePreview.tsx
+++ b/ui/ui-components/components/destination/profilePreview.tsx
@@ -3,10 +3,21 @@ import { useApi } from "../../hooks/useApi";
 import { Card, ListGroup } from "react-bootstrap";
 import Loader from "../loader";
 import { useRouter } from "next/router";
-import { Actions } from "../../utils/apiData";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { Models, Actions } from "../../utils/apiData";
 
 export default function ProfilePreview(props) {
-  const { errorHandler, destination, trackedGroupId, mappingOptions } = props;
+  const {
+    errorHandler,
+    destination,
+    trackedGroupId,
+    mappingOptions,
+  }: {
+    errorHandler: ErrorHandler;
+    destination: Models.DestinationType;
+    trackedGroupId: string;
+    mappingOptions: Actions.DestinationMappingOptions["options"];
+  } = props;
   const router = useRouter();
   const [profileId, setProfileId] = useState(
     router.query.profileId?.toString()

--- a/ui/ui-components/components/layouts/main.tsx
+++ b/ui/ui-components/components/layouts/main.tsx
@@ -7,9 +7,21 @@ import ErrorAlert from "../alerts/error";
 import Navigation from "../navigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import HydrationError from "../alerts/hydrationError";
+import { SuccessHandler } from "../../utils/successHandler";
+import { ErrorHandler } from "../../utils/errorHandler";
 
 export default function Main(props) {
-  const { children, successHandler, errorHandler, hydrationError } = props;
+  const {
+    children,
+    successHandler,
+    errorHandler,
+    hydrationError,
+  }: {
+    children: any;
+    successHandler: SuccessHandler;
+    errorHandler: ErrorHandler;
+    hydrationError: string;
+  } = props;
   const [navExpanded, setNavExpanded] = useState(true);
   const [alertWidth, setAlertWidth] = useState(500);
   const contentAreaLeftPadding = 250;

--- a/ui/ui-components/components/log/list.tsx
+++ b/ui/ui-components/components/log/list.tsx
@@ -9,9 +9,10 @@ import { ButtonGroup, Button, Alert } from "react-bootstrap";
 import Pagination from "../pagination";
 import LoadingTable from "../loadingTable";
 import { Models, Actions } from "../../utils/apiData";
+import { ErrorHandler } from "../../utils/errorHandler";
 
 export default function LogsList(props) {
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
+++ b/ui/ui-components/components/navigation/setupStepsNavProgressBar.tsx
@@ -5,10 +5,14 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Actions } from "../../utils/apiData";
+import { SetupStepHandler } from "../../utils/setupStepsHandler";
 
 export default function SetupStepsNavProgressBar({
   execApi,
   setupStepHandler,
+}: {
+  execApi: any;
+  setupStepHandler: SetupStepHandler;
 }) {
   const [steps, setSteps] = useState<Models.SetupStepType[]>([]);
   const [initialOnBoardingState, setInitialOnBoardingState] =
@@ -21,14 +25,13 @@ export default function SetupStepsNavProgressBar({
     getSetupSteps();
     router?.events?.on("routeChangeStart", getSetupSteps);
 
-    setupStepHandler?.subscribe("setup-steps-nav-progress-bar", getSetupSteps);
+    setupStepHandler?.subscribe("setup-steps-nav-progress-bar", () =>
+      getSetupSteps()
+    );
 
     return () => {
       router?.events?.off("routeChangeStart", getSetupSteps);
-      setupStepHandler?.unsubscribe(
-        "setup-steps-nav-progress-bar",
-        getSetupSteps
-      );
+      setupStepHandler?.unsubscribe("setup-steps-nav-progress-bar");
     };
   }, []);
 

--- a/ui/ui-components/components/profile/list.tsx
+++ b/ui/ui-components/components/profile/list.tsx
@@ -13,9 +13,13 @@ import { Models, Actions } from "../../utils/apiData";
 import ArrayProfilePropertyList from "./arrayProfilePropertyList";
 import StateBadge from "../badges/stateBadge";
 import { formatTimestamp } from "../../utils/formatTimestamp";
+import { ErrorHandler } from "../../utils/errorHandler";
 
 export default function ProfilesList(props) {
-  const { errorHandler, properties } = props;
+  const {
+    errorHandler,
+    properties,
+  }: { errorHandler: ErrorHandler; properties: Models.PropertyType[] } = props;
   const { execApi } = useApi(props, errorHandler);
   const router = useRouter();
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/components/property/add.tsx
+++ b/ui/ui-components/components/property/add.tsx
@@ -2,10 +2,14 @@ import { useState } from "react";
 import { useApi } from "../../hooks/useApi";
 import LoadingButton from "../loadingButton";
 import { useRouter } from "next/router";
-import { Actions } from "../../utils/apiData";
+import { Actions, Models } from "../../utils/apiData";
+import { ErrorHandler } from "../../utils/errorHandler";
 
 export default function AddPropertyForm(props) {
-  const { errorHandler, source } = props;
+  const {
+    errorHandler,
+    source,
+  }: { errorHandler: ErrorHandler; source: Models.SourceType } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/components/runs/list.tsx
+++ b/ui/ui-components/components/runs/list.tsx
@@ -12,9 +12,11 @@ import LoadingTable from "../loadingTable";
 import RunDurationChart from "../visualizations/runDurations";
 import { Models, Actions } from "../../utils/apiData";
 import { formatTimestamp } from "../../utils/formatTimestamp";
+import { ErrorHandler } from "../../utils/errorHandler";
 
 export default function RunsList(props) {
-  const { errorHandler, topic } = props;
+  const { errorHandler, topic }: { errorHandler: ErrorHandler; topic: string } =
+    props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/components/schedule/add.tsx
+++ b/ui/ui-components/components/schedule/add.tsx
@@ -2,10 +2,14 @@ import { useApi } from "../../hooks/useApi";
 import { useState } from "react";
 import { useRouter } from "next/router";
 import LoadingButton from "../loadingButton";
-import { Actions } from "../../utils/apiData";
+import { Actions, Models } from "../../utils/apiData";
+import { ErrorHandler } from "../../utils/errorHandler";
 
 export default function AddScheduleForm(props) {
-  const { errorHandler, source } = props;
+  const {
+    errorHandler,
+    source,
+  }: { errorHandler: ErrorHandler; source: Models.SourceType } = props;
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);
   const router = useRouter();

--- a/ui/ui-components/components/session/signIn.tsx
+++ b/ui/ui-components/components/session/signIn.tsx
@@ -5,8 +5,13 @@ import { Form } from "react-bootstrap";
 import LoadingButton from "../loadingButton";
 import { useForm } from "react-hook-form";
 import { Actions } from "../../utils/apiData";
+import { SessionHandler } from "../../utils/sessionHandler";
 
-export const createSession = async (data, sessionHandler, execApi) => {
+export const createSession = async (
+  data,
+  sessionHandler: SessionHandler,
+  execApi
+) => {
   const response: Actions.SessionCreate = await execApi(
     "post",
     `/session`,

--- a/ui/ui-components/components/session/signOut.tsx
+++ b/ui/ui-components/components/session/signOut.tsx
@@ -3,9 +3,20 @@ import { useRouter } from "next/router";
 import Loader from "../loader";
 import { useApi } from "../../hooks/useApi";
 import { disconnectWebsocket } from "../../hooks/useRealtimeStream";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { SuccessHandler } from "../../utils/successHandler";
+import { SessionHandler } from "../../utils/sessionHandler";
 
 export default function SignOutForm(props) {
-  const { errorHandler, successHandler, sessionHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+    sessionHandler,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    sessionHandler: SessionHandler;
+  } = props;
   const { execApi } = useApi(props, errorHandler);
   const router = useRouter();
 

--- a/ui/ui-components/components/settings/identifyingProperty.tsx
+++ b/ui/ui-components/components/settings/identifyingProperty.tsx
@@ -3,9 +3,14 @@ import { Card, Form } from "react-bootstrap";
 import { useState, useEffect } from "react";
 import { Models } from "../../utils/apiData";
 import LoadingButton from "../loadingButton";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { SuccessHandler } from "../../utils/successHandler";
 
 export default function IdentifyingProperty(props) {
-  const { errorHandler, successHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+  }: { errorHandler: ErrorHandler; successHandler: SuccessHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);
   const [properties, setProperties] = useState<Models.PropertyType[]>([]);

--- a/ui/ui-components/components/settings/importAndUpdate.tsx
+++ b/ui/ui-components/components/settings/importAndUpdate.tsx
@@ -3,9 +3,14 @@ import { useState } from "react";
 import { Card } from "react-bootstrap";
 import LoadingButton from "../loadingButton";
 import { Actions } from "../../utils/apiData";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { SuccessHandler } from "../../utils/successHandler";
 
 export default function ImportAndUpdateProfile(props) {
-  const { errorHandler, successHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+  }: { errorHandler: ErrorHandler; successHandler: SuccessHandler } = props;
   const [loading, setLoading] = useState(false);
   const { execApi } = useApi(props, errorHandler);
 

--- a/ui/ui-components/components/settings/resetCache.tsx
+++ b/ui/ui-components/components/settings/resetCache.tsx
@@ -3,9 +3,14 @@ import { useApi } from "../../hooks/useApi";
 import { Card } from "react-bootstrap";
 import LoadingButton from "../loadingButton";
 import { Actions } from "../../utils/apiData";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { SuccessHandler } from "../../utils/successHandler";
 
 export default function ResetCache(props) {
-  const { errorHandler, successHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+  }: { errorHandler: ErrorHandler; successHandler: SuccessHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);
 

--- a/ui/ui-components/components/settings/resetCluster.tsx
+++ b/ui/ui-components/components/settings/resetCluster.tsx
@@ -3,9 +3,14 @@ import { useState } from "react";
 import { Card } from "react-bootstrap";
 import LoadingButton from "../loadingButton";
 import { Actions } from "../../utils/apiData";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { SuccessHandler } from "../../utils/successHandler";
 
 export default function ResetCluster(props) {
-  const { errorHandler, successHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+  }: { errorHandler: ErrorHandler; successHandler: SuccessHandler } = props;
   const [loading, setLoading] = useState(false);
   const { execApi } = useApi(props, errorHandler);
 

--- a/ui/ui-components/components/settings/resetData.tsx
+++ b/ui/ui-components/components/settings/resetData.tsx
@@ -3,9 +3,14 @@ import { useApi } from "../../hooks/useApi";
 import { Card } from "react-bootstrap";
 import LoadingButton from "../loadingButton";
 import { Actions } from "../../utils/apiData";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { SuccessHandler } from "../../utils/successHandler";
 
 export default function ResetData(props) {
-  const { errorHandler, successHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+  }: { errorHandler: ErrorHandler; successHandler: SuccessHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);
 

--- a/ui/ui-components/pages/account.tsx
+++ b/ui/ui-components/pages/account.tsx
@@ -5,9 +5,20 @@ import { Form, Row, Col } from "react-bootstrap";
 import ProfileImageFromEmail from "../components/visualizations/profileImageFromEmail";
 import LoadingButton from "../components/loadingButton";
 import { Models, Actions } from "../utils/apiData";
+import { ErrorHandler } from "../utils/errorHandler";
+import { SuccessHandler } from "../utils/successHandler";
+import { SessionHandler } from "../utils/sessionHandler";
 
 export default function Page(props) {
-  const { errorHandler, successHandler, sessionHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+    sessionHandler,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    sessionHandler: SessionHandler;
+  } = props;
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);
   const [teamMember, setTeamMember] = useState<Models.TeamMemberType>(

--- a/ui/ui-components/pages/apiKeys.tsx
+++ b/ui/ui-components/pages/apiKeys.tsx
@@ -10,9 +10,10 @@ import Pagination from "../components/pagination";
 import LoadingTable from "../components/loadingTable";
 import { Models, Actions } from "../utils/apiData";
 import { formatTimestamp } from "../utils/formatTimestamp";
+import { ErrorHandler } from "../utils/errorHandler";
 
 export default function Page(props) {
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [apiKeys, setApiKeys] = useState<Models.ApiKeyType[]>(props.apiKeys);

--- a/ui/ui-components/pages/apps.tsx
+++ b/ui/ui-components/pages/apps.tsx
@@ -12,9 +12,10 @@ import StateBadge from "../components/badges/stateBadge";
 import { Button } from "react-bootstrap";
 import { Models, Actions } from "../utils/apiData";
 import { formatTimestamp } from "../utils/formatTimestamp";
+import { ErrorHandler } from "../utils/errorHandler";
 
 export default function Page(props) {
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [apps, setApps] = useState<Models.AppType[]>(props.apps);

--- a/ui/ui-components/pages/destination/[id]/edit.tsx
+++ b/ui/ui-components/pages/destination/[id]/edit.tsx
@@ -12,6 +12,9 @@ import DestinationTabs from "../../../components/tabs/destination";
 import LoadingButton from "../../../components/loadingButton";
 import Loader from "../../../components/loader";
 import { Models, Actions } from "../../../utils/apiData";
+import { ErrorHandler } from "../../../utils/errorHandler";
+import { SuccessHandler } from "../../../utils/successHandler";
+import { DestinationHandler } from "../../../utils/destinationHandler";
 
 export default function Page(props) {
   const {
@@ -19,6 +22,11 @@ export default function Page(props) {
     successHandler,
     destinationHandler,
     environmentVariableOptions,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    destinationHandler: DestinationHandler;
+    environmentVariableOptions: string[];
   } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);

--- a/ui/ui-components/pages/destination/[id]/edit.tsx
+++ b/ui/ui-components/pages/destination/[id]/edit.tsx
@@ -26,7 +26,7 @@ export default function Page(props) {
     errorHandler: ErrorHandler;
     successHandler: SuccessHandler;
     destinationHandler: DestinationHandler;
-    environmentVariableOptions: string[];
+    environmentVariableOptions: Actions.AppOptions["environmentVariableOptions"];
   } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);

--- a/ui/ui-components/pages/destination/new/[appId].tsx
+++ b/ui/ui-components/pages/destination/new/[appId].tsx
@@ -6,10 +6,17 @@ import LoadingButton from "../../../components/loadingButton";
 import AppIcon from "../../../components/appIcon";
 import { useRouter } from "next/router";
 import { humanizePluginName } from "../../../utils/languageHelper";
-import { Actions } from "../../../utils/apiData";
+import { Actions, Models } from "../../../utils/apiData";
+import { ErrorHandler } from "../../../utils/errorHandler";
 
 export default function Page(props) {
-  const { errorHandler, connectionApps } = props;
+  const {
+    errorHandler,
+    connectionApps,
+  }: {
+    errorHandler: ErrorHandler;
+    connectionApps: Actions.SourceConnectionApps["connectionApps"];
+  } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/pages/destinations.tsx
+++ b/ui/ui-components/pages/destinations.tsx
@@ -13,9 +13,10 @@ import AppIcon from "../components/appIcon";
 import StateBadge from "../components/badges/stateBadge";
 import { Models, Actions } from "../utils/apiData";
 import { formatTimestamp } from "../utils/formatTimestamp";
+import { ErrorHandler } from "../utils/errorHandler";
 
 export default function Page(props) {
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/pages/file/new.tsx
+++ b/ui/ui-components/pages/file/new.tsx
@@ -6,9 +6,19 @@ import { Form, ProgressBar } from "react-bootstrap";
 import { useRouter } from "next/router";
 import LoadingButton from "../../components/loadingButton";
 import { Actions } from "../../utils/apiData";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { UploadHandler } from "../../utils/uploadHandler";
 
 export default function Page(props) {
-  const { errorHandler, uploadHandler, types } = props;
+  const {
+    errorHandler,
+    uploadHandler,
+    types,
+  }: {
+    errorHandler: ErrorHandler;
+    uploadHandler: UploadHandler;
+    types: Actions.AppOptions["types"];
+  } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler, uploadHandler);
   const { handleSubmit, register } = useForm();

--- a/ui/ui-components/pages/files.tsx
+++ b/ui/ui-components/pages/files.tsx
@@ -12,11 +12,16 @@ import LoadingButton from "../components/loadingButton";
 import { Models, Actions } from "../utils/apiData";
 import { FilePreview, downloadFile } from "../components/filePreview";
 import { formatTimestamp } from "../utils/formatTimestamp";
+import { ErrorHandler } from "../utils/errorHandler";
+import { SuccessHandler } from "../utils/successHandler";
 
 const apiVersion = process.env.API_VERSION || "v1";
 
 export default function Page(props) {
-  const { errorHandler, successHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+  }: { errorHandler: ErrorHandler; successHandler: SuccessHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/pages/group/[id]/edit.tsx
+++ b/ui/ui-components/pages/group/[id]/edit.tsx
@@ -10,9 +10,20 @@ import LoadingButton from "../../../components/loadingButton";
 
 import { Models, Actions } from "../../../utils/apiData";
 import { formatTimestamp } from "../../../utils/formatTimestamp";
+import { ErrorHandler } from "../../../utils/errorHandler";
+import { SuccessHandler } from "../../../utils/successHandler";
+import { GroupHandler } from "../../../utils/groupHandler";
 
 export default function Page(props) {
-  const { errorHandler, successHandler, groupHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+    groupHandler,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    groupHandler: GroupHandler;
+  } = props;
   const router = useRouter();
   const [group, setGroup] = useState<Models.GroupType>(props.group);
   const { execApi } = useApi(props, errorHandler);

--- a/ui/ui-components/pages/group/new.tsx
+++ b/ui/ui-components/pages/group/new.tsx
@@ -6,9 +6,10 @@ import { useRouter } from "next/router";
 import { Form } from "react-bootstrap";
 import LoadingButton from "../../components/loadingButton";
 import { Actions } from "../../utils/apiData";
+import { ErrorHandler } from "../../utils/errorHandler";
 
 export default function NewGroup(props) {
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const { handleSubmit, register } = useForm();

--- a/ui/ui-components/pages/groups.tsx
+++ b/ui/ui-components/pages/groups.tsx
@@ -11,9 +11,10 @@ import LoadingTable from "../components/loadingTable";
 import StateBadge from "../components/badges/stateBadge";
 import { Models, Actions } from "../utils/apiData";
 import { formatTimestamp } from "../utils/formatTimestamp";
+import { ErrorHandler } from "../utils/errorHandler";
 
 export default function Page(props) {
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [groups, setGroups] = useState<Models.GroupType[]>(props.groups);

--- a/ui/ui-components/pages/notifications.tsx
+++ b/ui/ui-components/pages/notifications.tsx
@@ -10,9 +10,10 @@ import LoadingTable from "../components/loadingTable";
 import { Models, Actions } from "../utils/apiData";
 import { Badge } from "react-bootstrap";
 import { formatTimestamp } from "../utils/formatTimestamp";
+import { ErrorHandler } from "../utils/errorHandler";
 
 export default function Page(props) {
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [notifications, setNotifications] = useState<Models.NotificationType[]>(

--- a/ui/ui-components/pages/object/[id].tsx
+++ b/ui/ui-components/pages/object/[id].tsx
@@ -6,10 +6,11 @@ import { useApi } from "../../hooks/useApi";
 import { Actions } from "../../utils/apiData";
 import { Card } from "react-bootstrap";
 import { singular } from "pluralize";
+import { ErrorHandler } from "../../utils/errorHandler";
 
 export default function FindObject(props) {
   const router = useRouter();
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const [error, setError] = useState<string>(null);
   const [records, setRecords] = useState<string[]>([]);

--- a/ui/ui-components/pages/property/[id]/edit.tsx
+++ b/ui/ui-components/pages/property/[id]/edit.tsx
@@ -16,6 +16,9 @@ import PropertyTabs from "../../../components/tabs/property";
 import { Models, Actions } from "../../../utils/apiData";
 import { filtersAreEqual } from "../../../utils/filtersAreEqual";
 import { makeLocal } from "../../../utils/makeLocal";
+import { ErrorHandler } from "../../../utils/errorHandler";
+import { SuccessHandler } from "../../../utils/successHandler";
+import { PropertiesHandler } from "../../../utils/propertiesHandler";
 
 export default function Page(props) {
   const {
@@ -27,6 +30,15 @@ export default function Page(props) {
     filterOptions,
     properties,
     hydrationError,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    sources: Models.SourceType[];
+    propertiesHandler: PropertiesHandler;
+    types: Actions.AppOptions["types"];
+    filterOptions: Actions.ScheduleFilterOptions["options"];
+    properties: Models.PropertyType[];
+    hydrationError: Error;
   } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
@@ -71,7 +83,7 @@ export default function Page(props) {
     );
     if (response?.property) {
       setProperty(response.property);
-      propertiesHandler.set(response.property);
+      propertiesHandler.set([response.property]);
       if (response.property.state === "ready" && property.state === "draft") {
         successHandler.set({ message: "Property Created" });
         router.push(nextPage || "/properties");

--- a/ui/ui-components/pages/resque/delayed.tsx
+++ b/ui/ui-components/pages/resque/delayed.tsx
@@ -7,9 +7,14 @@ import { useRouter } from "next/router";
 import Head from "next/head";
 import ResqueTabs from "../../components/tabs/resque";
 import LoadingButton from "../../components/loadingButton";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { SuccessHandler } from "../../utils/successHandler";
 
 export default function ResqueDelayedList(props) {
-  const { errorHandler, successHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+  }: { errorHandler: ErrorHandler; successHandler: SuccessHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [timestamps, setTimestamps] = useState([]);

--- a/ui/ui-components/pages/resque/failed.tsx
+++ b/ui/ui-components/pages/resque/failed.tsx
@@ -7,9 +7,14 @@ import { useRouter } from "next/router";
 import Head from "next/head";
 import ResqueTabs from "../../components/tabs/resque";
 import LoadingButton from "../../components/loadingButton";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { SuccessHandler } from "../../utils/successHandler";
 
 export default function ResqueFailedList(props) {
-  const { errorHandler, successHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+  }: { errorHandler: ErrorHandler; successHandler: SuccessHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/pages/resque/locks.tsx
+++ b/ui/ui-components/pages/resque/locks.tsx
@@ -7,9 +7,14 @@ import { useRouter } from "next/router";
 import Head from "next/head";
 import ResqueTabs from "../../components/tabs/resque";
 import LoadingButton from "../../components/loadingButton";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { SuccessHandler } from "../../utils/successHandler";
 
 export default function ResqueLocksList(props) {
-  const { errorHandler, successHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+  }: { errorHandler: ErrorHandler; successHandler: SuccessHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props);
   const [locks, setLocks] = useState([]);

--- a/ui/ui-components/pages/resque/queue/[queue].tsx
+++ b/ui/ui-components/pages/resque/queue/[queue].tsx
@@ -7,9 +7,10 @@ import { useRouter } from "next/router";
 import Head from "next/head";
 import ResqueTabs from "../../../components/tabs/resque";
 import LoadingButton from "../../../components/loadingButton";
+import { ErrorHandler } from "../../../utils/errorHandler";
 
 export default function ResqueQueue(props) {
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [queue, setQueue] = useState(router.query.queue || "");

--- a/ui/ui-components/pages/resque/queue/index.tsx
+++ b/ui/ui-components/pages/resque/queue/index.tsx
@@ -4,9 +4,10 @@ import { Table } from "react-bootstrap";
 import Head from "next/head";
 import Link from "next/link";
 import ResqueTabs from "../../../components/tabs/resque";
+import { ErrorHandler } from "../../../utils/errorHandler";
 
 export default function ResqueQueue(props) {
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const [queues, setQueues] = useState({});
 

--- a/ui/ui-components/pages/resque/redis.tsx
+++ b/ui/ui-components/pages/resque/redis.tsx
@@ -3,9 +3,10 @@ import { useApi } from "../../hooks/useApi";
 import { Table, Row, Col } from "react-bootstrap";
 import Head from "next/head";
 import ResqueTabs from "../../components/tabs/resque";
+import { ErrorHandler } from "../../utils/errorHandler";
 
 export default function ResqueRedis(props) {
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const [redisInfo, setRedisInfo] = useState([]);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/pages/resque/workers.tsx
+++ b/ui/ui-components/pages/resque/workers.tsx
@@ -4,9 +4,14 @@ import { Table, Row, Col } from "react-bootstrap";
 import Head from "next/head";
 import ResqueTabs from "../../components/tabs/resque";
 import LoadingButton from "../../components/loadingButton";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { SuccessHandler } from "../../utils/successHandler";
 
 export default function ResqueWorkersList(props) {
-  const { errorHandler, successHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+  }: { errorHandler: ErrorHandler; successHandler: SuccessHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const [workers, setWorkers] = useState({});
   const [workerQueues, setWorkerQueues] = useState([]);

--- a/ui/ui-components/pages/run/[id]/edit.tsx
+++ b/ui/ui-components/pages/run/[id]/edit.tsx
@@ -9,9 +9,19 @@ import Head from "next/head";
 import LoadingButton from "../../../components/loadingButton";
 import { Models, Actions } from "../../../utils/apiData";
 import { formatTimestamp } from "../../../utils/formatTimestamp";
+import { SuccessHandler } from "../../../utils/successHandler";
+import { ErrorHandler } from "../../../utils/errorHandler";
 
 export default function Page(props) {
-  const { quantizedTimeline, successHandler, errorHandler } = props;
+  const {
+    quantizedTimeline,
+    successHandler,
+    errorHandler,
+  }: {
+    quantizedTimeline: any;
+    successHandler: SuccessHandler;
+    errorHandler: ErrorHandler;
+  } = props;
   const { execApi } = useApi(props, errorHandler);
   const [run, setRun] = useState<Models.RunType>(props.run);
   const { chartData, chartKeys } = buildChartData(quantizedTimeline);

--- a/ui/ui-components/pages/settings/[tab].tsx
+++ b/ui/ui-components/pages/settings/[tab].tsx
@@ -11,9 +11,19 @@ import IdentifyingProperty from "../../components/settings/identifyingProperty";
 import ResetCluster from "../../components/settings/resetCluster";
 import ResetData from "../../components/settings/resetData";
 import ResetCache from "../../components/settings/resetCache";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { SuccessHandler } from "../../utils/successHandler";
 
 export default function Page(props) {
-  const { errorHandler, successHandler, tab } = props;
+  const {
+    errorHandler,
+    successHandler,
+    tab,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    tab: string;
+  } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/pages/setup.tsx
+++ b/ui/ui-components/pages/setup.tsx
@@ -1,13 +1,17 @@
 import Head from "next/head";
-import Link from "next/link";
 import { useState } from "react";
 import { useApi } from "../hooks/useApi";
 import { Models } from "../utils/apiData";
 import { Row, Col, ProgressBar, Alert } from "react-bootstrap";
 import SetupStepCard from "../components/setupSteps/setupStepCard";
+import { ErrorHandler } from "../utils/errorHandler";
+import { SetupStepHandler } from "../utils/setupStepsHandler";
 
 export default function Page(props) {
-  const { errorHandler, setupStepHandler } = props;
+  const {
+    errorHandler,
+    setupStepHandler,
+  }: { errorHandler: ErrorHandler; setupStepHandler: SetupStepHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const [setupSteps, setSetupSteps] = useState<Models.SetupStepType[]>(
     props.setupSteps

--- a/ui/ui-components/pages/source/[id]/edit.tsx
+++ b/ui/ui-components/pages/source/[id]/edit.tsx
@@ -13,6 +13,9 @@ import { Models, Actions } from "../../../utils/apiData";
 import LoadingTable from "../../../components/loadingTable";
 import LoadingButton from "../../../components/loadingButton";
 import Loader from "../../../components/loader";
+import { ErrorHandler } from "../../../utils/errorHandler";
+import { SuccessHandler } from "../../../utils/successHandler";
+import { SourceHandler } from "../../../utils/sourceHandler";
 
 export default function Page(props) {
   const {
@@ -20,6 +23,11 @@ export default function Page(props) {
     successHandler,
     sourceHandler,
     environmentVariableOptions,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    sourceHandler: SourceHandler;
+    environmentVariableOptions: Actions.AppOptions["environmentVariableOptions"];
   } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);

--- a/ui/ui-components/pages/source/[id]/mapping.tsx
+++ b/ui/ui-components/pages/source/[id]/mapping.tsx
@@ -10,10 +10,23 @@ import StateBadge from "../../../components/badges/stateBadge";
 import LockedBadge from "../../../components/badges/lockedBadge";
 import { useRouter } from "next/router";
 import { Actions } from "../../../utils/apiData";
+import { ErrorHandler } from "../../../utils/errorHandler";
+import { SuccessHandler } from "../../../utils/successHandler";
 
 export default function Page(props) {
-  const { errorHandler, successHandler, types, scheduleCount, hydrationError } =
-    props;
+  const {
+    errorHandler,
+    successHandler,
+    types,
+    scheduleCount,
+    hydrationError,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    types: Actions.AppOptions["types"];
+    scheduleCount: number;
+    hydrationError: Error;
+  } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/pages/sources.tsx
+++ b/ui/ui-components/pages/sources.tsx
@@ -12,9 +12,14 @@ import StateBadge from "../components/badges/stateBadge";
 import { Models, Actions } from "../utils/apiData";
 import { Button } from "react-bootstrap";
 import { formatTimestamp } from "../utils/formatTimestamp";
+import { SuccessHandler } from "../utils/successHandler";
+import { ErrorHandler } from "../utils/errorHandler";
 
 export default function Page(props) {
-  const { successHandler, errorHandler } = props;
+  const {
+    successHandler,
+    errorHandler,
+  }: { successHandler: SuccessHandler; errorHandler: ErrorHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/pages/team/[id]/edit.tsx
+++ b/ui/ui-components/pages/team/[id]/edit.tsx
@@ -7,9 +7,20 @@ import { useRouter } from "next/router";
 import { Models, Actions } from "../../../utils/apiData";
 import TeamTabs from "../../../components/tabs/team";
 import LockedBadge from "../../../components/badges/lockedBadge";
+import { ErrorHandler } from "../../../utils/errorHandler";
+import { TeamHandler } from "../../../utils/teamHandler";
+import { SuccessHandler } from "../../../utils/successHandler";
 
 export default function Page(props) {
-  const { errorHandler, successHandler, teamHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+    teamHandler,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    teamHandler: TeamHandler;
+  } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/pages/team/initialize.tsx
+++ b/ui/ui-components/pages/team/initialize.tsx
@@ -7,9 +7,20 @@ import { Form, Card } from "react-bootstrap";
 import LoadingButton from "../../components/loadingButton";
 import { Actions } from "../../utils/apiData";
 import { createSession } from "../../components/session/signIn";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { SuccessHandler } from "../../utils/successHandler";
+import { SessionHandler } from "../../utils/sessionHandler";
 
 export default function TeamInitializePage(props) {
-  const { errorHandler, successHandler, sessionHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+    sessionHandler,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    sessionHandler: SessionHandler;
+  } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const { handleSubmit, register } = useForm();

--- a/ui/ui-components/pages/team/new.tsx
+++ b/ui/ui-components/pages/team/new.tsx
@@ -6,9 +6,10 @@ import { useRouter } from "next/router";
 import { Form } from "react-bootstrap";
 import LoadingButton from "../../components/loadingButton";
 import { Actions } from "../../utils/apiData";
+import { ErrorHandler } from "../../utils/errorHandler";
 
 export default function NewTeamPage(props) {
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const { handleSubmit, register } = useForm();

--- a/ui/ui-components/pages/teamMember/[id]/edit.tsx
+++ b/ui/ui-components/pages/teamMember/[id]/edit.tsx
@@ -8,9 +8,19 @@ import ProfileImageFromEmail from "../../../components/visualizations/profileIma
 import { Models, Actions } from "../../../utils/apiData";
 import TeamMemberTabs from "../../../components/tabs/teamMember";
 import { formatTimestamp } from "../../../utils/formatTimestamp";
+import { ErrorHandler } from "../../../utils/errorHandler";
+import { SuccessHandler } from "../../../utils/successHandler";
 
 export default function Page(props) {
-  const { errorHandler, successHandler, teams } = props;
+  const {
+    errorHandler,
+    successHandler,
+    teams,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    teams: Models.TeamType[];
+  } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-components/pages/teamMember/new.tsx
+++ b/ui/ui-components/pages/teamMember/new.tsx
@@ -5,10 +5,23 @@ import { useForm } from "react-hook-form";
 import { Form } from "react-bootstrap";
 import LoadingButton from "../../components/loadingButton";
 import { useRouter } from "next/router";
-import { Actions } from "../../utils/apiData";
+import { Actions, Models } from "../../utils/apiData";
+import { ErrorHandler } from "../../utils/errorHandler";
+import { TeamMemberHandler } from "../../utils/teamMembersHandler";
+import { SuccessHandler } from "../../utils/successHandler";
 
 export default function Page(props) {
-  const { errorHandler, successHandler, teamMemberHandler, teams } = props;
+  const {
+    errorHandler,
+    successHandler,
+    teamMemberHandler,
+    teams,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    teamMemberHandler: TeamMemberHandler;
+    teams: Models.TeamType[];
+  } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const { handleSubmit, register } = useForm();
@@ -27,7 +40,7 @@ export default function Page(props) {
     );
 
     if (response?.teamMember) {
-      teamMemberHandler.set(response.teamMember);
+      teamMemberHandler.set([response.teamMember]);
       successHandler.set({ message: "Team Member Created" });
       process.env.GROUPAROO_UI_EDITION === "enterprise"
         ? router.push(`/team/${response.teamMember.teamId}/members`)

--- a/ui/ui-components/utils/appHandler.ts
+++ b/ui/ui-components/utils/appHandler.ts
@@ -1,3 +1,4 @@
+import { Models } from "./apiData";
 import { EventDispatcher } from "./eventDispatcher";
 
-export class AppHandler extends EventDispatcher {}
+export class AppHandler extends EventDispatcher<Models.AppType> {}

--- a/ui/ui-components/utils/destinationHandler.ts
+++ b/ui/ui-components/utils/destinationHandler.ts
@@ -1,3 +1,4 @@
+import { Models } from "./apiData";
 import { EventDispatcher } from "./eventDispatcher";
 
-export class DestinationHandler extends EventDispatcher {}
+export class DestinationHandler extends EventDispatcher<Models.DestinationType> {}

--- a/ui/ui-components/utils/errorHandler.ts
+++ b/ui/ui-components/utils/errorHandler.ts
@@ -1,7 +1,7 @@
 import { EventDispatcher } from "./eventDispatcher";
 
-export class ErrorHandler extends EventDispatcher {
-  error: Error | string;
+export class ErrorHandler extends EventDispatcher<{ error: string | Error }> {
+  error: { error: string | Error };
 
   constructor() {
     super();

--- a/ui/ui-components/utils/eventDispatcher.ts
+++ b/ui/ui-components/utils/eventDispatcher.ts
@@ -1,4 +1,4 @@
-export class EventDispatcher {
+export class EventDispatcher<T> {
   subscriptions: {
     [key: string]: Function;
   };
@@ -11,7 +11,7 @@ export class EventDispatcher {
     this.publish(data);
   }
 
-  async publish(data) {
+  async publish<T>(data) {
     if (typeof this.beforePublish === "function") {
       await this.beforePublish(data);
     }
@@ -30,7 +30,7 @@ export class EventDispatcher {
   async beforePublish(data) {}
   async afterPublish(data) {}
 
-  async subscribe(name: string, handler: Function, matcher?: any) {
+  async subscribe(name: string, handler: (arg0: T) => any, matcher?: any) {
     if (typeof this.beforeSubscribe === "function") {
       await this.beforeSubscribe(name, handler, matcher);
     }

--- a/ui/ui-components/utils/eventDispatcher.ts
+++ b/ui/ui-components/utils/eventDispatcher.ts
@@ -7,11 +7,11 @@ export class EventDispatcher<T> {
     this.subscriptions = {};
   }
 
-  set(data) {
+  set(data: T) {
     this.publish(data);
   }
 
-  async publish<T>(data) {
+  async publish(data: T) {
     if (typeof this.beforePublish === "function") {
       await this.beforePublish(data);
     }
@@ -27,8 +27,8 @@ export class EventDispatcher<T> {
     }
   }
 
-  async beforePublish(data) {}
-  async afterPublish(data) {}
+  async beforePublish(data: T) {}
+  async afterPublish(data: T) {}
 
   async subscribe(name: string, handler: (arg0: T) => any, matcher?: any) {
     if (typeof this.beforeSubscribe === "function") {

--- a/ui/ui-components/utils/fileHandler.ts
+++ b/ui/ui-components/utils/fileHandler.ts
@@ -1,3 +1,4 @@
+import { Models } from "./apiData";
 import { EventDispatcher } from "./eventDispatcher";
 
-export class FileHandler extends EventDispatcher {}
+export class FileHandler extends EventDispatcher<Models.FileType> {}

--- a/ui/ui-components/utils/groupHandler.ts
+++ b/ui/ui-components/utils/groupHandler.ts
@@ -1,3 +1,4 @@
+import { Models } from "./apiData";
 import { EventDispatcher } from "./eventDispatcher";
 
-export class GroupHandler extends EventDispatcher {}
+export class GroupHandler extends EventDispatcher<Models.GroupType> {}

--- a/ui/ui-components/utils/profileHandler.ts
+++ b/ui/ui-components/utils/profileHandler.ts
@@ -1,3 +1,4 @@
+import { Models } from "./apiData";
 import { EventDispatcher } from "./eventDispatcher";
 
-export class ProfileHandler extends EventDispatcher {}
+export class ProfileHandler extends EventDispatcher<Models.ProfileType> {}

--- a/ui/ui-components/utils/propertiesHandler.ts
+++ b/ui/ui-components/utils/propertiesHandler.ts
@@ -1,3 +1,4 @@
+import { Models } from "./apiData";
 import { EventDispatcher } from "./eventDispatcher";
 
-export class PropertiesHandler extends EventDispatcher {}
+export class PropertiesHandler extends EventDispatcher<Models.PropertyType[]> {}

--- a/ui/ui-components/utils/runsHandler.ts
+++ b/ui/ui-components/utils/runsHandler.ts
@@ -1,3 +1,4 @@
+import { Models } from "./apiData";
 import { EventDispatcher } from "./eventDispatcher";
 
-export class RunsHandler extends EventDispatcher {}
+export class RunsHandler extends EventDispatcher<Models.RunType[]> {}

--- a/ui/ui-components/utils/scheduleHandler.ts
+++ b/ui/ui-components/utils/scheduleHandler.ts
@@ -1,3 +1,4 @@
+import { Models } from "./apiData";
 import { EventDispatcher } from "./eventDispatcher";
 
-export class ScheduleHandler extends EventDispatcher {}
+export class ScheduleHandler extends EventDispatcher<Models.ScheduleType> {}

--- a/ui/ui-components/utils/sessionHandler.ts
+++ b/ui/ui-components/utils/sessionHandler.ts
@@ -1,3 +1,4 @@
+import { Models } from "./apiData";
 import { EventDispatcher } from "./eventDispatcher";
 
-export class SessionHandler extends EventDispatcher {}
+export class SessionHandler extends EventDispatcher<Models.TeamMemberType> {}

--- a/ui/ui-components/utils/setupStepsHandler.ts
+++ b/ui/ui-components/utils/setupStepsHandler.ts
@@ -1,3 +1,3 @@
 import { EventDispatcher } from "./eventDispatcher";
 
-export class SetupStepHandler extends EventDispatcher {}
+export class SetupStepHandler extends EventDispatcher<string[]> {}

--- a/ui/ui-components/utils/sourceHandler.ts
+++ b/ui/ui-components/utils/sourceHandler.ts
@@ -1,3 +1,4 @@
+import { Models } from "./apiData";
 import { EventDispatcher } from "./eventDispatcher";
 
-export class SourceHandler extends EventDispatcher {}
+export class SourceHandler extends EventDispatcher<Models.SourceType> {}

--- a/ui/ui-components/utils/statusHandler.ts
+++ b/ui/ui-components/utils/statusHandler.ts
@@ -1,7 +1,9 @@
 import { EventDispatcher } from "./eventDispatcher";
 import { Actions, Misc } from "../utils/apiData";
 
-export class StatusHandler extends EventDispatcher {
+export class StatusHandler extends EventDispatcher<
+  Actions.PrivateStatus["metrics"]
+> {
   maxSamples: number;
   matchers: { [name: string]: { topic: string; collection: string } } = {};
   metrics: {

--- a/ui/ui-components/utils/successHandler.ts
+++ b/ui/ui-components/utils/successHandler.ts
@@ -1,7 +1,7 @@
 import { EventDispatcher } from "./eventDispatcher";
 
-export class SuccessHandler extends EventDispatcher {
-  message: string;
+export class SuccessHandler extends EventDispatcher<{ message: string }> {
+  message: { message: string };
 
   constructor() {
     super();

--- a/ui/ui-components/utils/teamHandler.ts
+++ b/ui/ui-components/utils/teamHandler.ts
@@ -1,3 +1,4 @@
+import { Models } from "./apiData";
 import { EventDispatcher } from "./eventDispatcher";
 
-export class TeamHandler extends EventDispatcher {}
+export class TeamHandler extends EventDispatcher<Models.TeamType> {}

--- a/ui/ui-components/utils/teamMembersHandler.ts
+++ b/ui/ui-components/utils/teamMembersHandler.ts
@@ -1,3 +1,6 @@
+import { Models } from "./apiData";
 import { EventDispatcher } from "./eventDispatcher";
 
-export class TeamMemberHandler extends EventDispatcher {}
+export class TeamMemberHandler extends EventDispatcher<
+  Models.TeamMemberType[]
+> {}

--- a/ui/ui-components/utils/uploadHandler.ts
+++ b/ui/ui-components/utils/uploadHandler.ts
@@ -1,3 +1,5 @@
 import { EventDispatcher } from "./eventDispatcher";
 
-export class UploadHandler extends EventDispatcher {}
+export class UploadHandler extends EventDispatcher<{
+  uploadPercentage: number;
+}> {}

--- a/ui/ui-config/pages/app/new.tsx
+++ b/ui/ui-config/pages/app/new.tsx
@@ -10,11 +10,11 @@ import { EventDispatcher } from "@grouparoo/ui-components/utils/eventDispatcher"
 
 import { Actions, Models } from "@grouparoo/ui-components/utils/apiData";
 
-class CustomErrorHandler extends EventDispatcher {
+class CustomErrorHandler extends EventDispatcher<{ error: string }> {
   error: Error | string | any;
-  parentErrorHandler: EventDispatcher;
+  parentErrorHandler: ErrorHandler;
 
-  constructor(parentErrorHandler: EventDispatcher) {
+  constructor(parentErrorHandler: ErrorHandler) {
     super();
 
     this.error = null;

--- a/ui/ui-config/pages/index.tsx
+++ b/ui/ui-config/pages/index.tsx
@@ -4,6 +4,7 @@ import Head from "next/head";
 import { Row, Col, Image, Button } from "react-bootstrap";
 import { useState, useEffect } from "react";
 import Loader from "../../ui-components/components/loader";
+import { Models } from "../../ui-components/utils/apiData";
 
 export default function Page(props) {
   const router = useRouter();
@@ -18,12 +19,12 @@ export default function Page(props) {
 
   useEffect(() => {
     if (navigationMode === "config:authenticated") {
-      getSetupSteps(props);
+      checkSetupSteps(props);
     } else {
       setShouldRender(true);
     }
 
-    async function getSetupSteps(props) {
+    async function checkSetupSteps(props) {
       const { execApi } = useApi(props);
       const { setupSteps } = await execApi("get", `/setupSteps`);
       const foundStep = await setupSteps.find(

--- a/ui/ui-config/pages/plugins.tsx
+++ b/ui/ui-config/pages/plugins.tsx
@@ -5,9 +5,14 @@ import { useApi } from "@grouparoo/ui-components/hooks/useApi";
 import { Actions } from "@grouparoo/ui-components/utils/apiData";
 import { Table, Alert, Button } from "react-bootstrap";
 import { CLIStream } from "../components/cliStream";
+import { SuccessHandler } from "../../ui-components/utils/successHandler";
+import { ErrorHandler } from "../../ui-components/utils/errorHandler";
 
 export default function PluginsPage(props) {
-  const { successHandler, errorHandler } = props;
+  const {
+    successHandler,
+    errorHandler,
+  }: { successHandler: SuccessHandler; errorHandler: ErrorHandler } = props;
   const [installedPlugins, setInstalledPlugins] = useState<
     Actions.PluginsInstalledList["plugins"]
   >(props.installedPlugins);

--- a/ui/ui-config/pages/session/sign-in.tsx
+++ b/ui/ui-config/pages/session/sign-in.tsx
@@ -6,9 +6,13 @@ import { useRouter } from "next/router";
 import { useApi } from "@grouparoo/ui-components/hooks/useApi";
 import { Actions } from "@grouparoo/ui-components/utils/apiData";
 import LoadingButton from "@grouparoo/ui-components/components/loadingButton";
+import { ErrorHandler } from "../../../ui-components/utils/errorHandler";
 
 export default function SignInPage(props) {
-  const { clusterName, errorHandler } = props;
+  const {
+    clusterName,
+    errorHandler,
+  }: { clusterName: any; errorHandler: ErrorHandler } = props;
   const { execApi } = useApi(props, errorHandler);
   const { handleSubmit, register } = useForm();
   const [loading, setLoading] = useState(false);

--- a/ui/ui-config/pages/validate.tsx
+++ b/ui/ui-config/pages/validate.tsx
@@ -4,9 +4,14 @@ import { Row, Col, Button } from "react-bootstrap";
 import { useApi } from "@grouparoo/ui-components/hooks/useApi";
 import { Actions } from "@grouparoo/ui-components/utils/apiData";
 import { CLIStream } from "../components/cliStream";
+import { SuccessHandler } from "../../ui-components/utils/successHandler";
+import { ErrorHandler } from "../../ui-components/utils/errorHandler";
 
 export default function ValidatePage(props) {
-  const { successHandler, errorHandler } = props;
+  const {
+    successHandler,
+    errorHandler,
+  }: { successHandler: SuccessHandler; errorHandler: ErrorHandler } = props;
   const [loading, setLoading] = useState(false);
   const { execApi } = useApi(props, errorHandler);
 

--- a/ui/ui-enterprise/pages/apiKey/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/apiKey/[id]/edit.tsx
@@ -7,11 +7,15 @@ import { useRouter } from "next/router";
 import ApiKeyTabs from "@grouparoo/ui-components/components/tabs/apiKey";
 import LoadingButton from "@grouparoo/ui-components/components/loadingButton";
 import LockedBadge from "@grouparoo/ui-components/components/badges/lockedBadge";
-
 import { Models, Actions } from "@grouparoo/ui-components/utils/apiData";
+import { ErrorHandler } from "../../../../ui-components/utils/errorHandler";
+import { SuccessHandler } from "../../../../ui-components/utils/successHandler";
 
 export default function Page(props) {
-  const { errorHandler, successHandler } = props;
+  const {
+    errorHandler,
+    successHandler,
+  }: { errorHandler: ErrorHandler; successHandler: SuccessHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);

--- a/ui/ui-enterprise/pages/apiKey/new.tsx
+++ b/ui/ui-enterprise/pages/apiKey/new.tsx
@@ -5,11 +5,11 @@ import { useForm } from "react-hook-form";
 import { useRouter } from "next/router";
 import { Form } from "react-bootstrap";
 import LoadingButton from "@grouparoo/ui-components/components/loadingButton";
-
 import { Actions } from "@grouparoo/ui-components/utils/apiData";
+import { ErrorHandler } from "../../../ui-components/utils/errorHandler";
 
 export default function Page(props) {
-  const { errorHandler } = props;
+  const { errorHandler }: { errorHandler: ErrorHandler } = props;
   const router = useRouter();
   const { execApi } = useApi(props, errorHandler);
   const { handleSubmit, register } = useForm();

--- a/ui/ui-enterprise/pages/source/[id]/runs.tsx
+++ b/ui/ui-enterprise/pages/source/[id]/runs.tsx
@@ -7,9 +7,23 @@ import PageHeader from "@grouparoo/ui-components/components/pageHeader";
 import StateBadge from "@grouparoo/ui-components/components/badges/stateBadge";
 import LockedBadge from "@grouparoo/ui-components/components/badges/lockedBadge";
 import { Button, Row, Col } from "react-bootstrap";
+import { ErrorHandler } from "../../../../ui-components/utils/errorHandler";
+import { SuccessHandler } from "../../../../ui-components/utils/successHandler";
+import { RunsHandler } from "../../../../ui-components/utils/runsHandler";
+import { Models } from "../../../../ui-components/utils/apiData";
 
 export default function Page(props) {
-  const { errorHandler, successHandler, runsHandler, source } = props;
+  const {
+    errorHandler,
+    successHandler,
+    runsHandler,
+    source,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    runsHandler: RunsHandler;
+    source: Models.SourceType;
+  } = props;
   const { execApi } = useApi(props, errorHandler);
   const [loading, setLoading] = useState(false);
 
@@ -18,7 +32,7 @@ export default function Page(props) {
     try {
       await execApi("post", `/schedule/${source.schedule.id}/run`);
       successHandler.set({ message: "run enqueued" });
-      runsHandler.set({});
+      runsHandler.set(null);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
Possibly replaces #2075

This PR adds Typescript Types to the UI Event Dispatchers.  This way, it's possible to know what types of objects the subscriptions respond with.  Now we'll see better errors when we use the subscriptions:

<img width="1096" alt="Screen Shot 2021-07-24 at 9 01 29 AM" src="https://user-images.githubusercontent.com/303226/126874682-a4d294fc-a7ff-4151-b68e-feab83939596.png">

This works because when we extend the generic EventDispatcher class, we add a `<type>` indicating the types of values it's allowed to use in publishing and subscribing.  

TODO: 
- [x] Ensure all EventDisplatchers are typed in all components - If we don't supply them with the Type they are, we con't know the types of the subscription responses. 