### PR TITLE
remove empty options objs in destination templates

### DIFF
--- a/plugins/@grouparoo/customerio/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/customerio/public/templates/destination/{{{id}}}.js.template
@@ -9,8 +9,6 @@ exports.default = async function buildConfig() {
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
-      options: {},
-
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       mapping: {

--- a/plugins/@grouparoo/eloqua/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/eloqua/public/templates/destination/{{{id}}}.js.template
@@ -9,8 +9,6 @@ exports.default = async function buildConfig() {
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
-      options: {},
-
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       mapping: {

--- a/plugins/@grouparoo/hubspot/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/hubspot/public/templates/destination/{{{id}}}.js.template
@@ -9,8 +9,6 @@ exports.default = async function buildConfig() {
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
-      options: {},
-
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       mapping: {

--- a/plugins/@grouparoo/iterable/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/iterable/public/templates/destination/{{{id}}}.js.template
@@ -9,8 +9,6 @@ exports.default = async function buildConfig() {
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
-      options: {},
-
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       mapping: {

--- a/plugins/@grouparoo/logger/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/logger/public/templates/destination/{{{id}}}.js.template
@@ -8,8 +8,6 @@ exports.default = async function buildConfig() {
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "iterable_app"`
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 
-      options: {},
-
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       mapping: {

--- a/plugins/@grouparoo/marketo/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/marketo/public/templates/destination/{{{id}}}.js.template
@@ -9,8 +9,6 @@ exports.default = async function buildConfig() {
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
-      options: {},
-
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       mapping: {

--- a/plugins/@grouparoo/onesignal/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/onesignal/public/templates/destination/{{{id}}}.js.template
@@ -9,8 +9,6 @@ exports.default = async function buildConfig() {
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "enrich"
 
-      options: {},
-
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       // Note that tags will be normalized to conform to OneSignal best practices (only lowercase letters, numbers and underscores)

--- a/plugins/@grouparoo/pardot/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/pardot/public/templates/destination/{{{id}}}.js.template
@@ -9,8 +9,6 @@ exports.default = async function buildConfig() {
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
-      options: {},
-
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       mapping: {

--- a/plugins/@grouparoo/pipedrive/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/pipedrive/public/templates/destination/{{{id}}}.js.template
@@ -9,8 +9,6 @@ exports.default = async function buildConfig() {
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
       
-      options: {},
-
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       mapping: {

--- a/plugins/@grouparoo/sailthru/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/sailthru/public/templates/destination/{{{id}}}.js.template
@@ -9,8 +9,6 @@ exports.default = async function buildConfig() {
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
-      options: {},
-
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       mapping: {

--- a/plugins/@grouparoo/sendgrid/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/sendgrid/public/templates/destination/{{{id}}}.js.template
@@ -9,8 +9,6 @@ exports.default = async function buildConfig() {
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
-      options: {},
-
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       mapping: {

--- a/plugins/@grouparoo/zendesk/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/zendesk/public/templates/destination/{{{id}}}.js.template
@@ -9,8 +9,6 @@ exports.default = async function buildConfig() {
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
-      options: {},
-
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.
       mapping: {


### PR DESCRIPTION
If there are no options for a destination, we won't show an empty options object in the config file anymore.
