### PR TITLE
fix: keepValueIfNotFound is applied when importing synchronously (Import and Export button)

### DIFF
--- a/core/__tests__/fixtures/codeConfig/changes/config.js
+++ b/core/__tests__/fixtures/codeConfig/changes/config.js
@@ -52,6 +52,7 @@ module.exports = async function getConfig() {
       identifying: true,
       unique: true,
       isArray: false,
+      keepValueIfNotFound: true,
       sourceId: "users_table", // sourceId -> `users_table`
       options: {
         column: "id",

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -114,6 +114,7 @@ describe("modules/codeConfig", () => {
         expect(property.type).toBe("integer");
         expect(property.unique).toBe(true);
         expect(property.identifying).toBe(true);
+        expect(property.keepValueIfNotFound).toBe(false);
         expect(property.state).toBe("ready");
         expect(property.locked).toBe("config:code");
       });
@@ -321,6 +322,16 @@ describe("modules/codeConfig", () => {
       expect(apps[0].locked).toBe("config:code");
       const options = await apps[0].getOptions();
       expect(options).toEqual({ fileId: "new-file-path.db" });
+    });
+
+    test("bootstrapped property can be updated to keepValueIfNotFound", async () => {
+      const property = await Property.findOne({
+        where: { directlyMapped: true },
+      });
+      expect(property.id).toBe("user_id");
+      expect(property.keepValueIfNotFound).toBe(true);
+      expect(property.state).toBe("ready");
+      expect(property.locked).toBe("config:code");
     });
 
     test("property keys changes will be updated", async () => {

--- a/core/src/modules/configLoaders/source.ts
+++ b/core/src/modules/configLoaders/source.ts
@@ -127,6 +127,10 @@ export async function loadSource(
   logModel(source, validate ? "validated" : isNew ? "created" : "updated");
 
   if (bootstrappedProperty) {
+    await bootstrappedProperty.update({
+      keepValueIfNotFound: bootstrappedPropertyConfig.keepValueIfNotFound,
+    });
+
     logModel(
       bootstrappedProperty,
       validate ? "validated" : isNew ? "created" : "updated"


### PR DESCRIPTION
- Load keepValueIfNotFound on bootstrapped properties through code config
- Use keepValueIfNotFound when importing through the "Import and Export" button