### PR TITLE
mimic "hello" submenu style on platform

### DIFF
--- a/ui/ui-components/components/navigation.tsx
+++ b/ui/ui-components/components/navigation.tsx
@@ -260,7 +260,8 @@ export default function Navigation(props) {
                               navigationMode={navigationMode}
                               statusHandler={statusHandler}
                             />
-                          ) : null}
+                          ) : null}{" "}
+                          »
                         </span>
                         <div style={{ padding: 6 }} />
                       </Accordion.Toggle>


### PR DESCRIPTION
Copies the style of the submenu beneath it.  If there are resque errors, the carets are after the errors... they don't change when the menu was expanded, but neither do the carets on "Hello _______ "

<img width="218" alt="Screen Shot 2021-07-29 at 4 32 23 PM" src="https://user-images.githubusercontent.com/63751206/127578437-a5e14038-91c2-461a-812c-34ff3ebfb59c.png">

<img width="220" alt="Screen Shot 2021-07-29 at 4 33 42 PM" src="https://user-images.githubusercontent.com/63751206/127578482-d0783d6e-549a-4c66-8040-4ee5ea1b6a2a.png">
