### PR TITLE
Fix Property Option `ownerType`

### DIFF
--- a/core/src/migrations/000056-propertiesModel.ts
+++ b/core/src/migrations/000056-propertiesModel.ts
@@ -1,3 +1,5 @@
+// Note: This migration should have also updated `options.ownerType`.  Corrected in migration 000079.
+
 export default {
   up: async function (migration) {
     await migration.sequelize.transaction(async () => {

--- a/core/src/migrations/000079-fixPropertyOwnerType.ts
+++ b/core/src/migrations/000079-fixPropertyOwnerType.ts
@@ -10,7 +10,7 @@ export default {
   down: async function (migration) {
     await migration.sequelize.transaction(async () => {
       await migration.sequelize.query(
-        `UPDATE "options" SET "ownerType"='profilePropertyRule' WHERE "ownerType"='profilePropertyRule';`
+        `UPDATE "options" SET "ownerType"='profilePropertyRule' WHERE "ownerType"='property';`
       );
     });
   },

--- a/core/src/migrations/000079-fixPropertyOwnerType.ts
+++ b/core/src/migrations/000079-fixPropertyOwnerType.ts
@@ -1,0 +1,17 @@
+export default {
+  up: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.sequelize.query(
+        `UPDATE "options" SET "ownerType"='property' WHERE "ownerType"='profilePropertyRule'`
+      );
+    });
+  },
+
+  down: async function (migration) {
+    await migration.sequelize.transaction(async () => {
+      await migration.sequelize.query(
+        `UPDATE "options" SET "ownerType"='profilePropertyRule' WHERE "ownerType"='profilePropertyRule';`
+      );
+    });
+  },
+};


### PR DESCRIPTION
This PR adds a missing update to the Options' ownerType for Properties.

NOTE: There may be a duplicate key error in this migration if you've partially updated your database between this migration and 000056