### PR TITLE
Provide types to Property Options via `PluginOptionType`

### DIFF
--- a/core/__tests__/models/app/app.ts
+++ b/core/__tests__/models/app/app.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { plugin, App, Option, Log, PluginOptionTypes } from "../../../src";
+import { plugin, App, Option, Log, PluginOptionType } from "../../../src";
 import { api, redis, utils } from "actionhero";
 import { ObfuscatedPasswordString } from "../../../src/modules/optionHelper";
 
@@ -341,7 +341,7 @@ describe("models/app", () => {
     let testCounter = 0;
     let profilePropertyCount = 0;
     let parallelism = Infinity;
-    let appOptionsReturnType: PluginOptionTypes = "list";
+    let appOptionsReturnType: PluginOptionType = "list";
 
     beforeAll(async () => {
       plugin.registerPlugin({

--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -234,7 +234,7 @@ describe("models/destination", () => {
       });
       expect(connectionOptions).toEqual({
         table: { type: "list", options: ["users_out"] },
-        receivedOptions: { type: "string", options: ["true"] },
+        receivedOptions: { type: "text", options: ["true"] },
       });
     });
 

--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -457,7 +457,7 @@ describe("models/source", () => {
       });
       expect(connectionOptions).toEqual({
         table: { options: ["users"], type: "list" },
-        receivedOptions: { type: "string", options: ["true"] },
+        receivedOptions: { type: "text", options: ["true"] },
       });
     });
 

--- a/core/src/classes/plugin.ts
+++ b/core/src/classes/plugin.ts
@@ -1,4 +1,4 @@
-import { App, AppOption, SimpleAppOptions } from "../models/App";
+import { App, SimpleAppOptions } from "../models/App";
 import { Source, SimpleSourceOptions, SourceMapping } from "../models/Source";
 import { Errors } from "../modules/errors";
 import {
@@ -9,7 +9,6 @@ import {
 } from "../models/Destination";
 import { Run } from "../models/Run";
 import {
-  PluginConnectionPropertyOption,
   SimplePropertyOptions,
   PropertyFiltersWithKey,
 } from "../models/Property";
@@ -50,6 +49,16 @@ export interface PluginApp {
     appOptions?: AppOptionsMethod;
     parallelism?: AppParallelismMethod;
   };
+}
+
+export interface AppOption {
+  key: string;
+  type?: PluginOptionType;
+  displayName?: string;
+  required: boolean;
+  description?: string;
+  placeholder?: string;
+  defaultValue?: string | number | boolean;
 }
 
 /**
@@ -107,6 +116,14 @@ export enum FilterOperation {
   NotContain = "does not contain",
   In = "in",
 }
+
+export type PluginOptionType =
+  | "list"
+  | "typeahead"
+  | "text"
+  | "textarea"
+  | "password"
+  | "pending";
 
 /**
  * Method to get one or many profiles to be saved/updated.
@@ -298,7 +315,7 @@ export interface ConnectionOption extends AppOption {}
 export interface AppOptionsMethod {
   (): Promise<{
     [optionName: string]: {
-      type: PluginOptionTypes;
+      type: PluginOptionType;
       options?: string[];
       descriptions?: string[];
     };
@@ -366,7 +383,7 @@ export interface SourceOptionsMethod {
 
 export interface SourceOptionsMethodResponse {
   [optionName: string]: {
-    type: PluginOptionTypes;
+    type: PluginOptionType;
     options?: string[];
     descriptions?: string[];
   };
@@ -468,6 +485,38 @@ export interface PropertyOptionsMethod {
 }
 
 /**
+ * Metadata and methods to return the options a Property for this connection/app.
+ * Options is a method which will poll the source for available options to select (ie: names of tables or columns)
+ */
+export interface PluginConnectionPropertyOption {
+  key: string;
+  displayName?: string;
+  required: boolean;
+  description: string;
+  type: PluginOptionType;
+  primary?: boolean;
+  options: (argument: {
+    connection: any;
+    app: App;
+    appId: string;
+    appOptions: SimpleAppOptions;
+    source: Source;
+    sourceId: string;
+    sourceOptions: SimpleSourceOptions;
+    sourceMapping: SourceMapping;
+    property: Property;
+    propertyId: string;
+  }) => Promise<
+    Array<{
+      key: string;
+      description?: string;
+      default?: boolean;
+      examples?: Array<any>;
+    }>
+  >;
+}
+
+/**
  * If a Property is created within the source creation workflow, what default options should that new rule get?
  */
 export interface UniquePropertyBootstrapOptions {
@@ -499,7 +548,7 @@ export interface DestinationOptionsMethod {
 
 export interface DestinationOptionsMethodResponse {
   [optionName: string]: {
-    type: PluginOptionTypes;
+    type: PluginOptionType;
     options?: string[];
     descriptions?: string[];
   };
@@ -572,13 +621,6 @@ export interface ExportArrayPropertiesMethod {
 }
 
 export type ExportArrayPropertiesMethodResponse = Array<string>;
-
-export type PluginOptionTypes =
-  | "string"
-  | "list"
-  | "typeahead"
-  | "pending"
-  | "password";
 
 /** Template Utils */
 

--- a/core/src/classes/plugin.ts
+++ b/core/src/classes/plugin.ts
@@ -39,7 +39,7 @@ export interface GrouparooPlugin {
  */
 export interface PluginApp {
   name: string;
-  options: AppOption[];
+  options: AppOptionsOption[];
   minInstances?: number;
   maxInstances?: number;
   methods: {
@@ -51,7 +51,7 @@ export interface PluginApp {
   };
 }
 
-export interface AppOption {
+export interface AppOptionsOption {
   key: string;
   type?: PluginOptionType;
   displayName?: string;
@@ -60,6 +60,8 @@ export interface AppOption {
   placeholder?: string;
   defaultValue?: string | number | boolean;
 }
+
+export interface ConnectionOptionsOption extends AppOptionsOption {}
 
 /**
  * A plugin's Connection
@@ -70,7 +72,7 @@ export interface PluginConnection {
   direction: "import" | "export";
   skipSourceMapping?: boolean;
   app: string;
-  options: ConnectionOption[];
+  options: ConnectionOptionsOption[];
   syncModes?: DestinationSyncMode[];
   defaultSyncMode?: DestinationSyncMode;
   groupAggregations?: AggregationMethod[];
@@ -305,8 +307,6 @@ export interface ErrorWithProfileId extends Error {
   profileId: string;
   errorLevel: Errors.ErrorLevel;
 }
-
-export interface ConnectionOption extends AppOption {}
 
 /**
  * Method to return the options available to this app.

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -31,7 +31,6 @@ export {
   Property,
   PropertyTypes,
   PropertyFiltersWithKey,
-  PluginConnectionPropertyOption,
   SimplePropertyOptions,
 } from "./models/Property";
 export { Filter } from "./models/Filter";

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -24,18 +24,7 @@ import { AppOps } from "../modules/ops/app";
 import { LockableHelper } from "../modules/lockableHelper";
 import { ConfigWriter } from "../modules/configWriter";
 import { APIData } from "../modules/apiData";
-import { PluginOptionTypes } from "../classes/plugin";
 import { AppConfigurationObject } from "../classes/codeConfig";
-
-export interface AppOption {
-  key: string;
-  type?: PluginOptionTypes;
-  displayName?: string;
-  required: boolean;
-  description?: string;
-  placeholder?: string;
-  defaultValue?: string | number | boolean;
-}
 
 export interface SimpleAppOptions extends OptionHelper.SimpleOptions {}
 

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -88,38 +88,6 @@ const STATE_TRANSITIONS = [
   },
 ];
 
-/**
- * Metadata and methods to return the options a Property for this connection/app.
- * Options is a method which will poll the source for available options to select (ie: names of tables or columns)
- */
-export interface PluginConnectionPropertyOption {
-  key: string;
-  displayName?: string;
-  required: boolean;
-  description: string;
-  type: string;
-  primary?: boolean;
-  options: (argument: {
-    connection: any;
-    app: App;
-    appId: string;
-    appOptions: SimpleAppOptions;
-    source: Source;
-    sourceId: string;
-    sourceOptions: SimpleSourceOptions;
-    sourceMapping: SourceMapping;
-    property: Property;
-    propertyId: string;
-  }) => Promise<
-    Array<{
-      key: string;
-      description?: string;
-      default?: boolean;
-      examples?: Array<any>;
-    }>
-  >;
-}
-
 export interface PropertyFiltersWithKey extends FilterHelper.FiltersWithKey {}
 
 export const CachedProperties: { expires: number; properties: Property[] } = {

--- a/core/src/modules/ops/property.ts
+++ b/core/src/modules/ops/property.ts
@@ -4,6 +4,7 @@ import { Option } from "../../models/Option";
 import { Mapping } from "../../models/Mapping";
 import { GroupRule } from "../../models/GroupRule";
 import { internalRun } from "../internalRun";
+import { PluginOptionType } from "../../classes/plugin";
 import { Op } from "sequelize";
 import Mustache from "mustache";
 
@@ -58,7 +59,7 @@ export namespace PropertyOps {
       displayName?: string;
       description: string;
       required: boolean;
-      type: string;
+      type: PluginOptionType;
       options: Array<{
         key: string;
         description?: string;

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -3,13 +3,14 @@ import {
   GrouparooPlugin,
   PluginConnection,
   PluginApp,
+  AppOption,
 } from "../classes/plugin";
 import { Option } from "./../models/Option";
 import { Source } from "./../models/Source";
 import { Destination } from "./../models/Destination";
 import { Schedule, SimpleScheduleOptions } from "./../models/Schedule";
 import { Property, SimplePropertyOptions } from "../models/Property";
-import { App, AppOption } from "./../models/App";
+import { App } from "./../models/App";
 import { LoggedModel } from "../classes/loggedModel";
 import { LockableHelper } from "./lockableHelper";
 import { plural } from "pluralize";

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -3,7 +3,7 @@ import {
   GrouparooPlugin,
   PluginConnection,
   PluginApp,
-  AppOption,
+  AppOptionsOption,
 } from "../classes/plugin";
 import { Option } from "./../models/Option";
 import { Source } from "./../models/Source";
@@ -392,7 +392,7 @@ export namespace OptionHelper {
   ) {
     const plugin = await getPlugin(instance);
 
-    let options: AppOption[] = [];
+    let options: AppOptionsOption[] = [];
     if (instance instanceof App && plugin.pluginApp) {
       options = plugin.pluginApp.options;
     } else if (

--- a/plugins/@grouparoo/app-templates/src/source/query/meta.ts
+++ b/plugins/@grouparoo/app-templates/src/source/query/meta.ts
@@ -15,7 +15,7 @@ import {
   GetChangedRowsMethod,
 } from "./options";
 import { GetTablesMethod } from "../table";
-import { ConnectionOption } from "@grouparoo/core";
+import { ConnectionOptionsOption } from "@grouparoo/core";
 
 export interface BuildConnectionMethod {
   (argument: {
@@ -24,7 +24,7 @@ export interface BuildConnectionMethod {
     app: string;
     tableOptionDescription?: string;
     tableOptionDisplayName?: string;
-    options?: ConnectionOption[];
+    options?: ConnectionOptionsOption[];
     executeQuery: ExecuteQueryMethod;
     validateQuery?: ValidateQueryMethod;
     getChangedRows?: GetChangedRowsMethod;

--- a/plugins/@grouparoo/app-templates/src/source/table/pluginMethods.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/pluginMethods.ts
@@ -1,5 +1,5 @@
 import {
-  ConnectionOption,
+  ConnectionOptionsOption,
   PropertyTypes,
   SimpleAppOptions,
   SimpleSourceOptions,
@@ -92,7 +92,7 @@ export interface GetPropertyValuesMethod {
   }): Promise<{ [primaryKey: string]: { [column: string]: DataResponse[] } }>;
 }
 export interface SourceOptionsExtra {
-  options: ConnectionOption[];
+  options: ConnectionOptionsOption[];
   // TODO later: can pass method here.
 }
 export interface TableDefinition {

--- a/plugins/@grouparoo/app-templates/src/source/table/sourceOptions.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/sourceOptions.ts
@@ -42,7 +42,7 @@ export const getSourceOptions: GetSourceOptionsMethod = ({
       response[option.key] = {
         // for now all strings, not lists.
         // we'd need a method to do that or pass in the options.
-        type: "string",
+        type: "text",
       };
     }
 

--- a/plugins/@grouparoo/csv/src/lib/remote-import/sourceOptions.ts
+++ b/plugins/@grouparoo/csv/src/lib/remote-import/sourceOptions.ts
@@ -5,7 +5,7 @@ import {
 
 export const sourceOptions: SourceOptionsMethod = async () => {
   const response: SourceOptionsMethodResponse = {
-    url: { type: "string", options: [], descriptions: [] },
+    url: { type: "text", options: [], descriptions: [] },
     fileAgeHours: {
       type: "list",
       options: ["1", "6", "12", "24"],

--- a/plugins/@grouparoo/mailchimp/src/lib/shared/connectionOptions.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/shared/connectionOptions.ts
@@ -4,7 +4,7 @@ import {
   SimpleAppOptions,
   SimpleSourceOptions,
   SimpleDestinationOptions,
-  PluginOptionTypes,
+  PluginOptionType,
   App,
 } from "@grouparoo/core";
 import { connect } from "../connect";
@@ -22,7 +22,7 @@ export interface ConnectionOptionsMethod {
 }
 export interface ConnectionMethodResponse {
   [optionName: string]: {
-    type: PluginOptionTypes;
+    type: PluginOptionType;
     options?: string[];
     descriptions?: string[];
   };

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -291,7 +291,7 @@ export namespace helper {
               };
               if (sourceOptions.options)
                 response["receivedOptions"] = {
-                  type: "string",
+                  type: "text",
                   options: [sourceOptions.options],
                 };
               return response;
@@ -405,7 +405,7 @@ export namespace helper {
               };
               if (destinationOptions.options)
                 response["receivedOptions"] = {
-                  type: "string",
+                  type: "text",
                   options: [destinationOptions.options],
                 };
               return response;
@@ -460,7 +460,7 @@ export namespace helper {
               };
               if (destinationOptions.options)
                 response["receivedOptions"] = {
-                  type: "string",
+                  type: "text",
                   options: [destinationOptions.options],
                 };
               return response;

--- a/ui/ui-components/pages/app/[id]/edit.tsx
+++ b/ui/ui-components/pages/app/[id]/edit.tsx
@@ -309,6 +309,19 @@ export default function Page(props) {
                                 </Form.Text>
                               </>
                             );
+                          } else if (
+                            optionOptions[opt.key]?.type === "pending"
+                          ) {
+                            return (
+                              <>
+                                <Form.Control
+                                  size="sm"
+                                  disabled
+                                  type="text"
+                                  value="pending another selection"
+                                ></Form.Control>
+                              </>
+                            );
                           } else {
                             return (
                               <>
@@ -317,7 +330,7 @@ export default function Page(props) {
                                   type={
                                     optionOptions[opt.key]?.type === "password"
                                       ? "password"
-                                      : "text"
+                                      : "text" // textarea not supported here
                                   }
                                   disabled={loading}
                                   defaultValue={app.options[

--- a/ui/ui-components/pages/destination/[id]/edit.tsx
+++ b/ui/ui-components/pages/destination/[id]/edit.tsx
@@ -35,7 +35,9 @@ export default function Page(props) {
   );
   const [loading, setLoading] = useState(false);
   const [loadingOptions, setLoadingOptions] = useState(false);
-  const [connectionOptions, setConnectionOptions] = useState({});
+  const [connectionOptions, setConnectionOptions] = useState<
+    Actions.DestinationConnectionOptions["options"]
+  >({});
   const { id } = router.query;
 
   useEffect(() => {
@@ -345,7 +347,7 @@ export default function Page(props) {
                               type={
                                 connectionOptions[opt.key]?.type === "password"
                                   ? "password"
-                                  : "text"
+                                  : "text" // textarea not supported here
                               }
                               disabled={loading || loadingOptions}
                               defaultValue={destination.options[

--- a/ui/ui-components/pages/property/[id]/edit.tsx
+++ b/ui/ui-components/pages/property/[id]/edit.tsx
@@ -403,14 +403,14 @@ export default function Page(props) {
                     </>
                   ) : null}
 
-                  {/* textarea options */}
-                  {opt.type === "text" ? (
+                  {/* text options */}
+                  {opt.type === "text" || opt.type === "password" ? (
                     <>
                       <Form.Group controlId="key">
                         <Form.Control
                           required
                           disabled={loading}
-                          type="text"
+                          type={opt.type}
                           value={property.options[opt.key]?.toString()}
                           onChange={(e) =>
                             updateOption(opt.key, e.target.value)
@@ -426,7 +426,7 @@ export default function Page(props) {
                     </>
                   ) : null}
 
-                  {/* text options */}
+                  {/* textarea options */}
                   {opt.type === "textarea" ? (
                     <>
                       <Form.Group controlId="key">
@@ -483,8 +483,21 @@ export default function Page(props) {
                       </p>
                     </>
                   ) : null}
+
+                  {/* pending options */}
+                  {opt.type === "pending" ? (
+                    <>
+                      <Form.Control
+                        size="sm"
+                        disabled
+                        type="text"
+                        value="pending another selection"
+                      ></Form.Control>
+                    </>
+                  ) : null}
                 </div>
               ))}
+
               {filterOptions.length > 0 ? (
                 <>
                   <hr />

--- a/ui/ui-components/pages/source/[id]/edit.tsx
+++ b/ui/ui-components/pages/source/[id]/edit.tsx
@@ -152,7 +152,7 @@ export default function Page(props) {
   // not every row returned is guaranteed to have the same columns
   const previewColumns = preview
     .map((row) => Object.keys(row))
-    .flat()
+    .reduce((acc, val) => acc.concat(val), [])
     .filter((value, index, self) => {
       return self.indexOf(value) === index;
     });
@@ -337,7 +337,7 @@ export default function Page(props) {
                               type={
                                 connectionOptions[opt.key]?.type === "password"
                                   ? "password"
-                                  : "text"
+                                  : "text" // textarea not supported here
                               }
                               disabled={loading || loadingOptions}
                               defaultValue={source.options[opt.key]?.toString()}


### PR DESCRIPTION
Provides better types for the Options that plugins can provide when declaring their AppOptions, SourceOptions, PropertyOptions, and DestinationOptions.  These types are used to help display and edit these options in the UIs.

```ts
export type PluginOptionType =
  | "list"
  | "typeahead"
  | "text"
  | "textarea"
  | "password"
  | "pending";
```

So you you'll get an error if you try to add an option type that isn't supported
![Screen Shot 2021-08-18 at 9 29 56 AM](https://user-images.githubusercontent.com/303226/129936608-bd585c18-0e22-4c59-8109-71c3b2e26484.png)
