### PR TITLE
Reload the record if import-export failed

### DIFF
--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -574,8 +574,6 @@ export namespace RecordOps {
       }
 
       return record;
-    } catch (error) {
-      throw error;
     } finally {
       if (toLock) await releaseLock();
     }

--- a/ui/ui-components/pages/record/[id]/edit.tsx
+++ b/ui/ui-components/pages/record/[id]/edit.tsx
@@ -59,13 +59,7 @@ export default function Page(props) {
       "get",
       `/record/${record.id}`
     );
-    if (response?.record) {
-      recordHandler.set(response.record);
-      setRecord(response.record);
-      setRecordProperties(response.record.properties);
-      setGroups(response.groups);
-    }
-    setLoading(false);
+    updateRecordState(response);
   }
 
   async function importAndExport() {
@@ -76,15 +70,23 @@ export default function Page(props) {
       `/record/${record.id}/importAndExport`
     );
     if (response?.record) {
+      updateRecordState(response);
+      successHandler.set({ message: "Import and Export Complete!" });
+    } else {
+      load(); // we may have done a partial import
+    }
+  }
+
+  function updateRecordState(
+    response: Actions.RecordView | Actions.RecordImportAndExport
+  ) {
+    if (response?.record) {
       recordHandler.set(response.record);
       setRecord(response.record);
       setRecordProperties(response.record.properties);
       setGroups(response.groups);
-      setLoading(false);
-      successHandler.set({ message: "Import and Export Complete!" });
-    } else {
-      load(); // reload regardless of success, we have done a partial import
     }
+    setLoading(false);
   }
 
   async function handleDelete() {

--- a/ui/ui-components/pages/record/[id]/edit.tsx
+++ b/ui/ui-components/pages/record/[id]/edit.tsx
@@ -76,10 +76,15 @@ export default function Page(props) {
       `/record/${record.id}/importAndExport`
     );
     if (response?.record) {
+      recordHandler.set(response.record);
+      setRecord(response.record);
+      setRecordProperties(response.record.properties);
+      setGroups(response.groups);
+      setLoading(false);
       successHandler.set({ message: "Import and Export Complete!" });
-      load();
+    } else {
+      load(); // reload regardless of success, we have done a partial import
     }
-    setLoading(false);
   }
 
   async function handleDelete() {


### PR DESCRIPTION
This PR follows https://github.com/grouparoo/grouparoo/pull/2330 - now if the `importAndExport` API returns an error, we still reload the record's information in the UI, as there may have been a partial import.