### PR TITLE
`grouparoo demo` can provide junk data

### DIFF
--- a/plugins/@grouparoo/demo/src/events/db.ts
+++ b/plugins/@grouparoo/demo/src/events/db.ts
@@ -41,7 +41,7 @@ export async function dbPurchaseCategories() {
 }
 
 export async function csvPurchaseCategories() {
-  const rows = readCsvTable("b2c", "purchases");
+  const rows = readCsvTable("b2c", "purchases", 0);
   const categories = {};
   for (const row of rows) {
     if (row.category) {

--- a/plugins/@grouparoo/demo/src/util/data.ts
+++ b/plugins/@grouparoo/demo/src/util/data.ts
@@ -2,9 +2,9 @@ export const TYPES = {
   users: {
     id: "INT NOT NULL PRIMARY KEY",
     account_id: "INT",
-    first_name: "VARCHAR(191) NOT NULL",
-    last_name: "VARCHAR(191) NOT NULL",
-    email: "VARCHAR(191) NOT NULL",
+    first_name: "VARCHAR(191)",
+    last_name: "VARCHAR(191)",
+    email: "VARCHAR(191)",
     gender: "VARCHAR(191)",
     ip_address: "VARCHAR(191)",
     avatar: "VARCHAR(191)",
@@ -17,8 +17,8 @@ export const TYPES = {
   purchases: {
     id: "INT NOT NULL PRIMARY KEY",
     user_id: "INT NOT NULL",
-    item: "VARCHAR(191) NOT NULL",
-    category: "VARCHAR(191) NOT NULL",
+    item: "VARCHAR(191)",
+    category: "VARCHAR(191)",
     price: "DECIMAL",
     state: "VARCHAR(191)",
     created_at: "TIMESTAMP NOT NULL",
@@ -26,8 +26,8 @@ export const TYPES = {
 
   accounts: {
     id: "INT NOT NULL PRIMARY KEY",
-    name: "VARCHAR(191) NOT NULL",
-    domain: "VARCHAR(191) NOT NULL",
+    name: "VARCHAR(191)",
+    domain: "VARCHAR(191)",
     plan_id: "INT",
     created_at: "TIMESTAMP NOT NULL",
     updated_at: "TIMESTAMP NOT NULL",
@@ -35,7 +35,7 @@ export const TYPES = {
 
   plans: {
     id: "INT NOT NULL PRIMARY KEY",
-    name: "VARCHAR(191) NOT NULL",
+    name: "VARCHAR(191)",
     seats: "INT NOT NULL",
     monthly_rate: "INT NOT NULL",
   },

--- a/plugins/@grouparoo/demo/src/util/sample_data.ts
+++ b/plugins/@grouparoo/demo/src/util/sample_data.ts
@@ -332,6 +332,14 @@ function junkRow(column: string, v: string) {
   if (v.includes(".") && !isNaN(parseFloat(v))) {
     v = Math.random() < 0.5 ? `-${v}` : "";
     v = v;
+  }
+  if (v.includes("@")) {
+    v =
+      Math.random() < 0.5
+        ? ` ${v} `
+        : Math.random() < 0.5
+        ? v.replace("@", "-")
+        : "";
   } else {
     v = Math.random() < 0.5 ? ` ${v} ` : "";
   }

--- a/plugins/@grouparoo/demo/src/util/sample_data.ts
+++ b/plugins/@grouparoo/demo/src/util/sample_data.ts
@@ -13,6 +13,7 @@ import { TYPES } from "./data";
 
 interface DataOptions {
   scale?: number;
+  junkPercent?: number;
 }
 
 export async function employees(db: Connection, options: DataOptions = {}) {
@@ -82,11 +83,19 @@ export async function plans(db: Connection, options: DataOptions = {}) {
   await createCsvTable(db, "b2b", "plans", "id", null, false, false, options);
 }
 
-export function readCsvTable(dataset: string, tableName: string) {
+export function readCsvTable(
+  dataset: string,
+  tableName: string,
+  junkPercent: number
+) {
   const filePath = path.resolve(
     path.join(__dirname, "..", "..", "data", dataset, `${tableName}.csv`)
   );
-  const rows = parse(fs.readFileSync(filePath), { columns: true });
+  const rows = junkifyData(
+    dataset,
+    parse(fs.readFileSync(filePath), { columns: true }),
+    junkPercent
+  );
   return rows;
 }
 
@@ -114,7 +123,8 @@ async function createCsvTable(
     typeName,
     createdAt,
     updatedAt,
-    options.scale
+    options.scale,
+    options.junkPercent
   );
   await db.disconnect();
 }
@@ -127,14 +137,15 @@ async function loadCsvTable(
   typeName: string,
   createdAt: boolean,
   updatedAt: boolean,
-  scale: number = 0
+  scale: number = 0,
+  junkPercent: number = 0
 ) {
-  if (!scale || scale < 1) {
-    scale = 1;
-  }
+  if (!scale || scale < 1) scale = 1;
+  if (!junkPercent || junkPercent < 1) junkPercent = 0;
+
   log(`Adding ${tableName}`);
   // read from data file
-  const rows = readCsvTable(dataset, tableName);
+  const rows = readCsvTable(dataset, tableName, junkPercent);
   const keys = Object.keys(rows[0]);
 
   if (createdAt) {
@@ -288,4 +299,42 @@ function parseValue(tableName: string, key: string, value: string) {
     return false;
   }
   return value;
+}
+
+function junkifyData(
+  dataset: string,
+  rows: Record<string, any>[],
+  junkPercent: number
+) {
+  let junkCounter = 0;
+  // skip the primary key (the first column)
+  const keys = Object.keys(rows[0]).slice(1, Object.keys(rows[0]).length - 1);
+  for (const row of rows) {
+    const toJunk = Math.random() < junkPercent / 100;
+    if (toJunk) {
+      junkCounter++;
+      const key = keys[Math.floor(Math.random() * keys.length)];
+      row[key] = junkRow(key, row[key]);
+    }
+  }
+
+  if (junkCounter > 0) {
+    log(`    created junk data on ${junkCounter} ${dataset} records`);
+  }
+
+  return rows;
+}
+
+function junkRow(column: string, v: string) {
+  // don't mess with primary keys
+  if (column.match(/_id$/)) return v;
+
+  if (v.includes(".") && !isNaN(parseFloat(v))) {
+    v = Math.random() < 0.5 ? `-${v}` : "";
+    v = v;
+  } else {
+    v = Math.random() < 0.5 ? ` ${v} ` : "";
+  }
+
+  return v;
 }


### PR DESCRIPTION
`grouparoo demo -c --junkScale=20` would make 20% of your source data have garbage data! 

* We don't mess with primary keys
* We don't mess with `*_id` relationship keys

What kind of junk do we have so far?
* Numbers might go negative or become null
* Strings might get random spaces added or become null 
* Sometimes email addresses loose the `@`

Help Text:

```
$ grouparoo demo -h

--------

Usage: grouparoo demo [options] [type] [type]

Load data into a source database, create properties, destinations, and other config.
A demo@grouparoo.com Team Member is created. Password: "password"

Valid Types:
b2c            (default) loads users and purchases into source
b2b            loads users, accounts, and payment data into source
purchases      same as b2c
accounts       same as b2b
reset          only clear Grouparoo database and don't load config
setup          only create the login Team Member
postgres       (default) load source data into local Postgres database
mongo          load specified source data into local MongoDB database
mysql          load specified source data into local MySQL database
snowflake      assumes a Snowflake instance with data already present
bigquery       assumes a BigQuery instance with data already present
mailchimp      create Mailchimp destination for data
salesforce     create Salesforce destination for data

Options:
  --scale [scale]              make the number more than 1 to multiple amount of data. (default: "1")
  --junkPercent [junkPercent]  what percent of the data should have problems? (default: "0")
  -c, --config                 add flag to write to config directory and not populate configuraiton into Grouparoo database
  -s, --seed                   add flag to only write (or output) demo source data and not touch Grouparoo database
  -f, --force                  add flag to ensure deletion of config directory
  -h, --help                   display help for command
```