### PR TITLE
`RecordProperties` do not create Logs

### DIFF
--- a/core/__tests__/actions/logs.ts
+++ b/core/__tests__/actions/logs.ts
@@ -78,28 +78,5 @@ describe("actions/logs", () => {
       expect(logs.length).toEqual(1);
       await record.destroy();
     });
-
-    test("a reader can ask for logs about a record and also see logs about properties", async () => {
-      const record = await helper.factories.record();
-      await record.buildNullProperties();
-
-      connection.params = {
-        csrfToken,
-        ownerId: record.id,
-      };
-
-      const { error, logs } = await specHelper.runAction<LogsList>(
-        "logs:list",
-        connection
-      );
-
-      expect(error).toBeUndefined();
-
-      expect(logs.length).toBeGreaterThan(1);
-      expect(logs.reverse()[0].topic).toBe("grouparooRecord");
-      expect(logs.reverse()[0].verb).toBe("create");
-      expect(logs.reverse()[1].topic).toBe("recordProperty");
-      expect(logs.reverse()[1].verb).toBe("create");
-    });
   });
 });

--- a/core/__tests__/models/recordProperty/recordProperty.ts
+++ b/core/__tests__/models/recordProperty/recordProperty.ts
@@ -92,32 +92,6 @@ describe("models/recordProperty", () => {
     await vipProperty.update({ state: "ready" });
   });
 
