### PR TITLE
Do not consider null responses when mapping non-unique value property responses

### DIFF
--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -309,9 +309,15 @@ export namespace SourceOps {
           );
         }
 
-        valueMap[property.id][
-          profileProperties[mappedProperty.key].values[0].toString()
-        ] = response[profile.id][property.id];
+        if (
+          profileProperties[mappedProperty.key].values.length > 0 &&
+          profileProperties[mappedProperty.key].values[0] !== null &&
+          profileProperties[mappedProperty.key].values[0] !== undefined
+        ) {
+          valueMap[property.id][
+            profileProperties[mappedProperty.key].values[0].toString()
+          ] = response[profile.id][property.id];
+        }
       }
     }
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/grouparoo/grouparoo/pull/2119 when the profile with a response had null data returned from the source - eg looking up an account name for an account id of null.