### PR TITLE
Non-unique mapping returns `undefined` when a match doesn't exist

### DIFF
--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -1035,7 +1035,7 @@ describe("models/source", () => {
         });
       });
 
-      test("it returns null when the source does not have a record for the property", async () => {
+      test("it returns undefined when the source does not have a record for the property", async () => {
         await luigi.addOrUpdateProperties({ lastName: ["x"] }); // change the value of the property that is mapped
 
         const profiles = [mario, luigi];
@@ -1051,7 +1051,7 @@ describe("models/source", () => {
 
         expect(response).toEqual({
           [mario.id]: { wordInSpanish: ["hola"], wordInFrench: ["bonjour"] },
-          [luigi.id]: { wordInSpanish: [null], wordInFrench: [null] },
+          [luigi.id]: { wordInSpanish: undefined, wordInFrench: undefined },
         });
       });
     });

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -329,10 +329,10 @@ export namespace SourceOps {
         for (const propertyKey of Object.keys(valueMap)) {
           const lookupValue =
             profileProperties[mappedProperty.key]?.values[0]?.toString();
-          response[profile.id][propertyKey] =
-            lookupValue && valueMap[propertyKey][lookupValue] !== undefined
-              ? valueMap[propertyKey][lookupValue]
-              : [null];
+          if (lookupValue) {
+            response[profile.id][propertyKey] =
+              valueMap[propertyKey][lookupValue];
+          }
         }
       }
     }


### PR DESCRIPTION
For unique mappings, no value (`undefined`) is returned for properties of non-existent profiles. `keepValueIfNotFound` relies on this behavior to know when a value was set or not for a property and either set the value to `null` or keep the old value. 

This PR changes non-unique mappings to exhibit the same behavior so `keepValueIfNotFound` works the same way. Because we're still setting the value to `null` if needed, there shouldn't be an issue with returning `undefined` at this step.