-  test("creating, editing, and deleting a record property creates a relevant log message", async () => {
-    const property = await RecordProperty.create({
-      recordId: record.id,
-      propertyId: ltvProperty.id,
-      rawValue: "123.0",
-    });
-
-    let log = await Log.findOne({
-      where: { topic: "recordProperty", verb: "create" },
-    });
-    expect(log.message).toMatch(/recordProperty .* created/);
-
-    property.rawValue = "100";
-    await property.save();
-    log = await Log.findOne({
-      where: { topic: "recordProperty", verb: "update" },
-    });
-    expect(log.message).toBe('recordProperty "ltv" updated: rawValue -> 100');
-
-    await property.destroy();
-    log = await Log.findOne({
-      where: { topic: "recordProperty", verb: "destroy" },
-    });
-    expect(log.message).toBe('recordProperty "ltv" destroyed');
-  });
-
   describe("array properties", () => {
     let purchasesProperty: Property;
 

--- a/core/src/actions/logs.ts
+++ b/core/src/actions/logs.ts
@@ -45,13 +45,6 @@ export class LogsList extends AuthenticatedAction {
     if (params.verb) search.where["verb"] = params.verb;
     if (params.ownerId) {
       const ownerIds = [params.ownerId];
-
-      // in the case we are dealing with a record
-      const recordProperties = await RecordProperty.findAll({
-        where: { recordId: params.ownerId },
-      });
-      recordProperties.forEach((prop) => ownerIds.push(prop.id));
-
       search.where["ownerId"] = { [Op.in]: ownerIds };
     }
 

--- a/core/src/classes/commonModel.ts
+++ b/core/src/classes/commonModel.ts
@@ -1,0 +1,91 @@
+import {
+  Column,
+  Model,
+  CreatedAt,
+  UpdatedAt,
+  BeforeCreate,
+  Length,
+  BeforeBulkCreate,
+} from "sequelize-typescript";
+import validator from "validator";
+import * as uuid from "uuid";
+
+export abstract class CommonModel<T> extends Model {
+  /**
+   * return the prefix for this type of class' id
+   */
+  abstract idPrefix(): string;
+
+  @Length({ min: 1, max: 191 })
+  @Column({ primaryKey: true })
+  id: string;
+
+  @BeforeCreate
+  static generateId(instance) {
+    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
+  }
+
+  @BeforeBulkCreate
+  static generateIds(instances) {
+    instances.forEach((instance) => this.generateId(instance));
+  }
+
+  @BeforeCreate
+  static validateId(instance) {
+    const id: string = instance.id;
+    let failing = false;
+    if (id.length > 191) failing = true;
+    if (!/^[A-Za-z0-9-_]+$/.test(id)) failing = true; // only allow letters, numbers, hyphen and underscore
+
+    if (failing) {
+      throw new Error(
+        `invalid id: \`${id}\` - ids must be less than 191 characters and not contain spaces or special characters`
+      );
+    }
+  }
+
+  @BeforeBulkCreate
+  static validateIds(instances) {
+    instances.forEach((instance) => this.validateId(instance));
+  }
+
+  @CreatedAt
+  createdAt: Date;
+
+  @UpdatedAt
+  updatedAt: Date;
+
+  async touch() {
+    this.changed("updatedAt", true);
+    return this.save({ hooks: false });
+  }
+
+  idIsDefault(): boolean {
+    const uuid = this.id.split("_").pop();
+    return this.id.startsWith(`${this.idPrefix()}_`) && validator.isUUID(uuid);
+  }
+
+  abstract apiData(): Promise<{ [key: string]: any }>;
+
+  // --- Class Methods --- //
+
+  /**
+   * Find an instance of this class, regardless of scope
+   */
+  static async findById(id: string): Promise<any> {
+    // static class definitions or type defining are not yet available in TS.  See:
+    // * https://github.com/microsoft/TypeScript/issues/14600
+    // * https://github.com/microsoft/TypeScript/issues/34516
+    // * https://github.com/microsoft/TypeScript/issues/33892
+
+    // So, each model will implement this method
+
+    throw new Error("not implemented");
+
+    // const instance: T = await this.scope(null).findOne({ where: { id } });
+    // if (!instance) {
+    //   throw new Error(`cannot find ${this.name} ${id}`);
+    // }
+    // return instance;
+  }
+}

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -293,10 +293,8 @@ export class Export extends Model {
   }
 
   @BeforeCreate
-  static generateId(instance) {
-    if (!instance.id) {
-      instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-    }
+  static generateId(instance: Export) {
+    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
   }
 
   @BeforeSave

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -1,19 +1,14 @@
 import {
-  Model,
   Table,
   Column,
-  CreatedAt,
-  UpdatedAt,
   AllowNull,
   Is,
   BelongsTo,
-  BeforeCreate,
   BeforeSave,
   ForeignKey,
   DataType,
   Default,
 } from "sequelize-typescript";
-import * as uuid from "uuid";
 import { Destination } from "./Destination";
 import { GrouparooRecord } from "./GrouparooRecord";
 import { plugin } from "../modules/plugin";
@@ -26,6 +21,7 @@ import { api, config } from "actionhero";
 import { ExportProcessor } from "./ExportProcessor";
 import { Errors } from "../modules/errors";
 import { PropertyTypes } from "./Property";
+import { CommonModel } from "../classes/commonModel";
 
 /**
  * The GrouparooRecord Properties in their normal data types (string, boolean, date, etc)
@@ -67,19 +63,10 @@ const STATE_TRANSITIONS = [
 ];
 
 @Table({ tableName: "exports", paranoid: false })
-export class Export extends Model {
+export class Export extends CommonModel<Export> {
   idPrefix() {
     return "exp";
   }
-
-  @Column({ primaryKey: true })
-  id: string;
-
-  @CreatedAt
-  createdAt: Date;
-
-  @UpdatedAt
-  updatedAt: Date;
 
   @AllowNull(false)
   @ForeignKey(() => Destination)
@@ -290,11 +277,6 @@ export class Export extends Model {
   @BeforeSave
   static async updateState(instance: Export) {
     await StateMachine.transition(instance, STATE_TRANSITIONS);
-  }
-
-  @BeforeCreate
-  static generateId(instance: Export) {
-    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
   }
 
   @BeforeSave

--- a/core/src/models/Filter.ts
+++ b/core/src/models/Filter.ts
@@ -89,9 +89,7 @@ export class Filter extends Model {
   // --- Class Methods --- //
 
   @BeforeCreate
-  static generateId(instance) {
-    if (!instance.id) {
-      instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-    }
+  static generateId(instance: Filter) {
+    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
   }
 }

--- a/core/src/models/Filter.ts
+++ b/core/src/models/Filter.ts
@@ -13,21 +13,13 @@ import * as uuid from "uuid";
 import { Property } from "./Property";
 import { Schedule } from "./Schedule";
 import { APIData } from "../modules/apiData";
+import { CommonModel } from "../classes/commonModel";
 
 @Table({ tableName: "filters", paranoid: false })
-export class Filter extends Model {
+export class Filter extends CommonModel<Filter> {
   idPrefix() {
     return "flt";
   }
-
-  @Column({ primaryKey: true })
-  id: string;
-
-  @CreatedAt
-  createdAt: Date;
-
-  @UpdatedAt
-  updatedAt: Date;
 
   @AllowNull(false)
   @ForeignKey(() => Property)
@@ -87,9 +79,4 @@ export class Filter extends Model {
   }
 
   // --- Class Methods --- //
-
-  @BeforeCreate
-  static generateId(instance: Filter) {
-    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-  }
 }

--- a/core/src/models/GroupMember.ts
+++ b/core/src/models/GroupMember.ts
@@ -1,9 +1,6 @@
 import {
-  Model,
   Table,
   Column,
-  CreatedAt,
-  UpdatedAt,
   AllowNull,
   BeforeCreate,
   BeforeBulkCreate,
@@ -14,27 +11,18 @@ import {
   AfterBulkCreate,
   AfterDestroy,
 } from "sequelize-typescript";
-import * as uuid from "uuid";
 import { Op, WhereAttributeHash } from "sequelize";
 import { Group } from "./Group";
 import { GrouparooRecord } from "./GrouparooRecord";
 import { Log } from "./Log";
 import { APIData } from "../modules/apiData";
+import { CommonModel } from "../classes/commonModel";
 
 @Table({ tableName: "groupMembers", paranoid: false })
-export class GroupMember extends Model {
+export class GroupMember extends CommonModel<GroupMember> {
   idPrefix() {
     return "mem";
   }
-
-  @Column({ primaryKey: true })
-  id: string;
-
-  @CreatedAt
-  createdAt: Date;
-
-  @UpdatedAt
-  updatedAt: Date;
 
   @AllowNull(false)
   @ForeignKey(() => GrouparooRecord)
@@ -71,16 +59,6 @@ export class GroupMember extends Model {
     const instance = await this.scope(null).findOne({ where: { id } });
     if (!instance) throw new Error(`cannot find ${this.name} ${id}`);
     return instance;
-  }
-
-  @BeforeCreate
-  static generateId(instance: GroupMember) {
-    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-  }
-
-  @BeforeBulkCreate
-  static generateIds(instances: GroupMember[]) {
-    instances.forEach((instance) => this.generateId(instance));
   }
 
   @BeforeSave

--- a/core/src/models/GroupMember.ts
+++ b/core/src/models/GroupMember.ts
@@ -75,9 +75,7 @@ export class GroupMember extends Model {
 
   @BeforeCreate
   static generateId(instance: GroupMember) {
-    if (!instance.id) {
-      instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-    }
+    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
   }
 
   @BeforeBulkCreate

--- a/core/src/models/GroupRule.ts
+++ b/core/src/models/GroupRule.ts
@@ -1,34 +1,21 @@
 import {
   Table,
-  Model,
   Column,
   AllowNull,
   ForeignKey,
-  CreatedAt,
-  UpdatedAt,
-  BeforeCreate,
   BelongsTo,
   BeforeSave,
 } from "sequelize-typescript";
-import * as uuid from "uuid";
 import { Group } from "./Group";
 import { Property } from "./Property";
 import { APIData } from "../modules/apiData";
+import { CommonModel } from "../classes/commonModel";
 
 @Table({ tableName: "groupRules", paranoid: false })
-export class GroupRule extends Model {
+export class GroupRule extends CommonModel<GroupRule> {
   idPrefix() {
     return "grr";
   }
-
-  @Column({ primaryKey: true })
-  id: string;
-
-  @CreatedAt
-  createdAt: Date;
-
-  @UpdatedAt
-  updatedAt: Date;
 
   @AllowNull(false)
   @ForeignKey(() => Group)
@@ -93,11 +80,6 @@ export class GroupRule extends Model {
     const instance = await this.scope(null).findOne({ where: { id } });
     if (!instance) throw new Error(`cannot find ${this.name} ${id}`);
     return instance;
-  }
-
-  @BeforeCreate
-  static generateId(instance: GroupRule) {
-    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
   }
 
   @BeforeSave

--- a/core/src/models/GroupRule.ts
+++ b/core/src/models/GroupRule.ts
@@ -96,10 +96,8 @@ export class GroupRule extends Model {
   }
 
   @BeforeCreate
-  static generateId(instance) {
-    if (!instance.id) {
-      instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-    }
+  static generateId(instance: GroupRule) {
+    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
   }
 
   @BeforeSave

--- a/core/src/models/GrouparooModel.ts
+++ b/core/src/models/GrouparooModel.ts
@@ -91,13 +91,6 @@ export class GrouparooModel extends LoggedModel<GrouparooModel> {
   }
 
   @BeforeCreate
-  static generateId(instance: GrouparooModel) {
-    if (!instance.id) {
-      instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-    }
-  }
-
-  @BeforeCreate
   @BeforeSave
   static async ensureValidType(instance: GrouparooModel) {
     if (!ModelTypes.includes(instance.type)) {

--- a/core/src/models/Import.ts
+++ b/core/src/models/Import.ts
@@ -1,20 +1,14 @@
 import {
-  Model,
   Table,
   Column,
-  CreatedAt,
-  UpdatedAt,
-  BeforeCreate,
   AllowNull,
   ForeignKey,
   BelongsTo,
   DataType,
   AfterCreate,
   Default,
-  BeforeBulkCreate,
   AfterBulkCreate,
 } from "sequelize-typescript";
-import * as uuid from "uuid";
 import { config } from "actionhero";
 import { CLS } from "../modules/cls";
 import { GrouparooRecord } from "./GrouparooRecord";
@@ -24,6 +18,7 @@ import Moment from "moment";
 import { Op } from "sequelize";
 import { ImportOps } from "../modules/ops/import";
 import { APIData } from "../modules/apiData";
+import { CommonModel } from "../classes/commonModel";
 
 export interface ImportData {
   [key: string]: any;
@@ -36,20 +31,10 @@ export interface ImportRecordProperties {
 const IMPORT_CREATORS = ["run"] as const;
 
 @Table({ tableName: "imports", paranoid: false })
-export class Import extends Model {
+export class Import extends CommonModel<Import> {
   idPrefix() {
     return "imp";
   }
-
-  @Column({ primaryKey: true })
-  id: string;
-
-  @CreatedAt
-  createdAt: Date;
-
-  @UpdatedAt
-  updatedAt: Date;
-
   @AllowNull(false)
   @Column(DataType.ENUM(...IMPORT_CREATORS))
   creatorType: typeof IMPORT_CREATORS[number];
@@ -226,16 +211,6 @@ export class Import extends Model {
     const instance = await this.scope(null).findOne({ where: { id } });
     if (!instance) throw new Error(`cannot find ${this.name} ${id}`);
     return instance;
-  }
-
-  @BeforeCreate
-  static generateId(instance: Import) {
-    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-  }
-
-  @BeforeBulkCreate
-  static generateIds(instances: Import[]) {
-    instances.forEach((instance) => this.generateId(instance));
   }
 
   @AfterCreate

--- a/core/src/models/Import.ts
+++ b/core/src/models/Import.ts
@@ -230,9 +230,7 @@ export class Import extends Model {
 
   @BeforeCreate
   static generateId(instance: Import) {
-    if (!instance.id) {
-      instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-    }
+    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
   }
 
   @BeforeBulkCreate

--- a/core/src/models/Log.ts
+++ b/core/src/models/Log.ts
@@ -2,29 +2,22 @@ import {
   Table,
   Column,
   AllowNull,
-  Model,
-  CreatedAt,
-  UpdatedAt,
   ForeignKey,
   BeforeCreate,
   AfterCreate,
-  BeforeBulkCreate,
 } from "sequelize-typescript";
 import { DataTypes } from "sequelize";
-import * as uuid from "uuid";
 import Moment from "moment";
 import { Op } from "sequelize";
 import { chatRoom } from "actionhero";
 import { APIData } from "../modules/apiData";
+import { CommonModel } from "../classes/commonModel";
 
 @Table({ tableName: "logs", paranoid: false })
-export class Log extends Model {
+export class Log extends CommonModel<Log> {
   idPrefix() {
     return "log";
   }
-
-  @Column({ primaryKey: true })
-  id: string;
 
   @AllowNull(false)
   @Column
@@ -61,12 +54,6 @@ export class Log extends Model {
   @Column
   message: string;
 
-  @CreatedAt
-  createdAt: Date;
-
-  @UpdatedAt
-  updatedAt: Date;
-
   async apiData() {
     return {
       id: this.id,
@@ -86,16 +73,6 @@ export class Log extends Model {
     const instance = await this.scope(null).findOne({ where: { id } });
     if (!instance) throw new Error(`cannot find ${this.name} ${id}`);
     return instance;
-  }
-
-  @BeforeCreate
-  static generateId(instance: Log) {
-    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-  }
-
-  @BeforeBulkCreate
-  static generateIds(instances: Log[]) {
-    instances.forEach((instance) => this.generateId(instance));
   }
 
   @BeforeCreate

--- a/core/src/models/RecordProperty.ts
+++ b/core/src/models/RecordProperty.ts
@@ -7,18 +7,13 @@ import {
   BelongsTo,
   BeforeSave,
   DataType,
-  Model,
-  BeforeCreate,
-  BeforeBulkCreate,
-  CreatedAt,
-  UpdatedAt,
 } from "sequelize-typescript";
 import { GrouparooRecord } from "./GrouparooRecord";
 import { Property } from "./Property";
 import { RecordPropertyOps } from "../modules/ops/recordProperty";
 import { StateMachine } from "../modules/stateMachine";
 import { APIData } from "../modules/apiData";
-import * as uuid from "uuid";
+import { CommonModel } from "../classes/commonModel";
 
 const STATES = ["draft", "pending", "ready"] as const;
 
@@ -30,10 +25,7 @@ const STATE_TRANSITIONS = [
 ];
 
 @Table({ tableName: "recordProperties", paranoid: false })
-export class RecordProperty extends Model {
-  @Column({ primaryKey: true })
-  id: string;
-
+export class RecordProperty extends CommonModel<RecordProperty> {
   idPrefix() {
     return "rpr";
   }
@@ -85,12 +77,6 @@ export class RecordProperty extends Model {
   @AllowNull(true)
   @Column
   startedAt: Date;
-
-  @CreatedAt
-  createdAt: Date;
-
-  @UpdatedAt
-  updatedAt: Date;
 
   @BelongsTo(() => GrouparooRecord)
   record: GrouparooRecord;
@@ -148,16 +134,6 @@ export class RecordProperty extends Model {
     const instance = await this.scope(null).findOne({ where: { id } });
     if (!instance) throw new Error(`cannot find ${this.name} ${id}`);
     return instance;
-  }
-
-  @BeforeCreate
-  static generateId(instance: RecordProperty) {
-    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-  }
-
-  @BeforeBulkCreate
-  static generateIds(instances: RecordProperty[]) {
-    instances.forEach((instance) => this.generateId(instance));
   }
 
   @BeforeSave

--- a/core/src/models/Run.ts
+++ b/core/src/models/Run.ts
@@ -327,10 +327,8 @@ export class Run extends Model {
   }
 
   @BeforeCreate
-  static generateId(instance) {
-    if (!instance.id) {
-      instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-    }
+  static generateId(instance: Run) {
+    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
   }
 
   @BeforeCreate

--- a/core/src/models/Run.ts
+++ b/core/src/models/Run.ts
@@ -1,11 +1,8 @@
 import Sequelize, { Op } from "sequelize";
 import { GrouparooRecord } from "./GrouparooRecord";
 import {
-  Model,
   Table,
   Column,
-  CreatedAt,
-  UpdatedAt,
   AllowNull,
   DataType,
   BeforeSave,
@@ -18,7 +15,6 @@ import {
   BeforeUpdate,
 } from "sequelize-typescript";
 import { chatRoom, log } from "actionhero";
-import * as uuid from "uuid";
 import { Schedule } from "./Schedule";
 import { Import } from "./Import";
 import { Group } from "./Group";
@@ -29,6 +25,7 @@ import { RunOps } from "../modules/ops/runs";
 import { plugin } from "../modules/plugin";
 import Moment from "moment";
 import { APIData } from "../modules/apiData";
+import { CommonModel } from "../classes/commonModel";
 
 export interface HighWaterMark {
   [key: string]: string | number | Date;
@@ -53,19 +50,10 @@ const STATE_TRANSITIONS = [
 ];
 
 @Table({ tableName: "runs", paranoid: false })
-export class Run extends Model {
+export class Run extends CommonModel<Run> {
   idPrefix() {
     return "run";
   }
-
-  @Column({ primaryKey: true })
-  id: string;
-
-  @CreatedAt
-  createdAt: Date;
-
-  @UpdatedAt
-  updatedAt: Date;
 
   @AllowNull(false)
   @ForeignKey(() => Schedule)
@@ -324,11 +312,6 @@ export class Run extends Model {
     const instance = await this.scope(null).findOne({ where: { id } });
     if (!instance) throw new Error(`cannot find ${this.name} ${id}`);
     return instance;
-  }
-
-  @BeforeCreate
-  static generateId(instance: Run) {
-    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
   }
 
   @BeforeCreate

--- a/core/src/models/Session.ts
+++ b/core/src/models/Session.ts
@@ -62,10 +62,8 @@ export class Session extends Model {
   }
 
   @BeforeCreate
-  static generateId(instance) {
-    if (!instance.id) {
-      instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
-    }
+  static generateId(instance: Session) {
+    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
   }
 
   static async sweep() {

--- a/core/src/models/Session.ts
+++ b/core/src/models/Session.ts
@@ -1,33 +1,15 @@
-import {
-  Model,
-  Table,
-  Column,
-  AllowNull,
-  ForeignKey,
-  CreatedAt,
-  UpdatedAt,
-  BeforeCreate,
-} from "sequelize-typescript";
-import * as uuid from "uuid";
+import { Table, Column, AllowNull, ForeignKey } from "sequelize-typescript";
 import { TeamMember } from "./TeamMember";
 import { APIData } from "../modules/apiData";
 import { Op } from "sequelize";
 import { api } from "actionhero";
+import { CommonModel } from "../classes/commonModel";
 
 @Table({ tableName: "sessions", paranoid: false })
-export class Session extends Model {
-  @Column({ primaryKey: true })
-  id: string;
-
+export class Session extends CommonModel<Session> {
   idPrefix() {
     return "ses";
   }
-
-  @CreatedAt
-  createdAt: Date;
-
-  @UpdatedAt
-  updatedAt: Date;
 
   @AllowNull(false)
   @Column
@@ -59,11 +41,6 @@ export class Session extends Model {
     const instance = await this.scope(null).findOne({ where: { id } });
     if (!instance) throw new Error(`cannot find ${this.name} ${id}`);
     return instance;
-  }
-
-  @BeforeCreate
-  static generateId(instance: Session) {
-    if (!instance.id) instance.id = `${instance.idPrefix()}_${uuid.v4()}`;
   }
 
   static async sweep() {

--- a/ui/ui-components/components/log/list.tsx
+++ b/ui/ui-components/components/log/list.tsx
@@ -35,7 +35,6 @@ export default function LogsList(props) {
     "group",
     "groupMember",
     "record",
-    "recordProperty",
     "property",
     "schedule",
     "setting",
@@ -70,11 +69,6 @@ export default function LogsList(props) {
 
     if (topic === "grouparooRecord") {
       topic = "record";
-    }
-
-    if (topic === "recordProperty") {
-      topic = "record";
-      ownerId = log.data.recordId;
     }
 
     if (topic === "groupMember") {


### PR DESCRIPTION
This PR removes Logging from RecordProperties.  This was creating a large volume of logs on every import.  These logs are not required as we store various timestamps on each RecordProperty to share the value's freshness.  This also removed a place in which PII was stored, as we were previously storing old and new property values in the log messages.  

In our demo dataset importing 1000 records:
* Before this PR: 26,247 Log Rows
* After this PR: 4,282 Log rows 

... that's ~85% less logs!

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

 * This PR should /improve/ database performance! 

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
