### PR TITLE
UI and Logging updates for Recods

### DIFF
--- a/core/__tests__/actions/logs.ts
+++ b/core/__tests__/actions/logs.ts
@@ -2,6 +2,7 @@ import { helper } from "@grouparoo/spec-helper";
 import { specHelper } from "actionhero";
 import { SessionCreate } from "../../src/actions/session";
 import { LogsList } from "../../src/actions/logs";
+import { GrouparooRecord } from "../../src/models/GrouparooRecord";
 
 describe("actions/logs", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -61,6 +62,21 @@ describe("actions/logs", () => {
       );
       expect(error).toBeUndefined();
       expect(logs.length).toBeGreaterThanOrEqual(3);
+    });
+
+    test("searching for records returns GrouparooRecords", async () => {
+      const record: GrouparooRecord = await helper.factories.record();
+      connection.params = {
+        csrfToken,
+        topic: "record",
+      };
+      const { error, logs } = await specHelper.runAction<LogsList>(
+        "logs:list",
+        connection
+      );
+      expect(error).toBeUndefined();
+      expect(logs.length).toEqual(1);
+      await record.destroy();
     });
 
     test("a reader can ask for logs about a record and also see logs about properties", async () => {

--- a/core/src/actions/logs.ts
+++ b/core/src/actions/logs.ts
@@ -36,7 +36,12 @@ export class LogsList extends AuthenticatedAction {
       where: {},
     };
 
-    if (params.topic) search.where["topic"] = params.topic;
+    let topic = params.topic;
+    if (topic) {
+      if (topic === "record") topic = "grouparooRecord";
+      search.where["topic"] = topic;
+    }
+
     if (params.verb) search.where["verb"] = params.verb;
     if (params.ownerId) {
       const ownerIds = [params.ownerId];

--- a/core/src/migrations/000081-profilesToRecords.ts
+++ b/core/src/migrations/000081-profilesToRecords.ts
@@ -97,6 +97,10 @@ export default {
 
     await queryInterface.renameTable("profileProperties", "recordProperties");
 
+    await queryInterface.sequelize.query(
+      `UPDATE "logs" SET "topic"='grouparooRecord' WHERE "topic"='profile'`
+    );
+
     if (config.sequelize?.dialect === "sqlite") {
       await queryInterface.addIndex(
         "recordProperties",

--- a/core/src/models/RecordProperty.ts
+++ b/core/src/models/RecordProperty.ts
@@ -112,7 +112,8 @@ export class RecordProperty extends LoggedModel<RecordProperty> {
     const property = await this.ensureProperty();
     const { rawValue, invalidValue } = await RecordPropertyOps.buildRawValue(
       value,
-      property.type
+      property.type,
+      this
     );
 
     this.rawValue = rawValue;

--- a/core/src/modules/cli.ts
+++ b/core/src/modules/cli.ts
@@ -100,14 +100,13 @@ export namespace GrouparooCLI {
     }
 
     export function deCamel(s: string) {
-      return s.replace(/([a-z])([A-Z])/g, "$1 $2");
+      return s
+        .replace(/([a-z])([A-Z])/g, "$1 $2")
+        .replace("Grouparoo Record", "Record"); // special replacement for logging "record"
     }
 
     export function deCamelAndCapitalize(s: string) {
-      return (
-        s.charAt(0).toUpperCase() +
-        s.slice(1).replace(/([a-z])([A-Z])/g, "$1 $2")
-      );
+      return s.charAt(0).toUpperCase() + deCamel(s.slice(1));
     }
 
     export function fatal(message: string) {
@@ -185,7 +184,6 @@ export namespace GrouparooCLI {
             }
           } else {
             for (const property in category) {
-              // GrouparooCLI.logger.log(logBlock);
               if (property !== "name") {
                 GrouparooCLI.logger.log(
                   category[property] === null

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -295,7 +295,11 @@ export namespace RecordOps {
                 p.position === position
             );
             const { rawValue, invalidValue } =
-              await RecordPropertyOps.buildRawValue(value, property.type);
+              await RecordPropertyOps.buildRawValue(
+                value,
+                property.type,
+                existingRecordProperty
+              );
 
             bulkCreates.push({
               id: existingRecordProperty

--- a/core/src/modules/ops/recordProperty.ts
+++ b/core/src/modules/ops/recordProperty.ts
@@ -17,7 +17,8 @@ export namespace RecordPropertyOps {
 
   export async function buildRawValue(
     value: any,
-    type: typeof PropertyTypes[number]
+    type: typeof PropertyTypes[number],
+    recordProperty?: RecordProperty
   ) {
     let rawValue: string = null;
     let invalidValue: string = null;
@@ -62,6 +63,9 @@ export namespace RecordPropertyOps {
     } catch (error) {
       rawValue = null;
       invalidValue = stringifiedValue;
+      if (recordProperty && error instanceof Error) {
+        error.message += ` for record ${recordProperty.recordId}`;
+      }
       log(error, "error");
     }
 

--- a/core/src/modules/ops/setupSteps.ts
+++ b/core/src/modules/ops/setupSteps.ts
@@ -81,11 +81,11 @@ export namespace SetupStepOps {
     },
     create_a_unique_record_property: {
       key: "create_a_unique_record_property",
-      title: "Create a Unique GrouparooRecord Property",
+      title: "Create a Unique Record Property",
       description:
-        "Create your first unique Property.  Grouparoo needs at least one unique Property to identify your GrouparooRecords (email, userId, etc).  You can have more than one!",
+        "Create your first unique Property.  Grouparoo needs at least one unique Property to identify your Records (email, userId, etc).  You can have more than one!",
       href: "/properties",
-      cta: "Add a GrouparooRecord Property",
+      cta: "Add a Record Property",
       helpLink: `${configURL}/properties`,
       check: async () => {
         const count = await Property.count({
@@ -95,7 +95,7 @@ export namespace SetupStepOps {
       },
       outcome: async () => {
         const count = await GrouparooRecord.count();
-        return `${count} GrouparooRecords created`;
+        return `${count} Records created`;
       },
     },
     create_a_schedule: {
@@ -117,11 +117,11 @@ export namespace SetupStepOps {
     },
     create_a_sample_record: {
       key: "create_a_sample_record",
-      title: "Create a Sample GrouparooRecord",
+      title: "Create a Sample Record",
       description:
-        "Create a Sample GrouparooRecord so you can validate your configuration is importing the correct data. These GrouparooRecords will allow you to test Group building and your Destination settings and mappings.",
+        "Create a Sample Record so you can validate your configuration is importing the correct data. These Records will allow you to test Group building and your Destination settings and mappings.",
       href: "/record/new",
-      cta: "Add a Sample GrouparooRecord",
+      cta: "Add a Sample Record",
       helpLink: `${configURL}/records`,
       check: async () => {
         const count = await GrouparooRecord.count();
@@ -132,7 +132,7 @@ export namespace SetupStepOps {
       key: "create_a_group",
       title: "Create a Group",
       description:
-        "Create a Group based on the Properties of your GrouparooRecords.  Groups will be kept up-to-date with changes to your GrouparooRecord's Properties.",
+        "Create a Group based on the Properties of your Records.  Groups will be kept up-to-date with changes to your Record's Properties.",
       href: "/groups",
       cta: "Add a Group",
       helpLink: `${configURL}/groups`,
@@ -149,7 +149,7 @@ export namespace SetupStepOps {
       key: "create_a_destination",
       title: "Create a Destination",
       description:
-        "Create a Destination to sync your GrouparooRecords and Group Memberships.  Grouparoo will automatically send all new information to the Destinations relevant to each GrouparooRecord.",
+        "Create a Destination to sync your Records and Group Memberships.  Grouparoo will automatically send all new information to the Destinations relevant to each Record.",
       href: "/destinations",
       cta: "Add a Destination",
       helpLink: `${configURL}/destinations`,
@@ -159,7 +159,7 @@ export namespace SetupStepOps {
       },
       outcome: async () => {
         const count = await Export.count();
-        return `${count} GrouparooRecords exported to a Destination`;
+        return `${count} Records exported to a Destination`;
       },
     },
   };


### PR DESCRIPTION
* Log `Record` not `Grouparoo Record` with grouparoo run output
* Remove "GrouparooRecord" from SetupSteps
* Show logs for records returns `grouparooRecords` when filtering for `records`
* Update old log rows from profile to grouparooRecord (migration)
* We now include the `recordId` (when possible) if we cannot save an invalid property
```
2021-09-20T22:48:39.955Z - error: email "asterman5h-demo.com" is not valid for record rec_742c016d-727c-417e-aaaa-8f6e2dab8b2f
2021-09-20T22:48:40.123Z - error: email "tkleimt2c-demo.com" is not valid for record rec_d621ae68-e879-488c-8698-e9bb3c5c7986
2021-09-20T22:48:40.227Z - error: email "colliar92-demo.com" is not valid for record rec_a10f31ef-3528-45d2-a371-7f323c323052
```