### PR TITLE
only show "add multiple properties" if possible to do

### DIFF
--- a/ui/ui-components/pages/source/[id]/overview.tsx
+++ b/ui/ui-components/pages/source/[id]/overview.tsx
@@ -116,7 +116,8 @@ export default function Page({
             successHandler={successHandler}
             source={source}
           />
-          {process.env.GROUPAROO_UI_EDITION !== "community" && (
+          {process.env.GROUPAROO_UI_EDITION !== "community" &&
+          source.previewAvailable === true ? (
             <>
               &nbsp;
               <Button
@@ -127,7 +128,7 @@ export default function Page({
                 Add Multiple Properties
               </Button>
             </>
-          )}
+          ) : null}
           <hr />
           <h2>Schedule</h2>
           <br />


### PR DESCRIPTION
Before:  
All Sources would show an "Add Multiple Properties" button.  The issue with this is that Query sources and Calculated Property sources don't support this feature.  Clicking the button on an unsupported Source produced an API error stating that it couldn't return a source preview. 

<img width="1192" alt="Screen Shot 2021-09-17 at 10 50 51 AM" src="https://user-images.githubusercontent.com/63751206/133803365-f853f830-7762-4f40-8ff2-c4dab912b62c.png">

After:
Now we only show that button if `previewAvailable = true`.  So Query and Calculated Property sources show:

<img width="1185" alt="Screen Shot 2021-09-17 at 10 52 17 AM" src="https://user-images.githubusercontent.com/63751206/133803569-dc3721ab-d9ed-4760-b58b-8e6af4ce4366.png">

And all other source types remain the same.
