### PR TITLE
Log Sequelize query execution time

### DIFF
--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -92,9 +92,9 @@ export const DEFAULT = {
     }
 
     /** Query Logging */
-    function logging(message) {
+    function logging(message: string, time: number) {
       if (typeof message !== "string") return;
-      log(message, "debug");
+      log(message, "debug", { time });
     }
 
     /** Load plugin migrations */
@@ -110,6 +110,7 @@ export const DEFAULT = {
     return {
       _toExpand: false,
       logging,
+      benchmark: true,
       autoMigrate:
         process.env.GROUPAROO_RUN_MODE === "cli:apply" ? false : true,
       dialect: dialect,


### PR DESCRIPTION
When `GROUPAROO_LOG_LEVEL=debug`, log lines now include the time each query took to execute.

```
2021-08-25T15:35:44.789Z - debug: Executed (baf4a0bd-1686-4fc9-8f60-6c8d6dba9865): START TRANSACTION; time=0 
2021-08-25T15:35:44.790Z - debug: Executed (baf4a0bd-1686-4fc9-8f60-6c8d6dba9865): SELECT "id", "pluginName", "key", "value", "defaultValue", "type", "locked", "title", "description", "variant", "createdAt", "updatedAt" FROM "settings" AS "Setting" WHERE "Setting"."pluginName" = 'core' AND "Setting"."key" = 'cluster-name' LIMIT 1; time=0 
2021-08-25T15:35:44.799Z - debug: Executed (baf4a0bd-1686-4fc9-8f60-6c8d6dba9865): COMMIT; time=6 
```