### PR TITLE
Better Action input Formatting

### DIFF
--- a/core/__tests__/modules/apiData.ts
+++ b/core/__tests__/modules/apiData.ts
@@ -1,0 +1,111 @@
+import { APIData } from "../../src/modules/apiData";
+
+describe("apiDAta", () => {
+  describe("#formatDate", () => {
+    test("it works for dates", () => {
+      const time = new Date(1577836801000);
+      expect(APIData.formatDate(time)).toEqual(1577836801000);
+    });
+
+    test("it works for strings", () => {
+      const time = "2020-01-01T00:00:01Z";
+      expect(APIData.formatDate(time)).toEqual(1577836801000);
+    });
+
+    test("it works for nulls", () => {
+      const time = null;
+      expect(APIData.formatDate(time)).toEqual(null);
+    });
+  });
+
+  describe("#ensureNumber", () => {
+    test("it works for numbers", () => {
+      const param = 1;
+      expect(APIData.ensureNumber(param)).toEqual(1);
+    });
+
+    test("it works for strings", () => {
+      const param = "1";
+      expect(APIData.ensureNumber(param)).toEqual(1);
+    });
+
+    test("it throws for everything else", () => {
+      const param = "foo";
+      expect(() => APIData.ensureNumber(param)).toThrow(
+        /foo cannot be converted to number/
+      );
+    });
+  });
+
+  describe("#ensureBoolean", () => {
+    test("it works for booleans", () => {
+      expect(APIData.ensureBoolean(true)).toEqual(true);
+      expect(APIData.ensureBoolean(false)).toEqual(false);
+    });
+
+    test("it works for numbers", () => {
+      expect(APIData.ensureBoolean(1)).toEqual(true);
+      expect(APIData.ensureBoolean(0)).toEqual(false);
+    });
+
+    test("it works for strings", () => {
+      expect(APIData.ensureBoolean("true")).toEqual(true);
+      expect(APIData.ensureBoolean("false")).toEqual(false);
+    });
+
+    test("it throws for everything else", () => {
+      expect(() => APIData.ensureBoolean("foo")).toThrow(
+        /foo cannot be converted to a boolean/
+      );
+      expect(() => APIData.ensureBoolean(6)).toThrow(
+        /6 cannot be converted to a boolean/
+      );
+    });
+  });
+
+  describe("#ensureObject", () => {
+    test("it works for simple objects", () => {
+      const obj = { a: 1, b: "yay", 3: false };
+      expect(APIData.ensureObject(JSON.stringify(obj))).toEqual(obj);
+    });
+
+    test("it works for nested objects", () => {
+      const obj = {
+        a: 1,
+        b: "yay",
+        3: false,
+        nested: { a: 1, something: "else" },
+      };
+      expect(APIData.ensureObject(JSON.stringify(obj))).toEqual(obj);
+    });
+
+    test("it works for simple arrays", () => {
+      const obj = [1, 2, "3", "four", false];
+      expect(APIData.ensureObject(JSON.stringify(obj))).toEqual(obj);
+    });
+
+    test("it works for nested arrays", () => {
+      const obj = [1, 2, "3", "four", false, { a: 1 }, { foo: "bar" }];
+      expect(APIData.ensureObject(JSON.stringify(obj))).toEqual(obj);
+    });
+
+    test("it works for partially stringified arrays", () => {
+      const obj = [
+        JSON.stringify({ a: 1, b: 2, c: "three" }),
+        JSON.stringify({ a: 4, b: 5, c: "six" }),
+      ];
+      expect(APIData.ensureObject(obj)).toEqual([
+        {
+          a: 1,
+          b: 2,
+          c: "three",
+        },
+        {
+          a: 4,
+          b: 5,
+          c: "six",
+        },
+      ]);
+    });
+  });
+});

--- a/core/src/actions/apps.ts
+++ b/core/src/actions/apps.ts
@@ -4,6 +4,7 @@ import { App } from "../models/App";
 import { GrouparooPlugin, PluginApp } from "../classes/plugin";
 import { OptionHelper } from "../modules/optionHelper";
 import { ConfigWriter } from "../modules/configWriter";
