### PR TITLE
Grouparoo Cloud CLI commands

### DIFF
--- a/apps/staging-community/.env.example
+++ b/apps/staging-community/.env.example
@@ -60,3 +60,13 @@ S3_BUCKET=""
 
 # change where the postgres demo database is, default to main database
 # DEMO_DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
+
+###########
+## CLOUD ##
+###########
+
+# set a token for all Cloud API calls
+# GROUPAROO_CLOUD_API_TOKEN=""
+
+# change the API url to point to a different cloud instance
+# GROUPAROO_CLOUD_API_URL="http://localhost:8080"

--- a/apps/staging-config/.env.example
+++ b/apps/staging-config/.env.example
@@ -61,3 +61,13 @@ CONFIG_DATABASE_URL = "sqlite://grouparoo_config.sqlite"
 
 # change where the postgres demo database is, default to main database
 # DEMO_DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
+
+###########
+## CLOUD ##
+###########
+
+# set a token for all Cloud API calls
+# GROUPAROO_CLOUD_API_TOKEN=""
+
+# change the API url to point to a different cloud instance
+# GROUPAROO_CLOUD_API_URL="http://localhost:8080"

--- a/apps/staging-enterprise/.env.example
+++ b/apps/staging-enterprise/.env.example
@@ -60,3 +60,13 @@ S3_BUCKET=""
 
 # change where the postgres demo database is, default to main database
 # DEMO_DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
+
+###########
+## CLOUD ##
+###########
+
+# set a token for all Cloud API calls
+# GROUPAROO_CLOUD_API_TOKEN=""
+
+# change the API url to point to a different cloud instance
+# GROUPAROO_CLOUD_API_URL="http://localhost:8080"

--- a/core/__tests__/bin/ci.ts
+++ b/core/__tests__/bin/ci.ts
@@ -1,0 +1,72 @@
+import path from "path";
+import nock from "nock";
+import { helper } from "@grouparoo/spec-helper";
+import { CI } from "../../src/bin/ci";
+
+describe("bin/ci", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  let messages = [];
+  let spies = [];
+
+  let prevCfgDir: string;
+  beforeAll(() => {
+    prevCfgDir = process.env.GROUPAROO_CONFIG_DIR;
+    process.env.GROUPAROO_CONFIG_DIR = path.join(
+      __dirname,
+      "../fixtures/codeConfig/initial"
+    );
+  });
+
+  afterAll(() => {
+    process.env.GROUPAROO_CONFIG_DIR = prevCfgDir;
+  });
+
+  beforeEach(async () => {
+    messages = [];
+    spies.push(
+      jest
+        .spyOn(console, "log")
+        .mockImplementation((message) => messages.push(message))
+    );
+    spies.push(
+      jest
+        .spyOn(console, "error")
+        .mockImplementation((message) => messages.push(message))
+    );
+  });
+
+  afterEach(async () => {
+    spies.map((s) => s.mockRestore());
+  });
+
+  test("runs pack and push (apply=false)", async () => {
+    nock("https://cloud.grouparoo.com")
+      .post("/api/v1/configuration")
+      .query(true)
+      .reply(200, {
+        configuration: { id: "config-id" },
+      });
+
+    nock("https://cloud.grouparoo.com")
+      .get("/api/v1/configuration/config-id")
+      .query(true)
+      .reply(200, {
+        configuration: { id: "config-id", state: "finished" },
+      });
+
+    const command = new CI();
+    const toStop = await command.run({
+      params: {
+        projectId: "my-project",
+        token: "some-token",
+      },
+    });
+    expect(toStop).toBe(true);
+
+    const output = messages.join(" ");
+    expect(output).toContain("✅ Saved config archive to");
+    expect(output).toContain(
+      "The configuration has been successfully validated"
+    );
+  });
+});

--- a/core/__tests__/bin/deploy.ts
+++ b/core/__tests__/bin/deploy.ts
@@ -1,0 +1,70 @@
+import path from "path";
+import nock from "nock";
+import { helper } from "@grouparoo/spec-helper";
+import { Deploy } from "../../src/bin/deploy";
+
+describe("bin/deploy", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  let messages = [];
+  let spies = [];
+
+  let prevCfgDir: string;
+  beforeAll(() => {
+    prevCfgDir = process.env.GROUPAROO_CONFIG_DIR;
+    process.env.GROUPAROO_CONFIG_DIR = path.join(
+      __dirname,
+      "../fixtures/codeConfig/initial"
+    );
+  });
+
+  afterAll(() => {
+    process.env.GROUPAROO_CONFIG_DIR = prevCfgDir;
+  });
+
+  beforeEach(async () => {
+    messages = [];
+    spies.push(
+      jest
+        .spyOn(console, "log")
+        .mockImplementation((message) => messages.push(message))
+    );
+    spies.push(
+      jest
+        .spyOn(console, "error")
+        .mockImplementation((message) => messages.push(message))
+    );
+  });
+
+  afterEach(async () => {
+    spies.map((s) => s.mockRestore());
+  });
+
+  test("runs pack and push (apply=true)", async () => {
+    nock("https://cloud.grouparoo.com")
+      .post("/api/v1/configuration")
+      .query(true)
+      .reply(200, {
+        configuration: { id: "config-id" },
+      });
+
+    nock("https://cloud.grouparoo.com")
+      .get("/api/v1/configuration/config-id")
+      .query(true)
+      .reply(200, {
+        configuration: { id: "config-id", state: "finished" },
+      });
+
+    const command = new Deploy();
+    const toStop = await command.run({
+      params: {
+        projectId: "my-project",
+        token: "some-token",
+      },
+    });
+    expect(toStop).toBe(true);
+
+    const output = messages.join(" ");
+    expect(output).toContain("✅ Saved config archive to");
+    expect(output).toContain("The configuration has been successfully applied");
+  });
+});

