### PR TITLE
Whenever confirming data, reset startedAt

### DIFF
--- a/core/src/modules/ops/profile.ts
+++ b/core/src/modules/ops/profile.ts
@@ -306,6 +306,7 @@ export namespace ProfileOps {
               position,
               rawValue,
               state: "ready",
+              startedAt: null,
               stateChangedAt: now,
               confirmedAt: now,
               valueChangedAt:
@@ -372,6 +373,7 @@ export namespace ProfileOps {
       {
         state: "ready",
         rawValue: null,
+        startedAt: null,
         stateChangedAt: new Date(),
         valueChangedAt: new Date(),
         confirmedAt: new Date(),

--- a/core/src/modules/ops/profileProperty.ts
+++ b/core/src/modules/ops/profileProperty.ts
@@ -220,6 +220,7 @@ async function preparePropertyImports(
     await ProfileProperty.update(
       {
         state: "ready",
+        startedAt: null,
         stateChangedAt: new Date(),
         confirmedAt: new Date(),
       },

--- a/core/src/tasks/profileProperty/importProfileProperties.ts
+++ b/core/src/tasks/profileProperty/importProfileProperties.ts
@@ -151,6 +151,7 @@ export class ImportProfileProperties extends RetryableTask {
       {
         state: "ready",
         rawValue: null,
+        startedAt: null,
         stateChangedAt: new Date(),
         confirmedAt: new Date(),
       },

--- a/core/src/tasks/profileProperty/importProfileProperty.ts
+++ b/core/src/tasks/profileProperty/importProfileProperty.ts
@@ -80,6 +80,7 @@ export class ImportProfileProperty extends RetryableTask {
         {
           state: "ready",
           rawValue: null,
+          startedAt: null,
           stateChangedAt: new Date(),
           confirmedAt: new Date(),
         },


### PR DESCRIPTION
Just a draft to show where I think we need to set `startedAt` back to `null` to show that it's not currently running.
This will allow it get picked up earlier by `profileProperties:enqueue` because this uses a 5 minute `defaultProfilePropertyProcessingDelay` in `processPendingProfileProperties`.

There might be some more spots or something I'm not considering.
