### PR TITLE
Simpler Source Property Create Page

### DIFF
--- a/core/__tests__/actions/sources.ts
+++ b/core/__tests__/actions/sources.ts
@@ -148,13 +148,13 @@ describe("actions/sources", () => {
       expect(preview).toEqual([]);
     });
 
-    test("a source can provide options to a preview", async () => {
+    test("a source can provide options to a preview and column speculation", async () => {
       connection.params = {
         csrfToken,
         id,
         options: { table: "users" },
       };
-      const { error, preview } = await specHelper.runAction(
+      const { error, preview, columnSpeculation } = await specHelper.runAction(
         "source:preview",
         connection
       );
@@ -162,6 +162,51 @@ describe("actions/sources", () => {
       expect(preview).toEqual([
         { id: 1, fname: "mario", lname: "mario" },
         { id: 2, fname: "luigi", lname: "mario" },
+      ]);
+      expect(columnSpeculation).toEqual({
+        id: { isUnique: true, type: "string" },
+        fname: { isUnique: false, type: "string" },
+        lname: { isUnique: false, type: "string" },
+      });
+    });
+
+    test("a source can provide default property options", async () => {
+      connection.params = {
+        csrfToken,
+        id,
+        options: { table: "users" },
+      };
+      const { error, defaultPropertyOptions } = await specHelper.runAction(
+        "source:defaultPropertyOptions",
+        connection
+      );
+      expect(error).toBeUndefined();
+      expect(defaultPropertyOptions).toEqual([
+        {
+          description: "the column to choose",
+          displayName: undefined,
+          key: "column",
+          options: [
+            { examples: [1, 2, 3], key: "id" },
+            { examples: ["mario", "luigi", "peach"], key: "fname" },
+            { examples: ["mario", "mario", "toadstool"], key: "lname" },
+          ],
+          required: true,
+          type: "list",
+        },
+        {
+          description: "how things are combined",
+          displayName: undefined,
+          key: "aggregationMethod",
+          options: [
+            { key: "exact", default: true },
+            { key: "count" },
+            { key: "min" },
+            { key: "max" },
+          ],
+          required: false,
+          type: "list",
+        },
       ]);
     });
 

--- a/core/__tests__/models/profile/profile.ts
+++ b/core/__tests__/models/profile/profile.ts
@@ -7,6 +7,7 @@ import {
   Property,
   Group,
   GroupMember,
+  Option,
   App,
   Source,
   Log,
@@ -789,7 +790,7 @@ describe("models/profile", () => {
       for (const m of members) await m.destroy();
       await group.destroy();
       await source.setMapping({});
-      await Property.truncate();
+      for (const property of await Property.findAll()) await property.destroy();
       await source.destroy();
       await app.destroy();
     });

--- a/core/__tests__/models/profile/profile.ts
+++ b/core/__tests__/models/profile/profile.ts
@@ -7,7 +7,6 @@ import {
   Property,
   Group,
   GroupMember,
-  Option,
   App,
   Source,
   Log,

--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -567,9 +567,26 @@ describe("models/source", () => {
     });
 
     test("bootstrapUniqueProperty will fail if the property cannot be created", async () => {
+      const blockingProperty = await Property.create({
+        sourceId: source.id,
+        id: "blocking_property",
+        key: "blockingProperty",
+        type: "string",
+        unique: true,
+        isArray: false,
+      });
+      await blockingProperty.setOptions({ column: "something" });
+      await blockingProperty.update({ state: "ready" });
+
       await expect(
-        source.bootstrapUniqueProperty("userId", "integer", "id")
+        source.bootstrapUniqueProperty(
+          "blockingProperty",
+          "integer",
+          "blocking_property"
+        )
       ).rejects.toThrow(/already in use/);
+
+      await blockingProperty.destroy();
     });
   });
 

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -714,7 +714,6 @@ describe("modules/configWriter", () => {
       expect(property.getConfigId()).toEqual(
         ConfigWriter.generateId(property.key)
       );
-      expect(property.getConfigId()).not.toEqual(property.id);
 
       property = await helper.factories.property(
         source,

--- a/core/__tests__/modules/tableSpeculation.ts
+++ b/core/__tests__/modules/tableSpeculation.ts
@@ -1,0 +1,52 @@
+import { TableSpeculation } from "../../src/modules/tableSpeculation";
+
+describe("tableSpeculation", () => {
+  describe("isUniqueColumn", () => {
+    const tests = [
+      { match: undefined, result: false },
+      { match: "", result: false },
+      { match: "foo", result: false },
+      { match: "money", result: false },
+      { match: "app_id", result: false },
+      { match: "appid", result: false },
+      // user-id like
+      { match: "id", result: true },
+      { match: "userId", result: true },
+      { match: "user_id", result: true },
+      { match: "user_ID", result: true },
+      { match: "USERID", result: true },
+      // email-like
+      { match: "email", result: true },
+      { match: "EMAIL", result: true },
+      { match: "CUSTOMEREMAIL", result: true },
+      { match: "CUSTOMER_EMAIL", result: true },
+      // phone-like
+      { match: "phone", result: true },
+      { match: "phonenumber", result: true },
+      { match: "phone number", result: true },
+      { match: "phone_number", result: true },
+    ];
+
+    tests.map(({ match, result }) => {
+      it(`guesses column ${match} correctly`, async () => {
+        expect(TableSpeculation.isUniqueColumn(match)).toBe(result);
+      });
+    });
+  });
+
+  describe("columnType", () => {
+    test("emails", () => {
+      expect(TableSpeculation.columnType("email", "string")).toBe("email");
+    });
+
+    test("phone numbers", () => {
+      expect(TableSpeculation.columnType("mobile_number", "string")).toBe(
+        "phoneNumber"
+      );
+    });
+
+    test("non-strings do not change", () => {
+      expect(TableSpeculation.columnType("email", "integer")).toBe("integer");
+    });
+  });
+});

--- a/core/src/actions/properties.ts
+++ b/core/src/actions/properties.ts
@@ -136,7 +136,8 @@ export class PropertyCreate extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "property", mode: "write" };
     this.inputs = {
-      key: { required: false },
+      id: { required: false },
+      key: { required: true },
       type: { required: true },
       unique: { required: false },
       isArray: { required: false },
@@ -149,6 +150,7 @@ export class PropertyCreate extends AuthenticatedAction {
 
   async runWithinTransaction({ params }) {
     const property = await Property.create({
+      id: params.id,
       key: params.key,
       type: params.type,
       unique: params.unique,

--- a/core/src/actions/properties.ts
+++ b/core/src/actions/properties.ts
@@ -137,7 +137,7 @@ export class PropertyCreate extends AuthenticatedAction {
     this.permission = { topic: "property", mode: "write" };
     this.inputs = {
       id: { required: false },
-      key: { required: true },
+      key: { required: false },
       type: { required: true },
       unique: { required: false },
       isArray: { required: false },

--- a/core/src/actions/sources.ts
+++ b/core/src/actions/sources.ts
@@ -263,6 +263,24 @@ export class SourcePreview extends AuthenticatedAction {
   }
 }
 
+export class SourceDefaultPropertyOptions extends AuthenticatedAction {
+  constructor() {
+    super();
+    this.name = "source:defaultPropertyOptions";
+    this.description = "view the default plugin options for a source";
+    this.outputExample = {};
+    this.permission = { topic: "source", mode: "read" };
+    this.inputs = {
+      id: { required: true },
+    };
+  }
+
+  async runWithinTransaction({ params }) {
+    const source = await Source.findById(params.id);
+    return { defaultPropertyOptions: await source.defaultPropertyOptions() };
+  }
+}
+
 export class SourceDestroy extends AuthenticatedAction {
   constructor() {
     super();

--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -63,6 +63,7 @@ export const DEFAULT = {
         { path: "/v:apiVersion/app/:id", action: "app:view" },
         { path: "/v:apiVersion/sources/connectionApps", action: "sources:connectionApps" },
         { path: "/v:apiVersion/source/:id", action: "source:view" },
+        { path: "/v:apiVersion/source/:id/defaultPropertyOptions", action: "source:defaultPropertyOptions" },
         { path: "/v:apiVersion/schedules", action: "schedules:list" },
         { path: "/v:apiVersion/schedule/:id", action: "schedule:view" },
         { path: "/v:apiVersion/schedule/:id/filterOptions", action: "schedule:filterOptions" },

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -55,3 +55,4 @@ export { StatusMetric } from "./modules/statusReporters";
 export { waitForLock } from "./modules/locks";
 export { Errors } from "./modules/errors";
 export * from "./modules/cache";
+export * from "./modules/tableSpeculation";

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -97,6 +97,7 @@ export interface PluginConnectionPropertyOption {
   required: boolean;
   description: string;
   type: string;
+  primary?: boolean;
   options: (argument: {
     connection: any;
     app: App;

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -112,6 +112,7 @@ export interface PluginConnectionPropertyOption {
     Array<{
       key: string;
       description?: string;
+      default?: boolean;
       examples?: Array<any>;
     }>
   >;

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -178,6 +178,10 @@ export class Source extends LoggedModel<Source> {
     return SourceOps.sourcePreview(this, sourceOptions);
   }
 
+  async defaultPropertyOptions() {
+    return SourceOps.defaultPropertyOptions(this);
+  }
+
   async apiData() {
     const app = await this.$get("app", { scope: null, include: [Option] });
     const schedule = await this.$get("schedule", { scope: null });

--- a/core/src/modules/ops/property.ts
+++ b/core/src/modules/ops/property.ts
@@ -62,6 +62,7 @@ export namespace PropertyOps {
       options: Array<{
         key: string;
         description?: string;
+        default?: boolean;
         examples?: Array<any>;
       }>;
     }> = [];

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -468,7 +468,7 @@ export namespace SourceOps {
       // build the default options
       const { pluginConnection } = await source.getPlugin();
       if (!local) {
-        let ruleOptions = {};
+        let ruleOptions: SimplePropertyOptions = {};
 
         if (
           typeof pluginConnection.methods.uniquePropertyBootstrapOptions ===

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -14,6 +14,7 @@ import { log, utils, api } from "actionhero";
 import { LoggedModel } from "../../classes/loggedModel";
 import { FilterHelper } from "../filterHelper";
 import { topologicalSort } from "../topologicalSort";
+import { ConfigWriter } from "../configWriter";
 
 export namespace SourceOps {
   /**
@@ -442,7 +443,7 @@ export namespace SourceOps {
     const identifying = existingIdentifying ? false : true;
 
     const property = Property.build({
-      id,
+      id: id ?? ConfigWriter.generateId(key),
       key,
       type,
       state: "ready",

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -376,6 +376,7 @@ export namespace SourceOps {
       description: string;
       required: boolean;
       type: string;
+      primary?: boolean;
       options: Array<{
         key: string;
         description?: string;
@@ -417,6 +418,7 @@ export namespace SourceOps {
         description: opt.description,
         required: opt.required,
         type: opt.type,
+        primary: opt.primary,
         options,
       });
     }

--- a/core/src/modules/tableSpeculation.ts
+++ b/core/src/modules/tableSpeculation.ts
@@ -1,23 +1,22 @@
 import { PropertyTypes } from "../models/Property";
 
 export namespace TableSpeculation {
-  export function isUniqueColumn(columnName: string) {
-    columnName = columnName.toLowerCase();
+  const uniqueMatchers = [
+    /email/,
+    /^id$/,
+    /^guid$/,
+    /^uuid$/,
+    /userid/,
+    /user_id/,
+    /phone/,
+    /mobile/,
+  ];
 
-    if (
-      [
-        "email",
-        "email_address",
-        "id",
-        "user_id",
-        "userid",
-        "uuid",
-        "guid",
-        "phonenumber",
-        "phone_number",
-      ].includes(columnName)
-    ) {
-      return true;
+  export function isUniqueColumn(columnName: string) {
+    if (!columnName) return false;
+
+    for (const matcher of uniqueMatchers) {
+      if (columnName.toLowerCase().match(matcher)) return true;
     }
 
     return false;
@@ -37,10 +36,7 @@ export namespace TableSpeculation {
       return "email";
     }
 
-    if (
-      columnName.includes("phonenumber") ||
-      columnName.includes("phone_number")
-    ) {
+    if (columnName.includes("phone") || columnName.includes("mobile")) {
       return "phoneNumber";
     }
 

--- a/core/src/modules/tableSpeculation.ts
+++ b/core/src/modules/tableSpeculation.ts
@@ -1,4 +1,4 @@
-import { PropertyTypes } from "@grouparoo/core";
+import { PropertyTypes } from "../models/Property";
 
 export namespace TableSpeculation {
   export function isUniqueColumn(columnName: string) {

--- a/plugins/@grouparoo/app-templates/src/source/table/propertyOptions.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/propertyOptions.ts
@@ -49,6 +49,7 @@ export const getPropertyOptions: GetPropertyOptionsMethod = async (
     displayName: "Column Name",
     required: true,
     description: "where the data comes from",
+    primary: true,
     type: "typeahead",
     options: async ({ connection, appOptions, appId, sourceOptions }) => {
       const tableName = sourceOptions[tableNameKey]?.toString();

--- a/plugins/@grouparoo/app-templates/src/source/table/propertyOptions.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/propertyOptions.ts
@@ -71,9 +71,12 @@ export const getPropertyOptions: GetPropertyOptionsMethod = async (
     description: "how we combine the data",
     type: "list",
     options: async () => {
-      const out = [];
+      const out: PluginConnectionPropertyOption[] = [];
       for (const key in aggregationOptions) {
-        out.push(Object.assign({ key }, aggregationOptions[key]));
+        const isDefault = key === AggregationMethod.Exact ? true : false;
+        out.push(
+          Object.assign({ key, default: isDefault }, aggregationOptions[key])
+        );
       }
       return out;
     },

--- a/plugins/@grouparoo/app-templates/src/source/table/templates.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/templates.ts
@@ -1,18 +1,20 @@
 import path from "path";
+
 import {
   ConfigTemplate,
   PropertyTypes,
   App,
   AggregationMethod,
   FilterOperation,
+  TableSpeculation,
 } from "@grouparoo/core";
+
 import {
   GetTablesMethod,
   GetColumnDefinitionsMethod,
   TableDefinitionMap,
   ColumnDefinitionMap,
 } from "./";
-import { TableSpeculation } from "./tableSpeculation";
 
 interface ConfigTemplateColumn {
   id?: string;

--- a/plugins/@grouparoo/csv/src/lib/file-import/propertyOptions.ts
+++ b/plugins/@grouparoo/csv/src/lib/file-import/propertyOptions.ts
@@ -27,7 +27,11 @@ export const propertyOptions: PropertyOptionsMethod = async () => [
     type: "list",
     options: async () => {
       return [
-        { key: AggregationMethod.Exact, description: "use the value directly" },
+        {
+          key: AggregationMethod.Exact,
+          description: "use the value directly",
+          default: true,
+        },
       ];
     },
   },

--- a/plugins/@grouparoo/csv/src/lib/file-import/propertyOptions.ts
+++ b/plugins/@grouparoo/csv/src/lib/file-import/propertyOptions.ts
@@ -6,6 +6,7 @@ export const propertyOptions: PropertyOptionsMethod = async () => [
     key: "column",
     displayName: "CSV Column",
     required: true,
+    primary: true,
     description: "where the data comes from",
     type: "typeahead",
     options: async ({ sourceOptions }) => {

--- a/plugins/@grouparoo/csv/src/lib/remote-import/propertyOptions.ts
+++ b/plugins/@grouparoo/csv/src/lib/remote-import/propertyOptions.ts
@@ -27,7 +27,11 @@ export const propertyOptions: PropertyOptionsMethod = async () => [
     type: "list",
     options: async () => {
       return [
-        { key: AggregationMethod.Exact, description: "use the value directly" },
+        {
+          key: AggregationMethod.Exact,
+          description: "use the value directly",
+          default: true,
+        },
       ];
     },
   },

--- a/plugins/@grouparoo/csv/src/lib/remote-import/propertyOptions.ts
+++ b/plugins/@grouparoo/csv/src/lib/remote-import/propertyOptions.ts
@@ -6,6 +6,7 @@ export const propertyOptions: PropertyOptionsMethod = async () => [
     key: "column",
     displayName: "CSV Column",
     required: true,
+    primary: true,
     description: "where the data comes from",
     type: "typeahead",
     options: async ({ sourceOptions, sourceId }) => {

--- a/plugins/@grouparoo/google-sheets/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/google-sheets/src/initializers/plugin.ts
@@ -67,7 +67,8 @@ export class Plugins extends Initializer {
               key: "sheet_url",
               displayName: "Google Sheet URL",
               required: true,
-              description: "The url of the Google Sheet.",
+              description:
+                "The url of the Google Sheet, with the gid (tab) included.",
             },
           ],
           groupAggregations: [],

--- a/plugins/@grouparoo/google-sheets/src/lib/sheet-import/propertyOptions.ts
+++ b/plugins/@grouparoo/google-sheets/src/lib/sheet-import/propertyOptions.ts
@@ -7,6 +7,7 @@ export const propertyOptions: PropertyOptionsMethod = async () => [
     required: true,
     description: "where the data comes from",
     type: "typeahead",
+    primary: true,
     options: async ({ appOptions, sourceOptions }) => {
       const rows = await sheetPreview({
         appOptions,

--- a/plugins/@grouparoo/spec-helper/src/lib/factories/property.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/factories/property.ts
@@ -23,6 +23,7 @@ export default async (
   props.sourceId = source.id;
   const mergedProps = await data(props);
   const instance = new Property(mergedProps);
+  if (instance.key && !instance.id) instance.id = instance.key;
   await instance.save();
 
   await instance.setOptions(options);

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -323,7 +323,7 @@ export namespace helper {
                 type: "list",
                 options: async () => {
                   return [
-                    { key: AggregationMethod.Exact },
+                    { key: AggregationMethod.Exact, default: true },
                     { key: AggregationMethod.Count },
                     { key: AggregationMethod.Min },
                     { key: AggregationMethod.Max },

--- a/ui/ui-components/components/tabs/source.tsx
+++ b/ui/ui-components/components/tabs/source.tsx
@@ -2,7 +2,7 @@ import Tabs from "../tabs";
 import { Models } from "../../utils/apiData";
 
 export default function SourceTabs({ source }: { source: Models.SourceType }) {
-  const tabs = ["overview", "edit"];
+  const tabs = ["overview", "edit", "properties"];
 
   if (source.previewAvailable) {
     tabs.push("mapping");

--- a/ui/ui-components/components/tabs/source.tsx
+++ b/ui/ui-components/components/tabs/source.tsx
@@ -2,7 +2,7 @@ import Tabs from "../tabs";
 import { Models } from "../../utils/apiData";
 
 export default function SourceTabs({ source }: { source: Models.SourceType }) {
-  const tabs = ["overview", "edit", "properties"];
+  const tabs = ["overview", "edit"];
 
   if (source.previewAvailable) {
     tabs.push("mapping");
@@ -11,6 +11,10 @@ export default function SourceTabs({ source }: { source: Models.SourceType }) {
   if (source.schedule) {
     tabs.push("schedule");
     if (process.env.GROUPAROO_UI_EDITION === "enterprise") tabs.push("runs");
+  }
+
+  if (process.env.GROUPAROO_UI_EDITION !== "community") {
+    tabs.push("properties");
   }
 
   return <Tabs name={source.name} draftType={source.type} tabs={tabs} />;

--- a/ui/ui-components/pages/property/[id]/edit.tsx
+++ b/ui/ui-components/pages/property/[id]/edit.tsx
@@ -35,7 +35,7 @@ export default function Page(props) {
     successHandler: SuccessHandler;
     sources: Models.SourceType[];
     propertiesHandler: PropertiesHandler;
-    types: Actions.AppOptions["types"];
+    types: Actions.PropertiesOptions["types"];
     filterOptions: Actions.ScheduleFilterOptions["options"];
     properties: Models.PropertyType[];
     hydrationError: Error;

--- a/ui/ui-components/pages/source/[id]/overview.tsx
+++ b/ui/ui-components/pages/source/[id]/overview.tsx
@@ -1,5 +1,5 @@
 import { useApi } from "../../../hooks/useApi";
-import { Row, Col, Table, Badge, Alert } from "react-bootstrap";
+import { Row, Col, Table, Badge, Alert, Button } from "react-bootstrap";
 import PageHeader from "../../../components/pageHeader";
 import StateBadge from "../../../components/badges/stateBadge";
 import LockedBadge from "../../../components/badges/lockedBadge";
@@ -116,6 +116,18 @@ export default function Page({
             successHandler={successHandler}
             source={source}
           />
+          {process.env.GROUPAROO_UI_EDITION !== "community" && (
+            <>
+              &nbsp;
+              <Button
+                href={`/source/${source.id}/properties`}
+                size="sm"
+                variant="outline-primary"
+              >
+                Add Multiple Properties
+              </Button>
+            </>
+          )}
           <hr />
           <h2>Schedule</h2>
           <br />

--- a/ui/ui-components/pages/source/[id]/properties.tsx
+++ b/ui/ui-components/pages/source/[id]/properties.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState } from "react";
 import { useApi } from "../../../hooks/useApi";
-import { Row, Col, Table, Button, Form, Badge, Alert } from "react-bootstrap";
+import { Row, Col, Table, Form, Badge } from "react-bootstrap";
 import PageHeader from "../../../components/pageHeader";
 import StateBadge from "../../../components/badges/stateBadge";
 import LockedBadge from "../../../components/badges/lockedBadge";
@@ -19,6 +19,7 @@ export default function Page(props) {
     successHandler,
     source,
     preview,
+    columnSpeculation,
     types,
     defaultPropertyOptions,
   }: {
@@ -26,6 +27,7 @@ export default function Page(props) {
     successHandler: SuccessHandler;
     source: Models.SourceType;
     preview: Actions.SourcePreview["preview"];
+    columnSpeculation: Actions.SourcePreview["columnSpeculation"];
     types: Actions.PropertiesOptions["types"];
     defaultPropertyOptions: Actions.SourceDefaultPropertyOptions["defaultPropertyOptions"];
   } = props;
@@ -58,10 +60,12 @@ export default function Page(props) {
       existingProperty ? existingProperty.key : column
     );
     const [type, setType] = useState<string>(
-      existingProperty ? existingProperty.type : "string"
+      existingProperty ? existingProperty.type : columnSpeculation[column].type
     );
     const [unique, setUnique] = useState(
-      existingProperty ? existingProperty.unique : false
+      existingProperty
+        ? existingProperty.unique
+        : columnSpeculation[column].isUnique
     );
     const [isArray, setIsArray] = useState(
       existingProperty ? existingProperty.isArray : false
@@ -104,7 +108,7 @@ export default function Page(props) {
 
     return (
       <tr>
-        <td>
+        {/* <td>
           <strong>
             {existingProperty ? (
               <Link
@@ -117,7 +121,7 @@ export default function Page(props) {
               column
             )}
           </strong>
-        </td>
+        </td> */}
         <td>
           <Form.Control
             type="text"
@@ -241,7 +245,6 @@ export default function Page(props) {
           <Table>
             <thead>
               <tr>
-                <th>column</th>
                 <th>id</th>
                 <th>key</th>
                 <th>type</th>
@@ -269,7 +272,10 @@ Page.getInitialProps = async (ctx) => {
   const { id } = ctx.query;
   const { execApi } = useApi(ctx);
   const { source } = await execApi("get", `/source/${id}`);
-  const { preview } = await execApi("get", `/source/${id}/preview`);
+  const { preview, columnSpeculation } = await execApi(
+    "get",
+    `/source/${id}/preview`
+  );
   const { defaultPropertyOptions } = await execApi(
     "get",
     `/source/${id}/defaultPropertyOptions`
@@ -277,5 +283,12 @@ Page.getInitialProps = async (ctx) => {
   const { properties } = await execApi("get", `/properties`);
   const { types } = await execApi("get", `/propertyOptions`);
 
-  return { source, properties, preview, types, defaultPropertyOptions };
+  return {
+    source,
+    properties,
+    columnSpeculation,
+    preview,
+    types,
+    defaultPropertyOptions,
+  };
 };

--- a/ui/ui-components/pages/source/[id]/properties.tsx
+++ b/ui/ui-components/pages/source/[id]/properties.tsx
@@ -1,0 +1,269 @@
+import { Fragment, useState } from "react";
+import { useApi } from "../../../hooks/useApi";
+import { Row, Col, Table, Button, Form, Badge, Alert } from "react-bootstrap";
+import PageHeader from "../../../components/pageHeader";
+import StateBadge from "../../../components/badges/stateBadge";
+import LockedBadge from "../../../components/badges/lockedBadge";
+import LoadingButton from "../../../components/loadingButton";
+import Link from "next/link";
+import Moment from "react-moment";
+import ScheduleAddButton from "../../../components/schedule/add";
+import PropertyAddButton from "../../../components/property/add";
+import SourceTabs from "../../../components/tabs/source";
+import Head from "next/head";
+import { Models, Actions } from "../../../utils/apiData";
+import { ErrorHandler } from "../../../utils/errorHandler";
+import { SuccessHandler } from "../../../utils/successHandler";
+import { formatTimestamp } from "../../../utils/formatTimestamp";
+import { makeLocal } from "../../../utils/makeLocal";
+
+export default function Page(props) {
+  const {
+    errorHandler,
+    successHandler,
+    source,
+    preview,
+    types,
+    defaultPropertyOptions,
+  }: {
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+    source: Models.SourceType;
+    preview: Actions.SourcePreview["preview"];
+    types: Actions.PropertiesOptions["types"];
+    defaultPropertyOptions: Actions.SourceDefaultPropertyOptions["defaultPropertyOptions"];
+  } = props;
+  const { execApi } = useApi(props, errorHandler);
+  const [loading, setLoading] = useState(false);
+  const [properties, setProperties] = useState<Models.PropertyType[]>(
+    props.properties
+  );
+
+  async function loadProperties() {
+    setLoading(true);
+    const response: Actions.PropertiesList = await execApi(
+      "get",
+      `/properties`
+    );
+    if (response?.properties) setProperties(response.properties);
+    setLoading(false);
+  }
+
+  function TableRow({ column }: { column: string }) {
+    const existingProperty =
+      properties.find((p) => p.key.toLowerCase() === column.toLowerCase()) ||
+      properties.find((p) => p.options?.column === column);
+    const disabled = existingProperty ? true : false;
+
+    const [id, setId] = useState(
+      existingProperty ? existingProperty.id : column
+    );
+    const [key, setKey] = useState(
+      existingProperty ? existingProperty.key : column
+    );
+    const [type, setType] = useState<string>(
+      existingProperty ? existingProperty.type : "string"
+    );
+    const [unique, setUnique] = useState(
+      existingProperty ? existingProperty.unique : false
+    );
+    const [isArray, setIsArray] = useState(
+      existingProperty ? existingProperty.isArray : false
+    );
+
+    const defaultOptions: { [key: string]: string } = {};
+    defaultPropertyOptions.map((propertyOption) => {
+      const defaultOption = propertyOption.options.find((o) => o.default) ??
+        propertyOption.options.find((o) => o.key === column) ??
+        propertyOption.options[0] ?? { key: "?" };
+      defaultOptions[propertyOption.key] = defaultOption.key;
+    });
+
+    const [options, setOptions] = useState(
+      existingProperty ? existingProperty.options : defaultOptions
+    );
+
+    async function createProperty() {
+      setLoading(true);
+      const response: Actions.PropertyCreate = await execApi(
+        "post",
+        `/property/`,
+        {
+          sourceId: source.id,
+          id,
+          key,
+          type,
+          unique,
+          isArray,
+          state: "ready",
+          options,
+        }
+      );
+      if (response.property) {
+        await loadProperties();
+        successHandler.set({ message: "Property Created!" });
+      }
+      setLoading(false);
+    }
+
+    return (
+      <tr>
+        <td>
+          <strong>
+            {existingProperty ? (
+              <Link href={`/property/${existingProperty.id}/edit`}>
+                <a>{column}</a>
+              </Link>
+            ) : (
+              column
+            )}
+          </strong>
+        </td>
+        <td>
+          <Form.Control
+            type="text"
+            value={id}
+            onChange={(e) => setId(e.target.value)}
+            disabled={disabled}
+          />
+        </td>
+        <td>
+          <Form.Control
+            type="text"
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+            disabled={disabled}
+          />
+        </td>
+        <td>
+          <Form.Control
+            as="select"
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            disabled={disabled}
+          >
+            {types.map((v) => (
+              <option key={`types-opt-${v}`}>{v}</option>
+            ))}
+          </Form.Control>
+        </td>
+        <td>
+          <Form.Check
+            checked={unique}
+            onChange={(e) => setUnique(e.target.checked)}
+            disabled={disabled}
+          />
+        </td>
+        <td>
+          <Form.Check
+            checked={isArray}
+            onChange={(e) => setIsArray(e.target.checked)}
+            disabled={disabled}
+          />
+        </td>
+        <td>
+          <code>
+            <Fragment key={`opts-${column}`}>
+              {Object.keys(options).map((opt) => (
+                <Form.Group as={Col} key={`opt-${column}-${opt}`}>
+                  <Form.Label>{opt}</Form.Label>
+                  <Form.Control
+                    style={{ fontSize: 10 }}
+                    type="text"
+                    value={options[opt].toString()}
+                    disabled={disabled}
+                    onChange={(e) => {
+                      const _options = makeLocal(options);
+                      _options[opt] = e.target.value;
+                      setOptions(_options);
+                    }}
+                  />
+                </Form.Group>
+              ))}
+            </Fragment>
+          </code>
+        </td>
+        <td>
+          {existingProperty ? (
+            <Badge variant="info">exists</Badge>
+          ) : (
+            // <Button
+            //   size="sm"
+            //   onClick={() => createProperty()}
+            //   disabled={loading}
+            // >
+            //   Create
+            // </Button>
+            <LoadingButton
+              size="sm"
+              disabled={loading}
+              onClick={() => createProperty()}
+            >
+              Create
+            </LoadingButton>
+          )}
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Grouparoo: {source.name}</title>
+      </Head>
+
+      <SourceTabs source={source} />
+
+      <PageHeader
+        icon={source.app.icon}
+        title={`${source.name} - Properties`}
+        badges={[
+          <LockedBadge object={source} />,
+          <StateBadge state={source.state} />,
+        ]}
+      />
+
+      <Row>
+        <Col>
+          <Table>
+            <thead>
+              <tr>
+                <th>column</th>
+                <th>id</th>
+                <th>key</th>
+                <th>type</th>
+                <th>unique</th>
+                <th>isArray</th>
+                <th>options</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {preview[0]
+                ? Object.keys(preview[0]).map((column) => (
+                    <TableRow key={`column-${column}`} column={column} />
+                  ))
+                : null}
+            </tbody>
+          </Table>
+        </Col>
+      </Row>
+    </>
+  );
+}
+
+Page.getInitialProps = async (ctx) => {
+  const { id } = ctx.query;
+  const { execApi } = useApi(ctx);
+  const { source } = await execApi("get", `/source/${id}`);
+  const { preview } = await execApi("get", `/source/${id}/preview`);
+  const { defaultPropertyOptions } = await execApi(
+    "get",
+    `/source/${id}/defaultPropertyOptions`
+  );
+  const { properties } = await execApi("get", `/properties`);
+  const { types } = await execApi("get", `/propertyOptions`);
+
+  return { source, properties, preview, types, defaultPropertyOptions };
+};

--- a/ui/ui-components/pages/source/[id]/properties.tsx
+++ b/ui/ui-components/pages/source/[id]/properties.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState } from "react";
 import { useApi } from "../../../hooks/useApi";
-import { Row, Col, Table, Form, Button } from "react-bootstrap";
+import { Alert, Row, Col, Table, Form, Button } from "react-bootstrap";
 import PageHeader from "../../../components/pageHeader";
 import StateBadge from "../../../components/badges/stateBadge";
 import LockedBadge from "../../../components/badges/lockedBadge";
@@ -12,6 +12,7 @@ import { Models, Actions } from "../../../utils/apiData";
 import { ErrorHandler } from "../../../utils/errorHandler";
 import { SuccessHandler } from "../../../utils/successHandler";
 import { generateId } from "../../../utils/generateId";
+import PropertyAddButton from "../../../components/property/add";
 
 export default function Page(props) {
   const {
@@ -36,6 +37,9 @@ export default function Page(props) {
   const [properties, setProperties] = useState<Models.PropertyType[]>(
     props.properties
   );
+  const primaryOptionKey = defaultPropertyOptions.find(
+    (dpo) => dpo.primary === true
+  )?.key; // e.g.: "column"
 
   async function loadProperties() {
     setLoading(true);
@@ -50,9 +54,10 @@ export default function Page(props) {
   function TableRow({ column }: { column: string }) {
     const existingProperty =
       properties.find(
-        (p) => p.options?.column === column && p.sourceId === source.id
+        (p) =>
+          p.options[primaryOptionKey] === column && p.sourceId === source.id
       ) ||
-      properties.find((p) => p.options?.column === column) ||
+      properties.find((p) => p.options[primaryOptionKey] === column) ||
       properties.find((p) => p.key.toLowerCase() === column.toLowerCase());
     const disabled = existingProperty
       ? existingProperty.sourceId === source.id
@@ -202,6 +207,37 @@ export default function Page(props) {
           )}
         </td>
       </tr>
+    );
+  }
+
+  if (!primaryOptionKey) {
+    return (
+      <>
+        <Head>
+          <title>Grouparoo: {source.name}</title>
+        </Head>
+
+        <SourceTabs source={source} />
+
+        <PageHeader
+          icon={source.app.icon}
+          title={`${source.name} - Properties`}
+          badges={[
+            <LockedBadge object={source} />,
+            <StateBadge state={source.state} />,
+          ]}
+        />
+
+        <Alert variant="warning">
+          <p>This source does not support quickly adding Properties.</p>
+
+          <PropertyAddButton
+            errorHandler={errorHandler}
+            successHandler={successHandler}
+            source={source}
+          />
+        </Alert>
+      </>
     );
   }
 

--- a/ui/ui-components/pages/source/[id]/properties.tsx
+++ b/ui/ui-components/pages/source/[id]/properties.tsx
@@ -112,11 +112,13 @@ export default function Page(props) {
                   <Form.Row>
                     <Col md={3}>
                       <code>
-                        <Form.Label>{opt}</Form.Label>
+                        <Form.Label>{opt}:</Form.Label>
                       </code>
                     </Col>
                     <Col>
-                      <Form.Control
+                      <strong>{options[opt].toString()}</strong>
+                      {/* We actually don't want to allow changes to the provided source options? */}
+                      {/* <Form.Control
                         size="sm"
                         type="text"
                         value={options[opt].toString()}
@@ -126,7 +128,7 @@ export default function Page(props) {
                           _options[opt] = e.target.value;
                           setOptions(_options);
                         }}
-                      />
+                      /> */}
                     </Col>
                   </Form.Row>
                 </Form.Group>

--- a/ui/ui-components/pages/source/[id]/properties.tsx
+++ b/ui/ui-components/pages/source/[id]/properties.tsx
@@ -6,15 +6,11 @@ import StateBadge from "../../../components/badges/stateBadge";
 import LockedBadge from "../../../components/badges/lockedBadge";
 import LoadingButton from "../../../components/loadingButton";
 import Link from "next/link";
-import Moment from "react-moment";
-import ScheduleAddButton from "../../../components/schedule/add";
-import PropertyAddButton from "../../../components/property/add";
 import SourceTabs from "../../../components/tabs/source";
 import Head from "next/head";
 import { Models, Actions } from "../../../utils/apiData";
 import { ErrorHandler } from "../../../utils/errorHandler";
 import { SuccessHandler } from "../../../utils/successHandler";
-import { formatTimestamp } from "../../../utils/formatTimestamp";
 import { makeLocal } from "../../../utils/makeLocal";
 
 export default function Page(props) {
@@ -111,7 +107,10 @@ export default function Page(props) {
         <td>
           <strong>
             {existingProperty ? (
-              <Link href={`/property/${existingProperty.id}/edit`}>
+              <Link
+                href={`/property/[id]/edit`}
+                as={`/property/${existingProperty.id}/edit`}
+              >
                 <a>{column}</a>
               </Link>
             ) : (
@@ -223,6 +222,19 @@ export default function Page(props) {
           <StateBadge state={source.state} />,
         ]}
       />
+
+      <p>
+        Here are the Properties that this source provides. You can quickly add
+        simple Properties from here. If you need more control over your
+        Properties, you can create a single Property from the{" "}
+        <Link
+          href={`/source/[id]/overview`}
+          as={`/source/${source.id}/overview`}
+        >
+          <a>Soruce Overview page</a>
+        </Link>
+        .
+      </p>
 
       <Row>
         <Col>

--- a/ui/ui-components/pages/source/[id]/properties.tsx
+++ b/ui/ui-components/pages/source/[id]/properties.tsx
@@ -87,7 +87,7 @@ export default function Page(props) {
       setLoading(true);
       const response: Actions.PropertyCreate = await execApi(
         "post",
-        `/property/`,
+        `/property`,
         {
           sourceId: source.id,
           id,
@@ -95,13 +95,13 @@ export default function Page(props) {
           type,
           unique,
           isArray,
-          state: "ready",
           options,
+          state: "ready",
         }
       );
       if (response.property) {
-        await loadProperties();
         successHandler.set({ message: "Property Created!" });
+        await loadProperties();
       }
       setLoading(false);
     }
@@ -167,36 +167,38 @@ export default function Page(props) {
         <td>
           <code>
             <Fragment key={`opts-${column}`}>
-              {Object.keys(options).map((opt) => (
-                <Form.Group as={Col} key={`opt-${column}-${opt}`}>
-                  <Form.Label>{opt}</Form.Label>
-                  <Form.Control
-                    style={{ fontSize: 10 }}
-                    type="text"
-                    value={options[opt].toString()}
-                    disabled={disabled}
-                    onChange={(e) => {
-                      const _options = makeLocal(options);
-                      _options[opt] = e.target.value;
-                      setOptions(_options);
-                    }}
-                  />
-                </Form.Group>
-              ))}
+              {Object.keys(options)
+                .sort()
+                .map((opt) => (
+                  <Form.Group as={Col} key={`opt-${column}-${opt}`}>
+                    <Form.Label>{opt}</Form.Label>
+                    <Form.Control
+                      style={{ fontSize: 10 }}
+                      type="text"
+                      value={options[opt].toString()}
+                      disabled={disabled}
+                      onChange={(e) => {
+                        const _options = makeLocal(options);
+                        _options[opt] = e.target.value;
+                        setOptions(_options);
+                      }}
+                    />
+                  </Form.Group>
+                ))}
             </Fragment>
           </code>
         </td>
         <td>
           {existingProperty ? (
-            <Badge variant="info">exists</Badge>
+            <Link
+              href={`/property/[id]/edit`}
+              as={`/property/${existingProperty.id}/edit`}
+            >
+              <a>
+                <Badge variant="info">exists</Badge>
+              </a>
+            </Link>
           ) : (
-            // <Button
-            //   size="sm"
-            //   onClick={() => createProperty()}
-            //   disabled={loading}
-            // >
-            //   Create
-            // </Button>
             <LoadingButton
               size="sm"
               disabled={loading}
@@ -227,15 +229,17 @@ export default function Page(props) {
         ]}
       />
 
+      <h2>Quickly Add Properties </h2>
+
       <p>
-        Here are the Properties that this source provides. You can quickly add
-        simple Properties from here. If you need more control over your
-        Properties, you can create a single Property from the{" "}
+        From this page, you can quickly add simple Properties, using default
+        options. If you need more control over your Properties, you can create a
+        single Property from the{" "}
         <Link
           href={`/source/[id]/overview`}
           as={`/source/${source.id}/overview`}
         >
-          <a>Soruce Overview page</a>
+          <a>Source Overview page</a>
         </Link>
         .
       </p>

--- a/ui/ui-components/pages/source/[id]/properties.tsx
+++ b/ui/ui-components/pages/source/[id]/properties.tsx
@@ -11,7 +11,7 @@ import Head from "next/head";
 import { Models, Actions } from "../../../utils/apiData";
 import { ErrorHandler } from "../../../utils/errorHandler";
 import { SuccessHandler } from "../../../utils/successHandler";
-import { makeLocal } from "../../../utils/makeLocal";
+import { generateId } from "../../../utils/generateId";
 
 export default function Page(props) {
   const {
@@ -49,15 +49,26 @@ export default function Page(props) {
 
   function TableRow({ column }: { column: string }) {
     const existingProperty =
-      properties.find((p) => p.key.toLowerCase() === column.toLowerCase()) ||
-      properties.find((p) => p.options?.column === column);
-    const disabled = existingProperty ? true : false;
+      properties.find(
+        (p) => p.options?.column === column && p.sourceId === source.id
+      ) ||
+      properties.find((p) => p.options?.column === column) ||
+      properties.find((p) => p.key.toLowerCase() === column.toLowerCase());
+    const disabled = existingProperty
+      ? existingProperty.sourceId === source.id
+      : false;
 
     const [key, setKey] = useState(
-      existingProperty ? existingProperty.key : column
+      existingProperty && existingProperty.sourceId === source.id
+        ? existingProperty.key
+        : existingProperty && existingProperty.sourceId !== source.id
+        ? generateId(`${source.name}-${column}`)
+        : generateId(column)
     );
     const [type, setType] = useState<string>(
-      existingProperty ? existingProperty.type : columnSpeculation[column].type
+      existingProperty && existingProperty.sourceId === source.id
+        ? existingProperty.type
+        : columnSpeculation[column].type
     );
     const [unique, setUnique] = useState(
       existingProperty
@@ -74,7 +85,9 @@ export default function Page(props) {
     });
     const hiddenOptions = ["aggregationMethod"];
     const [options, setOptions] = useState(
-      existingProperty ? existingProperty.options : defaultOptions
+      existingProperty && existingProperty.sourceId === source.id
+        ? existingProperty.options
+        : defaultOptions
     );
 
     async function createProperty() {
@@ -167,7 +180,7 @@ export default function Page(props) {
         </td>
 
         <td>
-          {existingProperty ? (
+          {existingProperty && existingProperty.sourceId === source.id ? (
             <Link
               href={`/property/[id]/edit`}
               as={`/property/${existingProperty.id}/edit`}

--- a/ui/ui-components/pages/source/[id]/schedule.tsx
+++ b/ui/ui-components/pages/source/[id]/schedule.tsx
@@ -68,7 +68,10 @@ export default function Page(props) {
       );
       setSchedule(response.schedule);
       if (response.schedule.state === "ready" && schedule.state === "draft") {
-        router.push("/source/[id]/overview", `/source/${source.id}/overview`);
+        router.push(
+          "/source/[id]/properties",
+          `/source/${source.id}/properties`
+        );
       } else {
         setLoading(false);
         successHandler.set({ message: "Schedule Updated" });

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -244,6 +244,7 @@ import {
   SourceView,
   SourcesList,
   sourceConnectionOptions,
+  SourceDefaultPropertyOptions,
   SourcePreview,
 } from "@grouparoo/core/src/actions/sources";
 import {
@@ -685,6 +686,9 @@ export namespace Actions {
   >;
   export type sourceConnectionOptions = AsyncReturnType<
     typeof sourceConnectionOptions.prototype.runWithinTransaction
+  >;
+  export type SourceDefaultPropertyOptions = AsyncReturnType<
+    typeof SourceDefaultPropertyOptions.prototype.runWithinTransaction
   >;
   export type SourcePreview = AsyncReturnType<
     typeof SourcePreview.prototype.runWithinTransaction

--- a/ui/ui-components/utils/generateId.ts
+++ b/ui/ui-components/utils/generateId.ts
@@ -1,0 +1,15 @@
+export function generateId(name, separator: string = "_"): string {
+  if (!name || name.length === 0) return;
+  const id = name
+    .toLowerCase()
+    // replace bad characters with a space
+    .replace(/[^a-zA-Z0-9\-_ ]/g, " ")
+    // remove spaces from beginning and end
+    .trim()
+    // replace spaces with underscore
+    .replace(/[ ]/g, separator)
+    // replace multiple word separators with an underscore
+    .replace(/[\-_ ][\-_ ]+/g, separator);
+  if (id.length === 0) throw new Error("Could not generate ID from name.");
+  return id;
+}

--- a/ui/ui-config/pages/source/[id]/properties.tsx
+++ b/ui/ui-config/pages/source/[id]/properties.tsx
@@ -1,0 +1,1 @@
+export { default } from "@grouparoo/ui-components/pages/source/[id]/properties";

--- a/ui/ui-enterprise/pages/source/[id]/properties.tsx
+++ b/ui/ui-enterprise/pages/source/[id]/properties.tsx
@@ -1,0 +1,1 @@
+export { default } from "@grouparoo/ui-components/pages/source/[id]/properties";


### PR DESCRIPTION
A faster way to add lots of Properties for a Source.  We may many assumptions on this page:
* We use the default `aggregationMethod` as defined by the source (usually "exact")
* We assume that these properties are not arrays
* We assume that an option names "column" is special and is what we are mapping

<img width="1528" alt="Screen Shot 2021-07-28 at 1 14 49 PM" src="https://user-images.githubusercontent.com/303226/127389565-b9cf64af-4077-4de6-bd20-07398ad3c4c5.png">

TODO: 

- [x] Hide on Community UI
- [x] Better UI
- [x] Guess types based on column names
- [x] Tests
- [x] How to handle when a Property with the same name is created by another source?