### PR TITLE
Sources can map via non-unique mapping

### DIFF
--- a/core/__tests__/data/translations.csv
+++ b/core/__tests__/data/translations.csv
@@ -1,0 +1,6 @@
+english_word,spanish_word,french_word,chinese_word
+French,Francés,français,法语
+Spanish,Español,Espagnol,西班牙语
+Chinese,Chino,Chinoise,中国人
+English,Inglés,Anglaise,英语
+

--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -749,29 +749,29 @@ describe("models/property", () => {
         await source.setMapping({ id: "userId" });
       });
 
-      test("properties mapped though unique properties can be unique", async () => {
+      test("properties mapped through unique properties can be unique", async () => {
         await source.setMapping({ id: "userId" });
         await property.update({ unique: true });
         expect((await property.reload()).unique).toEqual(true);
       });
 
-      test("properties mapped though unique properties can be arrays", async () => {
+      test("properties mapped through unique properties can be arrays", async () => {
         await source.setMapping({ id: "userId" });
         await property.update({ isArray: true });
         expect((await property.reload()).isArray).toEqual(true);
       });
 
-      test("properties mapped though non-unique properties cannot be unique", async () => {
+      test("properties mapped through non-unique properties cannot be unique", async () => {
         await source.setMapping({ id: "lastName" });
         await expect(property.update({ unique: true })).rejects.toThrow(
-          /A unique Property cannot be mapped though a non-unique Property/
+          /A unique Property cannot be mapped through a non-unique Property/
         );
       });
 
-      test("properties mapped though non-unique properties cannot be arrays", async () => {
+      test("properties mapped through non-unique properties cannot be arrays", async () => {
         await source.setMapping({ id: "lastName" });
         await expect(property.update({ isArray: true })).rejects.toThrow(
-          /An array Property cannot be mapped though a non-unique Property/
+          /An array Property cannot be mapped through a non-unique Property/
         );
       });
     });

--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -280,6 +280,7 @@ describe("models/property", () => {
       appId: app.id,
       type: "source-no-options",
     });
+    await source.setMapping({ id: "userId" });
     await source.update({ state: "ready" });
     const property = await Property.create({
       key: "property-no-options",
@@ -581,7 +582,7 @@ describe("models/property", () => {
     await source.destroy();
   });
 
-  describe("directlyMapping", () => {
+  describe("directlyMapped", () => {
     let userIdProperty: Property;
     let emailProperty: Property;
 
@@ -726,6 +727,53 @@ describe("models/property", () => {
 
     beforeEach(() => {
       queryCounter = 0;
+    });
+
+    describe("mapped though a non-unique property", () => {
+      let property: Property;
+
+      beforeAll(async () => {
+        property = await helper.factories.property(
+          source,
+          { key: "wordInSpanish" },
+          { column: "spanishWord" }
+        );
+      });
+
+      beforeEach(async () => {
+        await property.update({ unique: false, isArray: false });
+      });
+
+      afterAll(async () => {
+        await property.destroy();
+        await source.setMapping({ id: "userId" });
+      });
+
+      test("properties mapped though unique properties can be unique", async () => {
+        await source.setMapping({ id: "userId" });
+        await property.update({ unique: true });
+        expect((await property.reload()).unique).toEqual(true);
+      });
+
+      test("properties mapped though unique properties can be arrays", async () => {
+        await source.setMapping({ id: "userId" });
+        await property.update({ isArray: true });
+        expect((await property.reload()).isArray).toEqual(true);
+      });
+
+      test("properties mapped though non-unique properties cannot be unique", async () => {
+        await source.setMapping({ id: "lastName" });
+        await expect(property.update({ unique: true })).rejects.toThrow(
+          /A unique Property cannot be mapped though a non-unique Property/
+        );
+      });
+
+      test("properties mapped though non-unique properties cannot be arrays", async () => {
+        await source.setMapping({ id: "lastName" });
+        await expect(property.update({ isArray: true })).rejects.toThrow(
+          /An array Property cannot be mapped though a non-unique Property/
+        );
+      });
     });
 
     describe("filters", () => {

--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -971,6 +971,10 @@ describe("models/source", () => {
       await source.destroy();
     });
 
+    test("sources mapped though non-unique properties cannot have a schedule", async () => {
+      expect(await source.scheduleAvailable()).toBe(false);
+    });
+
     test("it will throw if the profile properties in are not ready", async () => {
       await mario.markPending();
 

--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -971,7 +971,7 @@ describe("models/source", () => {
       await source.destroy();
     });
 
-    test("sources mapped though non-unique properties cannot have a schedule", async () => {
+    test("sources mapped through non-unique properties cannot have a schedule", async () => {
       expect(await source.scheduleAvailable()).toBe(false);
     });
 

--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -1034,6 +1034,26 @@ describe("models/source", () => {
           [luigi.id]: { wordInSpanish: ["hola"], wordInFrench: ["bonjour"] },
         });
       });
+
+      test("it returns null when the source does not have a record for the property", async () => {
+        await luigi.addOrUpdateProperties({ lastName: ["x"] }); // change the value of the property that is mapped
+
+        const profiles = [mario, luigi];
+        const properties = [propertyA, propertyB];
+        const response = {
+          [mario.id]: { [propertyA.id]: ["hola"], [propertyB.id]: ["bonjour"] },
+        };
+        await SourceOps.applyNonUniqueMappedResultsToAllProfiles(response, {
+          profiles,
+          properties,
+          sourceMapping,
+        });
+
+        expect(response).toEqual({
+          [mario.id]: { wordInSpanish: ["hola"], wordInFrench: ["bonjour"] },
+          [luigi.id]: { wordInSpanish: [null], wordInFrench: [null] },
+        });
+      });
     });
   });
 });

--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -10,6 +10,7 @@ import {
   Option,
   ProfileProperty,
   Destination,
+  SourceMapping,
 } from "../../../src";
 import { Op } from "sequelize";
 import { SourceOps } from "../../../src/modules/ops/source";
@@ -496,6 +497,23 @@ describe("models/source", () => {
         })
       ).rejects.toThrow(/cannot find property TheUserID/);
     });
+
+    test("array properties cannot be used for mappings", async () => {
+      const firstSource = await Source.findOne({
+        where: { id: { [Op.ne]: source.id } },
+      });
+      const arrayProperty: Property = await helper.factories.property(
+        firstSource,
+        { key: "things", isArray: true },
+        { column: "things" }
+      );
+
+      await expect(
+        source.setMapping({ local_user_id: arrayProperty.key })
+      ).rejects.toThrow(/Sources cannot map to an array Property/);
+
+      await arrayProperty.destroy();
+    });
   });
 
   describe("defaultPropertyOptions", () => {
@@ -614,8 +632,12 @@ describe("models/source", () => {
     });
 
     test("bootstrapUniqueProperty will fail if the property cannot be created", async () => {
+      const otherSource: Source = await helper.factories.source();
+      await otherSource.setOptions({ table: "foo" });
+      await otherSource.update({ state: "ready" }, { hooks: false }); // normally you can't get into this situation
+
       const blockingProperty = await Property.create({
-        sourceId: source.id,
+        sourceId: otherSource.id,
         id: "blocking_property",
         key: "blockingProperty",
         type: "string",
@@ -623,7 +645,7 @@ describe("models/source", () => {
         isArray: false,
       });
       await blockingProperty.setOptions({ column: "something" });
-      await blockingProperty.update({ state: "ready" });
+      await blockingProperty.update({ state: "ready" }, { hooks: false }); // normally you can't get into this situation
 
       await expect(
         source.bootstrapUniqueProperty(
@@ -634,6 +656,7 @@ describe("models/source", () => {
       ).rejects.toThrow(/already in use/);
 
       await blockingProperty.destroy();
+      await otherSource.destroy();
     });
   });
 
@@ -902,6 +925,111 @@ describe("models/source", () => {
 
       expect(Object.keys(counts).length).toBe(1);
       expect(counts[emailProperty.sourceId]).toBe(1);
+    });
+  });
+
+  describe("#applyNonUniqueMappedResultsToAllProfiles", () => {
+    let source: Source;
+    let sourceMapping: SourceMapping;
+    let propertyA: Property;
+    let propertyB: Property;
+    let mario: Profile;
+    let luigi: Profile;
+
+    beforeAll(async () => {
+      source = await Source.create({
+        type: "test-plugin-import",
+        name: "translations source",
+        appId: app.id,
+      });
+
+      await source.setOptions({ table: "translations" });
+      await source.setMapping({ word: "lastName" });
+      await source.update({ state: "ready" });
+      sourceMapping = await source.getMapping();
+
+      propertyA = await helper.factories.property(
+        source,
+        { key: "wordInSpanish" },
+        { column: "spanishWord" }
+      );
+      propertyB = await helper.factories.property(
+        source,
+        { key: "wordInFrench" },
+        { column: "frenchWord" }
+      );
+
+      mario = await helper.factories.profile();
+      luigi = await helper.factories.profile();
+    });
+
+    afterAll(async () => {
+      await mario.destroy();
+      await luigi.destroy();
+      await propertyA.destroy();
+      await propertyB.destroy();
+      await source.destroy();
+    });
+
+    test("it will throw if the profile properties in are not ready", async () => {
+      await mario.markPending();
+
+      const profiles = [mario];
+      const properties = [propertyA];
+      const response = { [mario.id]: { [propertyA.id]: ["hello"] } };
+      await expect(
+        SourceOps.applyNonUniqueMappedResultsToAllProfiles(response, {
+          profiles,
+          properties,
+          sourceMapping,
+        })
+      ).rejects.toThrow(/ is not ready/);
+    });
+
+    describe("with ready profile properties", () => {
+      beforeAll(async () => {
+        await mario.import();
+        await luigi.import();
+      });
+
+      beforeEach(async () => {
+        await propertyA.update({ isArray: false, unique: false });
+        await propertyB.update({ isArray: false, unique: false });
+      });
+
+      test("it will apply non-unique properties to all profiles in the batch (1 property)", async () => {
+        const profiles = [mario, luigi];
+        const properties = [propertyA];
+        const response = { [mario.id]: { [propertyA.id]: ["hola"] } };
+        await SourceOps.applyNonUniqueMappedResultsToAllProfiles(response, {
+          profiles,
+          properties,
+          sourceMapping,
+        });
+
+        expect(response).toEqual({
+          [mario.id]: { wordInSpanish: ["hola"] },
+          [luigi.id]: { wordInSpanish: ["hola"] },
+        });
+      });
+
+      test("it will apply non-unique properties to all profiles in the batch (2 properties)", async () => {
+        const profiles = [mario, luigi];
+        const properties = [propertyA, propertyB];
+        const response = {
+          [mario.id]: { [propertyA.id]: ["hola"], [propertyB.id]: ["bonjour"] },
+        };
+        await SourceOps.applyNonUniqueMappedResultsToAllProfiles(response, {
+          profiles,
+          properties,
+          sourceMapping,
+        });
+
+        expect(response).toEqual({
+          [mario.id]: { wordInSpanish: ["hola"], wordInFrench: ["bonjour"] },
+          [luigi.id]: { wordInSpanish: ["hola"], wordInFrench: ["bonjour"] },
+        });
+      });
     });
   });
 });

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -529,11 +529,7 @@ export class Property extends LoggedModel<Property> {
     const source = await Source.findById(instance.sourceId);
     if (source.state !== "ready") return; // we are bootstrapping
     const sourceMapping = await source.getMapping();
-    if (Object.keys(sourceMapping).length === 0) {
-      throw new Error(
-        `Cannot make Property ready as source (${source.id}) is not mapped`
-      );
-    }
+    if (Object.keys(sourceMapping).length === 0) return; // Query source
     const mappedPropertyKey = Object.values(sourceMapping)[0];
     const mappedProperty = await Property.findOne({
       where: { key: mappedPropertyKey },

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -523,7 +523,7 @@ export class Property extends LoggedModel<Property> {
   }
 
   @BeforeSave
-  static async noUniqueOrArrayThoughNonUniqueMapping(instance: Property) {
+  static async noUniqueOrArrayThroughNonUniqueMapping(instance: Property) {
     if (instance.state === "draft") return;
 
     const source = await Source.findById(instance.sourceId);
@@ -539,12 +539,12 @@ export class Property extends LoggedModel<Property> {
 
     if (instance.unique)
       throw new Error(
-        `A unique Property cannot be mapped though a non-unique Property - ${mappedProperty.key} (${mappedProperty.id})`
+        `A unique Property cannot be mapped through a non-unique Property - ${mappedProperty.key} (${mappedProperty.id})`
       );
 
     if (instance.isArray)
       throw new Error(
-        `An array Property cannot be mapped though a non-unique Property - ${mappedProperty.key} (${mappedProperty.id})`
+        `An array Property cannot be mapped through a non-unique Property - ${mappedProperty.key} (${mappedProperty.id})`
       );
   }
 

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -216,10 +216,21 @@ export class Source extends LoggedModel<Source> {
 
   async scheduleAvailable() {
     const { pluginConnection } = await this.getPlugin();
-    if (typeof pluginConnection?.methods?.profiles === "function") {
+    if (typeof pluginConnection?.methods?.profiles !== "function") {
+      return false;
+    }
+
+    const mapping = await this.getMapping();
+    if (Object.values(mapping).length === 0) {
+      return true;
+    } else {
+      const propertyMappingKey = Object.values(mapping)[0];
+      const property = (await Property.findAllWithCache()).find(
+        (p) => p.key === propertyMappingKey
+      );
+      if (!property.unique) return false;
       return true;
     }
-    return false;
   }
 
   async previewAvailable() {

--- a/core/src/modules/mappingHelper.ts
+++ b/core/src/modules/mappingHelper.ts
@@ -80,6 +80,9 @@ export namespace MappingHelper {
       });
 
       if (!property) throw new Error(`cannot find property ${key}`);
+      if (property.isArray) {
+        throw new Error(`cannot map to an array property - ${key}`);
+      }
 
       const mapping = await Mapping.create({
         ownerId: instance.id,

--- a/core/src/modules/mappingHelper.ts
+++ b/core/src/modules/mappingHelper.ts
@@ -80,8 +80,10 @@ export namespace MappingHelper {
       });
 
       if (!property) throw new Error(`cannot find property ${key}`);
-      if (property.isArray) {
-        throw new Error(`cannot map to an array property - ${key}`);
+      if (instance instanceof Source && property.isArray) {
+        throw new Error(
+          `Sources cannot map to an array Property ${property.key} (${property.id})`
+        );
       }
 
       const mapping = await Mapping.create({

--- a/core/src/modules/ops/property.ts
+++ b/core/src/modules/ops/property.ts
@@ -123,11 +123,11 @@ export namespace PropertyOps {
     const properties = await Property.findAllWithCache();
 
     // does our source depend on another property to be mapped?
-    const remoteMappingKeys = Object.values(sourceMapping);
+    const remoteMappingKeys: string[] = Object.values(sourceMapping);
     properties
-      .filter((rule) => remoteMappingKeys.includes(rule.key))
-      .filter((rule) => rule.id !== property.id)
-      .forEach((rule) => dependencies.push(rule));
+      .filter((p) => remoteMappingKeys.includes(p.key))
+      .filter((p) => p.id !== property.id)
+      .forEach((p) => dependencies.push(p));
 
     // does this rule have any mustache variables depended on?
     for (const key in ruleOptions) {
@@ -136,9 +136,9 @@ export namespace PropertyOps {
         .filter((chunk) => chunk[0] === "name")
         .map((chunk) => chunk[1]);
       properties
-        .filter((rule) => mustacheVariables.includes(rule.key))
-        .filter((rule) => rule.id !== property.id)
-        .forEach((rule) => dependencies.push(rule));
+        .filter((p) => mustacheVariables.includes(p.key))
+        .filter((p) => p.id !== property.id)
+        .forEach((p) => dependencies.push(p));
     }
 
     // de-duplicate
@@ -148,13 +148,13 @@ export namespace PropertyOps {
   }
 
   /** Make this rule identifying */
-  export async function makeIdentifying(rule: Property) {
-    if (rule.identifying === true) return;
+  export async function makeIdentifying(p: Property) {
+    if (p.identifying === true) return;
 
     await Property.update(
       { identifying: false },
-      { where: { id: { [Op.ne]: rule.id } } }
+      { where: { id: { [Op.ne]: p.id } } }
     );
-    await rule.update({ identifying: true });
+    await p.update({ identifying: true });
   }
 }

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -273,7 +273,7 @@ export namespace SourceOps {
   }
 
   // for non-unique mappings, we need to fan out the values we received back from the source
-  async function applyNonUniqueMappedResultsToAllProfiles(
+  export async function applyNonUniqueMappedResultsToAllProfiles(
     response: ProfilePropertiesPluginMethodResponse,
     {
       profiles,
@@ -301,8 +301,6 @@ export namespace SourceOps {
       const profile = profiles.find((p) => p.id === profileId);
       const profileProperties = await profile.getProperties();
       for (const property of properties) {
-        if (property.unique) continue;
-        if (property.isArray) continue;
         if (!valueMap[property.id]) valueMap[property.id] = {};
         if (profileProperties[mappedProperty.key].state !== "ready") {
           throw new Error(
@@ -511,8 +509,7 @@ export namespace SourceOps {
     const existingIdentifying = await Property.findOne({
       where: { identifying: true },
     });
-    // if there isn't one already, make this one identifying
-    const identifying = existingIdentifying ? false : true;
+    const identifying = existingIdentifying ? false : true; // if there isn't one already, make this one identifying
 
     const property = Property.build({
       id: id ?? ConfigWriter.generateId(key),

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -1,8 +1,4 @@
-import {
-  Source,
-  SimpleSourceOptions,
-  SourceMapping,
-} from "../../models/Source";
+import { Source, SimpleSourceOptions } from "../../models/Source";
 import { ProfileProperty } from "../../models/ProfileProperty";
 import {
   Property,
@@ -19,7 +15,6 @@ import { LoggedModel } from "../../classes/loggedModel";
 import { FilterHelper } from "../filterHelper";
 import { topologicalSort } from "../topologicalSort";
 import { ConfigWriter } from "../configWriter";
-import { ProfilePropertiesPluginMethodResponse } from "../../classes/plugin";
 
 export namespace SourceOps {
   /**

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -320,10 +320,12 @@ export namespace SourceOps {
         response[profile.id] = {};
         const profileProperties = await profile.getProperties();
         for (const propertyKey of Object.keys(valueMap)) {
+          const lookupValue =
+            profileProperties[mappedProperty.key]?.values[0]?.toString();
           response[profile.id][propertyKey] =
-            valueMap[propertyKey][
-              profileProperties[mappedProperty.key].values[0].toString()
-            ];
+            lookupValue && valueMap[propertyKey][lookupValue] !== undefined
+              ? valueMap[propertyKey][lookupValue]
+              : [null];
         }
       }
     }

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -1,4 +1,8 @@
-import { Source, SimpleSourceOptions } from "../../models/Source";
+import {
+  Source,
+  SimpleSourceOptions,
+  SourceMapping,
+} from "../../models/Source";
 import { ProfileProperty } from "../../models/ProfileProperty";
 import {
   Property,
@@ -15,6 +19,7 @@ import { LoggedModel } from "../../classes/loggedModel";
 import { FilterHelper } from "../filterHelper";
 import { topologicalSort } from "../topologicalSort";
 import { ConfigWriter } from "../configWriter";
+import { ProfilePropertiesPluginMethodResponse } from "../../classes/plugin";
 
 export namespace SourceOps {
   /**
@@ -253,12 +258,80 @@ export namespace SourceOps {
         profileIds: profiles.map((p) => p.id),
       });
 
+      await applyNonUniqueMappedResultsToAllProfiles(response, {
+        source,
+        profiles,
+        properties,
+        sourceMapping,
+      });
+
       return response;
     } catch (error) {
       throw error;
     } finally {
       await app.checkAndUpdateParallelism("decr");
     }
+  }
+
+  // for non-unique mappings, we need to fan out the values we received back from the source
+  async function applyNonUniqueMappedResultsToAllProfiles(
+    response: ProfilePropertiesPluginMethodResponse,
+    {
+      source,
+      profiles,
+      properties,
+      sourceMapping,
+    }: {
+      source: Source;
+      profiles: Profile[];
+      properties: Property[];
+      sourceMapping: SourceMapping;
+    }
+  ) {
+    const mappedPropertyKey = Object.values(sourceMapping)[0];
+    const mappedProperty = await Property.findOne({
+      where: { key: mappedPropertyKey },
+    });
+
+    if (!mappedProperty) return;
+    if (mappedProperty.unique) return;
+
+    const valueMap: { [mappedPropertyId: string]: { [match: string]: any } } =
+      {};
+
+    // load up the values
+    for (const profileId of Object.keys(response)) {
+      const profile = profiles.find((p) => p.id === profileId);
+      const profileProperties = await profile.getProperties();
+      for (const property of properties) {
+        if (property.unique) continue;
+        if (property.isArray) continue;
+        if (!valueMap[property.id]) valueMap[property.id] = {};
+        if (profileProperties[mappedProperty.key].state !== "ready") {
+          throw new Error("ProfileProperty is not ready!");
+        }
+
+        valueMap[property.id][
+          profileProperties[mappedProperty.key].values[0].toString()
+        ] = response[profile.id][property.id];
+      }
+    }
+
+    console.log("valueMap", valueMap);
+
+    // apply the values
+    for (const profile of profiles) {
+      if (!response[profile.id]) response[profile.id] = {};
+      const profileProperties = await profile.getProperties();
+      for (const propertyKey of Object.keys(valueMap)) {
+        response[profile.id][propertyKey] =
+          valueMap[propertyKey][
+            profileProperties[mappedProperty.key].values[0].toString()
+          ];
+      }
+    }
+
+    console.log("response++", response);
   }
 
   /**

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -1,4 +1,8 @@
-import { Source, SimpleSourceOptions } from "../../models/Source";
+import {
+  Source,
+  SimpleSourceOptions,
+  SourceMapping,
+} from "../../models/Source";
 import { ProfileProperty } from "../../models/ProfileProperty";
 import {
   Property,
@@ -15,6 +19,7 @@ import { LoggedModel } from "../../classes/loggedModel";
 import { FilterHelper } from "../filterHelper";
 import { topologicalSort } from "../topologicalSort";
 import { ConfigWriter } from "../configWriter";
+import { ProfilePropertiesPluginMethodResponse } from "../../classes/plugin";
 
 export namespace SourceOps {
   /**
@@ -253,11 +258,76 @@ export namespace SourceOps {
         profileIds: profiles.map((p) => p.id),
       });
 
+      await applyNonUniqueMappedResultsToAllProfiles(response, {
+        profiles,
+        properties,
+        sourceMapping,
+      });
+
       return response;
     } catch (error) {
       throw error;
     } finally {
       await app.checkAndUpdateParallelism("decr");
+    }
+  }
+
+  // for non-unique mappings, we need to fan out the values we received back from the source
+  async function applyNonUniqueMappedResultsToAllProfiles(
+    response: ProfilePropertiesPluginMethodResponse,
+    {
+      profiles,
+      properties,
+      sourceMapping,
+    }: {
+      profiles: Profile[];
+      properties: Property[];
+      sourceMapping: SourceMapping;
+    }
+  ) {
+    const mappedPropertyKey = Object.values(sourceMapping)[0];
+    const mappedProperty = await Property.findOne({
+      where: { key: mappedPropertyKey },
+    });
+
+    if (!mappedProperty) return;
+    if (mappedProperty.unique) return;
+
+    const valueMap: { [mappedPropertyId: string]: { [match: string]: any } } =
+      {};
+
+    // load up the values
+    for (const profileId of Object.keys(response)) {
+      const profile = profiles.find((p) => p.id === profileId);
+      const profileProperties = await profile.getProperties();
+      for (const property of properties) {
+        if (property.unique) continue;
+        if (property.isArray) continue;
+        if (!valueMap[property.id]) valueMap[property.id] = {};
+        if (profileProperties[mappedProperty.key].state !== "ready") {
+          throw new Error(
+            `ProfileProperty ${mappedProperty.key} for profile ${profile.id} is not ready`
+          );
+        }
+
+        valueMap[property.id][
+          profileProperties[mappedProperty.key].values[0].toString()
+        ] = response[profile.id][property.id];
+      }
+    }
+
+    // apply the values
+    for (const profile of profiles) {
+      if (!response[profile.id]) {
+        response[profile.id] = {};
+        const profileProperties = await profile.getProperties();
+        for (const propertyKey of Object.keys(valueMap)) {
+          response[profile.id][propertyKey] =
+            valueMap[propertyKey][
+              profileProperties[mappedProperty.key].values[0].toString()
+            ];
+        }
+      }
     }
   }
 

--- a/core/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/src/tasks/profileProperty/importProfileProperties.ts
@@ -50,22 +50,16 @@ export class ImportProfileProperties extends RetryableTask {
       include: [Option, Mapping],
       scope: null,
     });
-    const sourceMapping = await source.getMapping();
-    const mappedPropertyKey = Object.values(sourceMapping)[0];
-    const mappedProperty = allProperties.find(
-      (p) => p.key === mappedPropertyKey
-    );
 
     const profilesToImport: Profile[] = [];
     const profilesNotReady: Profile[] = [];
-    const profilesToImportIndividually: Profile[] = [];
     const dependencies: { [key: string]: Property[] } = {};
     for (const property of properties) {
       dependencies[property.id] = await PropertyOps.dependencies(property);
     }
 
     for (const profile of profiles) {
-      let mode: "ready" | "notReady" | "importIndividually" = "ready";
+      let mode: "ready" | "notReady" = "ready";
 
       // all already (wrongly) ready?
       if (
@@ -89,20 +83,12 @@ export class ImportProfileProperties extends RetryableTask {
           });
       }
 
-      // we are mapped though a non-unique property and we need to do multiple imports
-      if (mode === "ready" && !mappedProperty.unique) {
-        mode = "importIndividually";
-      }
-
       switch (mode) {
         case "ready":
           profilesToImport.push(profile);
           break;
         case "notReady":
           profilesNotReady.push(profile);
-          break;
-        case "importIndividually":
-          profilesToImportIndividually.push(profile);
           break;
       }
     }
@@ -120,15 +106,6 @@ export class ImportProfileProperties extends RetryableTask {
           },
         }
       );
-    }
-
-    for (const profile of profilesToImportIndividually) {
-      for (const property of properties) {
-        await CLS.enqueueTask("profileProperty:importProfileProperty", {
-          profileId: profile.id,
-          propertyId: property.id,
-        });
-      }
     }
 
     if (profilesToImport.length === 0) return;
@@ -170,7 +147,6 @@ export class ImportProfileProperties extends RetryableTask {
     }
 
     // update the properties that got no data back
-
     const propertiesToKeep = properties.filter((p) => p.keepValueIfNotFound);
     if (propertiesToKeep.length > 0) {
       await ProfileProperty.update(

--- a/ui/ui-components/components/visualizations/homepageWidgets.tsx
+++ b/ui/ui-components/components/visualizations/homepageWidgets.tsx
@@ -420,10 +420,7 @@ export function PendingImports({
     }
 
     if (_sources) setSources(_sources);
-    if (_pendingImportKeys)
-      setPendingImportKeys(
-        _pendingImportKeys.sort((a, b) => a.localeCompare(b))
-      );
+    if (_pendingImportKeys) setPendingImportKeys(_pendingImportKeys);
     if (_chartData) setChartData(_chartData);
   }
 
@@ -523,9 +520,7 @@ export function PendingExports({
       }
 
       setDestinations(_destinations);
-      setPendingExportKeys(
-        _pendingExportKeys.sort((a, b) => a.localeCompare(b))
-      );
+      setPendingExportKeys(_pendingExportKeys);
       setChartData(_chartData);
     }
 

--- a/ui/ui-components/pages/source/[id]/mapping.tsx
+++ b/ui/ui-components/pages/source/[id]/mapping.tsx
@@ -258,6 +258,7 @@ export default function Page(props) {
                       </thead>
                       <tbody>
                         {properties
+                          .filter((p) => !p.isArray)
                           .sort((a, b) => {
                             if (a.unique && !b.unique) return -1;
                             if (b.unique && !a.unique) return 1;

--- a/ui/ui-components/pages/source/[id]/overview.tsx
+++ b/ui/ui-components/pages/source/[id]/overview.tsx
@@ -252,7 +252,8 @@ export default function Page({
             )
           ) : (
             <Alert variant="warning">
-              Schedule not available for this connection type
+              Schedule not available for this connection type or mapping
+              configuration
             </Alert>
           )}
           <hr />


### PR DESCRIPTION
This PR makes is possible to create Source Mappings against non-unique Properties. 

When importing, for efficiency, rather querying the Source multiple times for the same non-unique value, we take the value returned for one value of the mapped property and copy to all other Profiles with the same mapped lookup value.  


There are some new caveats:
* Mappings cannot be made against array properties
* If a Source is mapped though a non-unique Property, it cannot create unique Properties
* If a Source is mapped though a non-unique Property, it cannot create unique array Properties
* If a Source is mapped though a non-unique Property, it cannot have a Schedule



TODO: 
- [x] Tests
- [x] Ensure that batching only works for Exact properties with no filters
- [x] Prevent schedules on sources mapped though a non-unique property
- [x] Check nulls on import chain