### PR TITLE
Use node.js v16.8.0 for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     resource_class: "medium+"
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -169,7 +169,7 @@ jobs:
             - ui/ui-enterprise/.next
   license-checker:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -203,7 +203,7 @@ jobs:
           command: ./tools/license-checker/check
   spell-checker:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -237,7 +237,7 @@ jobs:
           command: ./tools/spell-checker/check
   linter:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -271,7 +271,7 @@ jobs:
           command: pnpm run lint
   test-core-actions:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -324,7 +324,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/actions --ci --maxWorkers 2
   test-core-bin:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -377,7 +377,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/bin --ci --maxWorkers 2
   test-core-classes:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -430,7 +430,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/classes --ci --maxWorkers 2
   test-core-initializers:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -483,7 +483,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/initializers --ci --maxWorkers 2
   test-core-integration:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -536,7 +536,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/integration --ci --maxWorkers 2
   test-core-models:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -589,7 +589,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/models --ci --maxWorkers 2
   test-core-modules:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -642,7 +642,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/modules --ci --maxWorkers 2
   test-core-notifiers:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -695,7 +695,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/notifiers --ci --maxWorkers 2
   test-core-snapshots:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -748,7 +748,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/snapshots --ci --maxWorkers 2
   test-core-tasks:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -801,7 +801,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/tasks --ci --maxWorkers 2
   test-core-local-models:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -838,7 +838,7 @@ jobs:
             DB_DIALECT: sqlite
   test-core-local-actions:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -875,7 +875,7 @@ jobs:
             DB_DIALECT: sqlite
   test-core-local-tasks:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -912,7 +912,7 @@ jobs:
             DB_DIALECT: sqlite
   test-ui-components:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -971,7 +971,7 @@ jobs:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-ui-community:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1030,7 +1030,7 @@ jobs:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-ui-enterprise:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1089,7 +1089,7 @@ jobs:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-ui-config:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1148,7 +1148,7 @@ jobs:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-staging-community:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1209,7 +1209,7 @@ jobs:
             WORKERS: 1
   test-staging-enterprise:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1270,7 +1270,7 @@ jobs:
             WORKERS: 1
   test-plugin-app-templates:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1323,7 +1323,7 @@ jobs:
           command: cd plugins/@grouparoo/app-templates && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-bigquery:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1376,7 +1376,7 @@ jobs:
           command: cd plugins/@grouparoo/bigquery && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-calculated-property:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1429,7 +1429,7 @@ jobs:
           command: cd plugins/@grouparoo/calculated-property && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-csv:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1482,7 +1482,7 @@ jobs:
           command: cd plugins/@grouparoo/csv && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-customerio:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1535,7 +1535,7 @@ jobs:
           command: cd plugins/@grouparoo/customerio && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-dbt:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1588,7 +1588,7 @@ jobs:
           command: cd plugins/@grouparoo/dbt && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-demo:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1641,7 +1641,7 @@ jobs:
           command: cd plugins/@grouparoo/demo && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-eloqua:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1694,7 +1694,7 @@ jobs:
           command: cd plugins/@grouparoo/eloqua && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-facebook:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1747,7 +1747,7 @@ jobs:
           command: cd plugins/@grouparoo/facebook && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-files-local:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1800,7 +1800,7 @@ jobs:
           command: cd plugins/@grouparoo/files-local && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-files-s3:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1853,7 +1853,7 @@ jobs:
           command: cd plugins/@grouparoo/files-s3 && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-google-sheets:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1906,7 +1906,7 @@ jobs:
           command: cd plugins/@grouparoo/google-sheets && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-hubspot:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1959,7 +1959,7 @@ jobs:
           command: cd plugins/@grouparoo/hubspot && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-intercom:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2012,7 +2012,7 @@ jobs:
           command: cd plugins/@grouparoo/intercom && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-iterable:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2065,7 +2065,7 @@ jobs:
           command: cd plugins/@grouparoo/iterable && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-logger:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2118,7 +2118,7 @@ jobs:
           command: cd plugins/@grouparoo/logger && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mailchimp:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2171,7 +2171,7 @@ jobs:
           command: cd plugins/@grouparoo/mailchimp && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mailjet:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2224,7 +2224,7 @@ jobs:
           command: cd plugins/@grouparoo/mailjet && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-marketo:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2277,7 +2277,7 @@ jobs:
           command: cd plugins/@grouparoo/marketo && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mixpanel:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2330,7 +2330,7 @@ jobs:
           command: cd plugins/@grouparoo/mixpanel && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mongo:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2387,7 +2387,7 @@ jobs:
           command: cd plugins/@grouparoo/mongo && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mysql:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2452,7 +2452,7 @@ jobs:
           command: cd plugins/@grouparoo/mysql && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-newrelic:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2505,7 +2505,7 @@ jobs:
           command: cd plugins/@grouparoo/newrelic && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-onesignal:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2558,7 +2558,7 @@ jobs:
           command: cd plugins/@grouparoo/onesignal && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-pardot:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2611,7 +2611,7 @@ jobs:
           command: cd plugins/@grouparoo/pardot && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-pipedrive:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2664,7 +2664,7 @@ jobs:
           command: cd plugins/@grouparoo/pipedrive && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-postgres:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2717,7 +2717,7 @@ jobs:
           command: cd plugins/@grouparoo/postgres && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-prometheus:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2770,7 +2770,7 @@ jobs:
           command: cd plugins/@grouparoo/prometheus && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-redshift:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2823,7 +2823,7 @@ jobs:
           command: cd plugins/@grouparoo/redshift && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sailthru:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2876,7 +2876,7 @@ jobs:
           command: cd plugins/@grouparoo/sailthru && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-salesforce:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2929,7 +2929,7 @@ jobs:
           command: cd plugins/@grouparoo/salesforce && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sendgrid:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2982,7 +2982,7 @@ jobs:
           command: cd plugins/@grouparoo/sendgrid && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sentry:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3035,7 +3035,7 @@ jobs:
           command: cd plugins/@grouparoo/sentry && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-snowflake:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3088,7 +3088,7 @@ jobs:
           command: cd plugins/@grouparoo/snowflake && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-spec-helper:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3141,7 +3141,7 @@ jobs:
           command: cd plugins/@grouparoo/spec-helper && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sqlite:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3194,7 +3194,7 @@ jobs:
           command: cd plugins/@grouparoo/sqlite && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-zendesk:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3247,7 +3247,7 @@ jobs:
           command: cd plugins/@grouparoo/zendesk && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-cli:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3281,7 +3281,7 @@ jobs:
           command: cd cli && pnpm test
   complete:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/apps/job.yml.template
