### PR TITLE
Remove batch-size Settings

### DIFF
--- a/core/__tests__/tasks/export/enqueue.ts
+++ b/core/__tests__/tasks/export/enqueue.ts
@@ -1,6 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { api, task, specHelper, utils } from "actionhero";
-import { Profile, Destination, Export, Run, plugin } from "../../../src";
+import { Profile, Destination, Export, Run } from "../../../src";
 
 describe("tasks/export:enqueue", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -197,10 +197,6 @@ describe("tasks/export:enqueue", () => {
       await deletedDestination.destroy();
     });
 
-    afterEach(async () => {
-      await plugin.updateSetting("core", "exports-profile-batch-size", 100);
-    });
-
     test("exports not yet exported or with an error will be enqueued", async () => {
       await specHelper.runTask("export:enqueue", {});
 
@@ -237,22 +233,6 @@ describe("tasks/export:enqueue", () => {
 
       const foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
       expect(foundTasks.length).toBe(0);
-    });
-
-    test("batch size is variable", async () => {
-      await plugin.updateSetting("core", "exports-profile-batch-size", 1);
-      await specHelper.runTask("export:enqueue", {}); // first batch (1 for each destination)
-
-      // another instance of the task should have been enqueued
-      let foundTasks = await specHelper.findEnqueuedTasks("export:enqueue");
-      expect(foundTasks.length).toBe(1);
-      expect(foundTasks[0].args[0]).toEqual({ count: 1 });
-
-      await specHelper.runTask("export:enqueue", {}); // second batch
-      await specHelper.runTask("export:enqueue", {}); // no one
-
-      foundTasks = await specHelper.findEnqueuedTasks("export:sendBatch");
-      expect(foundTasks.length).toBe(4); // (1 + 1) + 2
     });
   });
 });

