### PR TITLE
ImportAndExport does not use transaction isolation in order to save partial progress

### DIFF
--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -393,7 +393,7 @@ export namespace RecordOps {
                   {
                     state: "ready",
                     rawValue: null,
-                    invalidValue: `${attemptedRecordProperty.rawValue} (duplicate)`,
+                    invalidValue: `${attemptedRecordProperty.rawValue}`,
                     stateChangedAt: new Date(),
                     confirmedAt: new Date(),
                   },

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -20,7 +20,10 @@ import { LoggedModel } from "../../classes/loggedModel";
 import { FilterHelper } from "../filterHelper";
 import { topologicalSort } from "../topologicalSort";
 import { ConfigWriter } from "../configWriter";
-import { RecordPropertiesPluginMethodResponse } from "../../classes/plugin";
+import {
+  RecordPropertiesPluginMethodResponse,
+  RecordPropertyPluginMethodResponse,
+} from "../../classes/plugin";
 
 export namespace SourceOps {
   /**
@@ -342,7 +345,7 @@ export namespace SourceOps {
    * Import all record properties from a Source for a GrouparooRecord
    */
   export async function _import(source: Source, record: GrouparooRecord) {
-    const hash = {};
+    const hash: Record<string, RecordPropertyPluginMethodResponse> = {};
     const properties = await source.$get("properties", {
       where: { state: "ready" },
     });

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -534,7 +534,7 @@ export namespace Actions {
     typeof RecordEdit.prototype.runWithinTransaction
   >;
   export type RecordImportAndExport = AsyncReturnType<
-    typeof RecordImportAndExport.prototype.runWithinTransaction
+    typeof RecordImportAndExport.prototype.run
   >;
   export type RecordView = AsyncReturnType<
     typeof RecordView.prototype.runWithinTransaction


### PR DESCRIPTION
This PR enhances the `import and update` button on the `/record/{id}/edit` page in 2 ways:

* Stores the results of the import recordProperty-by-recordProperty (rather than in bulk) to allow any failures to be isolated and handled.  This allows a failing unique recordProperty to not cancel the whole import
* The action is not in a transaction so we can save as much of the import as we can if something fails.  Perhaps the import is OK but the export fails - now we will save the import data regardlesss