### PR TITLE
When Grouparoo versions change, clear redis and resque

### DIFF
--- a/core/__tests__/initializers/resque.ts
+++ b/core/__tests__/initializers/resque.ts
@@ -31,9 +31,9 @@ describe("initializers/resque", () => {
   helper.grouparooTestServer({ truncate: true });
 
   beforeEach(async () => {
-    helper.sleep(1000);
+    await helper.sleep(1000);
     await api.resque.queue.connection.redis.flushdb();
-    helper.sleep(1000);
+    await helper.sleep(1000);
   });
 
   test("it will check for missing periodic tasks if the resque leader", async () => {

--- a/core/__tests__/initializers/resque.ts
+++ b/core/__tests__/initializers/resque.ts
@@ -37,6 +37,7 @@ describe("initializers/resque", () => {
     await helper.sleep(1000);
   });
 
+  beforeEach(async () => (instance = new ResqueInitializer()));
   afterEach(async () => await instance.stop());
 
   test("it will check for missing periodic tasks if the resque leader", async () => {
@@ -46,7 +47,6 @@ describe("initializers/resque", () => {
     let found = await specHelper.findEnqueuedTasks("status");
     expect(found.length).toBe(0);
 
-    instance = new ResqueInitializer();
     await instance.recheckPeriodicTasks();
 
     found = await specHelper.findEnqueuedTasks("status");
@@ -60,7 +60,6 @@ describe("initializers/resque", () => {
     let found = await specHelper.findEnqueuedTasks("status");
     expect(found.length).toBe(0);
 
-    instance = new ResqueInitializer();
     await instance.recheckPeriodicTasks();
 
     found = await specHelper.findEnqueuedTasks("status");
@@ -80,7 +79,6 @@ describe("initializers/resque", () => {
       await client.set("grouparoo:version", "x");
       await task.enqueue("record:export", { recordId: "foo" });
 
-      instance = new ResqueInitializer();
       await instance.start();
 
       const foundTasks = await specHelper.findEnqueuedTasks("record:export");
@@ -92,7 +90,6 @@ describe("initializers/resque", () => {
       await client.set("grouparoo:version", grouparooVersion);
       await task.enqueue("record:export", { recordId: "foo" });
 
-      instance = new ResqueInitializer();
       await instance.start();
 
       const foundTasks = await specHelper.findEnqueuedTasks("record:export");

--- a/core/__tests__/initializers/resque.ts
+++ b/core/__tests__/initializers/resque.ts
@@ -29,12 +29,15 @@ jest.mock("../../src/config/tasks.ts", () => ({
 
 describe("initializers/resque", () => {
   helper.grouparooTestServer({ truncate: true });
+  let instance: ResqueInitializer;
 
   beforeEach(async () => {
     await helper.sleep(1000);
     await api.resque.queue.connection.redis.flushdb();
     await helper.sleep(1000);
   });
+
+  afterEach(async () => await instance.stop());
 
   test("it will check for missing periodic tasks if the resque leader", async () => {
     api.resque.scheduler.leader = true;
@@ -43,7 +46,7 @@ describe("initializers/resque", () => {
     let found = await specHelper.findEnqueuedTasks("status");
     expect(found.length).toBe(0);
 
-    const instance = new ResqueInitializer();
+    instance = new ResqueInitializer();
     await instance.recheckPeriodicTasks();
 
     found = await specHelper.findEnqueuedTasks("status");
@@ -57,7 +60,7 @@ describe("initializers/resque", () => {
     let found = await specHelper.findEnqueuedTasks("status");
     expect(found.length).toBe(0);
 
-    const instance = new ResqueInitializer();
+    instance = new ResqueInitializer();
     await instance.recheckPeriodicTasks();
 
     found = await specHelper.findEnqueuedTasks("status");
@@ -77,7 +80,7 @@ describe("initializers/resque", () => {
       await client.set("grouparoo:version", "x");
       await task.enqueue("record:export", { recordId: "foo" });
 
-      const instance = new ResqueInitializer();
+      instance = new ResqueInitializer();
       await instance.start();
 
       const foundTasks = await specHelper.findEnqueuedTasks("record:export");
@@ -89,7 +92,7 @@ describe("initializers/resque", () => {
       await client.set("grouparoo:version", grouparooVersion);
       await task.enqueue("record:export", { recordId: "foo" });
 
-      const instance = new ResqueInitializer();
+      instance = new ResqueInitializer();
       await instance.start();
 
       const foundTasks = await specHelper.findEnqueuedTasks("record:export");


### PR DESCRIPTION
This will prevent resque errors that occur when upgrading Grouparoo (eg: task names or input changes).  Grouparoo is resilient to redis failures and after a short delay, all processing will resume again. 