+++ b/tools/merger/data/ci/apps/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16.8.0
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/apps/job.yml.template
+++ b/tools/merger/data/ci/apps/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/base.yml.template
+++ b/tools/merger/data/ci/base.yml.template
@@ -18,7 +18,7 @@ jobs:
   build:
     resource_class: "medium+"
     docker:
-      - image: circleci/node:16.8.0
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -38,7 +38,7 @@ jobs:
 
   complete:
     docker:
-      - image: circleci/node:16.8.0
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/base.yml.template
+++ b/tools/merger/data/ci/base.yml.template
@@ -18,7 +18,7 @@ jobs:
   build:
     resource_class: "medium+"
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -38,7 +38,7 @@ jobs:
 
   complete:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/cli/job.yml.template
+++ b/tools/merger/data/ci/cli/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16.8.0
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/cli/job.yml.template
+++ b/tools/merger/data/ci/cli/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/client/job.yml.template
+++ b/tools/merger/data/ci/client/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16.8.0
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/client/job.yml.template
+++ b/tools/merger/data/ci/client/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/command/job.yml.template
+++ b/tools/merger/data/ci/command/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16.8.0
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/command/job.yml.template
+++ b/tools/merger/data/ci/command/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/core-local/job.yml.template
+++ b/tools/merger/data/ci/core-local/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16.8.0
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/core-local/job.yml.template
+++ b/tools/merger/data/ci/core-local/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/core/job.yml.template
+++ b/tools/merger/data/ci/core/job.yml.template
@@ -1,6 +1,6 @@
   test-{{{type}}}-{{{test_section}}}:
     docker:
-      - image: circleci/node:16.8.0
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/core/job.yml.template
+++ b/tools/merger/data/ci/core/job.yml.template
@@ -1,6 +1,6 @@
   test-{{{type}}}-{{{test_section}}}:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/plugin/job.yml.template
+++ b/tools/merger/data/ci/plugin/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16.8.0
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/plugin/job.yml.template
+++ b/tools/merger/data/ci/plugin/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/ui/job.yml.template
+++ b/tools/merger/data/ci/ui/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16.8.0
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/ui/job.yml.template
+++ b/tools/merger/data/ci/ui/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -5,6 +5,8 @@ const Mustache = require("mustache");
 const { allPackagePaths, allPluginPaths } = require("../../shared/packages");
 const execSync = require("../../shared/exec");
 
