### PR TITLE
Schdule options and filters can be changed

### DIFF
--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -179,6 +179,14 @@ export class Schedule extends LoggedModel<Schedule> {
     return FilterHelper.setFilters(this, filters, externallyValidate);
   }
 
+  async afterSetFilters(hasChanges: boolean) {
+    if (!hasChanges) return;
+    if (this.state !== "ready") return;
+
+    await this.resetHighWatermarks();
+    await this.enqueueRun();
+  }
+
   async runPercentComplete(run: Run) {
     return ScheduleOps.runPercentComplete(this, run);
   }

--- a/core/src/modules/reset.ts
+++ b/core/src/modules/reset.ts
@@ -108,20 +108,7 @@ export namespace Reset {
 
   export async function resetHighWatermarks() {
     const schedules = await Schedule.findAll();
-    for (const i in schedules) {
-      const runs = await Run.findAll({
-        where: {
-          creatorId: schedules[i].id,
-          highWaterMark: { [Op.ne]: null },
-        },
-      });
-
-      for (const j in runs) {
-        const run = runs[j];
-        if (run.state === "running") await run.stop();
-        await run.update({ highWaterMark: {} });
-      }
-    }
+    for (const schedule of schedules) await schedule.resetHighWatermarks();
   }
 
   async function logMethod(callerId: string, topic: string, data = {}) {

--- a/ui/ui-components/pages/source/[id]/schedule.tsx
+++ b/ui/ui-components/pages/source/[id]/schedule.tsx
@@ -369,16 +369,6 @@ export default function Page(props) {
                   </div>
                 ))}
 
-                {schedule.state === "ready" ? (
-                  <>
-                    <br />
-                    <Alert variant="info">
-                      Note that changing the options for a Schedule will reset
-                      the high water mark and stop all running Runs.
-                    </Alert>
-                  </>
-                ) : null}
-
                 {filterOptions.length > 0 ? (
                   <>
                     <hr />
@@ -560,6 +550,16 @@ export default function Page(props) {
                 ) : null}
               </>
               <hr />
+
+              {schedule.state === "ready" ? (
+                <>
+                  <Alert variant="info">
+                    Note that changing the options or filters for a Schedule
+                    will reset the high water mark and stop all running Runs.
+                  </Alert>
+                </>
+              ) : null}
+
               <LoadingButton variant="primary" type="submit" disabled={loading}>
                 Update
               </LoadingButton>

--- a/ui/ui-components/pages/source/[id]/schedule.tsx
+++ b/ui/ui-components/pages/source/[id]/schedule.tsx
@@ -555,7 +555,8 @@ export default function Page(props) {
                 <>
                   <Alert variant="info">
                     Note that changing the options or filters for a Schedule
-                    will reset the high water mark and stop all running Runs.
+                    will reset the high water mark and stop all running Runs. A
+                    new Run will be enqueued.
                   </Alert>
                 </>
               ) : null}

--- a/ui/ui-components/pages/source/[id]/schedule.tsx
+++ b/ui/ui-components/pages/source/[id]/schedule.tsx
@@ -47,16 +47,13 @@ export default function Page(props) {
 
   async function edit(event) {
     event.preventDefault();
+    setLoading(true);
 
     const _schedule = Object.assign({}, schedule, { state: "ready" });
-    if (schedule.state === "ready") {
-      delete _schedule.options; // they are immutable and cannot be changed once set; server will return an error
-    }
     if (recurringFrequencyMinutes) {
       _schedule.recurringFrequency = recurringFrequencyMinutes * (60 * 1000);
     }
 
-    setLoading(true);
     const response: Actions.ScheduleEdit = await execApi(
       "put",
       `/schedule/${schedule.id}`,
@@ -303,7 +300,7 @@ export default function Page(props) {
                           defaultValue={
                             schedule.options[opt.key]?.toString() || ""
                           }
-                          disabled={schedule.state !== "draft"}
+                          disabled={loading}
                           onChange={(e) => {
                             updateOption(opt.key, e.target.value);
                           }}
@@ -333,7 +330,7 @@ export default function Page(props) {
                         <Form.Control
                           required
                           type="text"
-                          disabled={schedule.state !== "draft"}
+                          disabled={loading}
                           value={schedule.options[opt.key]?.toString()}
                           onChange={(e) =>
                             updateOption(opt.key, e.target.value)
@@ -353,7 +350,7 @@ export default function Page(props) {
                           as="textarea"
                           rows={5}
                           value={schedule.options[opt.key]?.toString()}
-                          disabled={schedule.state !== "draft"}
+                          disabled={loading}
                           onChange={(e) =>
                             updateOption(opt.key, e.target["value"])
                           }
@@ -371,6 +368,16 @@ export default function Page(props) {
                     ) : null}
                   </div>
                 ))}
+
+                {schedule.state === "ready" ? (
+                  <>
+                    <br />
+                    <Alert variant="info">
+                      Note that changing the options for a Schedule will reset
+                      the high water mark and stop all running Runs.
+                    </Alert>
+                  </>
+                ) : null}
 
                 {filterOptions.length > 0 ? (
                   <>

--- a/ui/ui-components/pages/source/[id]/schedule.tsx
+++ b/ui/ui-components/pages/source/[id]/schedule.tsx
@@ -552,13 +552,11 @@ export default function Page(props) {
               <hr />
 
               {schedule.state === "ready" ? (
-                <>
-                  <Alert variant="info">
-                    Note that changing the options or filters for a Schedule
-                    will reset the high water mark and stop all running Runs. A
-                    new Run will be enqueued.
-                  </Alert>
-                </>
+                <Alert variant="info">
+                  Note that changing the options or filters for a Schedule will
+                  reset the high water mark and stop all running Runs. A new Run
+                  will be enqueued.
+                </Alert>
               ) : null}
 
               <LoadingButton variant="primary" type="submit" disabled={loading}>


### PR DESCRIPTION
Changing a Schedule's Options of Filters will now:
* Clear the high water mark by nulling out the highWaterMark on all previous runs
* Start a new run immediately. 

A small warning is added to the UIs

<img width="1145" alt="Screen Shot 2021-08-16 at 4 27 51 PM" src="https://user-images.githubusercontent.com/303226/129641485-77f8eda7-dfdb-4f26-b05d-b88ebfb8efda.png">
