### PR TITLE
fix: `grouparoo config` runs migrations

### DIFF
--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -113,7 +113,7 @@ export const DEFAULT = {
       (process.env.WORKERS
         ? parseInt(process.env.WORKERS)
         : 0 > 0 && process.env.GROUPAROO_RUN_MODE !== "cli:apply") ||
-      process.env.NODE_ENV === "test" || 
+      process.env.NODE_ENV === "test" ||
       process.env.GROUPAROO_RUN_MODE === "cli:config"
     ) {
       autoMigrate = true;

--- a/core/src/config/sequelize.ts
+++ b/core/src/config/sequelize.ts
@@ -113,7 +113,8 @@ export const DEFAULT = {
       (process.env.WORKERS
         ? parseInt(process.env.WORKERS)
         : 0 > 0 && process.env.GROUPAROO_RUN_MODE !== "cli:apply") ||
-      process.env.NODE_ENV === "test"
+      process.env.NODE_ENV === "test" || 
+      process.env.GROUPAROO_RUN_MODE === "cli:config"
     ) {
       autoMigrate = true;
     }

--- a/ui/ui-config/__tests__/bin/config.ts
+++ b/ui/ui-config/__tests__/bin/config.ts
@@ -1,10 +1,10 @@
-import { Apply } from "../../dist/bin/config";
+import { Config } from "../../dist/bin/config";
 
 describe("grouparoo config", () => {
-  let apply, testDatabaseUrl, testRedisUrl, testPort;
+  let config, testDatabaseUrl, testRedisUrl, testPort;
 
   beforeEach(() => {
-    apply = new Apply();
+    config = new Config();
 
     testDatabaseUrl = process.env.DATABASE_URL;
     testRedisUrl = process.env.REDIS_URL;
@@ -42,7 +42,7 @@ describe("grouparoo config", () => {
     expect(process.env.WEB_SERVER).toBeUndefined();
     expect(process.env.PORT).toBeUndefined();
 
-    apply.preInitialize();
+    config.preInitialize();
 
     expect(process.env.GROUPAROO_RUN_MODE).toBe("cli:config");
     expect(process.env.NEXT_DEVELOPMENT_MODE).toBe("false");
@@ -57,7 +57,7 @@ describe("grouparoo config", () => {
   test("sets DATABASE_URL from CONFIG_DATABASE_URL", () => {
     expect(process.env.DATABASE_URL).toBeUndefined();
     process.env.CONFIG_DATABASE_URL = "sqlite://grouparoo_config.sqlite";
-    apply.preInitialize();
+    config.preInitialize();
     expect(process.env.DATABASE_URL).toBe("sqlite://grouparoo_config.sqlite");
   });
 });

--- a/ui/ui-config/dist/bin/config.js
+++ b/ui/ui-config/dist/bin/config.js
@@ -3,7 +3,7 @@ const actionhero = require("actionhero");
 const { log } = require("actionhero");
 const open = require("open");
 
-class Apply extends actionhero.CLI {
+class Config extends actionhero.CLI {
   constructor() {
     super();
     this.preInitialize = () => {
@@ -39,4 +39,4 @@ class Apply extends actionhero.CLI {
   }
 }
 
-exports.Apply = Apply;
+exports.Config = Config;


### PR DESCRIPTION
As of #2309 only worker processes run migrations, but `grouparoo config` runs with 0 workers and _should_ run migrations. This was preventing config ui from starting up properly. 
The integration test did not catch this because `test` environments also auto run migrations.

Also cleans up ui-config a bit - looks like we copied some code from the Apply command that we forgot to update.