+import { APIData } from "../modules/apiData";
 
 export class AppsList extends AuthenticatedAction {
   constructor() {
@@ -13,11 +14,12 @@ export class AppsList extends AuthenticatedAction {
     this.permission = { topic: "app", mode: "read" };
     this.outputExample = {};
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: { required: true, default: 100, formatter: APIData.ensureNumber },
+      offset: { required: true, default: 0, formatter: APIData.ensureNumber },
       state: { required: false },
       order: {
         required: false,
+        formatter: APIData.ensureObject,
         default: [
           ["name", "desc"],
           ["createdAt", "desc"],
@@ -143,7 +145,7 @@ export class AppCreate extends AuthenticatedAction {
       name: { required: false },
       type: { required: true },
       state: { required: false },
-      options: { required: false },
+      options: { required: false, formatter: APIData.ensureObject },
     };
   }
 
@@ -174,15 +176,13 @@ export class AppEdit extends AuthenticatedAction {
       name: { required: false },
       type: { required: false },
       state: { required: false },
-      options: { required: false },
+      options: { required: false, formatter: APIData.ensureObject },
     };
   }
 
   async runWithinTransaction({ params }) {
     const app = await App.findById(params.id);
-    if (params.options) {
-      await app.setOptions(params.options);
-    }
+    if (params.options) await app.setOptions(params.options);
     await app.update(params);
 
     await ConfigWriter.run();
@@ -200,7 +200,7 @@ export class AppTest extends AuthenticatedAction {
     this.permission = { topic: "app", mode: "write" };
     this.inputs = {
       id: { required: true },
-      options: { required: false },
+      options: { required: false, formatter: APIData.ensureObject },
     };
   }
 

--- a/core/src/actions/config.ts
+++ b/core/src/actions/config.ts
@@ -3,6 +3,7 @@ import { OptionallyAuthenticatedAction } from "../classes/actions/optionallyAuth
 import { spawnPromise } from "../modules/spawnPromise";
 import { ConfigUser } from "../modules/configUser";
 import { ConfigWriter } from "../modules/configWriter";
+import { APIData } from "../modules/apiData";
 
 export class ConfigValidate extends AuthenticatedAction {
   constructor() {
@@ -14,15 +15,16 @@ export class ConfigValidate extends AuthenticatedAction {
       local: {
         required: true,
         default: "false",
+        formatter: APIData.ensureBoolean,
       },
     };
     this.outputExample = {};
   }
 
-  async runWithinTransaction({ params }) {
+  async runWithinTransaction({ params }: { params: { local: boolean } }) {
     return spawnPromise("./node_modules/.bin/grouparoo", [
       "validate",
-      params.local === "true" ? `--validate` : null,
+      params.local === true ? `--validate` : null,
     ]);
   }
 }
@@ -37,16 +39,16 @@ export class ConfigApply extends AuthenticatedAction {
       local: {
         required: true,
         default: false,
-        formatter: (p) => p.trim() === "true",
+        formatter: APIData.ensureBoolean,
       },
     };
     this.outputExample = {};
   }
 
-  async runWithinTransaction({ params }) {
+  async runWithinTransaction({ params }: { params: { local: boolean } }) {
     return spawnPromise("./node_modules/.bin/grouparoo", [
       "apply",
-      params.local === "true" ? `--validate` : null,
+      params.local === true ? `--validate` : null,
     ]);
   }
 }

--- a/core/src/actions/exportProcessors.ts
+++ b/core/src/actions/exportProcessors.ts
@@ -1,5 +1,6 @@
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { ExportProcessor } from "../models/ExportProcessor";
+import { APIData } from "../modules/apiData";
 
 export class ExportProcessorsList extends AuthenticatedAction {
   constructor() {
@@ -10,12 +11,13 @@ export class ExportProcessorsList extends AuthenticatedAction {
     this.permission = { topic: "export", mode: "read" };
     this.inputs = {
       destinationId: { required: false },
-      limit: { required: true, default: 100 },
-      offset: { required: true, default: 0 },
+      limit: { required: true, default: 100, formatter: APIData.ensureNumber },
+      offset: { required: true, default: 0, formatter: APIData.ensureNumber },
       state: { required: false },
       order: {
         required: false,
         default: [["createdAt", "desc"]],
+        formatter: APIData.ensureObject,
       },
     };
   }

--- a/core/src/actions/exports.ts
+++ b/core/src/actions/exports.ts
@@ -3,6 +3,7 @@ import { Export } from "../models/Export";
 import { ExportOps } from "../modules/ops/export";
 import { Destination } from "../models/Destination";
 import { Op } from "sequelize";
+import { APIData } from "../modules/apiData";
 
 export class ExportsList extends AuthenticatedAction {
   constructor() {
@@ -15,11 +16,12 @@ export class ExportsList extends AuthenticatedAction {
       profileId: { required: false },
       destinationId: { required: false },
       exportProcessorId: { required: false },
-      limit: { required: true, default: 100 },
-      offset: { required: true, default: 0 },
+      limit: { required: true, default: 100, formatter: APIData.ensureNumber },
+      offset: { required: true, default: 0, formatter: APIData.ensureNumber },
       state: { required: false },
       order: {
         required: false,
+        formatter: APIData.ensureObject,
         default: [["createdAt", "desc"]],
       },
     };

--- a/core/src/actions/files.ts
+++ b/core/src/actions/files.ts
@@ -2,6 +2,7 @@ import { api } from "actionhero";
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { File } from "../models/File";
 import fs from "fs-extra";
+import { APIData } from "../modules/apiData";
 
 export class FilesList extends AuthenticatedAction {
   constructor() {
@@ -11,10 +12,11 @@ export class FilesList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "file", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: { required: true, default: 100, formatter: APIData.ensureNumber },
+      offset: { required: true, default: 0, formatter: APIData.ensureNumber },
       order: {
         required: false,
+        formatter: APIData.ensureObject,
         default: [
           ["type", "desc"],
           ["path", "desc"],

--- a/core/src/actions/imports.ts
+++ b/core/src/actions/imports.ts
@@ -1,6 +1,7 @@
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { Import } from "../models/Import";
 import { Property } from "../models/Property";
+import { APIData } from "../modules/apiData";
 
 export class ImportsList extends AuthenticatedAction {
   constructor() {
@@ -12,10 +13,11 @@ export class ImportsList extends AuthenticatedAction {
     this.inputs = {
       creatorId: { required: false },
       profileId: { required: false },
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: { required: true, default: 100, formatter: APIData.ensureNumber },
+      offset: { required: true, default: 0, formatter: APIData.ensureNumber },
       order: {
         required: false,
+        formatter: APIData.ensureObject,
         default: [["createdAt", "desc"]],
       },
     };

--- a/core/src/actions/logs.ts
+++ b/core/src/actions/logs.ts
@@ -2,6 +2,7 @@ import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { ProfileProperty } from "../models/ProfileProperty";
 import { Log } from "../models/Log";
 import { Op } from "sequelize";
+import { APIData } from "../modules/apiData";
 
 export class LogsList extends AuthenticatedAction {
   constructor() {
@@ -14,10 +15,11 @@ export class LogsList extends AuthenticatedAction {
       topic: { required: false },
       verb: { required: false },
       ownerId: { required: false },
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: { required: true, default: 100, formatter: APIData.ensureNumber },
+      offset: { required: true, default: 0, formatter: APIData.ensureNumber },
       order: {
         required: false,
+        formatter: APIData.ensureObject,
         default: [
           ["createdAt", "desc"],
           ["topic", "desc"],

--- a/core/src/actions/notifications.ts
+++ b/core/src/actions/notifications.ts
@@ -1,6 +1,7 @@
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { Notification } from "../models/Notification";
 import { Op } from "sequelize";
+import { APIData } from "../modules/apiData";
 
 export class NotificationsList extends AuthenticatedAction {
   constructor() {
@@ -10,10 +11,11 @@ export class NotificationsList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "notification", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: { required: true, default: 100, formatter: APIData.ensureNumber },
+      offset: { required: true, default: 0, formatter: APIData.ensureNumber },
       order: {
         required: false,
+        formatter: APIData.ensureObject,
         default: [["createdAt", "desc"]],
       },
     };

--- a/core/src/actions/plugins.ts
+++ b/core/src/actions/plugins.ts
@@ -4,6 +4,7 @@ import { Plugins } from "../modules/plugins";
 import { api } from "actionhero";
 import path from "path";
 import fs from "fs";
+import { APIData } from "../modules/apiData";
 
 const restartSleepTime = 100;
 
@@ -55,13 +56,19 @@ export class PluginInstall extends AuthenticatedAction {
     this.permission = { topic: "system", mode: "write" };
     this.inputs = {
       plugin: { required: true },
-      restart: { required: false, default: "false" },
+      restart: {
+        required: false,
+        default: false,
+        formatter: APIData.ensureBoolean,
+      },
     };
     this.outputExample = {};
   }
 
   async runWithinTransaction({
     params,
+  }: {
+    params: { plugin: string; restart: boolean };
   }): Promise<{ success: boolean; checkIn?: number }> {
     const response = await Plugins.install(params.plugin);
 
@@ -82,12 +89,20 @@ export class PluginUninstall extends AuthenticatedAction {
     this.permission = { topic: "system", mode: "write" };
     this.inputs = {
       plugin: { required: true },
-      restart: { required: false, default: "false" },
+      restart: {
+        required: false,
+        default: false,
+        formatter: APIData.ensureBoolean,
+      },
     };
     this.outputExample = {};
   }
 
-  async runWithinTransaction({ params }) {
+  async runWithinTransaction({
+    params,
+  }: {
+    params: { plugin: string; restart: boolean };
+  }) {
     const response = await Plugins.uninstall(params.plugin);
 
     if (!response.success) return { success: false };

--- a/core/src/actions/profiles.ts
+++ b/core/src/actions/profiles.ts
@@ -8,6 +8,7 @@ import { ConfigWriter } from "../modules/configWriter";
 import { ProfileOps } from "../modules/ops/profile";
 import { AsyncReturnType } from "type-fest";
 import Sequelize from "sequelize";
+import { APIData } from "../modules/apiData";
 
 export class ProfilesList extends AuthenticatedAction {
   constructor() {
@@ -23,13 +24,13 @@ export class ProfilesList extends AuthenticatedAction {
       state: { required: false },
       caseSensitive: {
         required: false,
-        formatter: (p: string | boolean) =>
-          p.toString().toLowerCase() === "true",
+        formatter: APIData.ensureBoolean,
       },
-      limit: { required: true, default: 100 },
-      offset: { required: true, default: 0 },
+      limit: { required: true, default: 100, formatter: APIData.ensureNumber },
+      offset: { required: true, default: 0, formatter: APIData.ensureNumber },
       order: {
         required: false,
+        formatter: APIData.ensureObject,
         default: [["createdAt", "asc"]],
       },
     };
@@ -58,7 +59,11 @@ export class ProfileAutocompleteProfileProperty extends AuthenticatedAction {
       match: { required: true },
       limit: { required: false, default: 25 },
       offset: { required: false, default: 0 },
-      order: { required: false, default: [["rawValue", "asc"]] },
+      order: {
+        required: false,
+        formatter: APIData.ensureObject,
+        default: [["rawValue", "asc"]],
+      },
     };
   }
 
@@ -114,15 +119,20 @@ export class ProfileCreate extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "profile", mode: "write" };
     this.inputs = {
-      properties: { required: false, default: {} },
+      properties: {
+        required: false,
+        default: {},
+        formatter: APIData.ensureObject,
+      },
     };
   }
 
   async runWithinTransaction({ params }) {
     const profile = new Profile(params);
     await profile.save();
-    await profile.addOrUpdateProperties(params.properties);
-
+    if (params.properties) {
+      await profile.addOrUpdateProperties(params.properties);
+    }
     const groups = await profile.$get("groups");
 
     await ConfigWriter.run();
@@ -168,8 +178,16 @@ export class ProfileEdit extends AuthenticatedAction {
     this.permission = { topic: "profile", mode: "write" };
     this.inputs = {
       id: { required: true },
-      properties: { required: false, default: {} },
-      removedProperties: { required: false, default: [] },
+      properties: {
+        required: false,
+        default: {},
+        formatter: APIData.ensureObject,
+      },
+      removedProperties: {
+        required: false,
+        default: [],
+        formatter: APIData.ensureObject,
+      },
     };
   }
 
@@ -177,8 +195,12 @@ export class ProfileEdit extends AuthenticatedAction {
     const profile = await Profile.findById(params.id);
 
     await profile.update(params);
-    await profile.addOrUpdateProperties(params.properties);
-    await profile.removeProperties(params.removedProperties);
+    if (params.properties) {
+      await profile.addOrUpdateProperties(params.properties);
+    }
+    if (params.removedProperties) {
+      await profile.removeProperties(params.removedProperties);
+    }
 
     await profile.sync(false);
 

--- a/core/src/actions/reset.ts
+++ b/core/src/actions/reset.ts
@@ -9,7 +9,6 @@ export class ResetCluster extends AuthenticatedAction {
       "Reset all data in the Grouparoo Cluster except for Teams and Team Members";
     this.outputExample = {};
     this.permission = { topic: "app", mode: "write" };
-    this.inputs = {};
   }
 
   async runWithinTransaction({ session: { teamMember } }) {
@@ -25,7 +24,6 @@ export class ResetData extends AuthenticatedAction {
     this.description = "Reset the imported and exported data in this cluster";
     this.outputExample = {};
     this.permission = { topic: "app", mode: "write" };
-    this.inputs = {};
   }
 
   async runWithinTransaction({ session: { teamMember } }) {
@@ -41,7 +39,6 @@ export class ResetCache extends AuthenticatedAction {
     this.description = "Reset the cache";
     this.outputExample = {};
     this.permission = { topic: "app", mode: "write" };
-    this.inputs = {};
   }
 
   async runWithinTransaction({ session: { teamMember } }) {

--- a/core/src/actions/resque.ts
+++ b/core/src/actions/resque.ts
@@ -5,6 +5,7 @@ import { api, task, chatRoom } from "actionhero";
 import { CLS } from "../modules/cls";
 import { StatusReporters } from "../modules/statusReporters";
 import { Status } from "../modules/status";
+import { APIData } from "../modules/apiData";
 
 // Helper Classes for Permissions
 
@@ -52,7 +53,6 @@ export class ResqueRedisInfo extends ResqueActionRead {
     super();
     this.name = "resque:redisInfo";
     this.description = "I return the results of redis info";
-    this.inputs = {};
   }
 
   async runWithinTransaction() {
@@ -68,7 +68,6 @@ export class ResqueResqueDetails extends ResqueActionRead {
     super();
     this.name = "resque:resqueDetails";
     this.description = "I return the results of api.tasks.details";
-    this.inputs = {};
   }
 
   async runWithinTransaction() {
@@ -84,7 +83,6 @@ export class ResqueLoadWorkerQueues extends ResqueActionRead {
     super();
     this.name = "resque:loadWorkerQueues";
     this.description = "I return the results of api.tasks.workers";
-    this.inputs = {};
   }
 
   async runWithinTransaction() {
@@ -115,7 +113,6 @@ export class ResqueFailedCount extends ResqueActionRead {
     super();
     this.name = "resque:resqueFailedCount";
     this.description = "I return a count of failed jobs";
-    this.inputs = {};
   }
 
   async runWithinTransaction() {
@@ -134,12 +131,12 @@ export class ResqueQueued extends ResqueActionRead {
       },
       offset: {
         required: true,
-        formatter: parseInt,
+        formatter: APIData.ensureNumber,
         default: 0,
       },
       limit: {
         required: true,
-        formatter: parseInt,
+        formatter: APIData.ensureNumber,
         default: 100,
       },
     };
@@ -180,12 +177,12 @@ export class ResqueResqueFailed extends ResqueActionRead {
     this.inputs = {
       offset: {
         required: true,
-        formatter: parseInt,
+        formatter: APIData.ensureNumber,
         default: 0,
       },
       limit: {
         required: true,
-        formatter: parseInt,
+        formatter: APIData.ensureNumber,
         default: 100,
       },
     };
@@ -211,7 +208,7 @@ export class ResqueRemoveFailed extends ResqueActionWrite {
     this.inputs = {
       id: {
         required: true,
-        formatter: parseInt,
+        formatter: APIData.ensureNumber,
       },
     };
   }
@@ -229,7 +226,6 @@ export class ResqueRemoveAllFailed extends ResqueActionWrite {
     super();
     this.name = "resque:removeAllFailed";
     this.description = "I remove all failed jobs";
-    this.inputs = {};
   }
 
   async runWithinTransaction() {
@@ -251,7 +247,7 @@ export class ResqueRetryAndRemoveFailed extends ResqueActionWrite {
     this.inputs = {
       id: {
         required: true,
-        formatter: parseInt,
+        formatter: APIData.ensureNumber,
       },
     };
   }
@@ -269,7 +265,6 @@ export class ResqueRetryAndRemoveAllFailed extends ResqueActionWrite {
     super();
     this.name = "resque:retryAndRemoveAllFailed";
     this.description = "I retry all failed jobs";
-    this.inputs = {};
   }
 
   async runWithinTransaction() {
@@ -288,7 +283,6 @@ export class ResqueLocks extends ResqueActionRead {
     super();
     this.name = "resque:locks";
     this.description = "I return all locks";
-    this.inputs = {};
   }
 
   async runWithinTransaction() {
@@ -319,12 +313,12 @@ export class ResqueDelayedJobs extends ResqueActionRead {
     this.inputs = {
       offset: {
         required: true,
-        formatter: parseInt,
+        formatter: APIData.ensureNumber,
         default: 0,
       },
       limit: {
         required: true,
-        formatter: parseInt,
+        formatter: APIData.ensureNumber,
         default: 100,
       },
     };
@@ -362,11 +356,11 @@ export class ResqueDelDelayed extends ResqueActionWrite {
     this.inputs = {
       timestamp: {
         required: true,
-        formatter: parseInt,
+        formatter: APIData.ensureNumber,
       },
       count: {
         required: true,
-        formatter: parseInt,
+        formatter: APIData.ensureNumber,
       },
     };
   }
@@ -392,11 +386,11 @@ export class ResqueRunDelayed extends ResqueActionWrite {
     this.inputs = {
       timestamp: {
         required: true,
-        formatter: parseInt,
+        formatter: APIData.ensureNumber,
       },
       count: {
         required: true,
-        formatter: parseInt,
+        formatter: APIData.ensureNumber,
       },
     };
   }

--- a/core/src/actions/runs.ts
+++ b/core/src/actions/runs.ts
@@ -2,6 +2,7 @@ import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { Run } from "../models/Run";
 import { Op } from "sequelize";
 import { Schedule } from "../models/Schedule";
+import { APIData } from "../modules/apiData";
 
 export class RunsList extends AuthenticatedAction {
   constructor() {
@@ -15,10 +16,11 @@ export class RunsList extends AuthenticatedAction {
       topic: { required: false },
       state: { required: false },
       hasError: { required: false },
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: { required: true, default: 100, formatter: APIData.ensureNumber },
+      offset: { required: true, default: 0, formatter: APIData.ensureNumber },
       order: {
         required: false,
+        formatter: APIData.ensureObject,
         default: [["updatedAt", "desc"]],
       },
     };

--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -2,6 +2,7 @@ import { Schedule } from "../models/Schedule";
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { ConfigWriter } from "../modules/configWriter";
 import { FilterHelper } from "../modules/filterHelper";
+import { APIData } from "../modules/apiData";
 
 export class SchedulesList extends AuthenticatedAction {
   constructor() {
@@ -11,11 +12,12 @@ export class SchedulesList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "source", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: { required: true, default: 100, formatter: APIData.ensureNumber },
+      offset: { required: true, default: 0, formatter: APIData.ensureNumber },
       state: { required: false },
       order: {
         required: false,
+        formatter: APIData.ensureObject,
         default: [
           ["name", "desc"],
           ["createdAt", "desc"],
@@ -73,12 +75,16 @@ export class ScheduleCreate extends AuthenticatedAction {
     this.inputs = {
       name: { required: false },
       sourceId: { required: true },
-      recurring: { required: true },
-      confirmProfiles: { required: false },
+      recurring: { required: true, formatter: APIData.ensureBoolean },
+      confirmProfiles: { required: false, formatter: APIData.ensureBoolean },
       state: { required: false },
-      options: { required: false },
-      recurringFrequency: { required: true, default: 0 },
-      filters: { required: false },
+      options: { required: false, formatter: APIData.ensureObject },
+      recurringFrequency: {
+        required: true,
+        default: 0,
+        formatter: APIData.ensureNumber,
+      },
+      filters: { required: false, formatter: APIData.ensureObject },
     };
   }
 
@@ -115,12 +121,12 @@ export class ScheduleEdit extends AuthenticatedAction {
       id: { required: true },
       name: { required: false },
       sourceId: { required: false },
-      recurring: { required: false },
-      confirmProfiles: { required: false },
+      recurring: { required: false, formatter: APIData.ensureBoolean },
+      confirmProfiles: { required: false, formatter: APIData.ensureBoolean },
       state: { required: false },
-      options: { required: false },
-      recurringFrequency: { required: false },
-      filters: { required: false },
+      options: { required: false, formatter: APIData.ensureObject },
+      recurringFrequency: { required: false, formatter: APIData.ensureNumber },
+      filters: { required: false, formatter: APIData.ensureObject },
     };
   }
 

--- a/core/src/actions/settings.ts
+++ b/core/src/actions/settings.ts
@@ -2,6 +2,7 @@ import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { OptionallyAuthenticatedAction } from "../classes/actions/optionallyAuthenticatedAction";
 import { plugin } from "../modules/plugin";
 import { Setting } from "../models/Setting";
+import { APIData } from "../modules/apiData";
 
 export class SettingsList extends AuthenticatedAction {
   constructor() {
@@ -13,6 +14,7 @@ export class SettingsList extends AuthenticatedAction {
     this.inputs = {
       order: {
         required: false,
+        formatter: APIData.ensureObject,
         default: [
           ["pluginName", "desc"],
           ["title", "desc"],

--- a/core/src/actions/setupSteps.ts
+++ b/core/src/actions/setupSteps.ts
@@ -1,7 +1,7 @@
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { SetupStep } from "../models/SetupStep";
-import { Setting } from "../models/Setting";
 import { AsyncReturnType } from "type-fest";
+import { APIData } from "../modules/apiData";
 
 export class SetupStepsList extends AuthenticatedAction {
   constructor() {
@@ -41,7 +41,7 @@ export class SetupStepEdit extends AuthenticatedAction {
     this.outputExample = {};
     this.inputs = {
       id: { required: true },
-      skipped: { required: false },
+      skipped: { required: false, formatter: APIData.ensureBoolean },
     };
   }
 

--- a/core/src/actions/sources.ts
+++ b/core/src/actions/sources.ts
@@ -8,6 +8,7 @@ import { ConfigWriter } from "../modules/configWriter";
 import { PropertyTypes } from "../models/Property";
 import { AsyncReturnType } from "type-fest";
 import { TableSpeculation } from "../modules/tableSpeculation";
+import { APIData } from "../modules/apiData";
 
 export class SourcesList extends AuthenticatedAction {
   constructor() {
@@ -17,11 +18,12 @@ export class SourcesList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "source", mode: "read" };
     this.inputs = {
-      limit: { required: true, default: 100, formatter: parseInt },
-      offset: { required: true, default: 0, formatter: parseInt },
+      limit: { required: true, default: 100, formatter: APIData.ensureNumber },
+      offset: { required: true, default: 0, formatter: APIData.ensureNumber },
       state: { required: false },
       order: {
         required: false,
+        formatter: APIData.ensureObject,
         default: [
           ["appId", "desc"],
           ["createdAt", "asc"],
@@ -110,8 +112,8 @@ export class SourceCreate extends AuthenticatedAction {
       name: { required: false },
       type: { required: true },
       state: { required: false },
-      options: { required: false },
-      mapping: { required: false },
+      options: { required: false, formatter: APIData.ensureObject },
+      mapping: { required: false, formatter: APIData.ensureObject },
     };
   }
 
@@ -163,8 +165,8 @@ export class SourceEdit extends AuthenticatedAction {
       name: { required: false },
       type: { required: false },
       state: { required: false },
-      options: { required: false },
-      mapping: { required: false },
+      options: { required: false, formatter: APIData.ensureObject },
+      mapping: { required: false, formatter: APIData.ensureObject },
     };
   }
 
@@ -224,19 +226,13 @@ export class sourceConnectionOptions extends AuthenticatedAction {
     this.permission = { topic: "source", mode: "read" };
     this.inputs = {
       id: { required: true },
-      options: { required: false },
+      options: { required: false, formatter: APIData.ensureObject },
     };
   }
 
   async runWithinTransaction({ params }) {
     const source = await Source.findById(params.id);
-
-    const options =
-      typeof params.options === "string"
-        ? JSON.parse(params.options)
-        : params.options;
-
-    return { options: await source.sourceConnectionOptions(options) };
+    return { options: await source.sourceConnectionOptions(params.options) };
   }
 }
 
@@ -255,13 +251,7 @@ export class SourcePreview extends AuthenticatedAction {
 
   async runWithinTransaction({ params }) {
     const source = await Source.findById(params.id);
-
-    const options =
-      typeof params.options === "string"
-        ? JSON.parse(params.options)
-        : params.options;
-
-    const preview = await source.sourcePreview(options);
+    const preview = await source.sourcePreview(params.options);
 
     const columnSpeculation: {
       [column: string]: {

--- a/core/src/actions/sources.ts
+++ b/core/src/actions/sources.ts
@@ -245,7 +245,7 @@ export class SourcePreview extends AuthenticatedAction {
     this.permission = { topic: "source", mode: "read" };
     this.inputs = {
       id: { required: true },
-      options: { required: false },
+      options: { required: false, formatter: APIData.ensureObject },
     };
   }
 

--- a/core/src/actions/teamMembers.ts
+++ b/core/src/actions/teamMembers.ts
@@ -1,6 +1,7 @@
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { Team } from "../models/Team";
 import { TeamMember } from "../models/TeamMember";
+import { APIData } from "../modules/apiData";
 import { GrouparooSubscription } from "../modules/grouparooSubscription";
 
 export class TeamMembersList extends AuthenticatedAction {
@@ -45,7 +46,11 @@ export class TeamMemberCreate extends AuthenticatedAction {
       lastName: { required: true },
       password: { required: true },
       email: { required: true },
-      subscribed: { required: false, default: true },
+      subscribed: {
+        required: false,
+        default: true,
+        formatter: APIData.ensureBoolean,
+      },
     };
   }
 

--- a/core/src/modules/apiData.ts
+++ b/core/src/modules/apiData.ts
@@ -1,4 +1,51 @@
 export namespace APIData {
+  export function ensureObject(
+    param: { [key: string]: any } | string,
+    recursing = false
+  ) {
+    if (!param) {
+      return null;
+    } else if (Array.isArray(param)) {
+      try {
+        return param.map((row) => APIData.ensureObject(row, true));
+      } catch (error) {
+        throw new Error(
+          `${param} cannot be converted to JSON object (${error})`
+        );
+      }
+    } else if (typeof param === "string") {
+      try {
+        return JSON.parse(param) as { [key: string]: any };
+      } catch (error) {
+        if (recursing) {
+          return param;
+        } else {
+          throw new Error(
+            `${param} cannot be converted to JSON object (${error})`
+          );
+        }
+      }
+    } else {
+      return param;
+    }
+  }
+
+  export function ensureBoolean(param: boolean | string | number) {
+    if (param === true || param === false) return param;
+    if (param === 1 || param === "1" || param === "true") return true;
+    if (param === 0 || param === "0" || param === "false") return false;
+    throw new Error(`${param} cannot be converted to a boolean`);
+  }
+
+  export function ensureNumber(param: string | number) {
+    if (typeof param === "number") return param;
+    try {
+      return parseFloat(param);
+    } catch (error) {
+      throw new Error(`${param} cannot be converted to number (${error})`);
+    }
+  }
+
   export function formatDate(date: Date | string) {
     if (!date || date === "") return null;
     else if (date instanceof Date) return date.getTime();

--- a/core/src/modules/apiData.ts
+++ b/core/src/modules/apiData.ts
@@ -40,7 +40,9 @@ export namespace APIData {
   export function ensureNumber(param: string | number) {
     if (typeof param === "number") return param;
     try {
-      return parseFloat(param);
+      const parsed = parseFloat(param);
+      if (isNaN(parsed)) throw new Error("NaN");
+      return parsed;
     } catch (error) {
       throw new Error(`${param} cannot be converted to number (${error})`);
     }


### PR DESCRIPTION
This PR introduces a number of Action input formatters to help with non-string types: Booleans, Number, and nested JSON objects.  This allows the Grouparoo API to be accessed by simple CURL methods:

```bash
curl 
  -X PUT 
  -d 'apiKey=xxxxxxxxxxxxxxx' 
  -d 'options={"table":"users"}' 
  -d 'mapping={"id":"userId"}' 
  -d 'state=ready' 
'http://localhost:3000/api/v1/source/users_table'
```