### PR TITLE
Allow customer usage of Grouparoo with node.js >=12 (v16 included)

### DIFF
--- a/apps/staging-community/package.json
+++ b/apps/staging-community/package.json
@@ -6,7 +6,7 @@
   "license": "MPL-2.0",
   "private": true,
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "@grouparoo/bigquery": "0.6.0",

--- a/apps/staging-config/package.json
+++ b/apps/staging-config/package.json
@@ -6,7 +6,7 @@
   "license": "MPL-2.0",
   "private": true,
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "@grouparoo/core": "0.6.0",

--- a/apps/staging-enterprise/package.json
+++ b/apps/staging-enterprise/package.json
@@ -6,7 +6,7 @@
   "license": "unlicensed",
   "private": true,
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "@grouparoo/bigquery": "0.6.0",

--- a/cli/__tests__/test.sh
+++ b/cli/__tests__/test.sh
@@ -107,7 +107,7 @@ cat << EOF > "$WORKDIR/package.json"
   "license": "MPL-2.0",
   "private": true,
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "@grouparoo/core": "$PACKED_CORE",

--- a/cli/package.json
+++ b/cli/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "bin": {
     "grouparoo": "dist/grouparoo.js"

--- a/cli/templates/package.json
+++ b/cli/templates/package.json
@@ -6,7 +6,7 @@
   "license": "MPL-2.0",
   "private": true,
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "@grouparoo/core": "~~VERSION~~",

--- a/core/package.json
+++ b/core/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/app-templates/package.json
+++ b/plugins/@grouparoo/app-templates/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/bigquery/package.json
+++ b/plugins/@grouparoo/bigquery/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/calculated-property/package.json
+++ b/plugins/@grouparoo/calculated-property/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/csv/package.json
+++ b/plugins/@grouparoo/csv/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/customerio/package.json
+++ b/plugins/@grouparoo/customerio/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/dbt/package.json
+++ b/plugins/@grouparoo/dbt/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/demo/package.json
+++ b/plugins/@grouparoo/demo/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/eloqua/package.json
+++ b/plugins/@grouparoo/eloqua/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/facebook/package.json
+++ b/plugins/@grouparoo/facebook/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/files-local/package.json
+++ b/plugins/@grouparoo/files-local/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/files-s3/package.json
+++ b/plugins/@grouparoo/files-s3/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/google-sheets/package.json
+++ b/plugins/@grouparoo/google-sheets/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/hubspot/package.json
+++ b/plugins/@grouparoo/hubspot/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/intercom/package.json
+++ b/plugins/@grouparoo/intercom/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/iterable/package.json
+++ b/plugins/@grouparoo/iterable/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/logger/package.json
+++ b/plugins/@grouparoo/logger/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/mailchimp/package.json
+++ b/plugins/@grouparoo/mailchimp/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/mailjet/package.json
+++ b/plugins/@grouparoo/mailjet/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/marketo/package.json
+++ b/plugins/@grouparoo/marketo/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/mixpanel/package.json
+++ b/plugins/@grouparoo/mixpanel/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/mongo/package.json
+++ b/plugins/@grouparoo/mongo/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/mysql/package.json
+++ b/plugins/@grouparoo/mysql/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/newrelic/package.json
+++ b/plugins/@grouparoo/newrelic/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/onesignal/package.json
+++ b/plugins/@grouparoo/onesignal/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/pardot/package.json
+++ b/plugins/@grouparoo/pardot/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/pipedrive/package.json
+++ b/plugins/@grouparoo/pipedrive/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/postgres/package.json
+++ b/plugins/@grouparoo/postgres/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/prometheus/package.json
+++ b/plugins/@grouparoo/prometheus/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "lint": "prettier --check src __tests__",

--- a/plugins/@grouparoo/redshift/package.json
+++ b/plugins/@grouparoo/redshift/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/sailthru/package.json
+++ b/plugins/@grouparoo/sailthru/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/salesforce/package.json
+++ b/plugins/@grouparoo/salesforce/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/sendgrid/package.json
+++ b/plugins/@grouparoo/sendgrid/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/sentry/package.json
+++ b/plugins/@grouparoo/sentry/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/snowflake/package.json
+++ b/plugins/@grouparoo/snowflake/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/spec-helper/package.json
+++ b/plugins/@grouparoo/spec-helper/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "main": "dist/index",
   "homepage": "https://www.grouparoo.com",

--- a/plugins/@grouparoo/sqlite/package.json
+++ b/plugins/@grouparoo/sqlite/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/zendesk/package.json
+++ b/plugins/@grouparoo/zendesk/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/tools/merger/package.json
+++ b/tools/merger/package.json
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "private": true,
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "glob": "7.1.7",

--- a/ui/ui-community/package.json
+++ b/ui/ui-community/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/ui/ui-components/package.json
+++ b/ui/ui-components/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/ui/ui-config/package.json
+++ b/ui/ui-config/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/ui/ui-enterprise/package.json
+++ b/ui/ui-enterprise/package.json
@@ -9,7 +9,7 @@
     "access": "restricted"
   },
   "engines": {
-    "node": ">=12.0.0 <16.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {


### PR DESCRIPTION
Per https://github.com/grouparoo/grouparoo/pull/2129, the only holdup against using node.js v16 is `node-sass` + `next.js`.  We still need to use node.js to _build_ & develop Grouparoo, but once the packages are built customers can use any modern version of node.js to run grouparoo (eg v16). 

This PR, inspired by https://github.com/grouparoo/grouparoo/pull/2261, changes all of our customer-facing package.json files to allow any version of node.js `>= 12.0.0`.  This includes the generated CLI template files.

---

All of these changes are required to prevent errors like:

```
➜  grouparoo-node-v16 nvm use v16
Now using node v16.6.1 (npm v7.20.3)
➜  grouparoo-node-v16 npm install
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@grouparoo/core@0.6.0',
npm WARN EBADENGINE   required: { node: '>=12.0.0 <16.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.6.1', npm: '7.20.3' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@grouparoo/ui-community@0.6.0',
npm WARN EBADENGINE   required: { node: '>=12.0.0 <16.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.6.1', npm: '7.20.3' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@grouparoo/ui-config@0.6.0',
npm WARN EBADENGINE   required: { node: '>=12.0.0 <16.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.6.1', npm: '7.20.3' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'grouparoo@0.6.0',
npm WARN EBADENGINE   required: { node: '>=12.0.0 <16.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.6.1', npm: '7.20.3' }
npm WARN EBADENGINE }
```