+const docker_image = "circleci/node:16.8.0";
+
 module.exports.cmd = async function (vargs) {
   const instance = new Generator(vargs);
   await instance.generate();
@@ -367,6 +369,7 @@ class Generator {
 
   renderJob(job, name) {
     const template = readTemplate(name, job.type);
+    job.docker_image = docker_image;
     return Mustache.render(template, job);
   }
 
@@ -394,6 +397,7 @@ class Generator {
     // these get passed through
     view[".Branch"] = "{{ .Branch }}";
     view[".Revision"] = "{{ .Revision }}";
+    view.docker_image = docker_image;
 
     const methods = [
       "jobs",


### PR DESCRIPTION
The latest version of Node.js has a [bug when running jest](https://stackoverflow.com/questions/69118749/github-action-error-while-running-unit-test-pipeline).  For now, we'll lock CI to use `v16.8.0` rather than the latest, `v16.9.0`.

Re: https://github.com/nodejs/node/issues/40030

Prevents cool looking bugs like:

```
#
# Fatal error in , line 0
# Check failed: !holder_map.has_named_interceptor().
#
#
#
#FailureMessage Object: 0x7ffef0ac0510
 1: 0xb691f1  [/usr/local/bin/node]
 2: 0x1bf3094 V8_Fatal(char const*, ...) [/usr/local/bin/node]
 3: 0x10ac4a1 v8::internal::ConcurrentLookupIterator::TryGetPropertyCell(v8::internal::Isolate*, v8::internal::LocalIsolate*, v8::internal::Handle<v8::internal::JSGlobalObject>, v8::internal::Handle<v8::internal::Name>) [/usr/local/bin/node]
 4: 0x1c5aa55  [/usr/local/bin/node]
 5: 0x1c5b9eb v8::internal::compiler::JSGlobalObjectRef::GetPropertyCell(v8::internal::compiler::NameRef const&, v8::internal::compiler::SerializationPolicy) const [/usr/local/bin/node]
 6: 0x1e61ba3 v8::internal::compiler::JSNativeContextSpecialization::ReduceNamedAccess(v8::internal::compiler::Node*, v8::internal::compiler::Node*, v8::internal::compiler::NamedAccessFeedback const&, v8::internal::compiler::AccessMode, v8::internal::compiler::Node*) [/usr/local/bin/node]
 7: 0x1e623c4 v8::internal::compiler::JSNativeContextSpecialization::ReducePropertyAccess(v8::internal::compiler::Node*, v8::internal::compiler::Node*, v8::base::Optional<v8::internal::compiler::NameRef>, v8::internal::compiler::Node*, v8::internal::compiler::FeedbackSource const&, v8::internal::compiler::AccessMode) [/usr/local/bin/node]
 8: 0x1e62f0c v8::internal::compiler::JSNativeContextSpecialization::ReduceJSLoadProperty(v8::internal::compiler::Node*) [/usr/local/bin/node]
 9: 0x1df5e0a v8::internal::compiler::Reducer::Reduce(v8::internal::compiler::Node*, v8::internal::compiler::ObserveNodeManager*) [/usr/local/bin/node]
10: 0x1c92604  [/usr/local/bin/node]
11: 0x1df60be v8::internal::compiler::GraphReducer::Reduce(v8::internal::compiler::Node*) [/usr/local/bin/node]
12: 0x1df7895 v8::internal::compiler::GraphReducer::ReduceTop() [/usr/local/bin/node]
13: 0x1df7c48 v8::internal::compiler::GraphReducer::ReduceNode(v8::internal::compiler::Node*) [/usr/local/bin/node]
14: 0x1ca03fd v8::internal::compiler::InliningPhase::Run(v8::internal::compiler::PipelineData*, v8::internal::Zone*) [/usr/local/bin/node]
15: 0x1ca1291 v8::internal::compiler::PipelineImpl::CreateGraph() [/usr/local/bin/node]
16: 0x1ca1668 v8::internal::compiler::PipelineCompilationJob::PrepareJobImpl(v8::internal::Isolate*) [/usr/local/bin/node]
17: 0xd94f5d v8::internal::OptimizedCompilationJob::PrepareJob(v8::internal::Isolate*) [/usr/local/bin/node]
18: 0xd96358  [/usr/local/bin/node]
19: 0xd97e70 v8::internal::Compiler::CompileOptimized(v8::internal::Isolate*, v8::internal::Handle<v8::internal::JSFunction>, v8::internal::ConcurrencyMode, v8::internal::CodeKind) [/usr/local/bin/node]
20: 0x11f4463 v8::internal::Runtime_CompileOptimized_Concurrent(int, unsigned long*, v8::internal::Isolate*) [/usr/local/bin/node]
21: 0x15e67f9  [/usr/local/bin/node]
```