### PR TITLE
only show delete button in config ui

### DIFF
--- a/ui/ui-components/pages/profile/[id]/edit.tsx
+++ b/ui/ui-components/pages/profile/[id]/edit.tsx
@@ -221,16 +221,18 @@ export default function Page(props) {
               <br />
               <br />
 
-              <LoadingButton
-                disabled={loading}
-                variant="danger"
-                size="sm"
-                onClick={() => {
-                  handleDelete();
-                }}
-              >
-                Delete
-              </LoadingButton>
+              {process.env.GROUPAROO_UI_EDITION === "config" ? (
+                <LoadingButton
+                  disabled={loading}
+                  variant="danger"
+                  size="sm"
+                  onClick={() => {
+                    handleDelete();
+                  }}
+                >
+                  Delete
+                </LoadingButton>
+              ) : null}
             </Col>
           </Row>
         </Col>


### PR DESCRIPTION
Now that we can delete profiles from the source, we only want the "delete" button visible in Config UI. 