### PR TITLE
`@grouparoo/cloudwatch` plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
             - plugins/@grouparoo/bigquery/node_modules
             - plugins/@grouparoo/braze/node_modules
             - plugins/@grouparoo/calculated-property/node_modules
+            - plugins/@grouparoo/cloudwatch/node_modules
             - plugins/@grouparoo/csv/node_modules
             - plugins/@grouparoo/customerio/node_modules
             - plugins/@grouparoo/dbt/node_modules
@@ -117,6 +118,7 @@ jobs:
             - plugins/@grouparoo/bigquery/dist
             - plugins/@grouparoo/braze/dist
             - plugins/@grouparoo/calculated-property/dist
+            - plugins/@grouparoo/cloudwatch/dist
             - plugins/@grouparoo/csv/dist
             - plugins/@grouparoo/customerio/dist
             - plugins/@grouparoo/dbt/dist
@@ -1478,6 +1480,59 @@ jobs:
       - run:
           name: test
           command: cd plugins/@grouparoo/calculated-property && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
+  test-plugin-cloudwatch:
+    docker:
+      - image: circleci/node:16.8.0
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: redis:latest
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: circleci/postgres:9
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+        environment:
+          POSTGRES_PASSWORD: password
+    steps:
+      - checkout
+      - restore_cache:
+          <<: *module-other-cache
+      - restore_cache:
+          <<: *plugin-1-cache
+      - restore_cache:
+          <<: *plugin-2-cache
+      - restore_cache:
+          <<: *plugin-3-cache
+      - restore_cache:
+          <<: *plugin-4-cache
+      - restore_cache:
+          <<: *dist-1-cache
+      - restore_cache:
+          <<: *dist-2-cache
+      - restore_cache:
+          <<: *dist-3-cache
+      - restore_cache:
+          <<: *dist-4-cache
+      - restore_cache:
+          <<: *core-cache
+      - run:
+          name: update apt
+          command: sudo apt update
+      - run:
+          name: install postgresql client
+          command: sudo apt install -y postgresql-client
+      - run:
+          name: Wait for DB
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run:
+          name: create test databases
+          command: cd core && ./bin/create_test_databases
+      - run:
+          name: test
+          command: cd plugins/@grouparoo/cloudwatch && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-csv:
     docker:
       - image: circleci/node:16.8.0
@@ -3373,6 +3428,11 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
+      - test-plugin-cloudwatch:
+          filters:
+            <<: *ignored-branches
+          requires:
+            - build
       - test-plugin-csv:
           filters:
             <<: *ignored-branches
@@ -3568,6 +3628,7 @@ workflows:
             - test-plugin-bigquery
             - test-plugin-braze
             - test-plugin-calculated-property
+            - test-plugin-cloudwatch
             - test-plugin-csv
             - test-plugin-customerio
             - test-plugin-dbt

--- a/plugins/@grouparoo/cloudwatch/.npmignore
+++ b/plugins/@grouparoo/cloudwatch/.npmignore
@@ -1,0 +1,11 @@
+# General
+node_modules
+*.tgz
+.DS_Store
+.vscode
+npm-debug.log
+yarn-error.log
+.env
+dump.rdb
+*.retry
+coverage

--- a/plugins/@grouparoo/cloudwatch/LICENSE.txt
+++ b/plugins/@grouparoo/cloudwatch/LICENSE.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/plugins/@grouparoo/cloudwatch/README.md
+++ b/plugins/@grouparoo/cloudwatch/README.md
@@ -14,4 +14,4 @@ The following environment variables are required:
 - `S3_SECRET_ACCESS_KEY`
 - `S3_REGION`
 
-Note that, `GROUPAROO_LOG_LEVEL` also effects this logger. By default, the log-level of this logger is is "alert" NOT "info".
+Note that, `GROUPAROO_LOG_LEVEL` also effects this logger. By default, the log-level of this logger is is "notice" NOT "info".