--- a/core/__tests__/tasks/group/destroy.ts
+++ b/core/__tests__/tasks/group/destroy.ts
@@ -1,3 +1,5 @@
+process.env.GROUPAROO_IMPORTS_BATCH_SIZE = "100";
+
 import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
 import { api, task, specHelper } from "actionhero";
 import {
@@ -23,10 +25,6 @@ describe("tasks/group:destroy", () => {
     beforeEach(async () => {
       await api.resque.queue.connection.redis.flushdb();
       await Import.truncate();
-    });
-
-    beforeAll(async () => {
-      await plugin.updateSetting("core", "runs-profile-batch-size", 100);
     });
 
     beforeAll(async () => {

--- a/core/__tests__/tasks/group/run.ts
+++ b/core/__tests__/tasks/group/run.ts
@@ -1,3 +1,5 @@
+process.env.GROUPAROO_IMPORTS_BATCH_SIZE = "100";
+
 import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
 import { api, specHelper, task } from "actionhero";
 import {
@@ -6,7 +8,6 @@ import {
   Profile,
   GroupMember,
   Run,
-  plugin,
   ProfileProperty,
 } from "../../../src";
 
@@ -27,10 +28,6 @@ describe("tasks/group:run", () => {
     beforeEach(async () => {
       await api.resque.queue.connection.redis.flushdb();
       await Import.truncate();
-    });
-
-    beforeAll(async () => {
-      await plugin.updateSetting("core", "runs-profile-batch-size", 100);
     });
 
     beforeAll(async () => {

--- a/core/__tests__/tasks/group/updateCalculatedGroups.ts
+++ b/core/__tests__/tasks/group/updateCalculatedGroups.ts
@@ -26,7 +26,7 @@ describe("tasks/group:updateCalculatedGroups", () => {
         "core",
         "groups-calculation-delay-minutes"
       );
-      expect(setting.value).toBe("60");
+      expect(setting.value).toBe("1440");
     });
 
     test("running it will enqueue an update for groups that have never been calculated", async () => {

--- a/core/__tests__/tasks/profile/checkReady/checkReady.ts
+++ b/core/__tests__/tasks/profile/checkReady/checkReady.ts
@@ -2,12 +2,11 @@ import { helper } from "@grouparoo/spec-helper";
 import { api, config, task, specHelper } from "actionhero";
 import {
   Group,
-  plugin,
   Profile,
   ProfileProperty,
   Schedule,
   Source,
-} from "../../../src";
+} from "../../../../src";
 
 describe("tasks/profile:checkReady", () => {
   let source: Source;
@@ -21,10 +20,6 @@ describe("tasks/profile:checkReady", () => {
   });
   beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
   beforeAll(async () => await helper.factories.properties());
-
-  afterEach(async () => {
-    await plugin.updateSetting("core", "runs-profile-batch-size", 100);
-  });
 
   beforeAll(async () => {
     source = await Source.findOne();
@@ -106,28 +101,6 @@ describe("tasks/profile:checkReady", () => {
       await toad.destroy();
       await peach.destroy();
       await bowser.destroy();
-    });
-
-    test("batch size can be configured with a setting", async () => {
-      await plugin.updateSetting("core", "runs-profile-batch-size", 1);
-
-      const mario = await helper.factories.profile();
-      await mario.import();
-      await mario.update({ state: "pending" });
-
-      const luigi = await helper.factories.profile();
-      await luigi.import();
-      await luigi.update({ state: "pending" });
-
-      await specHelper.runTask("profiles:checkReady", {});
-
-      await mario.reload();
-      await luigi.reload();
-
-      expect([mario.state, luigi.state].sort()).toEqual(["pending", "ready"]);
-
-      await mario.destroy();
-      await luigi.destroy();
     });
 
     test("it updates the group memberships", async () => {

--- a/core/__tests__/tasks/profile/checkReady/smallerBatchSize.ts
+++ b/core/__tests__/tasks/profile/checkReady/smallerBatchSize.ts
@@ -1,0 +1,36 @@
+process.env.GROUPAROO_IMPORTS_BATCH_SIZE = "1";
+
+import { helper } from "@grouparoo/spec-helper";
+import { api, specHelper } from "actionhero";
+
+describe("tasks/profile:checkReady", () => {
+  helper.grouparooTestServer({
+    truncate: true,
+    enableTestPlugin: true,
+    disableTestPluginImport: true,
+  });
+  beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
+  beforeAll(async () => await helper.factories.properties());
+
+  describe("profiles:checkReady", () => {
+    test.only("batch size can be configured with a setting", async () => {
+      const mario = await helper.factories.profile();
+      await mario.import();
+      await mario.update({ state: "pending" });
+
+      const luigi = await helper.factories.profile();
+      await luigi.import();
+      await luigi.update({ state: "pending" });
+
+      await specHelper.runTask("profiles:checkReady", {});
+
+      await mario.reload();
+      await luigi.reload();
+
+      expect([mario.state, luigi.state].sort()).toEqual(["pending", "ready"]);
+
+      await mario.destroy();
+      await luigi.destroy();
+    });
+  });
+});

--- a/core/__tests__/tasks/profile/confirm/confirm.ts
+++ b/core/__tests__/tasks/profile/confirm/confirm.ts
@@ -10,7 +10,7 @@ import {
   Run,
   Schedule,
   Source,
-} from "../../../src";
+} from "../../../../src";
 
 describe("tasks/profiles:confirm", () => {
   helper.grouparooTestServer({
@@ -30,7 +30,6 @@ describe("tasks/profiles:confirm", () => {
   });
 
   afterEach(async () => {
-    await plugin.updateSetting("core", "runs-profile-batch-size", 100);
     await plugin.updateSetting("core", "confirm-profiles-days", 7);
   });
 
@@ -339,44 +338,5 @@ describe("tasks/profiles:confirm", () => {
 
     const count = await specHelper.runTask("profiles:confirm", {});
     expect(count).toBe(0); // nothing
-  });
-
-  test("only processes profiles up to the batch size", async () => {
-    await plugin.updateSetting("core", "runs-profile-batch-size", 2);
-
-    const profile1: Profile = await helper.factories.profile();
-    const profile2: Profile = await helper.factories.profile();
-    const profile3: Profile = await helper.factories.profile();
-
-    await ProfileProperty.update(
-      {
-        state: "ready",
-        confirmedAt: Moment().subtract(10, "days").toDate(),
-      },
-      {
-        where: {
-          profileId: [profile1.id, profile2.id, profile3.id],
-        },
-      }
-    );
-
-    await Profile.update(
-      { state: "ready" },
-      {
-        where: {
-          id: [profile1.id, profile2.id, profile3.id],
-        },
-      }
-    );
-
-    const count = await specHelper.runTask("profiles:confirm", {});
-    expect(count).toBe(2);
-
-    await profile1.reload();
-    await profile2.reload();
-    await profile3.reload();
-
-    const states = [profile1.state, profile2.state, profile3.state].sort();
-    expect(states).toEqual(["pending", "pending", "ready"]);
   });
 });

--- a/core/__tests__/tasks/profile/confirm/smallerBatchSize.ts
+++ b/core/__tests__/tasks/profile/confirm/smallerBatchSize.ts
@@ -1,0 +1,54 @@
+process.env.GROUPAROO_IMPORTS_BATCH_SIZE = "2";
+
+import { helper } from "@grouparoo/spec-helper";
+import Moment from "moment";
+import { api, specHelper } from "actionhero";
+import { Profile, ProfileProperty } from "../../../../src";
+
+describe("tasks/profiles:confirm", () => {
+  helper.grouparooTestServer({
+    truncate: true,
+    enableTestPlugin: true,
+    disableTestPluginImport: true,
+  });
+
+  beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
+  beforeEach(async () => await helper.factories.properties());
+
+  test("only processes profiles up to the batch size", async () => {
+    const profile1: Profile = await helper.factories.profile();
+    const profile2: Profile = await helper.factories.profile();
+    const profile3: Profile = await helper.factories.profile();
+
+    await ProfileProperty.update(
+      {
+        state: "ready",
+        confirmedAt: Moment().subtract(10, "days").toDate(),
+      },
+      {
+        where: {
+          profileId: [profile1.id, profile2.id, profile3.id],
+        },
+      }
+    );
+
+    await Profile.update(
+      { state: "ready" },
+      {
+        where: {
+          id: [profile1.id, profile2.id, profile3.id],
+        },
+      }
+    );
+
+    const count = await specHelper.runTask("profiles:confirm", {});
+    expect(count).toBe(2);
+
+    await profile1.reload();
+    await profile2.reload();
+    await profile3.reload();
+
+    const states = [profile1.state, profile2.state, profile3.state].sort();
+    expect(states).toEqual(["pending", "pending", "ready"]);
+  });
+});

--- a/core/__tests__/tasks/profile/enqueueExports/enqueueExports.ts
+++ b/core/__tests__/tasks/profile/enqueueExports/enqueueExports.ts
@@ -1,21 +1,11 @@
 import { helper } from "@grouparoo/spec-helper";
 import { api, task, specHelper } from "actionhero";
-import {
-  Import,
-  plugin,
-  Profile,
-  ProfileProperty,
-  Property,
-} from "../../../src";
+import { Import, Profile, ProfileProperty, Property } from "../../../../src";
 
 describe("tasks/profiles:enqueueExports", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
   beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
   beforeAll(async () => await helper.factories.properties());
-
-  afterEach(async () => {
-    await plugin.updateSetting("core", "runs-profile-batch-size", 100);
-  });
 
   describe("profiles:enqueueExports", () => {
     test("can be enqueued", async () => {
@@ -140,46 +130,6 @@ describe("tasks/profiles:enqueueExports", () => {
       await mario.destroy();
       await luigi.destroy();
       await toad.destroy();
-    });
-
-    test("batch size can be configured with a setting", async () => {
-      await plugin.updateSetting("core", "runs-profile-batch-size", 1);
-
-      const mario: Profile = await helper.factories.profile();
-      await mario.import();
-      await mario.update({ state: "ready" });
-      const marioImport: Import = await helper.factories.import(
-        null,
-        {},
-        mario.id
-      );
-      await marioImport.update({
-        groupsUpdatedAt: new Date(),
-        profileUpdatedAt: new Date(),
-        exportedAt: null,
-      });
-
-      const luigi: Profile = await helper.factories.profile();
-      await luigi.import();
-      await luigi.update({ state: "ready" });
-      const luigiImport: Import = await helper.factories.import(
-        null,
-        {},
-        luigi.id
-      );
-      await luigiImport.update({
-        groupsUpdatedAt: new Date(),
-        profileUpdatedAt: new Date(),
-        exportedAt: null,
-      });
-
-      await specHelper.runTask("profiles:enqueueExports", {});
-
-      const foundTasks = await specHelper.findEnqueuedTasks("profile:export");
-      expect(foundTasks.length).toEqual(1);
-
-      await mario.destroy();
-      await luigi.destroy();
     });
   });
 });

--- a/core/__tests__/tasks/profile/enqueueExports/smallerBatchSize.ts
+++ b/core/__tests__/tasks/profile/enqueueExports/smallerBatchSize.ts
@@ -1,0 +1,51 @@
+process.env.GROUPAROO_IMPORTS_BATCH_SIZE = "1";
+
+import { helper } from "@grouparoo/spec-helper";
+import { api, specHelper } from "actionhero";
+import { Import, Profile } from "../../../../src";
+
+describe("tasks/profiles:enqueueExports", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
+  beforeAll(async () => await helper.factories.properties());
+
+  describe("profiles:enqueueExports", () => {
+    test("batch size can be configured with a setting", async () => {
+      const mario: Profile = await helper.factories.profile();
+      await mario.import();
+      await mario.update({ state: "ready" });
+      const marioImport: Import = await helper.factories.import(
+        null,
+        {},
+        mario.id
+      );
+      await marioImport.update({
+        groupsUpdatedAt: new Date(),
+        profileUpdatedAt: new Date(),
+        exportedAt: null,
+      });
+
+      const luigi: Profile = await helper.factories.profile();
+      await luigi.import();
+      await luigi.update({ state: "ready" });
+      const luigiImport: Import = await helper.factories.import(
+        null,
+        {},
+        luigi.id
+      );
+      await luigiImport.update({
+        groupsUpdatedAt: new Date(),
+        profileUpdatedAt: new Date(),
+        exportedAt: null,
+      });
+
+      await specHelper.runTask("profiles:enqueueExports", {});
+
+      const foundTasks = await specHelper.findEnqueuedTasks("profile:export");
+      expect(foundTasks.length).toEqual(1);
+
+      await mario.destroy();
+      await luigi.destroy();
+    });
+  });
+});

--- a/core/__tests__/tasks/profileProperty/enqueue/enqueue.ts
+++ b/core/__tests__/tasks/profileProperty/enqueue/enqueue.ts
@@ -4,7 +4,6 @@ import {
   PluginConnection,
   ProfilePropertyPluginMethod,
   ProfilePropertiesPluginMethod,
-  plugin,
   Property,
   GrouparooPlugin,
   Source,
@@ -12,7 +11,7 @@ import {
   Profile,
   ProfileProperty,
   Schedule,
-} from "../../../src";
+} from "../../../../src";
 
 describe("tasks/profileProperties:enqueue", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -45,14 +44,6 @@ describe("tasks/profileProperties:enqueue", () => {
 
   afterAll(() => {
     resetPlugin();
-  });
-
-  afterEach(async () => {
-    await plugin.updateSetting(
-      "core",
-      "imports-profile-properties-batch-size",
-      50
-    );
   });
 
   describe("profileProperties:enqueue", () => {
@@ -248,46 +239,6 @@ describe("tasks/profileProperties:enqueue", () => {
           expect(importProfilePropertiesTasks.length).toBe(propertiesCount);
           importProfilePropertiesTasks.forEach((t) =>
             expect(t.args[0].profileIds.length).toBe(2)
-          );
-        });
-
-        test("the batch size can be configured via a setting", async () => {
-          await plugin.updateSetting(
-            "core",
-            "imports-profile-properties-batch-size",
-            1
-          );
-
-          const run = await helper.factories.run(schedule);
-          const marioImport = await helper.factories.import(run, {
-            email: "mario@example.com",
-            firstName: "Mario",
-          });
-          const luigiImport = await helper.factories.import(run, {
-            email: "luigi@example.com",
-          });
-
-          await specHelper.runTask("import:associateProfile", {
-            importId: marioImport.id,
-          });
-          await specHelper.runTask("import:associateProfile", {
-            importId: luigiImport.id,
-          });
-
-          await specHelper.runTask("profileProperties:enqueue", {});
-
-          const importProfilePropertiesTasks =
-            await specHelper.findEnqueuedTasks(
-              "profileProperty:importProfileProperties"
-            );
-          const importProfilePropertyTasks = await specHelper.findEnqueuedTasks(
-            "profileProperty:importProfileProperty"
-          );
-
-          expect(importProfilePropertyTasks.length).toBe(0);
-          expect(importProfilePropertiesTasks.length).toBe(propertiesCount);
-          importProfilePropertiesTasks.forEach((t) =>
-            expect(t.args[0].profileIds.length).toBe(1)
           );
         });
       });

--- a/core/__tests__/tasks/profileProperty/enqueue/smallerBatchSize.ts
+++ b/core/__tests__/tasks/profileProperty/enqueue/smallerBatchSize.ts
@@ -1,0 +1,91 @@
+process.env.GROUPAROO_IMPORTS_BATCH_SIZE = "1";
+
+import { helper } from "@grouparoo/spec-helper";
+import { api, specHelper } from "actionhero";
+import {
+  PluginConnection,
+  ProfilePropertyPluginMethod,
+  ProfilePropertiesPluginMethod,
+  Property,
+  GrouparooPlugin,
+  Source,
+  Schedule,
+} from "../../../../src";
+
+describe("tasks/profileProperties:enqueue", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
+
+  let propertiesCount: number;
+  let testPluginConnection: PluginConnection;
+  let prevProfilePropertyMethod: ProfilePropertyPluginMethod;
+  let prevProfilePropertiesMethod: ProfilePropertiesPluginMethod;
+
+  beforeAll(async () => {
+    const testPlugin: GrouparooPlugin = api.plugins.plugins.find(
+      (a) => a.name === "@grouparoo/test-plugin"
+    );
+
+    testPluginConnection = testPlugin.connections.find(
+      (c) => c.name === "test-plugin-import"
+    );
+
+    prevProfilePropertyMethod = testPluginConnection.methods.profileProperty;
+    prevProfilePropertiesMethod =
+      testPluginConnection.methods.profileProperties;
+  });
+
+  describe("profileProperties:enqueue", () => {
+    describe("with properties", () => {
+      let source: Source;
+      let schedule: Schedule;
+
+      beforeAll(async () => {
+        await helper.factories.properties();
+        propertiesCount = await Property.scope(null).count();
+        source = await Source.findOne();
+        schedule = await helper.factories.schedule(source);
+      });
+
+      describe("with profileProperties method", () => {
+        beforeAll(async () => {
+          delete testPluginConnection.methods.profileProperty;
+        });
+
+        test("the batch size can be configured via a setting", async () => {
+          const run = await helper.factories.run(schedule);
+          const marioImport = await helper.factories.import(run, {
+            email: "mario@example.com",
+            firstName: "Mario",
+          });
+          const luigiImport = await helper.factories.import(run, {
+            email: "luigi@example.com",
+          });
+
+          await specHelper.runTask("import:associateProfile", {
+            importId: marioImport.id,
+          });
+          await specHelper.runTask("import:associateProfile", {
+            importId: luigiImport.id,
+          });
+
+          await specHelper.runTask("profileProperties:enqueue", {});
+
+          const importProfilePropertiesTasks =
+            await specHelper.findEnqueuedTasks(
+              "profileProperty:importProfileProperties"
+            );
+          const importProfilePropertyTasks = await specHelper.findEnqueuedTasks(
+            "profileProperty:importProfileProperty"
+          );
+
+          expect(importProfilePropertyTasks.length).toBe(0);
+          expect(importProfilePropertiesTasks.length).toBe(propertiesCount);
+          importProfilePropertiesTasks.forEach((t) =>
+            expect(t.args[0].profileIds.length).toBe(1)
+          );
+        });
+      });
+    });
+  });
+});

--- a/core/__tests__/tasks/run/internalRun.ts
+++ b/core/__tests__/tasks/run/internalRun.ts
@@ -1,14 +1,9 @@
+process.env.GROUPAROO_IMPORTS_BATCH_SIZE = "100";
+
 import { helper } from "@grouparoo/spec-helper";
 import { api, task, specHelper } from "actionhero";
 import { internalRun } from "../../../src/modules/internalRun";
-import {
-  plugin,
-  Property,
-  Run,
-  Profile,
-  ProfileProperty,
-  Import,
-} from "../../../src";
+import { Property, Run, Profile, ProfileProperty, Import } from "../../../src";
 
 describe("tasks/run:internalRun", () => {
   helper.grouparooTestServer({
@@ -26,10 +21,6 @@ describe("tasks/run:internalRun", () => {
       await Run.truncate();
       profile = await helper.factories.profile();
       await profile.buildNullProperties();
-    });
-
-    beforeAll(async () => {
-      await plugin.updateSetting("core", "runs-profile-batch-size", 100);
     });
 
     beforeEach(async () => {

--- a/core/src/config/batchSize.ts
+++ b/core/src/config/batchSize.ts
@@ -1,0 +1,13 @@
+export const DEFAULT = {
+  batchSize: () => {
+    // prettier-ignore
+    return {
+      // How many Imports and should a Run enqueue in each batch before deferring to associate those Imports already enqueued?
+      imports: parseInt(process.env.GROUPAROO_IMPORTS_BATCH_SIZE ?? "1000"),
+      // How many Profile Properties needing import should we process at once?
+      profileProperties: parseInt(process.env.GROUPAROO_IMPORTS_BATCH_SIZE ?? "500"),
+      // How many Profiles should a Run try to send at once to Destinations which support batch exporting?
+      exports: parseInt(process.env.GROUPAROO_IMPORTS_BATCH_SIZE ?? "100"),
+    };
+  },
+};

--- a/core/src/initializers/settings.ts
+++ b/core/src/initializers/settings.ts
@@ -52,17 +52,9 @@ export class Plugins extends CLSInitializer {
       {
         key: "groups-calculation-delay-minutes",
         title: "Groups: Calculation Delay Minutes",
-        defaultValue: 60,
+        defaultValue: 60 * 24,
         description:
           "How many minutes should wait before recalculating a calculated Group's membership?",
-        type: "number",
-      },
-      {
-        key: "runs-profile-batch-size",
-        title: "Runs: Profile Batch Size",
-        defaultValue: 1000,
-        description:
-          "How many Imports and should a Run enqueue in each batch before deferring to associate those Imports already enqueued?",
         type: "number",
       },
       {
@@ -71,14 +63,6 @@ export class Plugins extends CLSInitializer {
         defaultValue: 0,
         description:
           "Should Grouparoo periodically re-import all of your profiles, and if so, how long between runs (in hours)?",
-        type: "number",
-      },
-      {
-        key: "imports-profile-properties-batch-size",
-        title: "Imports: Profile Property Batch Size",
-        defaultValue: 500,
-        description:
-          "How many Profile Properties needing import should we process at once?",
         type: "number",
       },
       {
@@ -97,14 +81,6 @@ export class Plugins extends CLSInitializer {
           "When creating a new Run for a Source/Schedule, we check the most recent complete run to configure it.  This includes setting the starting HighWaterMark for the Run.  Should we consider those Runs which have an error?",
         type: "boolean",
         variant: "warning",
-      },
-      {
-        key: "exports-profile-batch-size",
-        title: "Exports: Profile Batch Size",
-        defaultValue: 100,
-        description:
-          "How many Profiles should a Run try to send at once to Destinations which support batch exporting?",
-        type: "number",
       },
       {
         key: "exports-retry-delay-seconds",

--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -7,7 +7,7 @@ import { Destination } from "../../models/Destination";
 import { Export } from "../../models/Export";
 import { GroupMember } from "../../models/GroupMember";
 import { Log } from "../../models/Log";
-import { api } from "actionhero";
+import { api, config } from "actionhero";
 import Sequelize, {
   Op,
   OrderItem,
@@ -20,8 +20,6 @@ import { GroupRule } from "../../models/GroupRule";
 import { Import } from "../../models/Import";
 import { Mapping } from "../../models/Mapping";
 import { SourceOps } from "./source";
-import { plugin } from "../plugin";
-import { Run } from "../../models/Run";
 
 export interface ProfilePropertyType {
   [key: string]: {
@@ -704,10 +702,7 @@ export namespace ProfileOps {
    * Look for profiles that don't have a directlyMapped property and are done importing/exporting.
    */
   export async function getProfilesToDestroy() {
-    const limit: number = parseInt(
-      (await plugin.readSetting("core", "runs-profile-batch-size")).value
-    );
-
+    const limit: number = config.batchSize.imports;
     let profiles: Profile[] = [];
     const directlyMappedProperties = (await Property.findAllWithCache()).filter(
       (p) => p.directlyMapped

--- a/core/src/modules/ops/schedule.ts
+++ b/core/src/modules/ops/schedule.ts
@@ -3,8 +3,7 @@ import { Run, HighWaterMark } from "../../models/Run";
 import { Property } from "../../models/Property";
 import { Option } from "../../models/Option";
 import { Mapping } from "../../models/Mapping";
-import { plugin } from "../plugin";
-import { log } from "actionhero";
+import { log, config } from "actionhero";
 
 export namespace ScheduleOps {
   export async function run(schedule: Schedule, run: Run) {
@@ -30,10 +29,7 @@ export namespace ScheduleOps {
     const connection = await app.getConnection();
     await source.validateOptions(sourceOptions);
 
-    const limit: number = parseInt(
-      (await plugin.readSetting("core", "runs-profile-batch-size")).value
-    );
-
+    const limit: number = config.batchSize.imports;
     const sourceOffset: number | string = run.sourceOffset || 0;
 
     let highWaterMark = {};

--- a/core/src/tasks/export/enqueue.ts
+++ b/core/src/tasks/export/enqueue.ts
@@ -1,5 +1,5 @@
+import { log, config } from "actionhero";
 import { Destination } from "../../models/Destination";
-import { log } from "actionhero";
 import { ExportOps } from "../../modules/ops/export";
 import { RetryableTask } from "../../classes/tasks/retryableTask";
 import { plugin } from "../../modules/plugin";
@@ -20,9 +20,7 @@ export class EnqueueExports extends RetryableTask {
 
   async runWithinTransaction(params) {
     const count = params.count || 0;
-    const limit = parseInt(
-      (await plugin.readSetting("core", "exports-profile-batch-size")).value
-    );
+    const limit: number = config.batchSize.exports;
 
     const delayMs =
       parseInt(

--- a/core/src/tasks/group/destroy.ts
+++ b/core/src/tasks/group/destroy.ts
@@ -1,7 +1,7 @@
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { Group } from "../../models/Group";
 import { Run } from "../../models/Run";
-import { plugin } from "../../modules/plugin";
+import { config } from "actionhero";
 
 export class GroupDestroy extends CLSTask {
   constructor() {
@@ -17,9 +17,7 @@ export class GroupDestroy extends CLSTask {
   }
 
   async runWithinTransaction(params) {
-    const limit: number = parseInt(
-      (await plugin.readSetting("core", "runs-profile-batch-size")).value
-    );
+    const limit: number = config.batchSize.imports;
 
     const group = await Group.scope(null).findOne({
       where: { id: params.groupId, state: "deleted" },

--- a/core/src/tasks/group/exportToCSV.ts
+++ b/core/src/tasks/group/exportToCSV.ts
@@ -1,6 +1,5 @@
-import { api } from "actionhero";
+import { api, config } from "actionhero";
 import { Group } from "../../models/Group";
-import { plugin } from "../../modules/plugin";
 import { groupExportToCSV } from "../../modules/groupExport";
 import { CLSTask } from "../../classes/tasks/clsTask";
 
@@ -19,11 +18,7 @@ export class GroupExportToCSV extends CLSTask {
   }
 
   async runWithinTransaction(params) {
-    const limit: number =
-      params.limit ||
-      parseInt(
-        (await plugin.readSetting("core", "runs-profile-batch-size")).value
-      );
+    const limit: number = params.limit || config.batchSize.imports;
 
     const group = await Group.findById(params.groupId);
 

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -1,7 +1,7 @@
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { Group } from "../../models/Group";
 import { Run } from "../../models/Run";
-import { plugin } from "../../modules/plugin";
+import { config } from "actionhero";
 
 export class RunGroup extends CLSTask {
   constructor() {
@@ -38,11 +38,7 @@ export class RunGroup extends CLSTask {
     const method = run.groupMethod || "runAddGroupMembers";
     const highWaterMark: number = run.groupHighWaterMark || 0;
     const offset: number = run.groupMemberOffset || 0;
-    const limit: number =
-      run.groupMemberLimit ||
-      parseInt(
-        (await plugin.readSetting("core", "runs-profile-batch-size")).value
-      );
+    const limit: number = run.groupMemberLimit || config.batchSize.imports;
 
     let groupMembersCount = 0;
     let nextHighWaterMark = 0;

--- a/core/src/tasks/import/associateProfiles.ts
+++ b/core/src/tasks/import/associateProfiles.ts
@@ -1,6 +1,7 @@
 import { plugin } from "../../modules/plugin";
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { ImportOps } from "../../modules/ops/import";
+import { config } from "actionhero";
 
 export class ImportAssociateProfiles extends CLSTask {
   constructor() {
@@ -13,10 +14,7 @@ export class ImportAssociateProfiles extends CLSTask {
   }
 
   async runWithinTransaction() {
-    const limit = parseInt(
-      (await plugin.readSetting("core", "runs-profile-batch-size")).value
-    );
-
+    const limit: number = config.batchSize.imports;
     const delayMs =
       parseInt(
         (await plugin.readSetting("core", "imports-retry-delay-seconds")).value

--- a/core/src/tasks/profile/checkReady.ts
+++ b/core/src/tasks/profile/checkReady.ts
@@ -1,6 +1,6 @@
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { ProfileOps } from "../../modules/ops/profile";
-import { plugin } from "../../modules/plugin";
+import { config } from "actionhero";
 
 export class ProfilesCheckReady extends CLSTask {
   constructor() {
@@ -14,10 +14,7 @@ export class ProfilesCheckReady extends CLSTask {
   }
 
   async runWithinTransaction() {
-    const limit = parseInt(
-      (await plugin.readSetting("core", "runs-profile-batch-size")).value
-    );
-
+    const limit: number = config.batchSize.imports;
     const toExport = process.env.GROUPAROO_DISABLE_EXPORTS
       ? process.env.GROUPAROO_DISABLE_EXPORTS !== "true"
       : true;

--- a/core/src/tasks/profile/confirm.ts
+++ b/core/src/tasks/profile/confirm.ts
@@ -1,4 +1,5 @@
 import Moment from "moment";
+import { config } from "actionhero";
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { CLS } from "../../modules/cls";
 import { plugin } from "../../modules/plugin";
@@ -17,9 +18,7 @@ export class ProfilesConfirm extends CLSTask {
   }
 
   async runWithinTransaction() {
-    const limit = parseInt(
-      (await plugin.readSetting("core", "runs-profile-batch-size")).value
-    );
+    const limit: number = config.batchSize.imports;
     const confirmDays = parseInt(
       (await plugin.readSetting("core", "confirm-profiles-days")).value
     );

--- a/core/src/tasks/profile/enqueueExports.ts
+++ b/core/src/tasks/profile/enqueueExports.ts
@@ -1,9 +1,9 @@
 import { Op } from "sequelize";
+import { config } from "actionhero";
 import { Import } from "../../models/Import";
 import { Profile } from "../../models/Profile";
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { ProfileProperty } from "../../models/ProfileProperty";
-import { plugin } from "../../modules/plugin";
 import { CLS } from "../../modules/cls";
 
 export class ProfilesEnqueueExports extends CLSTask {
@@ -18,9 +18,7 @@ export class ProfilesEnqueueExports extends CLSTask {
   }
 
   async runWithinTransaction() {
-    const limit = parseInt(
-      (await plugin.readSetting("core", "runs-profile-batch-size")).value
-    );
+    const limit: number = config.batchSize.imports;
 
     const profiles = await Profile.findAll({
       limit,

--- a/core/src/tasks/profileProperty/enqueue.ts
+++ b/core/src/tasks/profileProperty/enqueue.ts
@@ -1,9 +1,8 @@
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { CLS } from "../../modules/cls";
 import { Source } from "../../models/Source";
-import { plugin } from "../../modules/plugin";
 import { ProfilePropertyOps } from "../../modules/ops/profileProperty";
-import { api, env } from "actionhero";
+import { api, env, config } from "actionhero";
 
 export class ProfilePropertiesEnqueue extends CLSTask {
   constructor() {
@@ -18,14 +17,7 @@ export class ProfilePropertiesEnqueue extends CLSTask {
 
   async runWithinTransaction(worker) {
     let count = 0;
-    const limit = parseInt(
-      (
-        await plugin.readSetting(
-          "core",
-          "imports-profile-properties-batch-size"
-        )
-      ).value
-    );
+    const limit: number = config.batchSize.profileProperties;
 
     const sources = await Source.findAll();
 

--- a/core/src/tasks/profileProperty/sweep.ts
+++ b/core/src/tasks/profileProperty/sweep.ts
@@ -1,8 +1,8 @@
+import { config } from "actionhero";
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { Profile } from "../../models/Profile";
 import { ProfileProperty } from "../../models/ProfileProperty";
 import { Property } from "../../models/Property";
-import { plugin } from "../../modules/plugin";
 
 export class ProfilePropertySweep extends CLSTask {
   constructor() {
@@ -17,15 +17,7 @@ export class ProfilePropertySweep extends CLSTask {
 
   async runWithinTransaction() {
     let count = 0;
-
-    const limit = parseInt(
-      (
-        await plugin.readSetting(
-          "core",
-          "imports-profile-properties-batch-size"
-        )
-      ).value
-    );
+    const limit: number = config.batchSize.profileProperties;
 
     // delete those profile properties who have no profile
     const profilePropertiesMissingProfile = await ProfileProperty.findAll({

--- a/core/src/tasks/run/internalRun.ts
+++ b/core/src/tasks/run/internalRun.ts
@@ -1,6 +1,6 @@
+import { config } from "actionhero";
 import { Run } from "../../models/Run";
 import { Profile } from "../../models/Profile";
-import { plugin } from "../../modules/plugin";
 import { ProfileProperty } from "../../models/ProfileProperty";
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { Op } from "sequelize";
@@ -29,11 +29,7 @@ export class RunInternalRun extends CLSTask {
     if (run.state === "stopped") return;
 
     const offset: number = run.groupMemberOffset || 0;
-    const limit: number =
-      run.groupMemberLimit ||
-      parseInt(
-        (await plugin.readSetting("core", "runs-profile-batch-size")).value
-      );
+    const limit: number = run.groupMemberLimit || config.batchSize.imports;
 
     const profiles = await Profile.findAll({
       order: [["createdAt", "asc"]],

--- a/plugins/@grouparoo/app-templates/src/source/query/profiles.ts
+++ b/plugins/@grouparoo/app-templates/src/source/query/profiles.ts
@@ -5,6 +5,7 @@ import {
   ProfilesPluginMethod,
   SimpleSourceOptions,
 } from "@grouparoo/core";
+import { config } from "actionhero";
 import { DataResponseRow } from "../shared/types";
 
 export interface GetChangedRowsMethod {
@@ -35,9 +36,7 @@ export const getProfilesMethod = (getChangedRows: GetChangedRowsMethod) => {
       : 0;
     const limit = highWaterMark.limit
       ? parseInt(highWaterMark.limit.toString())
-      : parseInt(
-          (await plugin.readSetting("core", "runs-profile-batch-size")).value
-        );
+      : config.batchSize.imports;
 
     const rows = await getChangedRows({
       appId,

--- a/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
+++ b/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
@@ -1,3 +1,5 @@
+process.env.GROUPAROO_IMPORTS_BATCH_SIZE = "100";
+
 import path from "path";
 process.env.GROUPAROO_INJECTED_PLUGINS = JSON.stringify({
   "@grouparoo/google-sheets": { path: path.join(__dirname, "..", "..") },

--- a/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
+++ b/plugins/@grouparoo/google-sheets/__tests__/integration/google-sheets-import.ts
@@ -62,10 +62,6 @@ describe("integration/runs/google-sheets", () => {
   });
 
   beforeAll(async () => {
-    await plugin.updateSetting("core", "runs-profile-batch-size", 100);
-  });
-
-  beforeAll(async () => {
     await helper.factories.properties();
     helper.disableTestPluginImport();
   });

--- a/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-import.ts
+++ b/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-import.ts
@@ -59,10 +59,6 @@ describe("integration/runs/mailchimp-import", () => {
   });
 
   beforeAll(async () => {
-    await plugin.updateSetting("core", "runs-profile-batch-size", 100);
-  });
-
-  beforeAll(async () => {
     await helper.factories.properties();
     helper.disableTestPluginImport();
   });

--- a/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-import.ts
+++ b/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-import.ts
@@ -1,3 +1,5 @@
+process.env.GROUPAROO_IMPORTS_BATCH_SIZE = "100";
+
 import path from "path";
 process.env.GROUPAROO_INJECTED_PLUGINS = JSON.stringify({
   "@grouparoo/mailchimp": { path: path.join(__dirname, "..", "..") },


### PR DESCRIPTION
The previous Grouparoo batch-size settings are set by default with reasonable values for most deployments.  To remove confusion, these settings have been removed.  

In extreme cases if these values need to be changes, they can be modified by ENV variables. 