### PR TITLE
Do not load a plugin if it can't be found

### DIFF
--- a/core/src/utils/pluginDetails.js
+++ b/core/src/utils/pluginDetails.js
@@ -109,9 +109,8 @@ function getPluginManifest() {
       }
     }
 
-    pluginPath = fs.realpathSync(pluginPath);
-
     if (!fs.existsSync(pluginPath)) continue;
+    pluginPath = fs.realpathSync(pluginPath);
 
     const pluginPkg = readPackageJson(path.join(pluginPath, "package.json"));
 


### PR DESCRIPTION
Closes https://github.com/grouparoo/grouparoo/issues/2078

With the addition of the code to autoload the UI plugins, we need to be considerate of the cases in which devDependencies are listed but not installed (eg: `npm install --production` or `npm run prune`)