### PR TITLE
`fake.unique` can use big numbers

### DIFF
--- a/plugins/@grouparoo/spec-helper/src/lib/factories/profile.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/factories/profile.ts
@@ -19,8 +19,9 @@ export default async (props = {}, properties = {}) => {
   const directlyMappedProperty = allProperties.find((p) => p.directlyMapped);
 
   if (directlyMappedProperty) {
-    properties[directlyMappedProperty.key] = parseInt(
-      `${new Date().getTime()}${faker.unique(faker.datatype.number)}`
+    properties[directlyMappedProperty.key] = faker.unique(
+      faker.datatype.number,
+      [{ min: 1, max: 999999999999 }]
     );
   }
 


### PR DESCRIPTION
A better solution to https://github.com/grouparoo/grouparoo/pull/2277