### PR TITLE
`grouaproo run` should end if there are Imports that had an error

### DIFF
--- a/core/src/modules/statusReporters.ts
+++ b/core/src/modules/statusReporters.ts
@@ -271,7 +271,9 @@ export namespace StatusReporters {
         collection: "pending",
         topic: "Import",
         aggregation: "count",
-        count: await Import.count({ where: { exportedAt: null } }),
+        count: await Import.count({
+          where: { exportedAt: null, errorMessage: null },
+        }),
       };
     }
 


### PR DESCRIPTION
This looks to be what was preventing `grouparoo run` from completing in the case that some imports failed.
For example, because of:
```
Error on step import:associateRecord: could not create a new record because no record property in {"User ID":[110821982]} is unique and owned by the source
```