### PR TITLE
remove `keepValueIfNotFound`

### DIFF
--- a/core/__tests__/actions/properties.ts
+++ b/core/__tests__/actions/properties.ts
@@ -101,7 +101,6 @@ describe("actions/properties", () => {
         key: "email",
         type: "string",
         unique: "true",
-        keepValueIfNotFound: "true",
       };
 
       const { error, property, pluginOptions } =
@@ -115,7 +114,6 @@ describe("actions/properties", () => {
       expect(property.key).toBe("email");
       expect(property.unique).toBe(true);
       expect(property.isArray).toBe(false);
-      expect(property.keepValueIfNotFound).toBe(true);
       expect(property.state).toBe("draft");
       expect(property.sourceId).toBe(source.id);
       expect(pluginOptions[0].key).toBe("column");
@@ -357,7 +355,6 @@ describe("actions/properties", () => {
         csrfToken,
         id,
         unique: true,
-        keepValueIfNotFound: false,
       };
       const { error, property } = await specHelper.runAction<PropertyEdit>(
         "property:edit",
@@ -365,7 +362,6 @@ describe("actions/properties", () => {
       );
       expect(error).toBeUndefined();
       expect(property.unique).toBe(true);
-      expect(property.keepValueIfNotFound).toBe(false);
     });
 
     test("an administrator can see a profile preview of a property", async () => {

--- a/core/__tests__/fixtures/codeConfig/bootstrapped-property-in-source/config.js
+++ b/core/__tests__/fixtures/codeConfig/bootstrapped-property-in-source/config.js
@@ -60,7 +60,6 @@ module.exports = async function getConfig() {
       type: "email",
       unique: true,
       isArray: false,
-      keepValueIfNotFound: true,
       sourceId: "users_table", // sourceId -> `users_table`
       options: {
         column: "email",

--- a/core/__tests__/fixtures/codeConfig/changes/config.js
+++ b/core/__tests__/fixtures/codeConfig/changes/config.js
@@ -52,7 +52,6 @@ module.exports = async function getConfig() {
       identifying: true,
       unique: true,
       isArray: false,
-      keepValueIfNotFound: true,
       sourceId: "users_table", // sourceId -> `users_table`
       options: {
         column: "id",

--- a/core/__tests__/fixtures/codeConfig/initial/config.js
+++ b/core/__tests__/fixtures/codeConfig/initial/config.js
@@ -68,7 +68,6 @@ module.exports = async function getConfig() {
       type: "email",
       unique: true,
       isArray: false,
-      keepValueIfNotFound: true,
       sourceId: "users_table", // sourceId -> `users_table`
       options: {
         column: "email",

--- a/core/__tests__/models/profile/profile.ts
+++ b/core/__tests__/models/profile/profile.ts
@@ -1006,41 +1006,6 @@ describe("models/profile", () => {
       });
     });
 
-    test("properties marked as keepValueIfNotFound=true will not be cleared if it no longer exists", async () => {
-      await Property.update(
-        { keepValueIfNotFound: true },
-        { where: { key: "email" } }
-      );
-
-      const profile = await Profile.create();
-      await profile.addOrUpdateProperties({
-        userId: [1006],
-        email: ["myemail@demo.com"],
-      });
-      let properties = await profile.getProperties();
-      expect(Object.keys(properties).sort()).toEqual([
-        "color",
-        "email",
-        "userId",
-      ]);
-
-      importResult = {};
-      await profile.markPending();
-      await profile.import();
-
-      properties = await profile.getProperties();
-      expect(simpleProfileValues(properties)).toEqual({
-        userId: [null],
-        color: [null],
-        email: ["myemail@demo.com"],
-      });
-
-      await Property.update(
-        { keepValueIfNotFound: false },
-        { where: { key: "email" } }
-      );
-    });
-
     describe("with a dependent source", () => {
       let purchasesTable: Source;
       let daisyProfile: Profile;

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -114,7 +114,6 @@ describe("modules/codeConfig", () => {
         expect(property.type).toBe("integer");
         expect(property.unique).toBe(true);
         expect(property.identifying).toBe(true);
-        expect(property.keepValueIfNotFound).toBe(false);
         expect(property.state).toBe("ready");
         expect(property.locked).toBe("config:code");
       });
@@ -158,12 +157,6 @@ describe("modules/codeConfig", () => {
           "config:code",
           "config:code",
           "config:code",
-        ]);
-        expect(rules.map((r) => r.keepValueIfNotFound).sort()).toEqual([
-          false,
-          false,
-          false,
-          true,
         ]);
 
         const options = await Promise.all(rules.map((r) => r.getOptions()));
@@ -322,16 +315,6 @@ describe("modules/codeConfig", () => {
       expect(apps[0].locked).toBe("config:code");
       const options = await apps[0].getOptions();
       expect(options).toEqual({ fileId: "new-file-path.db" });
-    });
-
-    test("bootstrapped property can be updated to keepValueIfNotFound", async () => {
-      const property = await Property.findOne({
-        where: { directlyMapped: true },
-      });
-      expect(property.id).toBe("user_id");
-      expect(property.keepValueIfNotFound).toBe(true);
-      expect(property.state).toBe("ready");
-      expect(property.locked).toBe("config:code");
     });
 
     test("property keys changes will be updated", async () => {

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -748,8 +748,7 @@ describe("modules/configWriter", () => {
       const config = await property.getConfigObject();
       expect(config.id).toBeTruthy();
 
-      const { key, type, unique, identifying, isArray, keepValueIfNotFound } =
-        property;
+      const { key, type, unique, identifying, isArray } = property;
 
       const options = await property.$get("__options");
       expect(options.length).toEqual(1);
@@ -763,7 +762,6 @@ describe("modules/configWriter", () => {
         unique,
         identifying,
         isArray,
-        keepValueIfNotFound,
         options: Object.fromEntries(options.map((o) => [o.key, o.value])),
         filters: [
           {

--- a/core/__tests__/tasks/profileProperty/importProfileProperties.ts
+++ b/core/__tests__/tasks/profileProperty/importProfileProperties.ts
@@ -232,46 +232,6 @@ describe("tasks/profileProperty:importProfileProperties", () => {
       spy.mockRestore();
     });
 
-    test("will keep old value if the profile property no longer exists and is marked as keepValueIfNotFound=true", async () => {
-      const spy = jest
-        .spyOn(testPluginConnection.methods, "profileProperties")
-        .mockImplementation(() => undefined);
-
-      const profile: Profile = await helper.factories.profile();
-      await profile.addOrUpdateProperties({
-        userId: [99],
-        email: ["someoldemail@example.com"],
-      });
-      const profileProperty = await ProfileProperty.findOne({
-        where: { rawValue: "99" },
-      });
-      await profileProperty.update({ state: "pending" });
-
-      await Property.update(
-        { keepValueIfNotFound: true },
-        { where: { key: "email" } }
-      );
-
-      await specHelper.runTask("profileProperty:importProfileProperties", {
-        profileIds: [profile.id],
-        propertyIds: [profileProperty.propertyId],
-      });
-
-      // new value and state
-      await profileProperty.reload();
-      expect(profileProperty.state).toBe("ready");
-      expect(profileProperty.rawValue).toBe(null);
-      await profile.destroy();
-
-      // reset property
-      await Property.update(
-        { keepValueIfNotFound: false },
-        { where: { key: "email" } }
-      );
-
-      spy.mockRestore();
-    });
-
     describe("with profiles", () => {
       let profileA: Profile;
       let profileB: Profile;

--- a/core/src/actions/properties.ts
+++ b/core/src/actions/properties.ts
@@ -145,7 +145,6 @@ export class PropertyCreate extends AuthenticatedAction {
       sourceId: { required: false },
       options: { required: false, formatter: APIData.ensureObject },
       filters: { required: false, formatter: APIData.ensureObject },
-      keepValueIfNotFound: { required: false },
     };
   }
 
@@ -157,7 +156,6 @@ export class PropertyCreate extends AuthenticatedAction {
       unique: params.unique,
       isArray: params.isArray,
       sourceId: params.sourceId,
-      keepValueIfNotFound: params.keepValueIfNotFound,
     });
     if (params.options) await property.setOptions(params.options);
     if (params.filters) await property.setFilters(params.filters);
@@ -189,7 +187,6 @@ export class PropertyEdit extends AuthenticatedAction {
       sourceId: { required: false },
       options: { required: false, formatter: APIData.ensureObject },
       filters: { required: false, formatter: APIData.ensureObject },
-      keepValueIfNotFound: { required: false },
     };
   }
 

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -65,7 +65,6 @@ export interface PropertyConfigurationObject extends ConfigurationObject {
   identifying?: boolean;
   unique?: boolean;
   isArray?: boolean;
-  keepValueIfNotFound?: boolean;
   options?: { [key: string]: any };
   filters?: PropertyFiltersWithKey[];
 }

--- a/core/src/migrations/000080-removeKeepValueIfNotFound.ts
+++ b/core/src/migrations/000080-removeKeepValueIfNotFound.ts
@@ -1,18 +1,11 @@
+import Sequelize from "sequelize";
+
 export default {
-  up: async function (migration, DataTypes) {
-    await migration.removeColumn("properties", "keepValueIfNotFound");
+  up: async (queryInterface: Sequelize.QueryInterface) => {
+    await queryInterface.removeColumn("properties", "keepValueIfNotFound");
   },
 
-  down: async function (migration, DataTypes) {
-    await migration.addColumn("properties", "keepValueIfNotFound", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: true,
-    });
-
-    await migration.changeColumn("properties", "keepValueIfNotFound", {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-    });
+  down: async () => {
+    throw new Error("irreversible migration");
   },
 };

--- a/core/src/migrations/000080-removeKeepValueIfNotFound.ts
+++ b/core/src/migrations/000080-removeKeepValueIfNotFound.ts
@@ -1,0 +1,18 @@
+export default {
+  up: async function (migration, DataTypes) {
+    await migration.removeColumn("properties", "keepValueIfNotFound");
+  },
+
+  down: async function (migration, DataTypes) {
+    await migration.addColumn("properties", "keepValueIfNotFound", {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    });
+
+    await migration.changeColumn("properties", "keepValueIfNotFound", {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+    });
+  },
+};

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -153,11 +153,6 @@ export class Property extends LoggedModel<Property> {
   @Column
   isArray: boolean;
 
-  @AllowNull(false)
-  @Default(false)
-  @Column
-  keepValueIfNotFound: boolean;
-
   @BelongsTo(() => Source)
   source: Source;
 
@@ -281,7 +276,6 @@ export class Property extends LoggedModel<Property> {
       unique: this.unique,
       identifying: this.identifying,
       directlyMapped: this.directlyMapped,
-      keepValueIfNotFound: this.keepValueIfNotFound,
       locked: this.locked,
       options,
       filters,
@@ -296,8 +290,7 @@ export class Property extends LoggedModel<Property> {
   }
 
   async getConfigObject(): Promise<PropertyConfigurationObject> {
-    const { key, type, unique, identifying, isArray, keepValueIfNotFound } =
-      this;
+    const { key, type, unique, identifying, isArray } = this;
 
     this.source = await this.$get("source");
     const sourceId = this.source?.getConfigId();
@@ -315,7 +308,6 @@ export class Property extends LoggedModel<Property> {
       unique,
       identifying,
       isArray,
-      keepValueIfNotFound,
       options,
       filters,
     };

--- a/core/src/modules/configLoaders/property.ts
+++ b/core/src/modules/configLoaders/property.ts
@@ -48,7 +48,6 @@ export async function loadProperty(
     key: configObject.key || configObject["name"],
     unique: configObject.unique,
     isArray: configObject.isArray,
-    keepValueIfNotFound: configObject.keepValueIfNotFound,
     locked: ConfigWriter.getLockKey(configObject),
   });
 

--- a/core/src/modules/configLoaders/source.ts
+++ b/core/src/modules/configLoaders/source.ts
@@ -127,10 +127,6 @@ export async function loadSource(
   logModel(source, validate ? "validated" : isNew ? "created" : "updated");
 
   if (bootstrappedProperty) {
-    await bootstrappedProperty.update({
-      keepValueIfNotFound: bootstrappedPropertyConfig.keepValueIfNotFound,
-    });
-
     logModel(
       bootstrappedProperty,
       validate ? "validated" : isNew ? "created" : "updated"

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -361,27 +361,15 @@ export namespace ProfileOps {
     });
 
     const clearProfilePropertyIds = [];
-    const keepProfilePropertyIds = [];
     for (let profileProperty of pendingProperties) {
       const property = await Property.findOneWithCache(
         profileProperty.propertyId
       );
       if (!sourceId || property.sourceId === sourceId) {
-        if (property.keepValueIfNotFound) {
-          keepProfilePropertyIds.push(profileProperty.id);
-        } else {
-          clearProfilePropertyIds.push(profileProperty.id);
-        }
+        clearProfilePropertyIds.push(profileProperty.id);
       }
     }
 
-    // Keep value for `keepValueIfNotFound=true`
-    await ProfileProperty.update(
-      { state: "ready", stateChangedAt: new Date(), confirmedAt: new Date() },
-      { where: { id: keepProfilePropertyIds } }
-    );
-
-    // Clear value for `keepValueIfNotFound=false`
     await ProfileProperty.update(
       {
         state: "ready",

--- a/core/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/src/tasks/profileProperty/importProfileProperties.ts
@@ -147,27 +147,6 @@ export class ImportProfileProperties extends RetryableTask {
     }
 
     // update the properties that got no data back
-    const propertiesToKeep = properties.filter((p) => p.keepValueIfNotFound);
-    if (propertiesToKeep.length > 0) {
-      await ProfileProperty.update(
-        {
-          state: "ready",
-          stateChangedAt: new Date(),
-          confirmedAt: new Date(),
-        },
-        {
-          where: {
-            propertyId: { [Op.in]: propertiesToKeep.map((p) => p.id) },
-            profileId: {
-              [Op.in]: profilesToImport.map((p) => p.id),
-            },
-            state: "pending",
-          },
-        }
-      );
-    }
-
-    // clear the rest
     await ProfileProperty.update(
       {
         state: "ready",

--- a/core/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/src/tasks/profileProperty/importProfileProperty.ts
@@ -79,7 +79,7 @@ export class ImportProfileProperty extends RetryableTask {
       await ProfileProperty.update(
         {
           state: "ready",
-          rawValue: property.keepValueIfNotFound ? undefined : null,
+          rawValue: null,
           stateChangedAt: new Date(),
           confirmedAt: new Date(),
         },

--- a/plugins/@grouparoo/demo/config/b2b/all/accounts/properties/account_name.json
+++ b/plugins/@grouparoo/demo/config/b2b/all/accounts/properties/account_name.json
@@ -7,7 +7,6 @@
   "unique": false,
   "identifying": false,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "exact",
     "column": "name"

--- a/plugins/@grouparoo/demo/config/b2b/all/accounts/properties/account_value.json
+++ b/plugins/@grouparoo/demo/config/b2b/all/accounts/properties/account_value.json
@@ -7,7 +7,6 @@
   "unique": false,
   "identifying": false,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "sum",
     "column": "amount"

--- a/plugins/@grouparoo/demo/config/b2b/all/identity/properties/account_id.json
+++ b/plugins/@grouparoo/demo/config/b2b/all/identity/properties/account_id.json
@@ -7,7 +7,6 @@
   "unique": false,
   "identifying": false,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "exact",
     "column": "account_id"

--- a/plugins/@grouparoo/demo/config/b2c/all/purchases/properties/last_purchase_category.json
+++ b/plugins/@grouparoo/demo/config/b2c/all/purchases/properties/last_purchase_category.json
@@ -7,7 +7,6 @@
   "unique": false,
   "identifying": false,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "most recent value",
     "column": "category",

--- a/plugins/@grouparoo/demo/config/b2c/all/purchases/properties/last_purchase_date.json
+++ b/plugins/@grouparoo/demo/config/b2c/all/purchases/properties/last_purchase_date.json
@@ -7,7 +7,6 @@
   "unique": false,
   "identifying": false,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "most recent value",
     "column": "created_at",

--- a/plugins/@grouparoo/demo/config/b2c/all/purchases/properties/ltv.json
+++ b/plugins/@grouparoo/demo/config/b2c/all/purchases/properties/ltv.json
@@ -7,7 +7,6 @@
   "unique": false,
   "identifying": false,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "sum",
     "column": "price"

--- a/plugins/@grouparoo/demo/config/b2c/all/purchases/properties/purchase_count.json
+++ b/plugins/@grouparoo/demo/config/b2c/all/purchases/properties/purchase_count.json
@@ -7,7 +7,6 @@
   "unique": false,
   "identifying": false,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "count",
     "column": "id"

--- a/plugins/@grouparoo/demo/config/shared/all/identity/properties/deactivated.json
+++ b/plugins/@grouparoo/demo/config/shared/all/identity/properties/deactivated.json
@@ -7,7 +7,6 @@
   "unique": false,
   "identifying": false,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "exact",
     "column": "deactivated"

--- a/plugins/@grouparoo/demo/config/shared/all/identity/properties/email.json
+++ b/plugins/@grouparoo/demo/config/shared/all/identity/properties/email.json
@@ -7,7 +7,6 @@
   "unique": true,
   "identifying": false,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "exact",
     "column": "email"

--- a/plugins/@grouparoo/demo/config/shared/all/identity/properties/first_name.json
+++ b/plugins/@grouparoo/demo/config/shared/all/identity/properties/first_name.json
@@ -7,7 +7,6 @@
   "unique": false,
   "identifying": false,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "exact",
     "column": "first_name"

--- a/plugins/@grouparoo/demo/config/shared/all/identity/properties/language.json
+++ b/plugins/@grouparoo/demo/config/shared/all/identity/properties/language.json
@@ -7,7 +7,6 @@
   "unique": false,
   "identifying": false,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "exact",
     "column": "language"

--- a/plugins/@grouparoo/demo/config/shared/all/identity/properties/last_name.json
+++ b/plugins/@grouparoo/demo/config/shared/all/identity/properties/last_name.json
@@ -7,7 +7,6 @@
   "unique": false,
   "identifying": false,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "exact",
     "column": "last_name"

--- a/plugins/@grouparoo/demo/config/shared/all/identity/properties/user_id.json
+++ b/plugins/@grouparoo/demo/config/shared/all/identity/properties/user_id.json
@@ -7,7 +7,6 @@
   "unique": true,
   "identifying": true,
   "isArray": false,
-  "keepValueIfNotFound": false,
   "options": {
     "aggregationMethod": "exact",
     "column": "id"

--- a/ui/ui-components/pages/property/[id]/edit.tsx
+++ b/ui/ui-components/pages/property/[id]/edit.tsx
@@ -273,15 +273,6 @@ export default function Page(props) {
                   disabled={loading}
                 />
               </Form.Group>
-              <Form.Group controlId="keepValueIfNotFound">
-                <Form.Check
-                  type="checkbox"
-                  label="Keep value if not found?"
-                  checked={property.keepValueIfNotFound}
-                  onChange={(e) => update(e)}
-                  disabled={loading}
-                />
-              </Form.Group>
               <Form.Group controlId="sourceId">
                 <Form.Label>Property Source</Form.Label>
                 <Form.Control as="select" disabled value={source.id}>


### PR DESCRIPTION
Now that we are not importing things that are not from the primary source (#2192), this doesn't make sense anymore. It was a workaround for a related use case that now has a solution better oriented towards data engineers.

This is technically a breaking change, but since it was only included in alpha releases we should be ok.