### PR TITLE
`schedules:run` action to run all Schedules

### DIFF
--- a/core/__tests__/integration/happyPath.ts
+++ b/core/__tests__/integration/happyPath.ts
@@ -416,12 +416,12 @@ describe("integration/happyPath", () => {
         csrfToken,
         id: scheduleId,
       };
-      const { error, success } = await specHelper.runAction<ScheduleRun>(
+      const { error, run } = await specHelper.runAction<ScheduleRun>(
         "schedule:run",
         connection
       );
       expect(error).toBeUndefined();
-      expect(success).toBe(true);
+      expect(run.id).toBeTruthy();
 
       const foundTasks = await specHelper.findEnqueuedTasks("schedule:run");
       expect(foundTasks.length).toBe(1);

--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -103,6 +103,7 @@ export const DEFAULT = {
         { path: "/v:apiVersion/source", action: "source:create" },
         { path: "/v:apiVersion/source/:id/bootstrapUniqueProperty", action: "source:bootstrapUniqueProperty" },
         { path: "/v:apiVersion/schedule", action: "schedule:create" },
+        { path: "/v:apiVersion/schedules/run", action: "schedules:run" },
         { path: "/v:apiVersion/schedule/:id/run", action: "schedule:run" },
         { path: "/v:apiVersion/destination", action: "destination:create" },
         { path: "/v:apiVersion/destination/:id/export", action: "destination:export" },

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -223,6 +223,8 @@ export class Schedule extends LoggedModel<Schedule> {
       { scheduleId: this.id, runId: run.id },
       "schedules"
     );
+
+    return run;
   }
 
   async resetHighWatermarks() {

--- a/plugins/@grouparoo/csv/__tests__/integration/csv-file.ts
+++ b/plugins/@grouparoo/csv/__tests__/integration/csv-file.ts
@@ -241,12 +241,12 @@ describe("integration/runs/csv/file", () => {
           csrfToken,
           id: schedule.id,
         };
-        const { error, success } = await specHelper.runAction<ScheduleRun>(
+        const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
           "schedule:run",
           session
         );
         expect(error).toBeUndefined();
-        expect(success).toBe(true);
+        expect(apiRun.id).toBeTruthy();
 
         // check that the run is enqueued
         const found = await specHelper.findEnqueuedTasks("schedule:run");
@@ -254,11 +254,7 @@ describe("integration/runs/csv/file", () => {
         expect(found[0].args[0].scheduleId).toBe(schedule.id);
 
         // run the schedule
-        const run = await Run.create({
-          creatorId: schedule.id,
-          creatorType: "schedule",
-          state: "running",
-        });
+        const run = await Run.findById(apiRun.id);
 
         // run the schedule twice to complete the run
         await specHelper.runTask("schedule:run", { runId: run.id });
@@ -327,12 +323,12 @@ describe("integration/runs/csv/file", () => {
           csrfToken,
           id: schedule.id,
         };
-        const { error, success } = await specHelper.runAction<ScheduleRun>(
+        const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
           "schedule:run",
           session
         );
         expect(error).toBeUndefined();
-        expect(success).toBe(true);
+        expect(apiRun.id).toBeTruthy();
 
         // check that the run is enqueued
         const found = await specHelper.findEnqueuedTasks("schedule:run");
@@ -340,11 +336,7 @@ describe("integration/runs/csv/file", () => {
         expect(found[1].args[0].scheduleId).toBe(schedule.id);
 
         // run the schedule
-        const run = await Run.create({
-          creatorId: schedule.id,
-          creatorType: "schedule",
-          state: "running",
-        });
+        const run = await Run.findById(apiRun.id);
 
         // run the schedule twice to complete the run
         await specHelper.runTask("schedule:run", { runId: run.id });

--- a/plugins/@grouparoo/csv/__tests__/integration/csv-remote.ts
+++ b/plugins/@grouparoo/csv/__tests__/integration/csv-remote.ts
@@ -216,12 +216,12 @@ describe("integration/runs/csv/remote", () => {
           csrfToken,
           id: schedule.id,
         };
-        const { error, success } = await specHelper.runAction<ScheduleRun>(
+        const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
           "schedule:run",
           session
         );
         expect(error).toBeUndefined();
-        expect(success).toBe(true);
+        expect(apiRun.id).toBeTruthy();
 
         // check that the run is enqueued
         const found = await specHelper.findEnqueuedTasks("schedule:run");
@@ -229,11 +229,7 @@ describe("integration/runs/csv/remote", () => {
         expect(found[0].args[0].scheduleId).toBe(schedule.id);
 
         // run the schedule
-        const run = await Run.create({
-          creatorId: schedule.id,
-          creatorType: "schedule",
-          state: "running",
-        });
+        const run = await Run.findById(apiRun.id);
 
         // run the schedule twice to complete the run
         await specHelper.runTask("schedule:run", { runId: run.id });
@@ -302,12 +298,12 @@ describe("integration/runs/csv/remote", () => {
           csrfToken,
           id: schedule.id,
         };
-        const { error, success } = await specHelper.runAction<ScheduleRun>(
+        const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
           "schedule:run",
           session
         );
         expect(error).toBeUndefined();
-        expect(success).toBe(true);
+        expect(apiRun.id).toBeTruthy();
 
         // check that the run is enqueued
         const found = await specHelper.findEnqueuedTasks("schedule:run");
@@ -315,11 +311,7 @@ describe("integration/runs/csv/remote", () => {
         expect(found[1].args[0].scheduleId).toBe(schedule.id);
 
         // run the schedule
-        const run = await Run.create({
-          creatorId: schedule.id,
-          creatorType: "schedule",
-          state: "running",
-        });
+        const run = await Run.findById(apiRun.id);
 
         // run the schedule twice to complete the run
         await specHelper.runTask("schedule:run", { runId: run.id });

--- a/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
+++ b/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
@@ -253,12 +253,12 @@ describe("integration/runs/google-sheets", () => {
           csrfToken,
           id: schedule.id,
         };
-        const { error, success } = await specHelper.runAction<ScheduleRun>(
+        const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
           "schedule:run",
           session
         );
         expect(error).toBeUndefined();
-        expect(success).toBe(true);
+        expect(apiRun.id).toBeTruthy();
 
         // check that the run is enqueued
         const found = await specHelper.findEnqueuedTasks("schedule:run");
@@ -266,11 +266,7 @@ describe("integration/runs/google-sheets", () => {
         expect(found[0].args[0].scheduleId).toBe(schedule.id);
 
         // run the schedule
-        const run = await Run.create({
-          creatorId: schedule.id,
-          creatorType: "schedule",
-          state: "running",
-        });
+        const run = await Run.findById(apiRun.id);
 
         // run the schedule twice to complete the run
         await specHelper.runTask("schedule:run", { runId: run.id });
@@ -351,19 +347,20 @@ describe("integration/runs/google-sheets", () => {
           csrfToken,
           id: schedule.id,
         };
-        const { error, success } = await specHelper.runAction<ScheduleRun>(
+        const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
           "schedule:run",
           session
         );
         expect(error).toBeUndefined();
-        expect(success).toBe(true);
+        expect(apiRun.id).toBeTruthy();
+
+        // check that the run is enqueued
+        const found = await specHelper.findEnqueuedTasks("schedule:run");
+        expect(found.length).toEqual(2);
+        expect(found[1].args[0].scheduleId).toBe(schedule.id);
 
         // run the schedule
-        const run = await Run.create({
-          creatorId: schedule.id,
-          creatorType: "schedule",
-          state: "running",
-        });
+        const run = await Run.findById(apiRun.id);
 
         // run the schedule twice to complete the run
         await specHelper.runTask("schedule:run", { runId: run.id });

--- a/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-import.ts
+++ b/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-import.ts
@@ -261,12 +261,12 @@ describe("integration/runs/mailchimp-import", () => {
           csrfToken,
           id: schedule.id,
         };
-        const { error, success } = await specHelper.runAction<ScheduleRun>(
+        const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
           "schedule:run",
           session
         );
         expect(error).toBeUndefined();
-        expect(success).toBe(true);
+        expect(apiRun.id).toBeTruthy();
 
         // check that the run is enqueued
         const found = await specHelper.findEnqueuedTasks("schedule:run");
@@ -274,11 +274,7 @@ describe("integration/runs/mailchimp-import", () => {
         expect(found[0].args[0].scheduleId).toBe(schedule.id);
 
         // run the schedule
-        const run = await Run.create({
-          creatorId: schedule.id,
-          creatorType: "schedule",
-          state: "running",
-        });
+        const run = await Run.findById(apiRun.id);
 
         // run the schedule twice to complete the run
         await specHelper.runTask("schedule:run", { runId: run.id });
@@ -360,19 +356,20 @@ describe("integration/runs/mailchimp-import", () => {
           csrfToken,
           id: schedule.id,
         };
-        const { error, success } = await specHelper.runAction<ScheduleRun>(
+        const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
           "schedule:run",
           session
         );
         expect(error).toBeUndefined();
-        expect(success).toBe(true);
+        expect(apiRun.id).toBeTruthy();
+
+        // check that the run is enqueued
+        const found = await specHelper.findEnqueuedTasks("schedule:run");
+        expect(found.length).toEqual(2);
+        expect(found[1].args[0].scheduleId).toBe(schedule.id);
 
         // run the schedule
-        const run = await Run.create({
-          creatorId: schedule.id,
-          creatorType: "schedule",
-          state: "running",
-        });
+        const run = await Run.findById(apiRun.id);
 
         // run the schedule twice to complete the run
         await specHelper.runTask("schedule:run", { runId: run.id });

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -381,12 +381,12 @@ describe("integration/runs/mysql", () => {
         csrfToken,
         id: schedule.id,
       };
-      const { error, success } = await specHelper.runAction<ScheduleRun>(
+      const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
         "schedule:run",
         session
       );
       expect(error).toBeUndefined();
-      expect(success).toBe(true);
+      expect(apiRun.id).toBeTruthy();
 
       // check that the run is enqueued
       const found = await specHelper.findEnqueuedTasks("schedule:run");
@@ -394,11 +394,7 @@ describe("integration/runs/mysql", () => {
       expect(found[0].args[0].scheduleId).toBe(schedule.id);
 
       // run the schedule
-      const run = await Run.create({
-        creatorId: schedule.id,
-        creatorType: "schedule",
-        state: "running",
-      });
+      const run = await Run.findById(apiRun.id);
 
       // run the schedule twice to complete the run
       await specHelper.runTask("schedule:run", { runId: run.id });
@@ -506,19 +502,20 @@ describe("integration/runs/mysql", () => {
         csrfToken,
         id: schedule.id,
       };
-      const { error, success } = await specHelper.runAction<ScheduleRun>(
+      const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
         "schedule:run",
         session
       );
       expect(error).toBeUndefined();
-      expect(success).toBe(true);
+      expect(apiRun.id).toBeTruthy();
+
+      // check that the run is enqueued
+      const found = await specHelper.findEnqueuedTasks("schedule:run");
+      expect(found.length).toEqual(2);
+      expect(found[1].args[0].scheduleId).toBe(schedule.id);
 
       // run the schedule
-      const run = await Run.create({
-        creatorId: schedule.id,
-        creatorType: "schedule",
-        state: "running",
-      });
+      const run = await Run.findById(apiRun.id);
 
       // run the schedule twice to complete the run
       await specHelper.runTask("schedule:run", { runId: run.id });

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
@@ -372,12 +372,12 @@ describe("integration/runs/postgres", () => {
         csrfToken,
         id: schedule.id,
       };
-      const { error, success } = await specHelper.runAction<ScheduleRun>(
+      const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
         "schedule:run",
         session
       );
       expect(error).toBeUndefined();
-      expect(success).toBe(true);
+      expect(apiRun.id).toBeTruthy();
 
       // check that the run is enqueued
       const found = await specHelper.findEnqueuedTasks("schedule:run");
@@ -385,11 +385,7 @@ describe("integration/runs/postgres", () => {
       expect(found[0].args[0].scheduleId).toBe(schedule.id);
 
       // run the schedule
-      const run = await Run.create({
-        creatorId: schedule.id,
-        creatorType: "schedule",
-        state: "running",
-      });
+      const run = await Run.findById(apiRun.id);
 
       // run the schedule twice to complete the run
       await specHelper.runTask("schedule:run", { runId: run.id });
@@ -498,19 +494,20 @@ describe("integration/runs/postgres", () => {
         csrfToken,
         id: schedule.id,
       };
-      const { error, success } = await specHelper.runAction<ScheduleRun>(
+      const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
         "schedule:run",
         session
       );
       expect(error).toBeUndefined();
-      expect(success).toBe(true);
+      expect(apiRun.id).toBeTruthy();
+
+      // check that the run is enqueued
+      const found = await specHelper.findEnqueuedTasks("schedule:run");
+      expect(found.length).toEqual(2);
+      expect(found[1].args[0].scheduleId).toBe(schedule.id);
 
       // run the schedule
-      const run = await Run.create({
-        creatorId: schedule.id,
-        creatorType: "schedule",
-        state: "running",
-      });
+      const run = await Run.findById(apiRun.id);
 
       // run the schedule twice to complete the run
       await specHelper.runTask("schedule:run", { runId: run.id });

--- a/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-table-import.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-table-import.ts
@@ -359,12 +359,12 @@ describe("integration/runs/sqlite", () => {
         csrfToken,
         id: schedule.id,
       };
-      const { error, success } = await specHelper.runAction<ScheduleRun>(
+      const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
         "schedule:run",
         session
       );
       expect(error).toBeUndefined();
-      expect(success).toBe(true);
+      expect(apiRun.id).toBeTruthy();
 
       // check that the run is enqueued
       const found = await specHelper.findEnqueuedTasks("schedule:run");
@@ -372,11 +372,7 @@ describe("integration/runs/sqlite", () => {
       expect(found[0].args[0].scheduleId).toBe(schedule.id);
 
       // run the schedule
-      const run = await Run.create({
-        creatorId: schedule.id,
-        creatorType: "schedule",
-        state: "running",
-      });
+      const run = await Run.findById(apiRun.id);
 
       // run the schedule twice to complete the run
       await specHelper.runTask("schedule:run", { runId: run.id });
@@ -485,19 +481,20 @@ describe("integration/runs/sqlite", () => {
         csrfToken,
         id: schedule.id,
       };
-      const { error, success } = await specHelper.runAction<ScheduleRun>(
+      const { error, run: apiRun } = await specHelper.runAction<ScheduleRun>(
         "schedule:run",
         session
       );
       expect(error).toBeUndefined();
-      expect(success).toBe(true);
+      expect(apiRun.id).toBeTruthy();
+
+      // check that the run is enqueued
+      const found = await specHelper.findEnqueuedTasks("schedule:run");
+      expect(found.length).toEqual(2);
+      expect(found[1].args[0].scheduleId).toBe(schedule.id);
 
       // run the schedule
-      const run = await Run.create({
-        creatorId: schedule.id,
-        creatorType: "schedule",
-        state: "running",
-      });
+      const run = await Run.findById(apiRun.id);
 
       // run the schedule twice to complete the run
       await specHelper.runTask("schedule:run", { runId: run.id });

--- a/ui/ui-components/pages/sources.tsx
+++ b/ui/ui-components/pages/sources.tsx
@@ -65,8 +65,25 @@ export default function Page(props) {
   async function enqueueScheduleRun(source: Models.SourceType) {
     setLoading(true);
     try {
-      await execApi("post", `/schedule/${source.schedule.id}/run`);
-      successHandler.set({ message: "run enqueued" });
+      const response: Actions.ScheduleRun = await execApi(
+        "post",
+        `/schedule/${source.schedule.id}/run`
+      );
+      successHandler.set({ message: `run ${response.run.id} enqueued` });
+    } finally {
+      setLoading(false);
+      load();
+    }
+  }
+
+  async function enqueueAllSchedulesRun() {
+    setLoading(true);
+    try {
+      const response: Actions.SchedulesRun = await execApi(
+        "post",
+        `/schedules/run`
+      );
+      successHandler.set({ message: `${response.runs.length} runs enqueued` });
     } finally {
       setLoading(false);
       load();
@@ -78,18 +95,14 @@ export default function Page(props) {
       <Head>
         <title>Grouparoo: Sources</title>
       </Head>
-
       <h1>Sources</h1>
-
       <p>{total} sources</p>
-
       <Pagination
         total={total}
         limit={limit}
         offset={offset}
         onPress={setOffset}
       />
-
       <LoadingTable loading={loading}>
         <thead>
           <tr>
@@ -182,16 +195,13 @@ export default function Page(props) {
           })}
         </tbody>
       </LoadingTable>
-
       <Pagination
         total={total}
         limit={limit}
         offset={offset}
         onPress={setOffset}
       />
-
       <br />
-
       {process.env.GROUPAROO_UI_EDITION !== "community" ? (
         <Button
           variant="primary"
@@ -200,6 +210,15 @@ export default function Page(props) {
           }}
         >
           Add new Source
+        </Button>
+      ) : null}
+      &nbsp;
+      {process.env.GROUPAROO_UI_EDITION !== "config" ? (
+        <Button
+          variant="outline-primary"
+          onClick={() => enqueueAllSchedulesRun()}
+        >
+          Run all Schedules
         </Button>
       ) : null}
     </>

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -217,6 +217,7 @@ import {
   ScheduleDestroy,
   ScheduleEdit,
   ScheduleRun,
+  SchedulesRun,
   ScheduleView,
   ScheduleFilterOptions,
   SchedulesList,
@@ -625,6 +626,9 @@ export namespace Actions {
   >;
   export type ScheduleRun = AsyncReturnType<
     typeof ScheduleRun.prototype.runWithinTransaction
+  >;
+  export type SchedulesRun = AsyncReturnType<
+    typeof SchedulesRun.prototype.runWithinTransaction
   >;
   export type ScheduleView = AsyncReturnType<
     typeof ScheduleView.prototype.runWithinTransaction

--- a/ui/ui-enterprise/pages/source/[id]/runs.tsx
+++ b/ui/ui-enterprise/pages/source/[id]/runs.tsx
@@ -10,7 +10,7 @@ import { Button, Row, Col } from "react-bootstrap";
 import { ErrorHandler } from "../../../../ui-components/utils/errorHandler";
 import { SuccessHandler } from "../../../../ui-components/utils/successHandler";
 import { RunsHandler } from "../../../../ui-components/utils/runsHandler";
-import { Models } from "../../../../ui-components/utils/apiData";
+import { Models, Actions } from "../../../../ui-components/utils/apiData";
 
 export default function Page(props) {
   const {
@@ -30,8 +30,11 @@ export default function Page(props) {
   async function enqueueScheduleRun() {
     setLoading(true);
     try {
-      await execApi("post", `/schedule/${source.schedule.id}/run`);
-      successHandler.set({ message: "run enqueued" });
+      const response: Actions.ScheduleRun = await execApi(
+        "post",
+        `/schedule/${source.schedule.id}/run`
+      );
+      successHandler.set({ message: `run ${response.run.id} enqueued` });
       runsHandler.set(null);
     } finally {
       setLoading(false);


### PR DESCRIPTION
This PR adds a new api endpoint, `/api/v1/schedules/run` to create a run for all Schedule.  This will work for both non-recurring and recurring schedules.  If a Schedule already has run in progress, we will not create a new one.

This PR also adds a button to the Sources list on the UI to activate this new API.

![Screen Shot 2021-08-23 at 11 03 02 AM](https://user-images.githubusercontent.com/303226/130496555-032e4618-6f13-4100-83c0-832313cbe959.png)
