### PR TITLE
`process.env.BIND_IP` and default to binding to both IPv4 and IPv6 socket

### DIFF
--- a/core/src/config/servers/web.ts
+++ b/core/src/config/servers/web.ts
@@ -1,5 +1,4 @@
 import os from "os";
-import { env } from "actionhero";
 
 export const DEFAULT = {
   servers: {

--- a/core/src/config/servers/web.ts
+++ b/core/src/config/servers/web.ts
@@ -1,4 +1,5 @@
 import os from "os";
+import { env } from "actionhero";
 
 export const DEFAULT = {
   servers: {
@@ -19,7 +20,7 @@ export const DEFAULT = {
         port: process.env.PORT || 8080,
         // Which IP to listen on (use '0.0.0.0' for all; '::' for all on ipv4 and ipv6)
         // Set to `null` when listening to socket
-        bindIP: "0.0.0.0",
+        bindIP: process.env.BIND_IP ?? "::",
         // Any additional headers you want actionhero to respond with
         httpHeaders: {
           "X-Powered-By": config.general.serverName,


### PR DESCRIPTION
Pros: 
* Grouparoo now binds to `::` rather than `0.0.0.0`, which will allow for both IPv4 and IPv6 connections.
* The new `process.env.BIND_IP` environment variable can be used to modify the above as needed

Cons:
* The logs look stranger with the IPv4 bind:
```
2021-08-04T20:26:34.038Z - notice: Starting server: `web` @ http://:::3000
2021-08-04T20:26:35.316Z - info: [ action @ web ] to=::ffff:127.0.0.1 action=navigation:list params={"action":"navigation:list","apiVersion":"1"} duration=5 method=GET pathname=/api/v1/navigation
```