### PR TITLE
Only worker processes run migrations

### DIFF
--- a/apps/staging-enterprise/__tests__/cli
+++ b/apps/staging-enterprise/__tests__/cli
@@ -12,6 +12,7 @@ CLI="$PROJECT_PATH/../../cli/dist/grouparoo.js"
 export REDIS_URL="redis://mock"
 export DATABASE_URL="sqlite://grouparoo_test.sqlite"
 export SERVER_TOKEN="ABC123"
+export WORKERS=1
 
 printf "*** Starting Tests ***\r\n"
 

--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -110,9 +110,10 @@ export const DEFAULT = {
     /** Run migrations */
     let autoMigrate = false;
     if (
-      process.env.WORKERS
+      (process.env.WORKERS
         ? parseInt(process.env.WORKERS)
-        : 0 > 0 && process.env.GROUPAROO_RUN_MODE !== "cli:apply"
+        : 0 > 0 && process.env.GROUPAROO_RUN_MODE !== "cli:apply") ||
+      process.env.NODE_ENV === "test"
     ) {
       autoMigrate = true;
     }

--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -107,12 +107,21 @@ export const DEFAULT = {
       }
     }
 
+    /** Run migrations */
+    let autoMigrate = false;
+    if (
+      process.env.WORKERS
+        ? parseInt(process.env.WORKERS)
+        : 0 > 0 && process.env.GROUPAROO_RUN_MODE !== "cli:apply"
+    ) {
+      autoMigrate = true;
+    }
+
     return {
       _toExpand: false,
       logging,
       benchmark: true,
-      autoMigrate:
-        process.env.GROUPAROO_RUN_MODE === "cli:apply" ? false : true,
+      autoMigrate,
       dialect: dialect,
       port: parseInt(port),
       database: database,

--- a/core/src/config/tasks.ts
+++ b/core/src/config/tasks.ts
@@ -1,7 +1,7 @@
 import { api } from "actionhero";
 
 export const DEFAULT = {
-  tasks: (config) => {
+  tasks: () => {
     return {
       _toExpand: false,
 

--- a/core/src/modules/cache.ts
+++ b/core/src/modules/cache.ts
@@ -1,4 +1,4 @@
-import { api, cache } from "actionhero";
+import { api, cache, env } from "actionhero";
 import { waitForLock } from "./locks";
 import crypto from "crypto";
 
@@ -100,9 +100,8 @@ export function makeBaseCacheKey({ objectId, cacheKey }): string {
 
 function useRedis() {
   const running = !!api?.redis?.clients;
-  if (!running && process.env.NODE_ENV === "test") {
-    return false;
-  }
+  if (!running && env === "test") return false;
+
   return true;
 }
 

--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -1,4 +1,4 @@
-import { CLI, api } from "actionhero";
+import { CLI, api, env } from "actionhero";
 import Colors from "colors/safe";
 import { FinalSummary } from "./status";
 import { FinalSummaryReporters } from "../../../core/src/modules/statusReporters";
@@ -112,7 +112,7 @@ export namespace GrouparooCLI {
 
     export function fatal(message: string) {
       logger.error("❌ " + message);
-      if (process.env.NODE_ENV !== "test") process.exit(1);
+      if (env !== "test") process.exit(1);
       return true;
     }
 

--- a/core/src/modules/grouparooSubscription.ts
+++ b/core/src/modules/grouparooSubscription.ts
@@ -1,7 +1,7 @@
 import { TeamMember } from "../models/TeamMember";
 import { CLS } from "../modules/cls";
 import { plugin } from "../modules/plugin";
-import { config, log } from "actionhero";
+import { config, log, env } from "actionhero";
 import path from "path";
 
 require("isomorphic-fetch"); // I need to be required vs imported to avoid TS conflicts with the @grouparoo/ui-* package which has its own fetch polyfill
@@ -26,7 +26,7 @@ export async function GrouparooSubscription({
   email?: string;
   subscribed: boolean;
 }) {
-  if (process.env.NODE_ENV === "test") return;
+  if (env === "test") return;
   if (!config.telemetry.enabled) return;
   if (!teamMember && !subscriberEmail) return;
 

--- a/core/src/tasks/system/status/status.ts
+++ b/core/src/tasks/system/status/status.ts
@@ -1,4 +1,4 @@
-import { api, log, task } from "actionhero";
+import { api, log, task, env } from "actionhero";
 import { GrouparooCLI } from "../../../modules/cli";
 import { APM } from "../../../modules/apm";
 import { Status, FinalSummary } from "../../../modules/status";
@@ -47,7 +47,7 @@ export class StatusTask extends CLSTask {
   }
 
   async logFinalSummary() {
-    if (process.env.NODE_ENV === "test") return;
+    if (env === "test") return;
 
     const finalSummaryLog = await FinalSummary.getFinalSummary();
     GrouparooCLI.logger.finalSummary(finalSummaryLog);
@@ -93,7 +93,7 @@ export class StatusTask extends CLSTask {
   }
 
   logSamples(samples: Status.StatusGetResponse) {
-    if (process.env.NODE_ENV === "test") return;
+    if (env === "test") return;
 
     const totalItems = [];
     const pendingItems = [];


### PR DESCRIPTION
To avoid deadlock contention when applying migrations, only Grouparoo processes with `WORKERS=(>0)` should run migrations.  For the majority of users who use a single Grouparoo process, there will be no change.  For deployments that split WEB and WORKER processes, only the WORKER will now run migrations. 