### PR TITLE
fix: dont crash on confirmProfiles if the schedule has no runs

### DIFF
--- a/core/__tests__/tasks/profile/confirm.ts
+++ b/core/__tests__/tasks/profile/confirm.ts
@@ -319,6 +319,18 @@ describe("tasks/profiles:confirm", () => {
     await schedule.destroy();
   });
 
+  test("silently exists if the schedule has no runs", async () => {
+    await plugin.updateSetting("core", "confirm-profiles-days", 0);
+
+    const source = await Source.findOne();
+    await helper.factories.schedule(source, {
+      confirmProfiles: true,
+    });
+
+    const count = await specHelper.runTask("profiles:confirm", {});
+    expect(count).toBe(0); // nothing
+  });
+
   test("only processes profiles up to the batch size", async () => {
     await plugin.updateSetting("core", "runs-profile-batch-size", 2);
 

--- a/core/src/tasks/profile/confirm.ts
+++ b/core/src/tasks/profile/confirm.ts
@@ -41,6 +41,8 @@ export class ProfilesConfirm extends CLSTask {
 
     for (const schedule of schedules) {
       const latestRun = schedule.runs[0];
+      if (!latestRun) continue;
+
       const pendingImports = await latestRun.$count("imports", {
         where: { profileAssociatedAt: null },
       });


### PR DESCRIPTION
Interestingly the `required: true` when using sequelize's `include` to fetch other models at the same time doesn't quite work the same if the included model specifies a `limit`. Without the limit, only one combined query is executed and rows that dont have matches for the included model are not returned. With the limit, it's instead split up into two queries and rows that dont have matches for the included model _are_ returned (just with an empty array)