--- a/core/__tests__/bin/pack.ts
+++ b/core/__tests__/bin/pack.ts
@@ -1,0 +1,120 @@
+import os from "os";
+import path from "path";
+import { mkdtemp, readFile, remove } from "fs-extra";
+import { existsSync } from "fs";
+import tar from "tar";
+import { helper } from "@grouparoo/spec-helper";
+import { Pack } from "../../src/bin/pack";
+
+describe("bin/pack", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
+  let tempDir: string;
+  let messages = [];
+  let spies = [];
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "grouparoo-pack-test-"));
+    messages = [];
+    spies.push(
+      jest
+        .spyOn(console, "log")
+        .mockImplementation((message) => messages.push(message))
+    );
+    spies.push(
+      jest
+        .spyOn(console, "error")
+        .mockImplementation((message) => messages.push(message))
+    );
+  });
+
+  afterEach(async () => {
+    spies.map((s) => s.mockRestore());
+    await remove(tempDir);
+  });
+
+  test("makes an archive with configured config directory", async () => {
+    process.env.GROUPAROO_CONFIG_DIR = path.join(
+      __dirname,
+      "../fixtures/codeConfig/initial"
+    );
+
+    const archivePath = path.join(tempDir, "grouparoo.tar.gz");
+    expect(existsSync(archivePath)).toBe(false);
+
+    const command = new Pack();
+    const toStop = await command.run({ params: { output: archivePath } });
+    expect(toStop).toBe(true);
+
+    const output = messages.join(" ");
+    expect(output).toContain("✅ Saved config archive");
+
+    expect(existsSync(archivePath)).toBe(true);
+
+    await tar.extract({ cwd: tempDir, file: archivePath });
+
+    const packageJson = path.join(tempDir, "package.json");
+    expect(existsSync(packageJson)).toBe(true);
+
+    const configFile = path.join(tempDir, "config", "config.js");
+    expect(existsSync(configFile)).toBe(true);
+  });
+
+  test("discards other file types", async () => {
+    process.env.GROUPAROO_CONFIG_DIR = path.join(
+      __dirname,
+      "../fixtures/codeConfig/additional-file-types"
+    );
+
+    const archivePath = path.join(tempDir, "grouparoo.tar.gz");
+    expect(existsSync(archivePath)).toBe(false);
+
+    const command = new Pack();
+    const toStop = await command.run({ params: { output: archivePath } });
+    expect(toStop).toBe(true);
+
+    const output = messages.join(" ");
+    expect(output).toContain("✅ Saved config archive");
+
+    expect(existsSync(archivePath)).toBe(true);
+
+    await tar.extract({ cwd: tempDir, file: archivePath });
+
+    const packageJson = path.join(tempDir, "package.json");
+    expect(existsSync(packageJson)).toBe(true);
+
+    const jsFile = path.join(tempDir, "config", "config.js");
+    expect(existsSync(jsFile)).toBe(true);
+
+    const jsonFile = path.join(tempDir, "config", "config.json");
+    expect(existsSync(jsonFile)).toBe(true);
+
+    const mdFile = path.join(tempDir, "config", "markdown.md");
+    expect(existsSync(mdFile)).toBe(false);
+  });
+
+  test("can save to a different file", async () => {
+    process.env.GROUPAROO_CONFIG_DIR = path.join(
+      __dirname,
+      "../fixtures/codeConfig/initial"
+    );
+
+    const archivePath = path.join(tempDir, "otherfile.tgz");
+    expect(existsSync(archivePath)).toBe(false);
+
+    const command = new Pack();
+    const toStop = await command.run({ params: { output: archivePath } });
+    expect(toStop).toBe(true);
+
+    const output = messages.join(" ");
+    expect(output).toContain("✅ Saved config archive");
+
+    expect(existsSync(archivePath)).toBe(true);
+
+    await tar.extract({ cwd: tempDir, file: archivePath });
+
+    const packageJson = path.join(tempDir, "package.json");
+    console.log((await readFile(packageJson)).toString());
+    expect(existsSync(packageJson)).toBe(true);
+  });
+});

--- a/core/__tests__/bin/push.ts
+++ b/core/__tests__/bin/push.ts
@@ -1,0 +1,218 @@
+import path from "path";
+import nock from "nock";
+import { helper } from "@grouparoo/spec-helper";
+import { Push } from "../../src/bin/push";
+
+describe("bin/push", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
+  let archivePath = path.join(__dirname, "../../package.json");
+  let messages = [];
+  let spies = [];
+
+  beforeEach(async () => {
+    messages = [];
+    spies.push(
+      jest
+        .spyOn(console, "log")
+        .mockImplementation((message) => messages.push(message))
+    );
+    spies.push(
+      jest
+        .spyOn(console, "error")
+        .mockImplementation((message) => messages.push(message))
+    );
+  });
+
+  afterEach(async () => {
+    spies.map((s) => s.mockRestore());
+  });
+
+  test("an auth token is required", async () => {
+    const command = new Push();
+    const toStop = await command.run({
+      params: {
+        archivePath,
+        projectId: "my-project",
+        apply: false,
+      },
+    });
+
+    expect(toStop).toBe(true);
+
+    const output = messages.join(" ");
+    expect(output).toContain("You must provide a Grouparoo Cloud token");
+  });
+
+  test.each([true, false])(
+    "uploads config and waits for `finished` state (toApply=%p)",
+    async (toApply) => {
+      nock("https://cloud.grouparoo.com")
+        .post("/api/v1/configuration")
+        .query(true)
+        .reply(200, {
+          configuration: { id: "config-id" },
+        });
+
+      nock("https://cloud.grouparoo.com")
+        .get("/api/v1/configuration/config-id")
+        .query(true)
+        .reply(200, {
+          configuration: { id: "config-id", state: "finished" },
+        });
+
+      const command = new Push();
+      const toStop = await command.run({
+        params: {
+          archivePath,
+          projectId: "my-project",
+          token: "some-token",
+          apply: toApply,
+        },
+      });
+      expect(toStop).toBe(true);
+
+      const output = messages.join(" ");
+      expect(output).toContain(
+        `The configuration has been successfully ${
+          toApply ? "applied" : "validated"
+        }`
+      );
+    }
+  );
+
+  test("validate and apply jobs are logged", async () => {
+    nock("https://cloud.grouparoo.com")
+      .post("/api/v1/configuration")
+      .query(true)
+      .reply(200, {
+        configuration: { id: "config-id" },
+      });
+
+    nock("https://cloud.grouparoo.com")
+      .get("/api/v1/configuration/config-id")
+      .query(true)
+      .reply(200, {
+        configuration: {
+          validateJobId: "validate-id",
+          state: "validated",
+        },
+      });
+
+    nock("https://cloud.grouparoo.com")
+      .get("/api/v1/configuration/config-id")
+      .query(true)
+      .reply(200, {
+        configuration: {
+          applyJobId: "apply-id",
+          state: "applied",
+        },
+      });
+
+    nock("https://cloud.grouparoo.com")
+      .get("/api/v1/configuration/config-id")
+      .query(true)
+      .reply(200, {
+        configuration: {
+          state: "finished",
+        },
+      });
+
+    nock("https://cloud.grouparoo.com")
+      .get("/api/v1/job/validate-id")
+      .query(true)
+      .reply(200, {
+        job: {
+          type: "validate",
+          logs: "validate job logs go here",
+        },
+      });
+
+    nock("https://cloud.grouparoo.com")
+      .get("/api/v1/job/apply-id")
+      .query(true)
+      .reply(200, {
+        job: {
+          type: "apply",
+          logs: "apply job logs go here",
+        },
+      });
+
+    const command = new Push();
+    const toStop = await command.run({
+      params: {
+        archivePath,
+        projectId: "my-project",
+        token: "some-token",
+        apply: true,
+      },
+    });
+    expect(toStop).toBe(true);
+
+    const output = messages.join(" ");
+    expect(output).toContain("Logging output for validate job (validate-id)");
+    expect(output).toContain("validate job logs go here");
+    expect(output).toContain("apply job logs go here");
+    expect(output).toContain("Logging output for apply job (apply-id)");
+    expect(output).toContain("The configuration has been successfully applied");
+  });
+
+  test("logs error if initial upload failed", async () => {
+    nock("https://cloud.grouparoo.com")
+      .post("/api/v1/configuration")
+      .query(true)
+      .reply(500, {
+        error: { message: "something weird happened here" },
+      });
+
+    const command = new Push();
+    const toStop = await command.run({
+      params: {
+        archivePath,
+        projectId: "my-project",
+        token: "some-token",
+        apply: false,
+      },
+    });
+    expect(toStop).toBe(true);
+
+    const output = messages.join(" ");
+    expect(output).toContain("❌ something weird happened here");
+  });
+
+  test("logs error if an error was attached to the configuration", async () => {
+    nock("https://cloud.grouparoo.com")
+      .post("/api/v1/configuration")
+      .query(true)
+      .reply(200, {
+        configuration: { id: "config-id" },
+      });
+
+    nock("https://cloud.grouparoo.com")
+      .get("/api/v1/configuration/config-id")
+      .query(true)
+      .reply(200, {
+        configuration: {
+          id: "config-id",
+          state: "failed",
+          errorMessage: "something happened with this thing",
+        },
+      });
+
+    const command = new Push();
+    const toStop = await command.run({
+      params: {
+        archivePath,
+        projectId: "my-project",
+        token: "some-token",
+        apply: false,
+      },
+    });
+    expect(toStop).toBe(true);
+
+    const output = messages.join(" ");
+    expect(output).toContain(
+      "❌ An error occurred while processing the config: something happened with this thing"
+    );
+  });
+});

