### PR TITLE
Mark RecordProperty as ready with null value on duplicate unique value

### DIFF
--- a/core/src/tasks/recordProperty/importRecordProperty.ts
+++ b/core/src/tasks/recordProperty/importRecordProperty.ts
@@ -6,6 +6,8 @@ import { Mapping } from "../../models/Mapping";
 import { Option } from "../../models/Option";
 import { PropertyOps } from "../../modules/ops/property";
 import { ImportOps } from "../../modules/ops/import";
+import { CLS } from "../../modules/cls";
+import { UniqueConstraintError } from "sequelize";
 
 export class ImportRecordProperty extends RetryableTask {
   constructor() {
@@ -70,7 +72,33 @@ export class ImportRecordProperty extends RetryableTask {
       hash[property.id] = Array.isArray(propertyValues)
         ? propertyValues
         : [propertyValues];
-      await record.addOrUpdateProperties(hash);
+
+      try {
+        await record.addOrUpdateProperties(hash);
+      } catch (error) {
+        if (property.unique && error instanceof UniqueConstraintError) {
+          await CLS.afterCommit(() =>
+            RecordProperty.update(
+              {
+                state: "ready",
+                rawValue: null,
+                invalidValue: hash[property.id].join(", "),
+                stateChangedAt: new Date(),
+                confirmedAt: new Date(),
+              },
+              {
+                where: {
+                  propertyId: property.id,
+                  recordId: record.id,
+                  state: "pending",
+                },
+              }
+            )
+          );
+        } else {
+          throw error;
+        }
+      }
     } else {
       // got no data back, clear value
       await RecordProperty.update(


### PR DESCRIPTION
This PR will denote a RecordProperty as "ready" when we encounter a duplicate value for a unique Property.  The RecordProperty will gain a value of `null` and the offending value will be stored in `recordProperty.invalidValue`.    For example, if you have denoted `email` to be a unique Grouparoo Property, but had 2 profiles with the same email address, you would end up with 1 Record in Grouparoo with the email filled in, and another with a "null" email and an `invalidValue`.

This means that much like https://github.com/grouparoo/grouparoo/pull/2307, Runs will complete when there is an error and we will store the problem for review later.  

This PR works only on the `recordProperty:importRecordProperty` (singular) task because thanks to https://github.com/grouparoo/grouparoo/pull/2311, any problems with `recordProperty:importRecordProperties` will be de-batched and tried again as single imports.  It is at that point that we can see if the single RecordProperty import failed because of a `UniqueConstraintError`.