### PR TITLE
Use Sequelize query builder directly for better types

### DIFF
--- a/core/src/actions/profiles.ts
+++ b/core/src/actions/profiles.ts
@@ -7,6 +7,7 @@ import { Op } from "sequelize";
 import { ConfigWriter } from "../modules/configWriter";
 import { ProfileOps } from "../modules/ops/profile";
 import { AsyncReturnType } from "type-fest";
+import Sequelize from "sequelize";
 
 export class ProfilesList extends AuthenticatedAction {
   constructor() {
@@ -68,10 +69,7 @@ export class ProfileAutocompleteProfileProperty extends AuthenticatedAction {
 
     const profileProperties = await ProfileProperty.findAll({
       attributes: [
-        [
-          api.sequelize.fn("DISTINCT", api.sequelize.col("rawValue")),
-          "rawValue",
-        ],
+        [Sequelize.fn("DISTINCT", Sequelize.col("rawValue")), "rawValue"],
         "propertyId",
       ],
       where: {

--- a/core/src/actions/teams.ts
+++ b/core/src/actions/teams.ts
@@ -1,4 +1,4 @@
-import { api } from "actionhero";
+import Sequelize from "sequelize";
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { CLSAction } from "../classes/actions/clsAction";
 import { Team } from "../models/Team";
@@ -162,7 +162,7 @@ export class TeamView extends AuthenticatedAction {
     const team = await Team.findOne({
       where: { id: params.id },
       include: [{ model: TeamMember }],
-      order: [[api.sequelize.literal(`"teamMembers.email"`), "desc"]],
+      order: [[Sequelize.literal(`"teamMembers.email"`), "desc"]],
     });
 
     if (!team) throw new Error("team not found");

--- a/core/src/actions/totals.ts
+++ b/core/src/actions/totals.ts
@@ -1,4 +1,5 @@
-import { api, config } from "actionhero";
+import { config } from "actionhero";
+import Sequelize from "sequelize";
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { Op } from "sequelize";
 import { Group } from "../models/Group";
@@ -69,8 +70,10 @@ export class TotalsAction extends AuthenticatedAction {
 
     const groupStatement =
       config.sequelize.dialect === "postgres"
-        ? api.sequelize.fn("date_trunc", "day", api.sequelize.col("createdAt"))
-        : api.sequelize.literal(`strftime('%Y %m %d', \`createdAt\`)`);
+        ? Sequelize.fn("date_trunc", "day", Sequelize.col("createdAt"))
+        : (Sequelize.literal(
+            `strftime('%Y %m %d', \`createdAt\`)`
+          ) as unknown as string);
     const rolling: Array<{ date: string; count: number }> = (
       await model.count({
         where: { createdAt: { [Op.gte]: new Date(dates[0]) } },

--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import { URL } from "url";
 import { join, isAbsolute } from "path";
 import { getParentPath, getPluginManifest } from "../utils/pluginDetails";
+import "ah-sequelize-plugin/dist/initializers/sequelize"; // load the type override for api.sequelize
 import { log } from "actionhero";
 
 import cls from "cls-hooked";

--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -2,7 +2,6 @@ import fs from "fs";
 import { URL } from "url";
 import { join, isAbsolute } from "path";
 import { getParentPath, getPluginManifest } from "../utils/pluginDetails";
-import "ah-sequelize-plugin/dist/initializers/sequelize"; // load the type override for api.sequelize
 import { log } from "actionhero";
 
 import cls from "cls-hooked";

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -51,6 +51,7 @@ export { Team } from "./models/Team";
 export { TeamMember } from "./models/TeamMember";
 
 export { StatusMetric } from "./modules/statusReporters";
+export { GrouparooCLI } from "./modules/cli";
 
 export { waitForLock } from "./modules/locks";
 export { Errors } from "./modules/errors";

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -344,7 +344,7 @@ export class Export extends Model {
         "SELECT changes() as count;",
         { type: QueryTypes.SELECT }
       );
-      responseCountWithCompleteExport = changesRows[0].count;
+      responseCountWithCompleteExport = changesRows[0]["count"];
     }
 
     // 2. If there are no complete Exports for the Profile, any old Exports can be deleted
@@ -374,7 +374,7 @@ export class Export extends Model {
         "SELECT changes() as count;",
         { type: QueryTypes.SELECT }
       );
-      responseCountWithNoCompleteExports = changesRows[0].count;
+      responseCountWithNoCompleteExports = changesRows[0]["count"];
     }
 
     return {

--- a/core/src/models/ExportProcessor.ts
+++ b/core/src/models/ExportProcessor.ts
@@ -201,7 +201,7 @@ export class ExportProcessor extends LoggedModel<ExportProcessor> {
         "SELECT changes() as count;",
         { type: QueryTypes.SELECT }
       );
-      responseCountWithNoExports = changesRows[0].count;
+      responseCountWithNoExports = changesRows[0]["count"];
     }
 
     return config.sequelize.dialect === "sqlite"

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -578,20 +578,20 @@ export class Group extends LoggedModel<Group> {
         switch (operation.op) {
           case "ne":
             reverseMatchWhere[Op.and].push(
-              Sequelize.where(castedValue, nullCheckedMatch.toString())
+              Sequelize.where(castedValue, nullCheckedMatch?.toString())
             );
             break;
           case "notLike":
             reverseMatchWhere[Op.and].push(
               Sequelize.where(castedValue, {
-                [Op.like.toString()]: nullCheckedMatch,
+                [Op.like]: nullCheckedMatch as string,
               })
             );
             break;
           case "notILike":
             reverseMatchWhere[Op.and].push(
               Sequelize.where(castedValue, {
-                [Op.iLike.toString()]: nullCheckedMatch,
+                [Op.iLike]: nullCheckedMatch as string,
               })
             );
             break;

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -15,7 +15,7 @@ import {
   Scopes,
 } from "sequelize-typescript";
 import { api, config } from "actionhero";
-import { Op, WhereAttributeHash } from "sequelize";
+import Sequelize, { Op, WhereAttributeHash } from "sequelize";
 import Moment from "moment";
 import { LoggedModel } from "../classes/loggedModel";
 import { GroupMember } from "./GroupMember";
@@ -512,9 +512,9 @@ export class Group extends LoggedModel<Group> {
       if (!topLevel) {
         // when we are considering a profile property
         localWhereGroup[Op.and] = [
-          api.sequelize.where(
-            api.sequelize.cast(
-              api.sequelize.col(`${alias}.rawValue`),
+          Sequelize.where(
+            Sequelize.cast(
+              Sequelize.col(`${alias}.rawValue`),
               propertyJSToSQLType(property.type)
             ),
             rawValueMatch
@@ -545,9 +545,9 @@ export class Group extends LoggedModel<Group> {
         const todayBoundMatch = {};
         todayBoundMatch[Op[operation.op === "gt" ? "lte" : "gte"]] =
           new Date().getTime();
-        todayBoundWhereGroup[Op.and] = api.sequelize.where(
-          api.sequelize.cast(
-            api.sequelize.col(`${alias}.rawValue`),
+        todayBoundWhereGroup[Op.and] = Sequelize.where(
+          Sequelize.cast(
+            Sequelize.col(`${alias}.rawValue`),
             propertyJSToSQLType(property.type)
           ),
           todayBoundMatch
@@ -564,42 +564,43 @@ export class Group extends LoggedModel<Group> {
         property.isArray &&
         ["ne", "notLike", "notILike"].includes(operation.op)
       ) {
-        let reverseMatchWhere = {
+        let reverseMatchWhere: { [op: string]: Sequelize.Utils.Where[] } = {
           [Op.and]: [{ propertyId: property.id }],
         };
-        const castedValue = api.sequelize.cast(
-          api.sequelize.col(`rawValue`),
+        const castedValue = Sequelize.cast(
+          Sequelize.col(`rawValue`),
           propertyJSToSQLType(property.type)
         );
         const nullCheckedMatch =
           match.toString().toLocaleLowerCase() === "null" ? null : match;
         switch (operation.op) {
           case "ne":
-            reverseMatchWhere[Op.and].push(
-              api.sequelize.where(castedValue, nullCheckedMatch)
+            reverseMatchWhere[Op.and.toString()].push(
+              Sequelize.where(castedValue, nullCheckedMatch.toString())
             );
             break;
           case "notLike":
-            reverseMatchWhere[Op.and].push(
-              api.sequelize.where(castedValue, {
-                [Op.like]: nullCheckedMatch,
+            reverseMatchWhere[Op.and.toString()].push(
+              Sequelize.where(castedValue, {
+                [Op.like.toString()]: nullCheckedMatch,
               })
             );
             break;
           case "notILike":
-            reverseMatchWhere[Op.and].push(
-              api.sequelize.where(castedValue, {
-                [Op.iLike]: nullCheckedMatch,
+            reverseMatchWhere[Op.and.toString()].push(
+              Sequelize.where(castedValue, {
+                [Op.iLike.toString()]: nullCheckedMatch,
               })
             );
             break;
         }
         const whereClause: string =
+          //@ts-ignore
           api.sequelize.queryInterface.queryGenerator.getWhereConditions(
             reverseMatchWhere
           );
 
-        const affirmativeArrayMatch = api.sequelize.literal(
+        const affirmativeArrayMatch = Sequelize.literal(
           `"ProfileMultipleAssociationShim"."id" NOT IN (SELECT "profileId" FROM "profileProperties" WHERE ${whereClause})`
         );
         localWhereGroup[Op.and].push(affirmativeArrayMatch);

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -564,7 +564,9 @@ export class Group extends LoggedModel<Group> {
         property.isArray &&
         ["ne", "notLike", "notILike"].includes(operation.op)
       ) {
-        let reverseMatchWhere: { [op: string]: Sequelize.Utils.Where[] } = {
+        let reverseMatchWhere: {
+          [Op.and]: (Sequelize.Utils.Where | WhereAttributeHash)[];
+        } = {
           [Op.and]: [{ propertyId: property.id }],
         };
         const castedValue = Sequelize.cast(
@@ -575,19 +577,19 @@ export class Group extends LoggedModel<Group> {
           match.toString().toLocaleLowerCase() === "null" ? null : match;
         switch (operation.op) {
           case "ne":
-            reverseMatchWhere[Op.and.toString()].push(
+            reverseMatchWhere[Op.and].push(
               Sequelize.where(castedValue, nullCheckedMatch.toString())
             );
             break;
           case "notLike":
-            reverseMatchWhere[Op.and.toString()].push(
+            reverseMatchWhere[Op.and].push(
               Sequelize.where(castedValue, {
                 [Op.like.toString()]: nullCheckedMatch,
               })
             );
             break;
           case "notILike":
-            reverseMatchWhere[Op.and.toString()].push(
+            reverseMatchWhere[Op.and].push(
               Sequelize.where(castedValue, {
                 [Op.iLike.toString()]: nullCheckedMatch,
               })

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -17,8 +17,8 @@ import {
   BeforeCreate,
   AfterSave,
 } from "sequelize-typescript";
-import { Op, WhereOptions } from "sequelize";
-import { env, api, redis, config } from "actionhero";
+import Sequelize, { Op, WhereOptions } from "sequelize";
+import { env, redis, config } from "actionhero";
 import { plugin } from "../modules/plugin";
 import { LoggedModel } from "../classes/loggedModel";
 import { Profile } from "./Profile";
@@ -452,12 +452,12 @@ export class Property extends LoggedModel<Property> {
       const valueCounts = await ProfileProperty.findAll({
         attributes: [
           "rawValue",
-          [api.sequelize.fn("COUNT", api.sequelize.col("rawValue")), "count"],
+          [Sequelize.fn("COUNT", Sequelize.col("rawValue")), "count"],
         ],
         group: ["rawValue"],
         where: { propertyId: instance.id },
-        having: api.sequelize.where(
-          api.sequelize.fn("COUNT", api.sequelize.col("rawValue")),
+        having: Sequelize.where(
+          Sequelize.fn("COUNT", Sequelize.col("rawValue")),
           { [Op.gt]: 1 }
         ),
         limit: 1,

--- a/core/src/models/Run.ts
+++ b/core/src/models/Run.ts
@@ -1,5 +1,4 @@
-import { Op } from "sequelize";
-import { api } from "actionhero";
+import Sequelize, { Op } from "sequelize";
 import { Profile } from "./Profile";
 import {
   Model,
@@ -179,10 +178,7 @@ export class Run extends Model {
 
   async buildErrorMessage() {
     const importErrorCounts = await Import.findAll({
-      attributes: [
-        "errorMessage",
-        [api.sequelize.fn("COUNT", "id"), "errorCount"],
-      ],
+      attributes: ["errorMessage", [Sequelize.fn("COUNT", "id"), "errorCount"]],
       where: {
         creatorId: this.id,
         errorMessage: { [Op.not]: null },

--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -43,7 +43,10 @@ export namespace GrouparooCLI {
   }
 
   export function setGrouparooRunMode(cli: CLI) {
-    process.env.GROUPAROO_RUN_MODE = `cli:${cli.name}`;
+    const onlyName = cli.name.split(" ")[0];
+    const prefixedName = `cli:${onlyName}`;
+    process.env.GROUPAROO_RUN_MODE = prefixedName;
+    return prefixedName;
   }
 
   export function setNextDevelopmentMode(nextDevelopmentMode = false) {

--- a/core/src/modules/mustacheUtils.ts
+++ b/core/src/modules/mustacheUtils.ts
@@ -50,7 +50,7 @@ export namespace MustacheUtils {
     const properties = await api.sequelize.models.Property.findAll();
     const searchItems: Array<{ id: string; key: string }> = [].concat(
       properties.map((p) => {
-        return { id: p.id, key: p.key };
+        return { id: p["id"], key: p["key"] };
       }),
       configObjects
         .filter((c) => c.class.toLowerCase() === "property")

--- a/core/src/modules/ops/group.ts
+++ b/core/src/modules/ops/group.ts
@@ -5,7 +5,7 @@ import { Profile } from "../../models/Profile";
 import { ProfileMultipleAssociationShim } from "../../models/ProfileMultipleAssociationShim";
 import { Import } from "../../models/Import";
 import { Op } from "sequelize";
-import { api, log } from "actionhero";
+import Sequelize from "sequelize";
 import { ProfileOps } from "./profile";
 
 export namespace GroupOps {
@@ -475,13 +475,10 @@ export namespace GroupOps {
     const newGroupMembers = await GroupMember.findAll({
       attributes: [
         "groupId",
-        [
-          api.sequelize.fn("max", api.sequelize.col("createdAt")),
-          "newestMemberAdded",
-        ],
+        [Sequelize.fn("max", Sequelize.col("createdAt")), "newestMemberAdded"],
       ],
       group: ["groupId"],
-      order: [[api.sequelize.col("newestMemberAdded"), "desc"]],
+      order: [[Sequelize.col("newestMemberAdded"), "desc"]],
       limit: limit,
     });
 

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -8,7 +8,12 @@ import { Export } from "../../models/Export";
 import { GroupMember } from "../../models/GroupMember";
 import { Log } from "../../models/Log";
 import { api } from "actionhero";
-import { Op, OrderItem, WhereAttributeHash, QueryTypes } from "sequelize";
+import Sequelize, {
+  Op,
+  OrderItem,
+  WhereAttributeHash,
+  QueryTypes,
+} from "sequelize";
 import { waitForLock } from "../locks";
 import { ProfilePropertyOps } from "./profileProperty";
 import { GroupRule } from "../../models/GroupRule";
@@ -132,7 +137,7 @@ export namespace ProfileOps {
     if (caseSensitive === undefined || caseSensitive === null)
       caseSensitive = true;
 
-    const ands: WhereAttributeHash[] = [];
+    const ands: (Sequelize.Utils.Where | WhereAttributeHash)[] = [];
     const include: Array<any> = [];
     let countRequiresIncludes = false;
 
@@ -149,30 +154,28 @@ export namespace ProfileOps {
       if (!property) throw new Error(`cannot find a property for ${searchKey}`);
 
       ands.push(
-        api.sequelize.where(
-          api.sequelize.col("profileProperties.propertyId"),
+        Sequelize.where(
+          Sequelize.col("profileProperties.propertyId"),
           property.id
         )
       );
       if (searchValue.toLowerCase() === "null" || searchValue === "") {
         ands.push(
-          api.sequelize.where(api.sequelize.col("profileProperties.rawValue"), {
-            [Op.eq]: null,
-          })
+          Sequelize.where(Sequelize.col("profileProperties.rawValue"), null)
         );
       } else {
         const op = searchValue.includes("%") ? Op.like : Op.eq;
         ands.push(
-          api.sequelize.where(
+          Sequelize.where(
             !caseSensitive
-              ? api.sequelize.fn(
+              ? Sequelize.fn(
                   "LOWER",
-                  api.sequelize.col("profileProperties.rawValue")
+                  Sequelize.col("profileProperties.rawValue")
                 )
-              : api.sequelize.col("profileProperties.rawValue"),
+              : Sequelize.col("profileProperties.rawValue"),
             {
               [op]: !caseSensitive
-                ? api.sequelize.fn("LOWER", searchValue)
+                ? Sequelize.fn("LOWER", searchValue)
                 : searchValue,
             }
           )
@@ -185,7 +188,7 @@ export namespace ProfileOps {
       countRequiresIncludes = true;
       include.push(GroupMember);
       ands.push(
-        api.sequelize.where(api.sequelize.col("groupMembers.groupId"), groupId)
+        Sequelize.where(Sequelize.col("groupMembers.groupId"), groupId)
       );
     }
 

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -1,3 +1,4 @@
+import Sequelize from "sequelize";
 import {
   Source,
   SimpleSourceOptions,
@@ -585,9 +586,9 @@ export namespace SourceOps {
       attributes: [
         "sourceId",
         [
-          api.sequelize.fn(
+          Sequelize.fn(
             "COUNT",
-            api.sequelize.fn("DISTINCT", api.sequelize.col("profileId"))
+            Sequelize.fn("DISTINCT", Sequelize.col("profileId"))
           ),
           "count",
         ],

--- a/core/src/modules/statusReporters.ts
+++ b/core/src/modules/statusReporters.ts
@@ -1,5 +1,6 @@
 import os from "os";
 import { api, env, task } from "actionhero";
+import Sequelize from "sequelize";
 import PluginDetails from "../utils/pluginDetails";
 import { Op } from "sequelize";
 import { App } from "../models/App";
@@ -564,10 +565,7 @@ export namespace FinalSummaryReporters {
       const exports = await Export.findAll({
         attributes: [
           "destinationId",
-          [
-            api.sequelize.fn("count", api.sequelize.col("id")),
-            "exportsCreated",
-          ],
+          [Sequelize.fn("count", Sequelize.col("id")), "exportsCreated"],
         ],
         where: { createdAt: { [Op.gte]: lastRunStart } },
         group: ["destinationId"],

--- a/core/src/tasks/run/updateCounts.ts
+++ b/core/src/tasks/run/updateCounts.ts
@@ -1,4 +1,4 @@
-import { api } from "actionhero";
+import { Sequelize } from "sequelize";
 import { Run } from "../../models/Run";
 import { Op } from "sequelize";
 import Moment from "moment";
@@ -26,7 +26,7 @@ export class UpdateRunCounts extends CLSTask {
           { importsCreated: 0 },
           {
             profilesImported: {
-              [Op.lt]: api.sequelize.col("importsCreated"),
+              [Op.lt]: Sequelize.col("importsCreated"),
             },
           },
         ],

--- a/plugins/@grouparoo/demo/src/bin/grouparoo/demo/demo.ts
+++ b/plugins/@grouparoo/demo/src/bin/grouparoo/demo/demo.ts
@@ -15,6 +15,7 @@ import {
 import { init, finalize } from "../../../util/shared";
 import { getConfig } from "../../../util/config";
 import { log } from "actionhero";
+import { GrouparooCLI } from "@grouparoo/core";
 
 export class Demo extends CLI {
   constructor() {
@@ -28,6 +29,10 @@ export class Demo extends CLI {
       force: { required: false, letter: "f", flag: true },
     };
   }
+
+  preInitialize = () => {
+    GrouparooCLI.setGrouparooRunMode(this);
+  };
 
   async run({ params }) {
     try {


### PR DESCRIPTION
As part of the work to combine `grouparoo apply` with migrations, it was discovered that the types of `api.sequelzie` were not loaded property.  This will be fixed soon, but generically it's better to use the `Sequelize` import directly for better types.