--- a/core/__tests__/bin/push.ts
+++ b/core/__tests__/bin/push.ts
@@ -177,7 +177,9 @@ describe("bin/push", () => {
     expect(toStop).toBe(true);
 
     const output = messages.join(" ");
-    expect(output).toContain("❌ something weird happened here");
+    expect(output).toContain(
+      "❌ Grouparoo Cloud error: something weird happened here"
+    );
   });
 
   test("logs error if an error was attached to the configuration", async () => {

--- a/core/__tests__/fixtures/codeConfig/additional-file-types/config.js
+++ b/core/__tests__/fixtures/codeConfig/additional-file-types/config.js
@@ -1,0 +1,64 @@
+module.exports = async function getConfig() {
+  return [
+    {
+      id: "setting_cluster_name", // this is actually ignored
+      class: "Setting",
+      pluginName: "core",
+      key: "cluster-name",
+      value: "Test Cluster",
+    },
+
+    {
+      id: "data_warehouse", // id -> `data_warehouse`
+      name: "Data Warehouse",
+      class: "App",
+      type: "test-plugin-app",
+      options: {
+        fileId: "test-file-path.db",
+      },
+    },
+
+    {
+      id: "users_table", // id -> `data_warehouse`
+      name: "Users Table",
+      class: "Source",
+      type: "test-plugin-import",
+      appId: "data_warehouse", // appId -> `data_warehouse`
+      options: {
+        table: "users",
+      },
+      mapping: {
+        id: "user_id",
+      },
+    },
+
+    {
+      id: "user_id", // id -> `user_id`
+      name: "userId",
+      class: "Property",
+      type: "integer",
+      identifying: true,
+      unique: true,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "id",
+      },
+      filters: [],
+    },
+
+    {
+      id: "email", // id -> `email`
+      name: "email",
+      class: "Property",
+      type: "email",
+      unique: true,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "email",
+      },
+      filters: [],
+    },
+  ];
+};

--- a/core/__tests__/fixtures/codeConfig/additional-file-types/config.json
+++ b/core/__tests__/fixtures/codeConfig/additional-file-types/config.json
@@ -1,0 +1,17 @@
+{
+  "id": "email_group",
+  "name": "People with Email Addresses",
+  "class": "Group",
+  "type": "calculated",
+  "rules": [
+    {
+      "propertyId": "user_id",
+      "operation": { "op": "exists" }
+    },
+    {
+      "propertyId": "email",
+      "operation": { "op": "like" },
+      "match": "%@%"
+    }
+  ]
+}

--- a/core/__tests__/fixtures/codeConfig/additional-file-types/markdown.md
+++ b/core/__tests__/fixtures/codeConfig/additional-file-types/markdown.md
@@ -1,0 +1,1 @@
+# This should not be packaged

--- a/core/package.json
+++ b/core/package.json
@@ -38,6 +38,7 @@
     "@types/validator": "*",
     "actionhero": "27.1.4",
     "ah-sequelize-plugin": "3.2.0",
+    "axios": "0.21.4",
     "bcryptjs": "2.4.3",
     "cls-hooked": "4.2.2",
     "colors": "1.4.0",
@@ -45,6 +46,7 @@
     "csv-stringify": "5.6.4",
     "date-fns": "2.23.0",
     "dotenv": "10.0.0",
+    "form-data": "4.0.0",
     "fs-extra": "10.0.0",
     "glob": "7.1.7",
     "grouparoo": "0.7.0-alpha.5",
