### PR TITLE
ApiKey values can be set via codeConfig

### DIFF
--- a/core/__tests__/fixtures/codeConfig/bootstrapped-property-in-source/config.js
+++ b/core/__tests__/fixtures/codeConfig/bootstrapped-property-in-source/config.js
@@ -150,6 +150,7 @@ module.exports = async function getConfig() {
       id: "website_key", // id -> `website_key`
       name: "web-api-key",
       class: "apiKey",
+      apiKey: "abc123",
       options: {
         permissionAllRead: true,
         permissionAllWrite: true,

--- a/core/__tests__/fixtures/codeConfig/changes/config.js
+++ b/core/__tests__/fixtures/codeConfig/changes/config.js
@@ -119,6 +119,7 @@ module.exports = async function getConfig() {
       id: "website_key", // id -> `website_key`
       name: "web-api-key",
       class: "apiKey",
+      apiKey: "def456",
       options: {
         permissionAllRead: true,
         permissionAllWrite: true,

--- a/core/__tests__/fixtures/codeConfig/error-changed-type-missing/config.js
+++ b/core/__tests__/fixtures/codeConfig/error-changed-type-missing/config.js
@@ -142,6 +142,7 @@ module.exports = async function getConfig() {
       id: "website_key", // id -> `website_key`
       name: "web-api-key",
       class: "apiKey",
+      apiKey: "abc123",
       options: {
         permissionAllRead: true,
         permissionAllWrite: true,

--- a/core/__tests__/fixtures/codeConfig/initial/config.js
+++ b/core/__tests__/fixtures/codeConfig/initial/config.js
@@ -159,6 +159,7 @@ module.exports = async function getConfig() {
       id: "website_key", // id -> `website_key`
       name: "web-api-key",
       class: "apiKey",
+      apiKey: "abc123",
       options: {
         permissionAllRead: true,
         permissionAllWrite: true,

--- a/core/__tests__/fixtures/codeConfig/multiple-sources/config.js
+++ b/core/__tests__/fixtures/codeConfig/multiple-sources/config.js
@@ -185,6 +185,7 @@ module.exports = async function getConfig() {
       id: "website_key", // id -> `website_key`
       name: "web-api-key",
       class: "apiKey",
+      apiKey: "abc123",
       options: {
         permissionAllRead: true,
         permissionAllWrite: true,

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -235,6 +235,7 @@ describe("modules/codeConfig", () => {
         expect(apiKeys.length).toBe(1);
         expect(apiKeys[0].id).toBe("website_key");
         expect(apiKeys[0].name).toBe("web-api-key");
+        expect(apiKeys[0].apiKey).toBe("abc123");
         expect(apiKeys[0].locked).toBe("config:code");
         expect(apiKeys[0].permissionAllRead).toBe(true);
         expect(apiKeys[0].permissionAllWrite).toBe(true);
@@ -425,6 +426,11 @@ describe("modules/codeConfig", () => {
       expect(teamMembers[0].firstName).toEqual("Example");
       expect(teamMembers[0].lastName).toEqual("Person");
       expect(await teamMembers[0].checkPassword("new-password")).toBe(true);
+    });
+
+    test("apiKeys can be updated", async () => {
+      const apiKeys = await ApiKey.findAll();
+      expect(apiKeys[0].apiKey).toBe("def456");
     });
   });
 

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -34,6 +34,7 @@ export interface ConfigurationObject {
   identifying?: boolean;
   unique?: boolean;
   isArray?: boolean;
+  apiKey?: string;
   rules?: GroupRuleWithKey[];
   recurring?: boolean;
   recurringFrequency?: number;

--- a/core/src/modules/configLoaders/apiKey.ts
+++ b/core/src/modules/configLoaders/apiKey.ts
@@ -29,7 +29,7 @@ export async function loadApiKey(
     });
   }
 
-  await apiKey.update({ type: configObject.type, name: configObject.name }, {});
+  await apiKey.update({ apiKey: configObject.apiKey, name: configObject.name });
 
   if (
     configObject.options?.permissionAllRead !== undefined &&


### PR DESCRIPTION
Allows users to choose a value for an API Key when using codeConfig, eg: 


```js
// from config/apiKeys/main.js

module.exports = function () {
  return {
    class: "apiKey",
    id: "main_api_key",
    name: "Main API Key",
    apiKey: process.env.MAIN_API_KEY, // <-- reference  MAIN_API_KEY from ENV
    options: {
      permissionAllRead: true,
      permissionAllWrite: true,
    },
  };
};

```