### PR TITLE
fix: dont throw on `profile:destroy` if it has already been deleted (backports #2298)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     resource_class: "medium+"
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -169,7 +169,7 @@ jobs:
             - ui/ui-enterprise/.next
   license-checker:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -203,7 +203,7 @@ jobs:
           command: ./tools/license-checker/check
   spell-checker:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -237,7 +237,7 @@ jobs:
           command: ./tools/spell-checker/check
   linter:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -271,7 +271,7 @@ jobs:
           command: pnpm run lint
   test-core-actions:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -324,7 +324,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/actions --ci --maxWorkers 2
   test-core-bin:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -377,7 +377,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/bin --ci --maxWorkers 2
   test-core-classes:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -430,7 +430,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/classes --ci --maxWorkers 2
   test-core-initializers:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -483,7 +483,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/initializers --ci --maxWorkers 2
   test-core-integration:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -536,7 +536,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/integration --ci --maxWorkers 2
   test-core-models:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -589,7 +589,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/models --ci --maxWorkers 2
   test-core-modules:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -642,7 +642,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/modules --ci --maxWorkers 2
   test-core-notifiers:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -695,7 +695,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/notifiers --ci --maxWorkers 2
   test-core-snapshots:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -748,7 +748,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/snapshots --ci --maxWorkers 2
   test-core-tasks:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -801,7 +801,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/tasks --ci --maxWorkers 2
   test-core-local-models:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -838,7 +838,7 @@ jobs:
             DB_DIALECT: sqlite
   test-core-local-actions:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -875,7 +875,7 @@ jobs:
             DB_DIALECT: sqlite
   test-core-local-tasks:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -912,7 +912,7 @@ jobs:
             DB_DIALECT: sqlite
   test-ui-components:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -971,7 +971,7 @@ jobs:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-ui-community:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1030,7 +1030,7 @@ jobs:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-ui-enterprise:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1089,7 +1089,7 @@ jobs:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-ui-config:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1148,7 +1148,7 @@ jobs:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-staging-community:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1209,7 +1209,7 @@ jobs:
             WORKERS: 1
   test-staging-enterprise:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1270,7 +1270,7 @@ jobs:
             WORKERS: 1
   test-plugin-app-templates:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1323,7 +1323,7 @@ jobs:
           command: cd plugins/@grouparoo/app-templates && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-bigquery:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1376,7 +1376,7 @@ jobs:
           command: cd plugins/@grouparoo/bigquery && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-calculated-property:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1429,7 +1429,7 @@ jobs:
           command: cd plugins/@grouparoo/calculated-property && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-csv:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1482,7 +1482,7 @@ jobs:
           command: cd plugins/@grouparoo/csv && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-customerio:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1535,7 +1535,7 @@ jobs:
           command: cd plugins/@grouparoo/customerio && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-dbt:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1588,7 +1588,7 @@ jobs:
           command: cd plugins/@grouparoo/dbt && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-demo:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1641,7 +1641,7 @@ jobs:
           command: cd plugins/@grouparoo/demo && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-eloqua:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1694,7 +1694,7 @@ jobs:
           command: cd plugins/@grouparoo/eloqua && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-facebook:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1747,7 +1747,7 @@ jobs:
           command: cd plugins/@grouparoo/facebook && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-files-local:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1800,7 +1800,7 @@ jobs:
           command: cd plugins/@grouparoo/files-local && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-files-s3:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1853,7 +1853,7 @@ jobs:
           command: cd plugins/@grouparoo/files-s3 && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-google-sheets:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1906,7 +1906,7 @@ jobs:
           command: cd plugins/@grouparoo/google-sheets && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-hubspot:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1959,7 +1959,7 @@ jobs:
           command: cd plugins/@grouparoo/hubspot && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-intercom:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2012,7 +2012,7 @@ jobs:
           command: cd plugins/@grouparoo/intercom && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-iterable:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2065,7 +2065,7 @@ jobs:
           command: cd plugins/@grouparoo/iterable && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-logger:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2118,7 +2118,7 @@ jobs:
           command: cd plugins/@grouparoo/logger && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mailchimp:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2171,7 +2171,7 @@ jobs:
           command: cd plugins/@grouparoo/mailchimp && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mailjet:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2224,7 +2224,7 @@ jobs:
           command: cd plugins/@grouparoo/mailjet && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-marketo:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2277,7 +2277,7 @@ jobs:
           command: cd plugins/@grouparoo/marketo && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mixpanel:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2330,7 +2330,7 @@ jobs:
           command: cd plugins/@grouparoo/mixpanel && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mongo:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2387,7 +2387,7 @@ jobs:
           command: cd plugins/@grouparoo/mongo && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mysql:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2452,7 +2452,7 @@ jobs:
           command: cd plugins/@grouparoo/mysql && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-newrelic:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2505,7 +2505,7 @@ jobs:
           command: cd plugins/@grouparoo/newrelic && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-onesignal:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2558,7 +2558,7 @@ jobs:
           command: cd plugins/@grouparoo/onesignal && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-pardot:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2611,7 +2611,7 @@ jobs:
           command: cd plugins/@grouparoo/pardot && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-pipedrive:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2664,7 +2664,7 @@ jobs:
           command: cd plugins/@grouparoo/pipedrive && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-postgres:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2717,7 +2717,7 @@ jobs:
           command: cd plugins/@grouparoo/postgres && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-prometheus:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2770,7 +2770,7 @@ jobs:
           command: cd plugins/@grouparoo/prometheus && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-redshift:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2823,7 +2823,7 @@ jobs:
           command: cd plugins/@grouparoo/redshift && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sailthru:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2876,7 +2876,7 @@ jobs:
           command: cd plugins/@grouparoo/sailthru && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-salesforce:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2929,7 +2929,7 @@ jobs:
           command: cd plugins/@grouparoo/salesforce && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sendgrid:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2982,7 +2982,7 @@ jobs:
           command: cd plugins/@grouparoo/sendgrid && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sentry:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3035,7 +3035,7 @@ jobs:
           command: cd plugins/@grouparoo/sentry && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-snowflake:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3088,7 +3088,7 @@ jobs:
           command: cd plugins/@grouparoo/snowflake && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-spec-helper:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3141,7 +3141,7 @@ jobs:
           command: cd plugins/@grouparoo/spec-helper && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sqlite:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3194,7 +3194,7 @@ jobs:
           command: cd plugins/@grouparoo/sqlite && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-zendesk:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3247,7 +3247,7 @@ jobs:
           command: cd plugins/@grouparoo/zendesk && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-cli:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3281,7 +3281,7 @@ jobs:
           command: cd cli && pnpm test
   complete:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:16.8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/core/__tests__/tasks/profile/destroy.ts
+++ b/core/__tests__/tasks/profile/destroy.ts
@@ -34,6 +34,14 @@ describe("tasks/profile:destroy", () => {
     expect(found[0].args[0].profileId).toBe("john-doe");
   });
 
+  test("wont throw if profile no longer exists", async () => {
+    expect(
+      specHelper.runTask("profile:destroy", {
+        profileId: "someProfileThatNoLongerExists",
+      })
+    ).resolves.toBe(undefined);
+  });
+
   test("does not delete profiles that aren't ready", async () => {
     const profile: Profile = await helper.factories.profile();
     await profile.update({ state: "pending" });

--- a/core/src/tasks/profile/destroy.ts
+++ b/core/src/tasks/profile/destroy.ts
@@ -16,9 +16,10 @@ export class ProfileDestroy extends CLSTask {
   }
 
   async runWithinTransaction({ profileId }: { profileId: string }) {
-    const profile = await Profile.findById(profileId);
+    const profile = await Profile.findOne({
+      where: { id: profileId, state: "ready" },
+    });
     if (!profile) return;
-    if (profile.state !== "ready") return;
 
     const pendingExports = await Export.count({
       where: {

--- a/plugins/@grouparoo/csv/__tests__/integration/csv-remote.ts
+++ b/plugins/@grouparoo/csv/__tests__/integration/csv-remote.ts
@@ -85,7 +85,7 @@ describe("integration/runs/csv/remote", () => {
         name: "csv source",
         appId: app.id,
         options: {
-          url: "https://raw.githubusercontent.com/grouparoo/grouparoo/main/core/__tests__/data/profiles-10.csv",
+          url: "https://raw.githubusercontent.com/grouparoo/grouparoo/main/core/__tests__/data/records-10.csv",
           fileAgeHours: 1,
         },
         mapping: { id: "userId" },

--- a/plugins/@grouparoo/csv/__tests__/remote-import/downloadAndRefreshFile.ts
+++ b/plugins/@grouparoo/csv/__tests__/remote-import/downloadAndRefreshFile.ts
@@ -3,7 +3,7 @@ import { downloadAndRefreshFile } from "../../src/lib/remote-import/downloadAndR
 
 describe("downloadAndRefreshFile", () => {
   const url =
-    "https://raw.githubusercontent.com/grouparoo/grouparoo/main/core/__tests__/data/profiles-10.csv";
+    "https://raw.githubusercontent.com/grouparoo/grouparoo/main/core/__tests__/data/records-10.csv";
   const fileAgeHours = 1;
   const sourceOptions = { url, fileAgeHours };
   const sourceId = "test";

--- a/plugins/@grouparoo/csv/__tests__/remote-import/profileProperties.ts
+++ b/plugins/@grouparoo/csv/__tests__/remote-import/profileProperties.ts
@@ -7,7 +7,7 @@ import { Profile, Property, SimpleSourceOptions } from "@grouparoo/core";
 import { profileProperties } from "../../src/lib/remote-import/profileProperties";
 
 const sourceOptions: SimpleSourceOptions = {
-  url: "https://raw.githubusercontent.com/grouparoo/grouparoo/main/core/__tests__/data/profiles-10.csv",
+  url: "https://raw.githubusercontent.com/grouparoo/grouparoo/main/core/__tests__/data/records-10.csv",
   fileAgeHours: 1,
 };
 let profile: Profile;

--- a/plugins/@grouparoo/csv/__tests__/remote-import/profileProperty.ts
+++ b/plugins/@grouparoo/csv/__tests__/remote-import/profileProperty.ts
@@ -7,7 +7,7 @@ import { Profile, Property, SimpleSourceOptions } from "@grouparoo/core";
 import { profileProperty } from "../../src/lib/remote-import/profileProperty";
 
 const sourceOptions: SimpleSourceOptions = {
-  url: "https://raw.githubusercontent.com/grouparoo/grouparoo/main/core/__tests__/data/profiles-10.csv",
+  url: "https://raw.githubusercontent.com/grouparoo/grouparoo/main/core/__tests__/data/records-10.csv",
   fileAgeHours: 1,
 };
 let profile: Profile;

--- a/plugins/@grouparoo/csv/__tests__/remote-import/profiles.ts
+++ b/plugins/@grouparoo/csv/__tests__/remote-import/profiles.ts
@@ -8,7 +8,7 @@ import { profiles } from "../../src/lib/remote-import/profiles";
 
 // these used and set by test
 const sourceOptions: SimpleSourceOptions = {
-  url: "https://raw.githubusercontent.com/grouparoo/grouparoo/main/core/__tests__/data/profiles-10.csv",
+  url: "https://raw.githubusercontent.com/grouparoo/grouparoo/main/core/__tests__/data/records-10.csv",
   fileAgeHours: 1,
 };
 

--- a/plugins/@grouparoo/csv/__tests__/remote-import/propertyOptions.ts
+++ b/plugins/@grouparoo/csv/__tests__/remote-import/propertyOptions.ts
@@ -7,7 +7,7 @@ import { SimpleSourceOptions } from "@grouparoo/core";
 import { propertyOptions } from "../../src/lib/remote-import/propertyOptions";
 
 const sourceOptions: SimpleSourceOptions = {
-  url: "https://raw.githubusercontent.com/grouparoo/grouparoo/main/core/__tests__/data/profiles-10.csv",
+  url: "https://raw.githubusercontent.com/grouparoo/grouparoo/main/core/__tests__/data/records-10.csv",
   fileAgeHours: 1,
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,42 +20,42 @@ importers:
 
   apps/staging-community:
     specifiers:
-      '@grouparoo/bigquery': 0.6.2-alpha.1
-      '@grouparoo/calculated-property': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/csv': 0.6.2-alpha.1
-      '@grouparoo/customerio': 0.6.2-alpha.1
-      '@grouparoo/demo': 0.6.2-alpha.1
-      '@grouparoo/eloqua': 0.6.2-alpha.1
-      '@grouparoo/facebook': 0.6.2-alpha.1
-      '@grouparoo/files-s3': 0.6.2-alpha.1
-      '@grouparoo/google-sheets': 0.6.2-alpha.1
-      '@grouparoo/hubspot': 0.6.2-alpha.1
-      '@grouparoo/intercom': 0.6.2-alpha.1
-      '@grouparoo/iterable': 0.6.2-alpha.1
-      '@grouparoo/logger': 0.6.2-alpha.1
-      '@grouparoo/mailchimp': 0.6.2-alpha.1
-      '@grouparoo/mailjet': 0.6.2-alpha.1
-      '@grouparoo/marketo': 0.6.2-alpha.1
-      '@grouparoo/mixpanel': 0.6.2-alpha.1
-      '@grouparoo/mongo': 0.6.2-alpha.1
-      '@grouparoo/mysql': 0.6.2-alpha.1
-      '@grouparoo/onesignal': 0.6.2-alpha.1
-      '@grouparoo/pardot': 0.6.2-alpha.1
-      '@grouparoo/pipedrive': 0.6.2-alpha.1
-      '@grouparoo/postgres': 0.6.2-alpha.1
-      '@grouparoo/prometheus': 0.6.2-alpha.1
-      '@grouparoo/redshift': 0.6.2-alpha.1
-      '@grouparoo/sailthru': 0.6.2-alpha.1
-      '@grouparoo/salesforce': 0.6.2-alpha.1
-      '@grouparoo/sendgrid': 0.6.2-alpha.1
-      '@grouparoo/sentry': 0.6.2-alpha.1
-      '@grouparoo/snowflake': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
-      '@grouparoo/sqlite': 0.6.2-alpha.1
-      '@grouparoo/ui-community': 0.6.2-alpha.1
-      '@grouparoo/ui-config': 0.6.2-alpha.1
-      '@grouparoo/zendesk': 0.6.2-alpha.1
+      '@grouparoo/bigquery': 0.6.2
+      '@grouparoo/calculated-property': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/csv': 0.6.2
+      '@grouparoo/customerio': 0.6.2
+      '@grouparoo/demo': 0.6.2
+      '@grouparoo/eloqua': 0.6.2
+      '@grouparoo/facebook': 0.6.2
+      '@grouparoo/files-s3': 0.6.2
+      '@grouparoo/google-sheets': 0.6.2
+      '@grouparoo/hubspot': 0.6.2
+      '@grouparoo/intercom': 0.6.2
+      '@grouparoo/iterable': 0.6.2
+      '@grouparoo/logger': 0.6.2
+      '@grouparoo/mailchimp': 0.6.2
+      '@grouparoo/mailjet': 0.6.2
+      '@grouparoo/marketo': 0.6.2
+      '@grouparoo/mixpanel': 0.6.2
+      '@grouparoo/mongo': 0.6.2
+      '@grouparoo/mysql': 0.6.2
+      '@grouparoo/onesignal': 0.6.2
+      '@grouparoo/pardot': 0.6.2
+      '@grouparoo/pipedrive': 0.6.2
+      '@grouparoo/postgres': 0.6.2
+      '@grouparoo/prometheus': 0.6.2
+      '@grouparoo/redshift': 0.6.2
+      '@grouparoo/sailthru': 0.6.2
+      '@grouparoo/salesforce': 0.6.2
+      '@grouparoo/sendgrid': 0.6.2
+      '@grouparoo/sentry': 0.6.2
+      '@grouparoo/snowflake': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
+      '@grouparoo/sqlite': 0.6.2
+      '@grouparoo/ui-community': 0.6.2
+      '@grouparoo/ui-config': 0.6.2
+      '@grouparoo/zendesk': 0.6.2
       jest: 27.1.0
     dependencies:
       '@grouparoo/bigquery': link:../../plugins/@grouparoo/bigquery
@@ -99,13 +99,13 @@ importers:
 
   apps/staging-config:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/demo': 0.6.2-alpha.1
-      '@grouparoo/postgres': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
-      '@grouparoo/sqlite': 0.6.2-alpha.1
-      '@grouparoo/ui-config': 0.6.2-alpha.1
-      grouparoo: 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/demo': 0.6.2
+      '@grouparoo/postgres': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
+      '@grouparoo/sqlite': 0.6.2
+      '@grouparoo/ui-config': 0.6.2
+      grouparoo: 0.6.2
       jest: 27.1.0
     dependencies:
       '@grouparoo/core': link:../../core
@@ -120,41 +120,41 @@ importers:
 
   apps/staging-enterprise:
     specifiers:
-      '@grouparoo/bigquery': 0.6.2-alpha.1
-      '@grouparoo/calculated-property': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/csv': 0.6.2-alpha.1
-      '@grouparoo/customerio': 0.6.2-alpha.1
-      '@grouparoo/demo': 0.6.2-alpha.1
-      '@grouparoo/eloqua': 0.6.2-alpha.1
-      '@grouparoo/facebook': 0.6.2-alpha.1
-      '@grouparoo/files-s3': 0.6.2-alpha.1
-      '@grouparoo/google-sheets': 0.6.2-alpha.1
-      '@grouparoo/hubspot': 0.6.2-alpha.1
-      '@grouparoo/intercom': 0.6.2-alpha.1
-      '@grouparoo/iterable': 0.6.2-alpha.1
-      '@grouparoo/logger': 0.6.2-alpha.1
-      '@grouparoo/mailchimp': 0.6.2-alpha.1
-      '@grouparoo/mailjet': 0.6.2-alpha.1
-      '@grouparoo/marketo': 0.6.2-alpha.1
-      '@grouparoo/mixpanel': 0.6.2-alpha.1
-      '@grouparoo/mongo': 0.6.2-alpha.1
-      '@grouparoo/mysql': 0.6.2-alpha.1
-      '@grouparoo/onesignal': 0.6.2-alpha.1
-      '@grouparoo/pardot': 0.6.2-alpha.1
-      '@grouparoo/pipedrive': 0.6.2-alpha.1
-      '@grouparoo/postgres': 0.6.2-alpha.1
-      '@grouparoo/redshift': 0.6.2-alpha.1
-      '@grouparoo/sailthru': 0.6.2-alpha.1
-      '@grouparoo/salesforce': 0.6.2-alpha.1
-      '@grouparoo/sendgrid': 0.6.2-alpha.1
-      '@grouparoo/sentry': 0.6.2-alpha.1
-      '@grouparoo/snowflake': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
-      '@grouparoo/sqlite': 0.6.2-alpha.1
-      '@grouparoo/ui-config': 0.6.2-alpha.1
-      '@grouparoo/ui-enterprise': 0.6.2-alpha.1
-      '@grouparoo/zendesk': 0.6.2-alpha.1
+      '@grouparoo/bigquery': 0.6.2
+      '@grouparoo/calculated-property': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/csv': 0.6.2
+      '@grouparoo/customerio': 0.6.2
+      '@grouparoo/demo': 0.6.2
+      '@grouparoo/eloqua': 0.6.2
+      '@grouparoo/facebook': 0.6.2
+      '@grouparoo/files-s3': 0.6.2
+      '@grouparoo/google-sheets': 0.6.2
+      '@grouparoo/hubspot': 0.6.2
+      '@grouparoo/intercom': 0.6.2
+      '@grouparoo/iterable': 0.6.2
+      '@grouparoo/logger': 0.6.2
+      '@grouparoo/mailchimp': 0.6.2
+      '@grouparoo/mailjet': 0.6.2
+      '@grouparoo/marketo': 0.6.2
+      '@grouparoo/mixpanel': 0.6.2
+      '@grouparoo/mongo': 0.6.2
+      '@grouparoo/mysql': 0.6.2
+      '@grouparoo/onesignal': 0.6.2
+      '@grouparoo/pardot': 0.6.2
+      '@grouparoo/pipedrive': 0.6.2
+      '@grouparoo/postgres': 0.6.2
+      '@grouparoo/redshift': 0.6.2
+      '@grouparoo/sailthru': 0.6.2
+      '@grouparoo/salesforce': 0.6.2
+      '@grouparoo/sendgrid': 0.6.2
+      '@grouparoo/sentry': 0.6.2
+      '@grouparoo/snowflake': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
+      '@grouparoo/sqlite': 0.6.2
+      '@grouparoo/ui-config': 0.6.2
+      '@grouparoo/ui-enterprise': 0.6.2
+      '@grouparoo/zendesk': 0.6.2
       jest: 27.1.0
     dependencies:
       '@grouparoo/bigquery': link:../../plugins/@grouparoo/bigquery
@@ -228,7 +228,7 @@ importers:
 
   core:
     specifiers:
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/spec-helper': 0.6.2
       '@types/fs-extra': '*'
       '@types/jest': '*'
       '@types/node': '*'
@@ -248,7 +248,7 @@ importers:
       dotenv: 10.0.0
       fs-extra: 10.0.0
       glob: 7.1.7
-      grouparoo: 0.6.2-alpha.1
+      grouparoo: 0.6.2
       ioredis: 4.27.9
       ioredis-mock: 5.6.0
       isomorphic-fetch: 3.0.0
@@ -341,8 +341,8 @@ importers:
 
   plugins/@grouparoo/app-templates:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       '@types/uuid': '*'
@@ -370,9 +370,9 @@ importers:
   plugins/@grouparoo/bigquery:
     specifiers:
       '@google-cloud/bigquery': 5.8.0
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -402,8 +402,8 @@ importers:
 
   plugins/@grouparoo/calculated-property:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -427,8 +427,8 @@ importers:
 
   plugins/@grouparoo/csv:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -458,9 +458,9 @@ importers:
 
   plugins/@grouparoo/customerio:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -495,8 +495,8 @@ importers:
 
   plugins/@grouparoo/dbt:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -522,8 +522,8 @@ importers:
 
   plugins/@grouparoo/demo:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -567,9 +567,9 @@ importers:
 
   plugins/@grouparoo/eloqua:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -600,9 +600,9 @@ importers:
 
   plugins/@grouparoo/facebook:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -641,7 +641,7 @@ importers:
 
   plugins/@grouparoo/files-local:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -664,7 +664,7 @@ importers:
 
   plugins/@grouparoo/files-s3:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -689,8 +689,8 @@ importers:
 
   plugins/@grouparoo/google-sheets:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -722,9 +722,9 @@ importers:
 
   plugins/@grouparoo/hubspot:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -761,9 +761,9 @@ importers:
 
   plugins/@grouparoo/intercom:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -796,9 +796,9 @@ importers:
 
   plugins/@grouparoo/iterable:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -831,9 +831,9 @@ importers:
 
   plugins/@grouparoo/logger:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -856,9 +856,9 @@ importers:
 
   plugins/@grouparoo/mailchimp:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -893,9 +893,9 @@ importers:
 
   plugins/@grouparoo/mailjet:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -930,10 +930,10 @@ importers:
 
   plugins/@grouparoo/marketo:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
       '@grouparoo/node-marketo-rest': 0.7.10
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -965,9 +965,9 @@ importers:
 
   plugins/@grouparoo/mixpanel:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -998,9 +998,9 @@ importers:
 
   plugins/@grouparoo/mongo:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -1029,9 +1029,9 @@ importers:
 
   plugins/@grouparoo/mysql:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/mysql': '*'
       '@types/node': '*'
@@ -1060,8 +1060,8 @@ importers:
 
   plugins/@grouparoo/newrelic:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -1085,9 +1085,9 @@ importers:
 
   plugins/@grouparoo/onesignal:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -1120,9 +1120,9 @@ importers:
 
   plugins/@grouparoo/pardot:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -1159,9 +1159,9 @@ importers:
 
   plugins/@grouparoo/pipedrive:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -1194,9 +1194,9 @@ importers:
 
   plugins/@grouparoo/postgres:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       '@types/pg': '*'
@@ -1235,8 +1235,8 @@ importers:
 
   plugins/@grouparoo/prometheus:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -1260,10 +1260,10 @@ importers:
 
   plugins/@grouparoo/redshift:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/postgres': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/postgres': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       '@types/pg': '*'
@@ -1291,9 +1291,9 @@ importers:
 
   plugins/@grouparoo/sailthru:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -1326,9 +1326,9 @@ importers:
 
   plugins/@grouparoo/salesforce:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -1361,9 +1361,9 @@ importers:
 
   plugins/@grouparoo/sendgrid:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@sendgrid/client': 7.4.6
       '@types/jest': '*'
       '@types/node': '*'
@@ -1396,8 +1396,8 @@ importers:
 
   plugins/@grouparoo/sentry:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@sentry/node': 6.12.0
       '@sentry/tracing': 6.12.0
       '@types/jest': '*'
@@ -1423,9 +1423,9 @@ importers:
 
   plugins/@grouparoo/snowflake:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -1458,7 +1458,7 @@ importers:
 
   plugins/@grouparoo/spec-helper:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
       '@types/faker': '*'
       '@types/jest': '*'
       '@types/node': '*'
@@ -1493,9 +1493,9 @@ importers:
 
   plugins/@grouparoo/sqlite:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       '@types/pg': '*'
@@ -1532,9 +1532,9 @@ importers:
 
   plugins/@grouparoo/zendesk:
     specifiers:
-      '@grouparoo/app-templates': 0.6.2-alpha.1
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
+      '@grouparoo/app-templates': 0.6.2
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
       '@types/jest': '*'
       '@types/node': '*'
       actionhero: 27.0.3
@@ -1567,9 +1567,9 @@ importers:
 
   ui/ui-community:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
-      '@grouparoo/ui-components': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
+      '@grouparoo/ui-components': 0.6.2
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1618,7 +1618,7 @@ importers:
       '@fortawesome/free-brands-svg-icons': 5.15.4
       '@fortawesome/free-solid-svg-icons': 5.15.4
       '@fortawesome/react-fontawesome': 0.1.15
-      '@grouparoo/core': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
       '@testing-library/jest-dom': 5.14.1
       '@testing-library/react': 12.0.0
       '@types/jest': '*'
@@ -1692,9 +1692,9 @@ importers:
 
   ui/ui-config:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
-      '@grouparoo/ui-components': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
+      '@grouparoo/ui-components': 0.6.2
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1743,9 +1743,9 @@ importers:
 
   ui/ui-enterprise:
     specifiers:
-      '@grouparoo/core': 0.6.2-alpha.1
-      '@grouparoo/spec-helper': 0.6.2-alpha.1
-      '@grouparoo/ui-components': 0.6.2-alpha.1
+      '@grouparoo/core': 0.6.2
+      '@grouparoo/spec-helper': 0.6.2
+      '@grouparoo/ui-components': 0.6.2
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -14012,7 +14012,7 @@ packages:
       '@types/jest': 27.0.1
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.1.0_ts-node@10.2.1
+      jest: 27.1.0
       jest-util: 27.1.1
       json5: 2.2.0
       lodash: 4.17.21

--- a/tools/merger/data/ci/apps/job.yml.template
+++ b/tools/merger/data/ci/apps/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/base.yml.template
+++ b/tools/merger/data/ci/base.yml.template
@@ -18,7 +18,7 @@ jobs:
   build:
     resource_class: "medium+"
     docker:
-      - image: circleci/node:16
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -38,7 +38,7 @@ jobs:
 
   complete:
     docker:
-      - image: circleci/node:16
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/cli/job.yml.template
+++ b/tools/merger/data/ci/cli/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/client/job.yml.template
+++ b/tools/merger/data/ci/client/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/command/job.yml.template
+++ b/tools/merger/data/ci/command/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/core-local/job.yml.template
+++ b/tools/merger/data/ci/core-local/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/core/job.yml.template
+++ b/tools/merger/data/ci/core/job.yml.template
@@ -1,6 +1,6 @@
   test-{{{type}}}-{{{test_section}}}:
     docker:
-      - image: circleci/node:16
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/plugin/job.yml.template
+++ b/tools/merger/data/ci/plugin/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/data/ci/ui/job.yml.template
+++ b/tools/merger/data/ci/ui/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     docker:
-      - image: circleci/node:16
+      - image: {{{docker_image}}}
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -5,6 +5,8 @@ const Mustache = require("mustache");
 const { allPackagePaths, allPluginPaths } = require("../../shared/packages");
 const execSync = require("../../shared/exec");
 
+const docker_image = "circleci/node:16.8.0";
+
 module.exports.cmd = async function (vargs) {
   const instance = new Generator(vargs);
   await instance.generate();
@@ -367,6 +369,7 @@ class Generator {
 
   renderJob(job, name) {
     const template = readTemplate(name, job.type);
+    job.docker_image = docker_image;
     return Mustache.render(template, job);
   }
 
@@ -394,6 +397,7 @@ class Generator {
     // these get passed through
     view[".Branch"] = "{{ .Branch }}";
     view[".Revision"] = "{{ .Revision }}";
+    view.docker_image = docker_image;
 
     const methods = [
       "jobs",


### PR DESCRIPTION
backports #2298 to v0.6.2

To make tests pass I had to swap some things in the csv tests (it was pulling a file that has been renamed from main) and cherry-pick a fix @evantahler had made that uses node 16.8 for CI.