### PR TITLE
Match actionhero versions

### DIFF
--- a/plugins/@grouparoo/calculated-property/package.json
+++ b/plugins/@grouparoo/calculated-property/package.json
@@ -32,7 +32,7 @@
     "@grouparoo/spec-helper": "0.5.3-alpha.5",
     "@types/jest": "*",
     "@types/node": "*",
-    "actionhero": "26.1.3",
+    "actionhero": "27.0.1",
     "jest": "27.0.6",
     "prettier": "2.3.2",
     "ts-jest": "27.0.4",


### PR DESCRIPTION
Fixes a bug with actionhero versions not matching.

That’s why those `.en.json`  files kept appearing