@@ -77,6 +79,7 @@
   },
   "devDependencies": {
     "@grouparoo/spec-helper": "0.7.0-alpha.5",
+    "@types/isomorphic-fetch": "0.0.35",
     "@types/jest": "*",
     "@types/pacote": "11.1.1",
     "@types/pluralize": "0.0.29",

--- a/core/package.json
+++ b/core/package.json
@@ -38,7 +38,6 @@
     "@types/validator": "*",
     "actionhero": "27.1.4",
     "ah-sequelize-plugin": "3.2.0",
-    "axios": "0.21.4",
     "bcryptjs": "2.4.3",
     "cls-hooked": "4.2.2",
     "colors": "1.4.0",

--- a/core/src/bin/ci.ts
+++ b/core/src/bin/ci.ts
@@ -1,13 +1,12 @@
-import path from "path";
 import { CLI } from "actionhero";
 import { GrouparooCLI } from "../modules/cli";
 import { Pack } from "./pack";
 import { Push } from "./push";
 
-export class Deploy extends CLI {
+export class CI extends CLI {
   constructor() {
     super();
-    this.name = "deploy";
+    this.name = "ci";
     this.description = "Packages and applies config";
     this.inputs = {
       projectId: {
@@ -50,7 +49,7 @@ export class Deploy extends CLI {
         token: params.token,
         projectId: params.projectId,
         archivePath: "./auto-grouparoo.tar.gz",
-        apply: true,
+        apply: false,
       },
     });
 

--- a/core/src/bin/ci.ts
+++ b/core/src/bin/ci.ts
@@ -1,7 +1,9 @@
+import os from "os";
 import { CLI } from "actionhero";
+import { remove, mkdtemp } from "fs-extra";
+import path from "path";
 import { GrouparooCLI } from "../modules/cli";
-import { Pack } from "./pack";
-import { Push } from "./push";
+import { CloudCLI } from "../modules/cloudCli";
 
 export class CI extends CLI {
   constructor() {
@@ -39,20 +41,7 @@ export class CI extends CLI {
     };
   }) {
     GrouparooCLI.logCLI(this.name);
-
-    const pack = new Pack();
-    await pack.run({ params: { output: "./auto-grouparoo.tar.gz" } });
-
-    const push = new Push();
-    await push.run({
-      params: {
-        token: params.token,
-        projectId: params.projectId,
-        archivePath: "./auto-grouparoo.tar.gz",
-        apply: false,
-      },
-    });
-
+    await CloudCLI.packAndPush({ ...params, apply: false });
     return true;
   }
 }

--- a/core/src/bin/deploy.ts
+++ b/core/src/bin/deploy.ts
@@ -1,8 +1,6 @@
-import path from "path";
 import { CLI } from "actionhero";
 import { GrouparooCLI } from "../modules/cli";
-import { Pack } from "./pack";
-import { Push } from "./push";
+import { CloudCLI } from "../modules/cloudCli";
 
 export class Deploy extends CLI {
   constructor() {
@@ -40,20 +38,7 @@ export class Deploy extends CLI {
     };
   }) {
     GrouparooCLI.logCLI(this.name);
-
-    const pack = new Pack();
-    await pack.run({ params: { output: "./auto-grouparoo.tar.gz" } });
-
-    const push = new Push();
-    await push.run({
-      params: {
-        token: params.token,
-        projectId: params.projectId,
-        archivePath: "./auto-grouparoo.tar.gz",
-        apply: true,
-      },
-    });
-
+    await CloudCLI.packAndPush({ ...params, apply: true });
     return true;
   }
 }

--- a/core/src/bin/deploy.ts
+++ b/core/src/bin/deploy.ts
@@ -1,0 +1,138 @@
+import path from "path";
+import FormData from "form-data";
+import { CLI, utils } from "actionhero";
+import { mkdtemp, copy, remove, readFile } from "fs-extra";
+import { GrouparooCLI } from "../modules/cli";
+import { getConfigDir, getParentPath } from "../modules/pluginDetails";
+import {
+  CloudClient,
+  CloudError,
+  ConfigurationApiData,
+  packageConfig,
+} from "../modules/cloud";
+import axios, { AxiosError } from "axios";
+
+const CLOUD_API = "http://localhost:8080";
+
+export class Deploy extends CLI {
+  constructor() {
+    super();
+    this.name = "deploy";
+    this.description =
+      "Uploads current configuration to a Grouparoo Cloud project";
+    this.inputs = {
+      projectId: {
+        required: true,
+        description: "Grouparoo Cloud Project ID",
+        letter: "p",
+      },
+      token: {
+        required: false,
+        description:
+          "Grouparoo Cloud Organization Token. This can also be set by using the GROUPAROO_CLOUD_TOKEN environment variable.",
+        letter: "t",
+      },
+      output: {
+        required: false,
+        default: "./grouparoo.tar.gz",
+        description: "Where should we generate the archive?",
+        letter: "o",
+      },
+    };
+
+    GrouparooCLI.timestampOption(this);
+  }
+
+  preInitialize() {
+    GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
+  }
+
+  async logJob(cloud: CloudClient, jobId: string) {
+    if (jobId) {
+      const job = await cloud.getJob(jobId);
+      GrouparooCLI.logger.log(
+        GrouparooCLI.logger.cyanBold(
+          `\nLogging output for ${job.type} job ${jobId}\n`
+        )
+      );
+      GrouparooCLI.logger.log(job.logs);
+      GrouparooCLI.logger.log("");
+    }
+  }
+
+  async run({
+    params,
+  }: {
+    params: { token?: string; projectId: string; output: string };
+  }) {
+    GrouparooCLI.logCLI(this.name);
+    const configDir = await getConfigDir(true);
+    const projectPath = getParentPath();
+    const tarballPath = path.isAbsolute(params.output)
+      ? params.output
+      : path.join(projectPath, params.output);
+
+    GrouparooCLI.logger.log(`Project directory: ${projectPath}`);
+    GrouparooCLI.logger.log(`Config directory: ${configDir}`);
+    GrouparooCLI.logger.log("");
+
+    const configArchive = await packageConfig(
+      projectPath,
+      configDir,
+      tarballPath
+    );
+
+    const cloudToken = params.token ?? process.env.GROUPAROO_CLOUD_TOKEN;
+    if (!cloudToken)
+      GrouparooCLI.logger.fatal(
+        "You must provide a Grouparoo Cloud token to upload configuration. Use the --token argument or set the GROUPAROO_CLOUD_TOKEN environment variable to provide the auth token."
+      );
+
+    try {
+      const toApply = false;
+      const cloud = new CloudClient(params.projectId, cloudToken, CLOUD_API);
+      const { id: configId } = await cloud.createConfiguration(
+        configArchive,
+        toApply
+      );
+
+      let lastState: string;
+      while (true) {
+        const config = await cloud.getConfiguration(configId);
+        if (config.errorMessage) {
+          await this.logJob(cloud, config.applyJobId ?? config.validateJobId);
+
+          GrouparooCLI.logger.fatal(
+            `An error occurred while processing the config: ${config.errorMessage}`
+          );
+        }
+
+        if (config.state !== lastState) {
+          if (config.state === "validated") {
+            await this.logJob(cloud, config.validateJobId);
+          } else if (config.state === "applied") {
+            await this.logJob(cloud, config.applyJobId);
+          }
+          GrouparooCLI.logger.log(`Configuration ${config.state}...`);
+        }
+        lastState = config.state;
+
+        if (config.state === "finished") {
+          GrouparooCLI.logger.log(
+            `\nThe configuration has been successfully ${
+              toApply ? "applied" : "validated"
+            }!`
+          );
+          process.exit(0);
+        }
+
+        await utils.sleep(1000);
+      }
+    } catch (err) {
+      GrouparooCLI.logger.fatal(err.message);
+    }
+
+    return true;
+  }
+}

--- a/core/src/bin/pack.ts
+++ b/core/src/bin/pack.ts
@@ -1,0 +1,52 @@
+import path from "path";
+import { CLI } from "actionhero";
+import { GrouparooCLI } from "../modules/cli";
+import { getConfigDir, getParentPath } from "../modules/pluginDetails";
+import { packageConfig } from "../modules/cloud";
+
+export class Pack extends CLI {
+  constructor() {
+    super();
+    this.name = "pack";
+    this.description = "Packages a grouparoo project into a .tar.gz archive";
+    this.inputs = {
+      output: {
+        required: false,
+        default: "./grouparoo.tar.gz",
+        description: "Where should we generate the archive?",
+        letter: "o",
+      },
+    };
+
+    GrouparooCLI.timestampOption(this);
+  }
+
+  preInitialize = () => {
+    GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
+  };
+
+  async run({ params }: { params: { output: string } }) {
+    GrouparooCLI.logCLI(this.name);
+
+    const configDir = await getConfigDir(true);
+    const projectPath = getParentPath();
+
+    const tarballPath = path.isAbsolute(params.output)
+      ? params.output
+      : path.join(projectPath, params.output);
+
+    GrouparooCLI.logger.log(`Project directory: ${projectPath}`);
+    GrouparooCLI.logger.log(`Config directory: ${configDir}`);
+
+    const configArchive = await packageConfig(
+      projectPath,
+      configDir,
+      tarballPath
+    );
+
+    GrouparooCLI.logger.log(`✅ Saved config archive to ${configArchive}`);
+
+    return true;
+  }
+}

--- a/core/src/bin/pack.ts
+++ b/core/src/bin/pack.ts
@@ -1,8 +1,6 @@
-import path from "path";
 import { CLI } from "actionhero";
 import { GrouparooCLI } from "../modules/cli";
-import { getConfigDir, getParentPath } from "../modules/pluginDetails";
-import { packageConfig } from "../modules/cloud";
+import { CloudCLI } from "../modules/cloudCli";
 
 export class Pack extends CLI {
   constructor() {
@@ -28,25 +26,7 @@ export class Pack extends CLI {
 
   async run({ params }: { params: { output: string } }) {
     GrouparooCLI.logCLI(this.name);
-
-    const configDir = await getConfigDir(true);
-    const projectPath = getParentPath();
-
-    const tarballPath = path.isAbsolute(params.output)
-      ? params.output
-      : path.join(projectPath, params.output);
-
-    GrouparooCLI.logger.log(`Project directory: ${projectPath}`);
-    GrouparooCLI.logger.log(`Config directory: ${configDir}`);
-
-    const configArchive = await packageConfig(
-      projectPath,
-      configDir,
-      tarballPath
-    );
-
-    GrouparooCLI.logger.log(`✅ Saved config archive to ${configArchive}`);
-
+    await CloudCLI.pack(params.output);
     return true;
   }
 }

--- a/core/src/bin/push.ts
+++ b/core/src/bin/push.ts
@@ -50,7 +50,7 @@ export class Push extends CLI {
       const job = await cloud.getJob(jobId);
       GrouparooCLI.logger.log(
         GrouparooCLI.logger.cyanBold(
-          `\nLogging output for ${job.type} job ${jobId}\n`
+          `\nLogging output for ${job.type} job (${jobId})\n`
         )
       );
       GrouparooCLI.logger.log(job.logs);
@@ -114,7 +114,8 @@ export class Push extends CLI {
               toApply ? "applied" : "validated"
             }!`
           );
-          process.exit(0);
+
+          break;
         }
 
         lastState = config.state;

--- a/core/src/bin/push.ts
+++ b/core/src/bin/push.ts
@@ -1,0 +1,129 @@
+import path from "path";
+import { CLI, utils } from "actionhero";
+import { GrouparooCLI } from "../modules/cli";
+import { getParentPath } from "../modules/pluginDetails";
+import { CloudClient } from "../modules/cloud";
+
+export class Push extends CLI {
+  constructor() {
+    super();
+    this.name = "push";
+    this.description =
+      "Uploads a packaged configuration to a Grouparoo Cloud project";
+    this.inputs = {
+      projectId: {
+        required: true,
+        description: "Grouparoo Cloud Project ID",
+        letter: "p",
+      },
+      token: {
+        required: false,
+        description:
+          "Grouparoo Cloud Organization Token. This can also be set by using the GROUPAROO_CLOUD_API_TOKEN environment variable.",
+        letter: "t",
+      },
+      archivePath: {
+        required: false,
+        default: "./grouparoo.tar.gz",
+        description:
+          "Path to the .tar.gz file that contains the configuration to upload.",
+        letter: "c",
+      },
+      apply: {
+        required: false,
+        default: false,
+        description: "Should the changes be applied?",
+        letter: "a",
+      },
+    };
+
+    GrouparooCLI.timestampOption(this);
+  }
+
+  preInitialize() {
+    GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
+  }
+
+  async logJob(cloud: CloudClient, jobId: string) {
+    if (jobId) {
+      const job = await cloud.getJob(jobId);
+      GrouparooCLI.logger.log(
+        GrouparooCLI.logger.cyanBold(
+          `\nLogging output for ${job.type} job ${jobId}\n`
+        )
+      );
+      GrouparooCLI.logger.log(job.logs);
+      GrouparooCLI.logger.log("");
+    }
+  }
+
+  async run({
+    params,
+  }: {
+    params: {
+      token?: string;
+      projectId: string;
+      archivePath: string;
+      apply: boolean | string;
+    };
+  }) {
+    GrouparooCLI.logCLI(this.name);
+    const projectPath = getParentPath();
+    const tarballPath = path.isAbsolute(params.archivePath)
+      ? params.archivePath
+      : path.join(projectPath, params.archivePath);
+
+    const cloudToken = params.token ?? process.env.GROUPAROO_CLOUD_API_TOKEN;
+    if (!cloudToken)
+      GrouparooCLI.logger.fatal(
+        "You must provide a Grouparoo Cloud token to upload configuration. Use the --token argument or set the GROUPAROO_CLOUD_TOKEN environment variable to provide the auth token."
+      );
+
+    try {
+      const toApply = params.apply !== "false" && Boolean(params.apply);
+      const cloud = new CloudClient(params.projectId, cloudToken);
+      const { id: configId } = await cloud.createConfiguration(
+        tarballPath,
+        toApply
+      );
+
+      let lastState: string;
+      while (true) {
+        const config = await cloud.getConfiguration(configId);
+        if (config.errorMessage) {
+          await this.logJob(cloud, config.applyJobId ?? config.validateJobId);
+
+          GrouparooCLI.logger.fatal(
+            `An error occurred while processing the config: ${config.errorMessage}`
+          );
+        }
+
+        if (config.state !== lastState) {
+          if (config.state === "validated") {
+            await this.logJob(cloud, config.validateJobId);
+          } else if (config.state === "applied") {
+            await this.logJob(cloud, config.applyJobId);
+          }
+          GrouparooCLI.logger.log(`Configuration ${config.state}...`);
+        }
+
+        if (config.state === "finished") {
+          GrouparooCLI.logger.log(
+            `\nThe configuration has been successfully ${
+              toApply ? "applied" : "validated"
+            }!`
+          );
+          process.exit(0);
+        }
+
+        lastState = config.state;
+        await utils.sleep(1000);
+      }
+    } catch (err) {
+      GrouparooCLI.logger.fatal(err.message);
+    }
+
+    return true;
+  }
+}

--- a/core/src/bin/push.ts
+++ b/core/src/bin/push.ts
@@ -1,8 +1,7 @@
-import path from "path";
-import { CLI, utils } from "actionhero";
+import { CLI } from "actionhero";
 import { GrouparooCLI } from "../modules/cli";
-import { getParentPath } from "../modules/pluginDetails";
 import { CloudClient } from "../modules/cloud";
+import { CloudCLI } from "../modules/cloudCli";
 
 export class Push extends CLI {
   constructor() {
@@ -69,62 +68,7 @@ export class Push extends CLI {
     };
   }) {
     GrouparooCLI.logCLI(this.name);
-    const projectPath = getParentPath();
-    const tarballPath = path.isAbsolute(params.archivePath)
-      ? params.archivePath
-      : path.join(projectPath, params.archivePath);
-
-    const cloudToken = params.token ?? process.env.GROUPAROO_CLOUD_API_TOKEN;
-    if (!cloudToken)
-      GrouparooCLI.logger.fatal(
-        "You must provide a Grouparoo Cloud token to upload configuration. Use the --token argument or set the GROUPAROO_CLOUD_TOKEN environment variable to provide the auth token."
-      );
-
-    try {
-      const toApply = params.apply !== "false" && Boolean(params.apply);
-      const cloud = new CloudClient(params.projectId, cloudToken);
-      const { id: configId } = await cloud.createConfiguration(
-        tarballPath,
-        toApply
-      );
-
-      let lastState: string;
-      while (true) {
-        const config = await cloud.getConfiguration(configId);
-        if (config.errorMessage) {
-          await this.logJob(cloud, config.applyJobId ?? config.validateJobId);
-
-          GrouparooCLI.logger.fatal(
-            `An error occurred while processing the config: ${config.errorMessage}`
-          );
-        }
-
-        if (config.state !== lastState) {
-          if (config.state === "validated") {
-            await this.logJob(cloud, config.validateJobId);
-          } else if (config.state === "applied") {
-            await this.logJob(cloud, config.applyJobId);
-          }
-          GrouparooCLI.logger.log(`Configuration ${config.state}...`);
-        }
-
-        if (config.state === "finished") {
-          GrouparooCLI.logger.log(
-            `\nThe configuration has been successfully ${
-              toApply ? "applied" : "validated"
-            }!`
-          );
-
-          break;
-        }
-
-        lastState = config.state;
-        await utils.sleep(1000);
-      }
-    } catch (err) {
-      GrouparooCLI.logger.fatal(err.message);
-    }
-
+    await CloudCLI.push(params);
     return true;
   }
 }

--- a/core/src/modules/cloud.ts
+++ b/core/src/modules/cloud.ts
@@ -43,9 +43,7 @@ export async function packageConfig(
     ["."]
   );
 
-  //   console.log("tmp", tempDir);
   await remove(tempDir);
-
   return tarballPath;
 }
 

--- a/core/src/modules/cloud.ts
+++ b/core/src/modules/cloud.ts
@@ -3,7 +3,7 @@ import path from "path";
 import tar from "tar";
 import fs from "fs";
 import FormData from "form-data";
-import { mkdtemp, copy, remove, readFile } from "fs-extra";
+import { mkdtemp, copy, remove } from "fs-extra";
 import axios, { AxiosError, AxiosInstance } from "axios";
 
 export class CloudError extends Error {

--- a/core/src/modules/cloud.ts
+++ b/core/src/modules/cloud.ts
@@ -1,0 +1,155 @@
+import os from "os";
+import path from "path";
+import tar from "tar";
+import fs from "fs";
+import FormData from "form-data";
+import { mkdtemp, copy, remove, readFile } from "fs-extra";
+import axios, { AxiosError, AxiosInstance } from "axios";
+
+export class CloudError extends Error {
+  code: string;
+
+  constructor({ code, message }: { code: string; message: string }) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export async function packageConfig(
+  projectPath: string,
+  configDirPath: string,
+  tarballPath: string
+) {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "grouparoo-pack-"));
+  await copy(
+    path.join(projectPath, "package.json"),
+    path.join(tempDir, "package.json")
+  );
+
+  await copy(configDirPath, path.join(tempDir, "config"), {
+    filter: (src) => {
+      const ext = path.extname(src);
+      return !ext || [".json", ".js"].includes(ext);
+    },
+  });
+
+  await tar.create(
+    {
+      file: tarballPath,
+      cwd: tempDir,
+      gzip: true,
+      strict: true,
+    },
+    ["."]
+  );
+
+  //   console.log("tmp", tempDir);
+  await remove(tempDir);
+
+  return tarballPath;
+}
+
+export interface ConfigurationApiData {
+  id: string;
+  state: string;
+  projectId: string;
+  toApply: boolean;
+  errorMessage?: string;
+  applyJobId?: string;
+  validateJobId?: string;
+  coreVersion: string;
+  processedAt: string;
+  validatedAt: string;
+  appliedAt: string;
+  finishedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JobApiData {
+  id: string;
+  type: string;
+  state: string;
+  configurationId: string;
+  logs: string;
+  completedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export class CloudClient {
+  request: AxiosInstance;
+  token: string;
+  projectId: string;
+
+  constructor(
+    projectId: string,
+    token: string,
+    apiBase: string = "https://cloud.grouparoo.com"
+  ) {
+    this.projectId = projectId;
+    this.token = token;
+    this.request = axios.create({
+      baseURL: `${apiBase}/api/v1`,
+      params: {
+        apiKey: token,
+      },
+    });
+  }
+
+  async createConfiguration(tarballPath: string, toApply: boolean) {
+    const formData = new FormData();
+    formData.append("_file", fs.createReadStream(tarballPath));
+    formData.append("projectId", this.projectId);
+    formData.append("toApply", toApply.toString());
+
+    try {
+      const res = await this.request.post("/configuration", formData, {
+        headers: formData.getHeaders(),
+      });
+
+      const data: {
+        configuration: ConfigurationApiData;
+        requesterInformation: any;
+      } = res.data;
+      return data.configuration;
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const axiosErr = err as AxiosError;
+        const cloudError = axiosErr.response?.data?.error;
+        if (cloudError) throw new CloudError(cloudError);
+      }
+      throw err;
+    }
+  }
+
+  async getConfiguration(configurationId: string) {
+    try {
+      const res = await this.request.get(`/configuration/${configurationId}`);
+      const data: { configuration: ConfigurationApiData } = res.data;
+      return data.configuration;
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const axiosErr = err as AxiosError;
+        const cloudError = axiosErr.response?.data?.error;
+        if (cloudError) throw new CloudError(cloudError);
+      }
+      throw err;
+    }
+  }
+
+  async getJob(jobId: string) {
+    try {
+      const res = await this.request.get(`/job/${jobId}`);
+      const data: { job: JobApiData } = res.data;
+      return data.job;
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const axiosErr = err as AxiosError;
+        const cloudError = axiosErr.response?.data?.error;
+        if (cloudError) throw new CloudError(cloudError);
+      }
+      throw err;
+    }
+  }
+}

--- a/core/src/modules/cloud.ts
+++ b/core/src/modules/cloud.ts
@@ -79,18 +79,14 @@ export interface JobApiData {
 
 export class CloudClient {
   request: AxiosInstance;
-  token: string;
   projectId: string;
 
-  constructor(
-    projectId: string,
-    token: string,
-    apiBase: string = "https://cloud.grouparoo.com"
-  ) {
+  constructor(projectId: string, token: string) {
+    const apiUrl =
+      process.env.GROUPAROO_CLOUD_API_URL ?? "https://cloud.grouparoo.com";
     this.projectId = projectId;
-    this.token = token;
     this.request = axios.create({
-      baseURL: `${apiBase}/api/v1`,
+      baseURL: `${apiUrl}/api/v1`,
       params: {
         apiKey: token,
       },

--- a/core/src/modules/cloudCli.ts
+++ b/core/src/modules/cloudCli.ts
@@ -1,0 +1,129 @@
+import os from "os";
+import path from "path";
+import { utils } from "actionhero";
+import { GrouparooCLI } from "./cli";
+import { getConfigDir, getParentPath } from "./pluginDetails";
+import { CloudClient, packageConfig } from "./cloud";
+import { mkdtemp, remove } from "fs-extra";
+
+export namespace CloudCLI {
+  export async function pack(output: string) {
+    const configDir = await getConfigDir(true);
+    const projectPath = getParentPath();
+
+    const tarballPath = path.isAbsolute(output)
+      ? output
+      : path.join(projectPath, output);
+
+    GrouparooCLI.logger.log(`Project directory: ${projectPath}`);
+    GrouparooCLI.logger.log(`Config directory: ${configDir}`);
+
+    const configArchive = await packageConfig(
+      projectPath,
+      configDir,
+      tarballPath
+    );
+
+    GrouparooCLI.logger.log(`✅ Saved config archive to ${configArchive}`);
+  }
+
+  async function logJob(cloud: CloudClient, jobId: string) {
+    if (jobId) {
+      const job = await cloud.getJob(jobId);
+      GrouparooCLI.logger.log(
+        GrouparooCLI.logger.cyanBold(
+          `\nLogging output for ${job.type} job (${jobId})\n`
+        )
+      );
+      GrouparooCLI.logger.log(job.logs);
+      GrouparooCLI.logger.log("");
+    }
+  }
+
+  export async function push(params: {
+    token?: string;
+    projectId: string;
+    archivePath: string;
+    apply: boolean | string;
+  }) {
+    const projectPath = getParentPath();
+    const tarballPath = path.isAbsolute(params.archivePath)
+      ? params.archivePath
+      : path.join(projectPath, params.archivePath);
+
+    const cloudToken = params.token ?? process.env.GROUPAROO_CLOUD_API_TOKEN;
+    if (!cloudToken)
+      GrouparooCLI.logger.fatal(
+        "You must provide a Grouparoo Cloud token to upload configuration. Use the --token argument or set the GROUPAROO_CLOUD_TOKEN environment variable to provide the auth token."
+      );
+
+    try {
+      const toApply = params.apply !== "false" && Boolean(params.apply);
+      const cloud = new CloudClient(params.projectId, cloudToken);
+      const { id: configId } = await cloud.createConfiguration(
+        tarballPath,
+        toApply
+      );
+
+      let lastState: string;
+      while (true) {
+        const config = await cloud.getConfiguration(configId);
+        if (config.errorMessage) {
+          await logJob(cloud, config.applyJobId ?? config.validateJobId);
+
+          GrouparooCLI.logger.fatal(
+            `An error occurred while processing the config: ${config.errorMessage}`
+          );
+        }
+
+        if (config.state !== lastState) {
+          if (config.state === "validated") {
+            await logJob(cloud, config.validateJobId);
+          } else if (config.state === "applied") {
+            await logJob(cloud, config.applyJobId);
+          }
+          GrouparooCLI.logger.log(`Configuration ${config.state}...`);
+        }
+
+        if (config.state === "finished") {
+          GrouparooCLI.logger.log(
+            `\nThe configuration has been successfully ${
+              toApply ? "applied" : "validated"
+            }!`
+          );
+
+          break;
+        }
+
+        lastState = config.state;
+        await utils.sleep(1000);
+      }
+    } catch (err) {
+      GrouparooCLI.logger.fatal(err.message);
+    }
+  }
+
+  export async function packAndPush(params: {
+    token?: string;
+    projectId: string;
+    apply: boolean | string;
+  }) {
+    const tempPath = await mkdtemp(path.join(os.tmpdir(), "grouparoo-cli-"));
+    const archivePath = path.join(tempPath, "grouparoo.tar.gz");
+
+    GrouparooCLI.logger.log("Building config archive...\n");
+
+    await CloudCLI.pack(archivePath);
+
+    GrouparooCLI.logger.log("\nUploading config...\n");
+
+    await CloudCLI.push({
+      archivePath,
+      token: params.token,
+      projectId: params.projectId,
+      apply: params.apply,
+    });
+
+    await remove(archivePath);
+  }
+}

--- a/core/src/modules/cloudCli.ts
+++ b/core/src/modules/cloudCli.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { utils } from "actionhero";
 import { GrouparooCLI } from "./cli";
 import { getConfigDir, getParentPath } from "./pluginDetails";
-import { CloudClient, packageConfig } from "./cloud";
+import { CloudClient, CloudError, packageConfig } from "./cloud";
 import { mkdtemp, remove } from "fs-extra";
 
 export namespace CloudCLI {
@@ -99,7 +99,9 @@ export namespace CloudCLI {
         await utils.sleep(1000);
       }
     } catch (err) {
-      GrouparooCLI.logger.fatal(err.message);
+      let prefix = "";
+      if (err instanceof CloudError) prefix = "Grouparoo Cloud error: ";
+      GrouparooCLI.logger.fatal(prefix + err.message);
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,7 +235,6 @@ importers:
       '@types/validator': '*'
       actionhero: 27.1.4
       ah-sequelize-plugin: 3.2.0
-      axios: 0.21.4
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
       colors: 1.4.0
@@ -287,7 +286,6 @@ importers:
       '@types/validator': 13.6.3
       actionhero: 27.1.4
       ah-sequelize-plugin: 3.2.0_a871b01706fb480c03a1aa51348e041e
-      axios: 0.21.4
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
       colors: 1.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,7 @@ importers:
     specifiers:
       '@grouparoo/spec-helper': 0.7.0-alpha.5
       '@types/fs-extra': '*'
+      '@types/isomorphic-fetch': 0.0.35
       '@types/jest': '*'
       '@types/node': '*'
       '@types/pacote': 11.1.1
@@ -234,6 +235,7 @@ importers:
       '@types/validator': '*'
       actionhero: 27.1.4
       ah-sequelize-plugin: 3.2.0
+      axios: 0.21.4
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
       colors: 1.4.0
@@ -242,6 +244,7 @@ importers:
       csv-stringify: 5.6.4
       date-fns: 2.23.0
       dotenv: 10.0.0
+      form-data: 4.0.0
       fs-extra: 10.0.0
       glob: 7.1.7
       grouparoo: 0.7.0-alpha.5
@@ -284,6 +287,7 @@ importers:
       '@types/validator': 13.6.3
       actionhero: 27.1.4
       ah-sequelize-plugin: 3.2.0_a871b01706fb480c03a1aa51348e041e
+      axios: 0.21.4
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
       colors: 1.4.0
@@ -291,6 +295,7 @@ importers:
       csv-stringify: 5.6.4
       date-fns: 2.23.0
       dotenv: 10.0.0
+      form-data: 4.0.0
       fs-extra: 10.0.0
       glob: 7.1.7
       grouparoo: link:../cli
@@ -322,6 +327,7 @@ importers:
       ws: 8.2.1
     devDependencies:
       '@grouparoo/spec-helper': link:../plugins/@grouparoo/spec-helper
+      '@types/isomorphic-fetch': 0.0.35
       '@types/jest': 27.0.1
       '@types/pacote': 11.1.1
       '@types/pluralize': 0.0.29
@@ -3869,6 +3875,10 @@ packages:
     dependencies:
       '@types/node': 16.9.1
 
+  /@types/isomorphic-fetch/0.0.35:
+    resolution: {integrity: sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==}
+    dev: true
+
   /@types/istanbul-lib-coverage/2.0.3:
     resolution: {integrity: sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==}
     dev: true
@@ -4684,7 +4694,7 @@ packages:
   /axios/0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.3
+      follow-redirects: 1.14.4
     transitivePeerDependencies:
       - debug
     dev: false
@@ -4692,7 +4702,7 @@ packages:
   /axios/0.21.4_debug@3.2.7:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.3_debug@3.2.7
+      follow-redirects: 1.14.4_debug@3.2.7
     transitivePeerDependencies:
       - debug
     dev: false
@@ -7160,8 +7170,18 @@ packages:
       debug:
         optional: true
 
-  /follow-redirects/1.14.3_debug@3.2.7:
-    resolution: {integrity: sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==}
+  /follow-redirects/1.14.4:
+    resolution: {integrity: sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
+  /follow-redirects/1.14.4_debug@3.2.7:
+    resolution: {integrity: sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'


### PR DESCRIPTION
New commands:
- `grouparoo pack`: generates a `.tar.gz` file with the project's package.json and config directory contents. It uses `getConfigDir()` to get the config directory, so no matter how the project's configured it should find it. Files that are not `.json` or `.js` are filtered out.
- `grouparoo push`: uploads a `.tar.gz` file to a Grouparoo Cloud project, creating a Configuration. Token can be loaded from an argument or env var (`GROUPAROO_CLOUD_API_TOKEN`). By default will only run `validate`. Pass `--apply` and will also apply the config.
- `grouparoo ci`: equivalent to running `grouparoo pack` and `grouparoo push`. The archive is saved to a temp dir and then deleted.
- `grouparoo deploy`: equivalent to running `grouparoo pack` and `grouparoo push --apply`. The archive is saved to a temp dir and then deleted.

**Note:** These commands must be run from within an installed Grouparoo project.

To use a different cloud api endpoint (staging, local dev), the `GROUPAROO_CLOUD_API_URL` env var can be set. By default it will point to `https://cloud.grouparoo.com`