--- a/plugins/@grouparoo/cloudwatch/README.md
+++ b/plugins/@grouparoo/cloudwatch/README.md
@@ -1,0 +1,15 @@
+# @grouparoo/cloudwatch
+
+A [Grouparoo](https://www.grouparoo.com) plugin for sending application logs to AWS Cloudwatch
+
+Learn more about Grouparoo Plugins at [www.grouparoo.com/docs/plugins](https://www.grouparoo.com/docs/plugins).
+
+## Installation
+
+In your Grouparoo project, run `grouparoo install @grouparoo/cloudwatch`.
+
+The following environment variables are required:
+
+- `S3_ACCESS_KEY`
+- `S3_SECRET_ACCESS_KEY`
+- `S3_REGION`

--- a/plugins/@grouparoo/cloudwatch/README.md
+++ b/plugins/@grouparoo/cloudwatch/README.md
@@ -13,3 +13,5 @@ The following environment variables are required:
 - `S3_ACCESS_KEY`
 - `S3_SECRET_ACCESS_KEY`
 - `S3_REGION`
+
+There is an optional variable, `GROUPAROO_CLOUDWATCH_LOG_LEVEL` which will allow you to customize the log level of only this logger to record more or less information. By default, the `GROUPAROO_CLOUDWATCH_LOG_LEVEL` is "alert".

--- a/plugins/@grouparoo/cloudwatch/README.md
+++ b/plugins/@grouparoo/cloudwatch/README.md
@@ -14,4 +14,4 @@ The following environment variables are required:
 - `S3_SECRET_ACCESS_KEY`
 - `S3_REGION`
 
-There is an optional variable, `GROUPAROO_CLOUDWATCH_LOG_LEVEL` which will allow you to customize the log level of only this logger to record more or less information. By default, the `GROUPAROO_CLOUDWATCH_LOG_LEVEL` is "alert".
+Note that, `GROUPAROO_LOG_LEVEL` also effects this logger. By default, the log-level of this logger is is "alert" NOT "info".

--- a/plugins/@grouparoo/cloudwatch/package.json
+++ b/plugins/@grouparoo/cloudwatch/package.json
@@ -35,9 +35,12 @@
   "devDependencies": {
     "@grouparoo/core": "0.7.0-alpha.7",
     "@grouparoo/spec-helper": "0.7.0-alpha.7",
+    "@types/jest": "*",
     "@types/node": "*",
     "actionhero": "27.1.4",
+    "jest": "27.1.0",
     "prettier": "2.3.2",
+    "ts-jest": "27.0.5",
     "type-fest": "2.1.0",
     "typescript": "4.4.2"
   },

--- a/plugins/@grouparoo/cloudwatch/package.json
+++ b/plugins/@grouparoo/cloudwatch/package.json
@@ -1,0 +1,57 @@
+{
+  "author": "Grouparoo Inc <hello@grouparoo.com>",
+  "name": "@grouparoo/cloudwatch",
+  "description": "The Grouparoo Cloudwatch Plugin",
+  "version": "0.7.0-alpha.7",
+  "license": "MPL-2.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "homepage": "https://www.grouparoo.com",
+  "bugs": {
+    "url": "https://github.com/grouparoo/grouparoo/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/grouparoo/grouparoo.git",
+    "directory": "plugins/@grouparoo/cloudwatch"
+  },
+  "scripts": {
+    "prepare": "rm -rf dist && tsc --declaration",
+    "test": "echo 'no tests'",
+    "pretest": "npm run lint && npm run prepare",
+    "lint": "prettier --check src __tests__",
+    "watch": "tsc --watch"
+  },
+  "dependencies": {
+    "aws-sdk": "2.995.0",
+    "winston": "3.3.3",
+    "winston-cloudwatch": "3.0.2"
+  },
+  "devDependencies": {
+    "@grouparoo/core": "0.7.0-alpha.7",
+    "@grouparoo/spec-helper": "0.7.0-alpha.7",
+    "@types/jest": "*",
+    "@types/node": "*",
+    "actionhero": "27.1.4",
+    "jest": "27.1.0",
+    "prettier": "2.3.2",
+    "ts-jest": "27.0.5",
+    "type-fest": "2.1.0",
+    "typescript": "4.4.2"
+  },
+  "grouparoo": {
+    "env": {
+      "api": [
+        "S3_ACCESS_KEY",
+        "S3_SECRET_ACCESS_KEY",
+        "S3_REGION"
+      ]
+    }
+  },
+  "gitHead": "d87e6adcefcc3e55d671121157b8eda1ae89f22a"
+}

--- a/plugins/@grouparoo/cloudwatch/package.json
+++ b/plugins/@grouparoo/cloudwatch/package.json
@@ -24,7 +24,7 @@
     "prepare": "rm -rf dist && tsc --declaration",
     "test": "echo 'no tests'",
     "pretest": "npm run lint && npm run prepare",
-    "lint": "prettier --check src __tests__",
+    "lint": "prettier --check src",
     "watch": "tsc --watch"
   },
   "dependencies": {
@@ -35,12 +35,9 @@
   "devDependencies": {
     "@grouparoo/core": "0.7.0-alpha.7",
     "@grouparoo/spec-helper": "0.7.0-alpha.7",
-    "@types/jest": "*",
     "@types/node": "*",
     "actionhero": "27.1.4",
-    "jest": "27.1.0",
     "prettier": "2.3.2",
-    "ts-jest": "27.0.5",
     "type-fest": "2.1.0",
     "typescript": "4.4.2"
   },

--- a/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
@@ -27,7 +27,7 @@ export default class CloudwatchInitializer extends Initializer {
 
     const cloudwatchLogger = new WinstonCloudWatch({
       name,
-      level: process.env.GROUPAROO_CLOUDWATCH_LOG_LEVEL ?? "notice",
+      level: process.env.GROUPAROO_LOG_LEVEL ?? "notice",
       logGroupName: name,
       logStreamName: () => {
         let date = new Date().toISOString().split("T")[0];

--- a/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
@@ -1,0 +1,53 @@
+import { Initializer, loggers, env, ActionheroLogLevel } from "actionhero";
+import { URL } from "url";
+import * as winston from "winston";
+import WinstonCloudWatch from "winston-cloudwatch";
+
+const packageJSON = require("./../../package.json");
+
+export default class CloudwatchInitializer extends Initializer {
+  constructor() {
+    super();
+    this.name = packageJSON.name;
+    this.loadPriority = 1;
+  }
+
+  async initialize() {
+    if (!process.env.S3_ACCESS_KEY) return;
+    if (!process.env.S3_SECRET_ACCESS_KEY) return;
+    if (!process.env.S3_REGION) return;
+
+    // try to extract the name of the instance from the URL we are using
+    // we could alternatively use the ClusterName setting
+    let name = `grouparoo-${env}`;
+    if (process.env.WEB_URL) {
+      const parsed = new URL(process.env.WEB_URL);
+      name = parsed.host.split(":")[0].replace(/\./g, "-");
+    }
+
+    const cloudwatchLogger = new WinstonCloudWatch({
+      name,
+      level: "notice" as ActionheroLogLevel,
+      logGroupName: name,
+      logStreamName: () => {
+        let date = new Date().toISOString().split("T")[0];
+        return `${name}-${date}`;
+      },
+      jsonMessage: true,
+      retentionInDays: 30, // store the logs for 30 days
+      awsAccessKeyId: process.env.S3_ACCESS_KEY,
+      awsSecretKey: process.env.S3_SECRET_ACCESS_KEY,
+      awsRegion: process.env.S3_REGION,
+    });
+
+    // stop method from https://github.com/lazywithclass/winston-cloudwatch#programmatically-flush-logs-and-exit
+    cloudwatchLogger.kthxbye = () => {};
+
+    const preparedLogger = winston.createLogger({
+      levels: winston.config.syslog.levels,
+      transports: [cloudwatchLogger],
+    });
+
+    loggers.push(preparedLogger);
+  }
+}

--- a/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
@@ -1,4 +1,4 @@
-import { Initializer, loggers, env, ActionheroLogLevel } from "actionhero";
+import { Initializer, loggers, id, env } from "actionhero";
 import { URL } from "url";
 import * as winston from "winston";
 import WinstonCloudWatch from "winston-cloudwatch";
@@ -22,16 +22,16 @@ export default class CloudwatchInitializer extends Initializer {
     let name = `grouparoo-${env}`;
     if (process.env.WEB_URL) {
       const parsed = new URL(process.env.WEB_URL);
-      name = parsed.host.split(":")[0].replace(/\./g, "-");
+      name = parsed.host.split(":")[0].replace(/\./g, "-") + `-${env}`;
     }
 
     const cloudwatchLogger = new WinstonCloudWatch({
       name,
-      level: "notice" as ActionheroLogLevel,
+      level: process.env.GROUPAROO_CLOUDWATCH_LOG_LEVEL ?? "notice",
       logGroupName: name,
       logStreamName: () => {
         let date = new Date().toISOString().split("T")[0];
-        return `${name}-${date}`;
+        return `${name}-${id}-${date}`;
       },
       jsonMessage: true,
       retentionInDays: 7, // store the logs for 7 days

--- a/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
@@ -34,7 +34,7 @@ export default class CloudwatchInitializer extends Initializer {
         return `${name}-${date}`;
       },
       jsonMessage: true,
-      retentionInDays: 30, // store the logs for 30 days
+      retentionInDays: 7, // store the logs for 7 days
       awsAccessKeyId: process.env.S3_ACCESS_KEY,
       awsSecretKey: process.env.S3_SECRET_ACCESS_KEY,
       awsRegion: process.env.S3_REGION,

--- a/plugins/@grouparoo/cloudwatch/tsconfig.json
+++ b/plugins/@grouparoo/cloudwatch/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "allowJs": true,
+    "module": "commonjs",
+    "target": "es2019",
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["./src/**/*"],
+  "exclude": ["./../node_modules"]
+}


### PR DESCRIPTION
The `@grouparoo/cloudwatch` plugin will send Grouparoo application logs to AWS cloudwatch!

<img width="1910" alt="Screen Shot 2021-09-27 at 12 11 08 PM" src="https://user-images.githubusercontent.com/303226/134970600-6f4c58b1-ac4d-48d0-9cf4-9d9039c8dbe1.png">

Outstanding Questions:
* If we use the default `info` level, will that be too much data being stored? If we send log messages with the `notice` level or higher, will we miss important messages (eg: a task is running slow)?
* Is it OK to use the environment variables as chosen (eg: assume there is one collection of S3 credentials for the application to use)
