### PR TITLE
Update cloudwatch ENV variables to be generic for AWS

### DIFF
--- a/apps/staging-community/.env.example
+++ b/apps/staging-community/.env.example
@@ -49,7 +49,7 @@ DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
 ## AWS ##
 #########
 
-# AWS_ACCESS_KEY=""
+# AWS_ACCESS_KEY_ID=""
 # AWS_SECRET_ACCESS_KEY=""
 # AWS_REGION=""
 

--- a/apps/staging-community/.env.example
+++ b/apps/staging-community/.env.example
@@ -45,14 +45,13 @@ DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
 # DATABASE_SSL=true
 # DATABASE_SSL_SELF_SIGNED=true
 
-########
-## S3 ##
-########
+#########
+## AWS ##
+#########
 
-S3_ACCESS_KEY=""
-S3_SECRET_ACCESS_KEY=""
-S3_REGION=""
-S3_BUCKET=""
+# AWS_ACCESS_KEY=""
+# AWS_SECRET_ACCESS_KEY=""
+# AWS_REGION=""
 
 ##########
 ## DEMO ##

--- a/apps/staging-config/.env.example
+++ b/apps/staging-config/.env.example
@@ -50,7 +50,7 @@ CONFIG_DATABASE_URL = "sqlite://grouparoo_config.sqlite"
 ## AWS ##
 #########
 
-# AWS_ACCESS_KEY=""
+# AWS_ACCESS_KEY_ID=""
 # AWS_SECRET_ACCESS_KEY=""
 # AWS_REGION=""
 

--- a/apps/staging-config/.env.example
+++ b/apps/staging-config/.env.example
@@ -46,14 +46,13 @@ CONFIG_DATABASE_URL = "sqlite://grouparoo_config.sqlite"
 # DATABASE_SSL=true
 # DATABASE_SSL_SELF_SIGNED=true
 
-########
-## S3 ##
-########
+#########
+## AWS ##
+#########
 
-# S3_ACCESS_KEY=""
-# S3_SECRET_ACCESS_KEY=""
-# S3_REGION=""
-# S3_BUCKET=""
+# AWS_ACCESS_KEY=""
+# AWS_SECRET_ACCESS_KEY=""
+# AWS_REGION=""
 
 ##########
 ## DEMO ##

--- a/apps/staging-enterprise/.env.example
+++ b/apps/staging-enterprise/.env.example
@@ -49,7 +49,7 @@ DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
 ## AWS ##
 #########
 
-# AWS_ACCESS_KEY=""
+# AWS_ACCESS_KEY_ID=""
 # AWS_SECRET_ACCESS_KEY=""
 # AWS_REGION=""
 

--- a/apps/staging-enterprise/.env.example
+++ b/apps/staging-enterprise/.env.example
@@ -45,14 +45,13 @@ DATABASE_URL="postgresql://localhost:5432/grouparoo_development"
 # DATABASE_SSL=true
 # DATABASE_SSL_SELF_SIGNED=true
 
-########
-## S3 ##
-########
+#########
+## AWS ##
+#########
 
-S3_ACCESS_KEY=""
-S3_SECRET_ACCESS_KEY=""
-S3_REGION=""
-S3_BUCKET=""
+# AWS_ACCESS_KEY=""
+# AWS_SECRET_ACCESS_KEY=""
+# AWS_REGION=""
 
 ##########
 ## DEMO ##

--- a/plugins/@grouparoo/cloudwatch/README.md
+++ b/plugins/@grouparoo/cloudwatch/README.md
@@ -10,7 +10,7 @@ In your Grouparoo project, run `grouparoo install @grouparoo/cloudwatch`.
 
 The following environment variables are required:
 
-- `AWS_ACCESS_KEY`
+- `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 - `AWS_REGION`
 

--- a/plugins/@grouparoo/cloudwatch/README.md
+++ b/plugins/@grouparoo/cloudwatch/README.md
@@ -10,8 +10,8 @@ In your Grouparoo project, run `grouparoo install @grouparoo/cloudwatch`.
 
 The following environment variables are required:
 
-- `S3_ACCESS_KEY`
-- `S3_SECRET_ACCESS_KEY`
-- `S3_REGION`
+- `AWS_ACCESS_KEY`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION`
 
 Note that, `GROUPAROO_LOG_LEVEL` also effects this logger. By default, the log-level of this logger is is "notice" NOT "info".

--- a/plugins/@grouparoo/cloudwatch/package.json
+++ b/plugins/@grouparoo/cloudwatch/package.json
@@ -47,9 +47,9 @@
   "grouparoo": {
     "env": {
       "api": [
-        "S3_ACCESS_KEY",
-        "S3_SECRET_ACCESS_KEY",
-        "S3_REGION"
+        "AWS_ACCESS_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_REGION"
       ]
     }
   },

--- a/plugins/@grouparoo/cloudwatch/package.json
+++ b/plugins/@grouparoo/cloudwatch/package.json
@@ -47,7 +47,7 @@
   "grouparoo": {
     "env": {
       "api": [
-        "AWS_ACCESS_KEY",
+        "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
         "AWS_REGION"
       ]

--- a/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
@@ -13,9 +13,9 @@ export default class CloudwatchInitializer extends Initializer {
   }
 
   async initialize() {
-    if (!process.env.S3_ACCESS_KEY) return;
-    if (!process.env.S3_SECRET_ACCESS_KEY) return;
-    if (!process.env.S3_REGION) return;
+    if (!process.env.AWS_ACCESS_KEY) return;
+    if (!process.env.AWS_SECRET_ACCESS_KEY) return;
+    if (!process.env.AWS_REGION) return;
 
     // try to extract the name of the instance from the URL we are using
     // we could alternatively use the ClusterName setting
@@ -35,9 +35,9 @@ export default class CloudwatchInitializer extends Initializer {
       },
       jsonMessage: true,
       retentionInDays: 7, // store the logs for 7 days
-      awsAccessKeyId: process.env.S3_ACCESS_KEY,
-      awsSecretKey: process.env.S3_SECRET_ACCESS_KEY,
-      awsRegion: process.env.S3_REGION,
+      awsAccessKeyId: process.env.AWS_ACCESS_KEY,
+      awsSecretKey: process.env.AWS_SECRET_ACCESS_KEY,
+      awsRegion: process.env.AWS_REGION,
     });
 
     // stop method from https://github.com/lazywithclass/winston-cloudwatch#programmatically-flush-logs-and-exit

--- a/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
@@ -13,7 +13,7 @@ export default class CloudwatchInitializer extends Initializer {
   }
 
   async initialize() {
-    if (!process.env.AWS_ACCESS_KEY) return;
+    if (!process.env.AWS_ACCESS_KEY_ID) return;
     if (!process.env.AWS_SECRET_ACCESS_KEY) return;
     if (!process.env.AWS_REGION) return;
 
@@ -35,7 +35,7 @@ export default class CloudwatchInitializer extends Initializer {
       },
       jsonMessage: true,
       retentionInDays: 7, // store the logs for 7 days
-      awsAccessKeyId: process.env.AWS_ACCESS_KEY,
+      awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID,
       awsSecretKey: process.env.AWS_SECRET_ACCESS_KEY,
       awsRegion: process.env.AWS_REGION,
     });


### PR DESCRIPTION
Use better names for the AWS Environment Variables 

- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `AWS_REGION`
