### PR TITLE
Request plugin information in parallel

### DIFF
--- a/core/src/modules/plugins.ts
+++ b/core/src/modules/plugins.ts
@@ -56,28 +56,31 @@ export namespace Plugins {
     ].concat(pluginManifest.plugins);
 
     const pluginResponse: PluginWithVersions[] = [];
-    for (const plugin of plugins) {
-      let latestVersion = "unknown";
 
-      try {
-        const manifest = await getLatestNPMVersion(plugin);
-        latestVersion = manifest.version;
-      } catch (error) {
-        log(error.toString(), "info");
-      }
+    await Promise.all(
+      plugins.map(async (plugin) => {
+        let latestVersion = "unknown";
 
-      pluginResponse.push({
-        name: plugin.name,
-        currentVersion: plugin.version,
-        license: plugin.license,
-        url: plugin.url,
-        latestVersion,
-        upToDate:
-          latestVersion === "unknown"
-            ? true
-            : compareVersions(plugin.version, latestVersion) >= 0,
-      });
-    }
+        try {
+          const manifest = await getLatestNPMVersion(plugin);
+          latestVersion = manifest.version;
+        } catch (error) {
+          log(error.toString(), "info");
+        }
+
+        pluginResponse.push({
+          name: plugin.name,
+          currentVersion: plugin.version,
+          license: plugin.license,
+          url: plugin.url,
+          latestVersion,
+          upToDate:
+            latestVersion === "unknown"
+              ? true
+              : compareVersions(plugin.version, latestVersion) >= 0,
+        });
+      })
+    );
 
     return pluginResponse;
   }


### PR DESCRIPTION
This PR checks the available NPM versions in parallel rather than serially for the information we display on the `/about` page

While testing in my hotel:

Before: 4768ms
After: 2177ms

... 2x faster?