### PR TITLE
Reducing Imports under load

### DIFF
--- a/cli/__tests__/test.sh
+++ b/cli/__tests__/test.sh
@@ -169,7 +169,7 @@ PID=$!
 echo ""
 echo ""
 
-sleep 10
+sleep 30
 
 echo ""
 echo "--- test: status ---"

--- a/core/__tests__/models/record/__snapshots__/snapshot-testing.ts.snap
+++ b/core/__tests__/models/record/__snapshots__/snapshot-testing.ts.snap
@@ -8,7 +8,7 @@ Object {
   "locked": null,
   "matchType": "all",
   "name": "test group",
-  "nextCalculatedAt": Any<Number>,
+  "nextCalculatedAt": null,
   "recordsCount": 1,
   "rules": Array [
     Object {
@@ -152,7 +152,7 @@ Object {
       "locked": null,
       "matchType": "all",
       "name": "test group",
-      "nextCalculatedAt": Any<Number>,
+      "nextCalculatedAt": null,
       "recordsCount": 1,
       "rules": Array [
         Object {

--- a/core/__tests__/models/record/snapshot-testing.ts
+++ b/core/__tests__/models/record/snapshot-testing.ts
@@ -98,7 +98,7 @@ describe("test grouparoo records", () => {
         id: expect.stringMatching(/^grp_/),
         createdAt: expect.any(Number),
         updatedAt: expect.any(Number),
-        nextCalculatedAt: expect.any(Number),
+        nextCalculatedAt: null,
       });
     });
 

--- a/core/__tests__/modules/codeConfig/__snapshots__/snapshotTest.ts.snap
+++ b/core/__tests__/modules/codeConfig/__snapshots__/snapshotTest.ts.snap
@@ -39,7 +39,7 @@ Object {
       "locked": "config:code",
       "matchType": "all",
       "name": "People with Email Addresses",
-      "nextCalculatedAt": Any<Number>,
+      "nextCalculatedAt": null,
       "recordsCount": 1,
       "rules": Array [
         Object {
@@ -194,7 +194,7 @@ Object {
       "locked": "config:code",
       "matchType": "all",
       "name": "People with Email Addresses",
-      "nextCalculatedAt": Any<Number>,
+      "nextCalculatedAt": null,
       "recordsCount": 1,
       "rules": Array [
         Object {

--- a/core/__tests__/snapshots/__snapshots__/snapshot-testing.ts.snap
+++ b/core/__tests__/snapshots/__snapshots__/snapshot-testing.ts.snap
@@ -8,7 +8,7 @@ Object {
   "locked": null,
   "matchType": "all",
   "name": "test group",
-  "nextCalculatedAt": Any<Number>,
+  "nextCalculatedAt": null,
   "recordsCount": 1,
   "rules": Array [
     Object {
@@ -152,7 +152,7 @@ Object {
       "locked": null,
       "matchType": "all",
       "name": "test group",
-      "nextCalculatedAt": Any<Number>,
+      "nextCalculatedAt": null,
       "recordsCount": 1,
       "rules": Array [
         Object {

--- a/core/__tests__/snapshots/snapshot-testing.ts
+++ b/core/__tests__/snapshots/snapshot-testing.ts
@@ -99,7 +99,7 @@ describe("test grouparoo records", () => {
         id: expect.stringMatching(/^grp_/),
         createdAt: expect.any(Number),
         updatedAt: expect.any(Number),
-        nextCalculatedAt: expect.any(Number),
+        nextCalculatedAt: null,
       });
     });
 

--- a/core/__tests__/tasks/group/updateCalculatedGroups.ts
+++ b/core/__tests__/tasks/group/updateCalculatedGroups.ts
@@ -1,20 +1,19 @@
 import { helper } from "@grouparoo/spec-helper";
 import { api, specHelper } from "actionhero";
-import { plugin, Group, Run } from "../../../src";
+import { plugin, Group, Run, Property } from "../../../src";
 import { Op } from "sequelize";
 
 let group: Group;
 
 describe("tasks/group:updateCalculatedGroups", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  beforeAll(async () => await helper.factories.properties());
   beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
   beforeEach(async () => await group.reload());
 
   describe("record:updateCalculatedGroups", () => {
     beforeAll(async () => {
       group = await helper.factories.group();
-      group.type = "calculated";
-      await group.save();
     });
 
     beforeEach(async () => {
@@ -29,86 +28,148 @@ describe("tasks/group:updateCalculatedGroups", () => {
       expect(setting.value).toBe("1440");
     });
 
-    test("running it will enqueue an update for groups that have never been calculated", async () => {
-      await group.update({ state: "ready", calculatedAt: null });
-      await specHelper.runTask("group:updateCalculatedGroups", {});
-
-      const runs = await Run.findAll({ where: { creatorId: group.id } });
-      expect(runs.length).toBe(1);
-    });
-
-    test("running it will enqueue an update for groups that were last recalculated in the far past", async () => {
-      await group.update({ state: "ready", calculatedAt: new Date(0) }); // ~1970 or so
-      await specHelper.runTask("group:updateCalculatedGroups", {});
-
-      const runs = await Run.findAll({ where: { creatorId: group.id } });
-      expect(runs.length).toBe(1);
-    });
-
-    test("running it will not enqueue an update for groups that were last recalculated recently", async () => {
-      await group.update({ state: "ready", calculatedAt: new Date() }); // now
-      await specHelper.runTask("group:updateCalculatedGroups", {});
-
-      const runs = await Run.findAll({ where: { creatorId: group.id } });
-      expect(runs.length).toBe(0);
-    });
-
-    test("groups already calculating will not be calculated again if they have been checked recently", async () => {
-      await group.update({ state: "updating", calculatedAt: new Date() }); // now
-      await specHelper.runTask("group:updateCalculatedGroups", {});
-
-      const runs = await Run.findAll({ where: { creatorId: group.id } });
-      expect(runs.length).toBe(0);
-    });
-
-    test("groups already calculating will not be calculated again if it is time but they have a running run (old)", async () => {
-      await group.update({ state: "updating", calculatedAt: new Date(0) }); // ~1970 or so
-      const runningRun = await Run.create({
-        creatorId: group.id,
-        creatorType: "group",
-        state: "running",
+    describe("calculated groups with relative rules", () => {
+      beforeAll(async () => {
+        await group.update({ type: "calculated" });
+        await group.setRules([
+          {
+            key: "lastLoginAt",
+            operation: { op: "gt" },
+            relativeMatchDirection: "subtract",
+            relativeMatchNumber: 1,
+            relativeMatchUnit: "days",
+          },
+        ]);
       });
-      await specHelper.runTask("group:updateCalculatedGroups", {});
 
-      const runs = await Run.findAll({
-        where: { creatorId: group.id, id: { [Op.ne]: runningRun.id } },
+      test("running it will enqueue an update for groups that have never been calculated", async () => {
+        await group.update({ state: "ready", calculatedAt: null });
+        await specHelper.runTask("group:updateCalculatedGroups", {});
+
+        const runs = await Run.findAll({ where: { creatorId: group.id } });
+        expect(runs.length).toBe(1);
       });
-      expect(runs.length).toBe(0);
+
+      test("running it will enqueue an update for groups that were last recalculated in the far past", async () => {
+        await group.update({ state: "ready", calculatedAt: new Date(0) }); // ~1970 or so
+        await specHelper.runTask("group:updateCalculatedGroups", {});
+
+        const runs = await Run.findAll({ where: { creatorId: group.id } });
+        expect(runs.length).toBe(1);
+      });
+
+      test("running it will not enqueue an update for groups that were last recalculated recently", async () => {
+        await group.update({ state: "ready", calculatedAt: new Date() }); // now
+        await specHelper.runTask("group:updateCalculatedGroups", {});
+
+        const runs = await Run.findAll({ where: { creatorId: group.id } });
+        expect(runs.length).toBe(0);
+      });
+
+      test("groups already calculating will not be calculated again if they have been checked recently", async () => {
+        await group.update({ state: "updating", calculatedAt: new Date() }); // now
+        await specHelper.runTask("group:updateCalculatedGroups", {});
+
+        const runs = await Run.findAll({ where: { creatorId: group.id } });
+        expect(runs.length).toBe(0);
+      });
+
+      test("groups already calculating will not be calculated again if it is time but they have a running run (old)", async () => {
+        await group.update({ state: "updating", calculatedAt: new Date(0) }); // ~1970 or so
+        const runningRun = await Run.create({
+          creatorId: group.id,
+          creatorType: "group",
+          state: "running",
+        });
+        await specHelper.runTask("group:updateCalculatedGroups", {});
+
+        const runs = await Run.findAll({
+          where: { creatorId: group.id, id: { [Op.ne]: runningRun.id } },
+        });
+        expect(runs.length).toBe(0);
+      });
+
+      test("groups already calculating will not be calculated again if it is time but they have a running run (null)", async () => {
+        await group.update({ state: "updating", calculatedAt: null }); // ~1970 or so
+        const runningRun = await Run.create({
+          creatorId: group.id,
+          creatorType: "group",
+          state: "running",
+        });
+        await specHelper.runTask("group:updateCalculatedGroups", {});
+
+        const runs = await Run.findAll({
+          where: { creatorId: group.id, id: { [Op.ne]: runningRun.id } },
+        });
+        expect(runs.length).toBe(0);
+      });
+
+      test("groups already calculating will be calculated again if it is time and they don't have a related run (old)", async () => {
+        await group.update({ state: "updating", calculatedAt: new Date(0) }); // ~1970 or so
+        await specHelper.runTask("group:updateCalculatedGroups", {});
+
+        const runs = await Run.findAll({
+          where: { creatorId: group.id },
+        });
+        expect(runs.length).toBe(1);
+      });
+
+      test("groups already calculating will be calculated again if it is time and they don't have a related run (null)", async () => {
+        await group.update({ state: "updating", calculatedAt: null }); // null
+        await specHelper.runTask("group:updateCalculatedGroups", {});
+
+        const runs = await Run.findAll({
+          where: { creatorId: group.id },
+        });
+        expect(runs.length).toBe(1);
+      });
     });
 
-    test("groups already calculating will not be calculated again if it is time but they have a running run (null)", async () => {
-      await group.update({ state: "updating", calculatedAt: null }); // ~1970 or so
-      const runningRun = await Run.create({
-        creatorId: group.id,
-        creatorType: "group",
-        state: "running",
+    describe("calculated groups without relative rules", () => {
+      beforeAll(async () => {
+        await group.update({ type: "calculated" });
+        await group.setRules([
+          {
+            key: "ltv",
+            operation: { op: "gt" },
+            match: "3",
+          },
+        ]);
       });
-      await specHelper.runTask("group:updateCalculatedGroups", {});
 
-      const runs = await Run.findAll({
-        where: { creatorId: group.id, id: { [Op.ne]: runningRun.id } },
+      test("running it will not enqueue an update for groups that have never been calculated", async () => {
+        await group.update({ state: "ready", calculatedAt: null });
+        await specHelper.runTask("group:updateCalculatedGroups", {});
+        const runs = await Run.findAll({ where: { creatorId: group.id } });
+        expect(runs.length).toBe(0);
       });
-      expect(runs.length).toBe(0);
+
+      test("running it will not enqueue an update for groups that were last recalculated in the far past", async () => {
+        await group.update({ state: "ready", calculatedAt: new Date(0) }); // ~1970 or so
+        await specHelper.runTask("group:updateCalculatedGroups", {});
+        const runs = await Run.findAll({ where: { creatorId: group.id } });
+        expect(runs.length).toBe(0);
+      });
     });
 
-    test("groups already calculating will be calculated again if it is time and they don't have a related run (old)", async () => {
-      await group.update({ state: "updating", calculatedAt: new Date(0) }); // ~1970 or so
-      await specHelper.runTask("group:updateCalculatedGroups", {});
-
-      const runs = await Run.findAll({
-        where: { creatorId: group.id },
+    describe("manual groups", () => {
+      beforeAll(async () => {
+        await group.update({ type: "manual" });
       });
-      expect(runs.length).toBe(1);
-    });
 
-    test("groups already calculating will be calculated again if it is time and they don't have a related run (null)", async () => {
-      await group.update({ state: "updating", calculatedAt: null }); // null
-      await specHelper.runTask("group:updateCalculatedGroups", {});
-
-      const runs = await Run.findAll({
-        where: { creatorId: group.id },
+      test("running it will not enqueue an update for groups that have never been calculated", async () => {
+        await group.update({ state: "ready", calculatedAt: null });
+        await specHelper.runTask("group:updateCalculatedGroups", {});
+        const runs = await Run.findAll({ where: { creatorId: group.id } });
+        expect(runs.length).toBe(0);
       });
-      expect(runs.length).toBe(1);
+
+      test("running it will not enqueue an update for groups that were last recalculated in the far past", async () => {
+        await group.update({ state: "ready", calculatedAt: new Date(0) }); // ~1970 or so
+        await specHelper.runTask("group:updateCalculatedGroups", {});
+        const runs = await Run.findAll({ where: { creatorId: group.id } });
+        expect(runs.length).toBe(0);
+      });
     });
   });
 });

--- a/core/__tests__/tasks/run/tick.ts
+++ b/core/__tests__/tasks/run/tick.ts
@@ -1,6 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { task, api, specHelper } from "actionhero";
-import { Run } from "../../../src";
+import { Run, Group, StatusMetric, Status } from "../../../src";
 import { internalRun } from "../../../src/modules/internalRun";
 
 describe("tasks/run:tick", () => {
@@ -8,6 +8,11 @@ describe("tasks/run:tick", () => {
   beforeAll(async () => await helper.factories.properties());
   beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
   beforeEach(async () => await Run.truncate());
+
+  let group: Group;
+  beforeAll(async () => {
+    group = await helper.factories.group();
+  });
 
   test("complete runs will not be run", async () => {
     const run = await helper.factories.run(null, { state: "complete" });
@@ -41,7 +46,6 @@ describe("tasks/run:tick", () => {
   });
 
   test("running group runs will be enqueued", async () => {
-    const group = await helper.factories.group();
     const run = await helper.factories.run(group, { state: "running" });
     await helper.changeTimestamps(run);
 
@@ -76,5 +80,77 @@ describe("tasks/run:tick", () => {
     const foundTasks = await specHelper.findEnqueuedTasks("run:internalRun");
     expect(foundTasks.length).toBe(1);
     expect(foundTasks[0].args[0].runId).toBe(run.id);
+  });
+
+  describe("circutbreaker disabled", () => {
+    beforeEach(async () => {
+      const metrics: StatusMetric[] = [
+        {
+          topic: "Import",
+          collection: "pending",
+          aggregation: "count",
+          value: "0",
+        },
+        {
+          topic: "Export",
+          collection: "pending",
+          aggregation: "count",
+          value: "10",
+        },
+        {
+          topic: "GrouparooRecord",
+          collection: "pending",
+          aggregation: "count",
+          value: "100",
+        },
+      ];
+
+      await Status.set(metrics);
+    });
+
+    ["Import", "Export", "GrouparooRecord"].map((topic) =>
+      test(`if there are not many pending ${topic}s, runs will be ticked`, async () => {
+        const run = await helper.factories.run(group, { state: "running" });
+        await helper.changeTimestamps(run);
+        const enqueued = await specHelper.runTask("run:tick", {});
+        expect(enqueued).toBe(1);
+      })
+    );
+  });
+
+  describe("circutbreaker active", () => {
+    beforeEach(async () => {
+      const metrics: StatusMetric[] = [
+        {
+          topic: "Import",
+          collection: "pending",
+          aggregation: "count",
+          value: "99999999",
+        },
+        {
+          topic: "Export",
+          collection: "pending",
+          aggregation: "count",
+          value: "99999999",
+        },
+        {
+          topic: "GrouparooRecord",
+          collection: "pending",
+          aggregation: "count",
+          value: "99999999",
+        },
+      ];
+
+      await Status.set(metrics);
+    });
+
+    ["Import", "Export", "GrouparooRecord"].map((topic) =>
+      test(`if there are too many pending ${topic}s, runs will not be ticked`, async () => {
+        const run = await helper.factories.run(group, { state: "running" });
+        await helper.changeTimestamps(run);
+        const enqueued = await specHelper.runTask("run:tick", {});
+        expect(enqueued).toBe(0);
+      })
+    );
   });
 });

--- a/core/__tests__/tasks/run/tick.ts
+++ b/core/__tests__/tasks/run/tick.ts
@@ -1,6 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { task, api, specHelper } from "actionhero";
-import { Run, Group, StatusMetric, Status } from "../../../src";
+import { Run, Group } from "../../../src";
 import { internalRun } from "../../../src/modules/internalRun";
 
 describe("tasks/run:tick", () => {
@@ -80,77 +80,5 @@ describe("tasks/run:tick", () => {
     const foundTasks = await specHelper.findEnqueuedTasks("run:internalRun");
     expect(foundTasks.length).toBe(1);
     expect(foundTasks[0].args[0].runId).toBe(run.id);
-  });
-
-  describe("circutbreaker disabled", () => {
-    beforeEach(async () => {
-      const metrics: StatusMetric[] = [
-        {
-          topic: "Import",
-          collection: "pending",
-          aggregation: "count",
-          value: "0",
-        },
-        {
-          topic: "Export",
-          collection: "pending",
-          aggregation: "count",
-          value: "10",
-        },
-        {
-          topic: "GrouparooRecord",
-          collection: "pending",
-          aggregation: "count",
-          value: "100",
-        },
-      ];
-
-      await Status.set(metrics);
-    });
-
-    ["Import", "Export", "GrouparooRecord"].map((topic) =>
-      test(`if there are not many pending ${topic}s, runs will be ticked`, async () => {
-        const run = await helper.factories.run(group, { state: "running" });
-        await helper.changeTimestamps(run);
-        const enqueued = await specHelper.runTask("run:tick", {});
-        expect(enqueued).toBe(1);
-      })
-    );
-  });
-
-  describe("circutbreaker active", () => {
-    beforeEach(async () => {
-      const metrics: StatusMetric[] = [
-        {
-          topic: "Import",
-          collection: "pending",
-          aggregation: "count",
-          value: "99999999",
-        },
-        {
-          topic: "Export",
-          collection: "pending",
-          aggregation: "count",
-          value: "99999999",
-        },
-        {
-          topic: "GrouparooRecord",
-          collection: "pending",
-          aggregation: "count",
-          value: "99999999",
-        },
-      ];
-
-      await Status.set(metrics);
-    });
-
-    ["Import", "Export", "GrouparooRecord"].map((topic) =>
-      test(`if there are too many pending ${topic}s, runs will not be ticked`, async () => {
-        const run = await helper.factories.run(group, { state: "running" });
-        await helper.changeTimestamps(run);
-        const enqueued = await specHelper.runTask("run:tick", {});
-        expect(enqueued).toBe(0);
-      })
-    );
   });
 });

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -348,8 +348,16 @@ export class Group extends LoggedModel<Group> {
   }
 
   async nextCalculatedAt() {
-    if (!this.calculatedAt) return Moment().toDate();
+    if (this.type === "manual") return null;
 
+    let hasRelativeRule = false;
+    const rules = await this.getRules();
+    for (const rule of rules) {
+      if (rule.relativeMatchDirection) hasRelativeRule = true;
+    }
+    if (!hasRelativeRule) return null;
+
+    if (!this.calculatedAt) return Moment().toDate();
     const setting = await Setting.findOne({
       where: { pluginName: "core", key: "groups-calculation-delay-minutes" },
     });

--- a/core/src/modules/ops/recordProperty.ts
+++ b/core/src/modules/ops/recordProperty.ts
@@ -136,6 +136,7 @@ export namespace RecordPropertyOps {
             [Op.or]: [null, { [Op.lt]: new Date().getTime() - delayMs }],
           },
         },
+        order: [["updatedAt", "asc"]],
         limit: limit * propertyGroups[aggregationMethod].length,
       });
 
@@ -159,6 +160,7 @@ export namespace RecordPropertyOps {
             [Op.or]: [null, { [Op.lt]: new Date().getTime() - delayMs }],
           },
         },
+        order: [["updatedAt", "asc"]],
         limit,
       });
 

--- a/core/src/tasks/group/updateCalculatedGroups.ts
+++ b/core/src/tasks/group/updateCalculatedGroups.ts
@@ -30,14 +30,9 @@ export class GroupsUpdateCalculatedGroups extends CLSTask {
 
     for (const group of calculatedGroups) {
       const calculatedAt = group.calculatedAt?.getTime() ?? 0;
+      const nextCalculatedAt = await group.nextCalculatedAt();
 
-      let hasRelativeRule = false;
-      const rules = await group.getRules();
-      for (const rule of rules) {
-        if (rule.relativeMatchDirection) hasRelativeRule = true;
-      }
-
-      if (hasRelativeRule && calculatedAt < lastCheckTime.getTime()) {
+      if (nextCalculatedAt && calculatedAt < lastCheckTime.getTime()) {
         if (group.state === "ready") {
           groupsToRun.push(group);
         } else if (group.state === "updating") {

--- a/core/src/tasks/group/updateCalculatedGroups.ts
+++ b/core/src/tasks/group/updateCalculatedGroups.ts
@@ -29,9 +29,15 @@ export class GroupsUpdateCalculatedGroups extends CLSTask {
     });
 
     for (const group of calculatedGroups) {
-      const calculatedAt = group.calculatedAt?.getTime() || 0;
+      const calculatedAt = group.calculatedAt?.getTime() ?? 0;
 
-      if (calculatedAt < lastCheckTime.getTime()) {
+      let hasRelativeRule = false;
+      const rules = await group.getRules();
+      for (const rule of rules) {
+        if (rule.relativeMatchDirection) hasRelativeRule = true;
+      }
+
+      if (hasRelativeRule && calculatedAt < lastCheckTime.getTime()) {
         if (group.state === "ready") {
           groupsToRun.push(group);
         } else if (group.state === "updating") {

--- a/core/src/tasks/run/tick.ts
+++ b/core/src/tasks/run/tick.ts
@@ -1,10 +1,9 @@
 import { Run } from "../../models/Run";
 import { CLSTask } from "../../classes/tasks/clsTask";
-import { config, log } from "actionhero";
+import { config } from "actionhero";
 import { CLS } from "../../modules/cls";
 import { Op } from "sequelize";
 import { RunOps } from "../../modules/ops/runs";
-import { Status } from "../../modules/status";
 
 export class RunsTick extends CLSTask {
   constructor() {
@@ -15,31 +14,7 @@ export class RunsTick extends CLSTask {
     this.queue = "runs";
   }
 
-  async shouldWaitForPending(topic: string, limit: number) {
-    const metrics = await Status.getCurrent();
-    if (!metrics[topic]) return false;
-
-    const value = metrics[topic]?.pending[0]?.metric?.value;
-
-    if (value) {
-      if (parseInt(value) > limit) {
-        log(
-          `pausing runs as there are too many pending ${topic.toLowerCase()}s (${value})`,
-          "warning"
-        );
-        return true;
-      }
-    }
-
-    return false;
-  }
-
   async runWithinTransaction() {
-    const circuitBreakerLimit = config.batchSize.profileProperties * 10;
-    for (const topic of ["Import", "Export", "GrouparooRecord"]) {
-      if (await this.shouldWaitForPending(topic, circuitBreakerLimit)) return 0;
-    }
-
     const lastCheck = new Date().getTime() - Math.max(this.frequency, 1000);
     const runs = await Run.findAll({
       where: { state: "running", updatedAt: { [Op.lt]: lastCheck } },


### PR DESCRIPTION
This PR includes 2 enchantments to reduce the load created by Grouparoo.

1. Do not recalculate GroupMembers if the Group does not contain any relative rules (e.g: people in this group have signupDate less than 7 days ago).  Static Group rules do not need to be checked periodically as we will always re-check a Grouparoo Record's membership any time a Property changes.
2. Sort pending RecordProperties about to be imported by updatedAt (oldest first). 
 
(2) prevents a situation that's possible to get into wherin a recurring schedule runs so quickly that we get in a cycle where:
* Run A created a bunch of Imports, which made a bunch of profiles pending.  
* Run A completed, but the Profiles were still pending
* Run B starts, and makes the profiles all pending again
* The bottom chunk of those imports + profiles never get to be complete. 