### PR TITLE
resolve pending properties before sync-importing dependent source

### DIFF
--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -482,10 +482,13 @@ export namespace ProfileOps {
         const { canImport, properties } = await source.import(profile);
 
         // We need to save each property as it is loaded so it can be used as a mapping for the next source
-        if (canImport && toSave) {
+        if (toSave) {
           await addOrUpdateProperties([profile], [properties], false);
-          await resolvePendingProperties(profile, source.id);
           await buildNullProperties([profile]);
+
+          if (canImport) {
+            await resolvePendingProperties(profile, source.id);
+          }
         }
       }
 

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -387,6 +387,7 @@ export namespace ProfileOps {
         state: "ready",
         rawValue: null,
         stateChangedAt: new Date(),
+        valueChangedAt: new Date(),
         confirmedAt: new Date(),
       },
       { where: { id: clearProfilePropertyIds } }


### PR DESCRIPTION
When synchronously importing a profile via the "Import and Export" button, importing properties that depended on another property that was found to no longer exist would use the old value for the calculation. This is because these non-existent values were being cleared _after_ all sources completed importing. 

This change moves the resolution of pending properties for a source to right after properties for that source are updated, so the next source has the cleared value if necessary.