### PR TITLE
Destinations can track all Records of a Model

### DIFF
--- a/core/__tests__/actions/destinations.ts
+++ b/core/__tests__/actions/destinations.ts
@@ -658,10 +658,13 @@ describe("actions/destinations", () => {
         id,
         groupId: "_none",
       };
-      const { destination } = await specHelper.runAction<DestinationEdit>(
-        "destination:edit",
-        connection
-      );
+      const { destination, error } =
+        await specHelper.runAction<DestinationEdit>(
+          "destination:edit",
+          connection
+        );
+
+      expect(error).toBeUndefined();
       expect(destination.group).toBe(null);
     });
 

--- a/core/__tests__/actions/destinations.ts
+++ b/core/__tests__/actions/destinations.ts
@@ -331,7 +331,7 @@ describe("actions/destinations", () => {
         connection.params = {
           csrfToken,
           id,
-          trackedGroupId: group.id,
+          groupId: group.id,
         };
 
         const { destination, run, error } =
@@ -505,7 +505,7 @@ describe("actions/destinations", () => {
         connection.params = {
           csrfToken,
           id,
-          trackedGroupId: null,
+          groupId: null,
         };
         const {
           destination: updatedDestination,
@@ -526,7 +526,7 @@ describe("actions/destinations", () => {
         connection.params = {
           csrfToken,
           id,
-          trackedGroupId: group.id,
+          groupId: group.id,
         };
         const { destination: _destination } =
           await specHelper.runAction<DestinationEdit>(
@@ -645,7 +645,7 @@ describe("actions/destinations", () => {
       connection.params = {
         csrfToken,
         id,
-        trackedGroupId: "_none",
+        groupId: "_none",
       };
       const { destination } = await specHelper.runAction<DestinationEdit>(
         "destination:edit",

--- a/core/__tests__/actions/destinations.ts
+++ b/core/__tests__/actions/destinations.ts
@@ -24,7 +24,6 @@ import {
   DestinationView,
 } from "../../src/actions/destinations";
 import { SessionCreate } from "../../src/actions/session";
-import { APIData } from "../../src/modules/apiData";
 
 describe("actions/destinations", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -684,7 +683,7 @@ describe("actions/destinations", () => {
       connection.params = {
         csrfToken,
         id,
-        groupId: APIData.nullKey,
+        groupId: "_none",
       };
       const { destination, error } =
         await specHelper.runAction<DestinationEdit>(

--- a/core/__tests__/actions/groups.ts
+++ b/core/__tests__/actions/groups.ts
@@ -124,7 +124,7 @@ describe("actions/groups", () => {
     test("an administrator can view the destinations tracking a group", async () => {
       const destination = await helper.factories.destination();
       const group = await Group.findById(id);
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       connection.params = {
         csrfToken,
@@ -139,14 +139,14 @@ describe("actions/groups", () => {
       expect(destinations.length).toBe(1);
       expect(destinations[0].id).toEqual(destination.id);
 
-      await destination.unTrackGroup();
+      await destination.updateTracking(null, null);
       await destination.destroy();
     });
 
     test("an administrator cannot destroy a group used by a destination", async () => {
       const destination = await helper.factories.destination();
       const group = await Group.findById(id);
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       connection.params = {
         csrfToken,
@@ -160,7 +160,7 @@ describe("actions/groups", () => {
         /this group still in use by 1 destinations, cannot delete/
       );
 
-      await destination.unTrackGroup();
+      await destination.updateTracking(null, null);
       await destination.destroy();
     });
 

--- a/core/__tests__/actions/groups.ts
+++ b/core/__tests__/actions/groups.ts
@@ -139,7 +139,7 @@ describe("actions/groups", () => {
       expect(destinations.length).toBe(1);
       expect(destinations[0].id).toEqual(destination.id);
 
-      await destination.updateTracking(null, null);
+      await destination.updateTracking("none");
       await destination.destroy();
     });
 
@@ -160,7 +160,7 @@ describe("actions/groups", () => {
         /this group still in use by 1 destinations, cannot delete/
       );
 
-      await destination.updateTracking(null, null);
+      await destination.updateTracking("none");
       await destination.destroy();
     });
 

--- a/core/__tests__/actions/records/importAndExport.ts
+++ b/core/__tests__/actions/records/importAndExport.ts
@@ -64,7 +64,7 @@ describe("actions/records", () => {
       await group.update({ state: "ready" });
 
       destination = await helper.factories.destination();
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
       await destination.update({ state: "ready" });
     });
 

--- a/core/__tests__/fixtures/codeConfig/bootstrapped-property-in-source/config.js
+++ b/core/__tests__/fixtures/codeConfig/bootstrapped-property-in-source/config.js
@@ -144,6 +144,7 @@ module.exports = async function getConfig() {
       type: "test-plugin-export",
       appId: "data_warehouse", // id -> data_warehouse
       groupId: "email_group", // id -> email_group
+      collection: "group",
       modelId: "mod_profiles",
       syncMode: "additive",
       options: {

--- a/core/__tests__/fixtures/codeConfig/error-changed-type-duplicate/config.js
+++ b/core/__tests__/fixtures/codeConfig/error-changed-type-duplicate/config.js
@@ -133,6 +133,7 @@ module.exports = async function getConfig() {
       type: "test-plugin-export",
       appId: "data_warehouse", // id -> data_warehouse
       groupId: "email_group", // id -> email_group
+      collection: "group",
       modelId: "mod_profiles",
       options: {
         table: "output",

--- a/core/__tests__/fixtures/codeConfig/error-changed-type-missing/config.js
+++ b/core/__tests__/fixtures/codeConfig/error-changed-type-missing/config.js
@@ -135,6 +135,7 @@ module.exports = async function getConfig() {
       type: "test-plugin-export",
       appId: "data_warehouse", // id -> data_warehouse
       groupId: "email_group", // id -> email_group
+      collection: "group",
       modelId: "mod_profiles",
       options: {
         table: "output",

--- a/core/__tests__/fixtures/codeConfig/initial/config.js
+++ b/core/__tests__/fixtures/codeConfig/initial/config.js
@@ -154,6 +154,7 @@ module.exports = async function getConfig() {
       type: "test-plugin-export",
       appId: "data_warehouse", // id -> data_warehouse
       groupId: "email_group", // id -> email_group
+      collection: "group",
       syncMode: "additive",
       options: {
         table: "output",

--- a/core/__tests__/fixtures/codeConfig/multiple-sources/config.js
+++ b/core/__tests__/fixtures/codeConfig/multiple-sources/config.js
@@ -178,6 +178,7 @@ module.exports = async function getConfig() {
       type: "test-plugin-export",
       appId: "data_warehouse", // id -> data_warehouse
       groupId: "email_group", // id -> email_group
+      collection: "group",
       syncMode: "additive",
       modelId: "mod_profiles",
       options: {

--- a/core/__tests__/integration/multipleModels.ts
+++ b/core/__tests__/integration/multipleModels.ts
@@ -161,11 +161,11 @@ describe("multiple models", () => {
   });
 
   test("destinations can only track groups of the same model", async () => {
-    await expect(adminDestination.trackGroup(profileGroup)).rejects.toThrow(
-      /do not share the same modelId/
-    );
+    await expect(
+      adminDestination.updateTracking("group", profileGroup.id)
+    ).rejects.toThrow(/do not share the same modelId/);
 
-    await adminDestination.trackGroup(adminGroup);
+    await adminDestination.updateTracking("group", adminGroup.id);
   });
 
   test("destination options only use properties of the same model", async () => {

--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -1,6 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
 import { cache } from "actionhero";
-import { GrouparooModel } from "../../..";
 import {
   App,
   Destination,
@@ -9,6 +8,7 @@ import {
   Group,
   GrouparooModel,
   Log,
+  GrouparooModel,
   Mapping,
   Option,
   Run,

--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -8,7 +8,6 @@ import {
   Group,
   GrouparooModel,
   Log,
-  GrouparooModel,
   Mapping,
   Option,
   Run,

--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -771,9 +771,15 @@ describe("models/destination", () => {
           type: "profile",
         });
 
+        const otherGroup = await helper.factories.group({
+          modelId: otherModel.id,
+        });
+
         await expect(
-          destination.updateTracking("model", otherModel.id)
-        ).rejects.toThrow(/cannot track another model/);
+          destination.updateTracking("group", otherGroup.id)
+        ).rejects.toThrow(/do not share the same modelId/);
+
+        await otherGroup.destroy();
         await otherModel.destroy();
       });
 
@@ -863,6 +869,15 @@ describe("models/destination", () => {
         await destination.updateTracking("group", group.id);
         const _group = await destination.$get("group");
         expect(_group.id).toBe(group.id);
+      });
+
+      test("a group cannot be tracked in any other collection", async () => {
+        await expect(
+          destination.updateTracking("none", group.id)
+        ).rejects.toThrow(/cannot track/);
+        await expect(
+          destination.updateTracking("model", group.id)
+        ).rejects.toThrow(/cannot track/);
       });
 
       test("tracking a group will enqueue runs", async () => {

--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -706,7 +706,11 @@ describe("models/destination", () => {
       });
 
       test("a destination cannot track an unrelated model", async () => {
-        const otherModel = await helper.factories.model();
+        const otherModel = await helper.factories.model({
+          id: "otherModel",
+          name: "Other Model",
+          type: "profile",
+        });
 
         await expect(
           destination.updateTracking("model", otherModel.id)

--- a/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
+++ b/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
@@ -5,7 +5,7 @@ import {
   Destination,
   GrouparooRecord,
   Group,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
   GrouparooModel,
 } from "../../../../src";
 import { DestinationOps } from "../../../../src/modules/ops/destination";
@@ -24,7 +24,7 @@ describe("models/destination", () => {
       input: any,
       output: any,
       grouparooType: string,
-      destinationType: DestinationMappingOptionsResponseTypes
+      destinationType: DestinationMappingOptionsResponseType
     ) {
       if (output !== null) {
         expect(
@@ -59,17 +59,21 @@ describe("models/destination", () => {
         ["https://www.grouparoo.com", "url"],
       ];
 
-      mapping.map(([input, type]: [any, string]) => {
+      mapping.map(([input, type]) => {
         test(`exporting type ${type} to any`, () => {
           expect(
-            DestinationOps.formatOutgoingRecordProperties(input, type, "any")
+            DestinationOps.formatOutgoingRecordProperties(
+              input,
+              type as string,
+              "any"
+            )
           ).toEqual(input);
         });
       });
     });
 
     describe("null types", () => {
-      const types: DestinationMappingOptionsResponseTypes[] = [
+      const types: DestinationMappingOptionsResponseType[] = [
         "boolean",
         "integer",
         "float",
@@ -110,14 +114,15 @@ describe("models/destination", () => {
         ["date", null],
       ];
 
-      mapping.map(
-        ([destinationType, output]: [
-          DestinationMappingOptionsResponseTypes,
-          any
-        ]) =>
-          test(`exporting ${grouparooType} to ${destinationType}`, () => {
-            testValues(input, output, grouparooType, destinationType);
-          })
+      mapping.map(([destinationType, output]) =>
+        test(`exporting ${grouparooType} to ${destinationType}`, () => {
+          testValues(
+            input,
+            output,
+            grouparooType,
+            destinationType as DestinationMappingOptionsResponseType
+          );
+        })
       );
     });
 
@@ -136,14 +141,15 @@ describe("models/destination", () => {
         ["date", null],
       ];
 
-      mapping.map(
-        ([destinationType, output]: [
-          DestinationMappingOptionsResponseTypes,
-          any
-        ]) =>
-          test(`exporting ${grouparooType} to ${destinationType}`, () => {
-            testValues(input, output, grouparooType, destinationType);
-          })
+      mapping.map(([destinationType, output]) =>
+        test(`exporting ${grouparooType} to ${destinationType}`, () => {
+          testValues(
+            input,
+            output,
+            grouparooType,
+            destinationType as DestinationMappingOptionsResponseType
+          );
+        })
       );
     });
 
@@ -162,14 +168,15 @@ describe("models/destination", () => {
         ["date", null],
       ];
 
-      mapping.map(
-        ([destinationType, output]: [
-          DestinationMappingOptionsResponseTypes,
-          any
-        ]) =>
-          test(`exporting ${grouparooType} to ${destinationType}`, () => {
-            testValues(input, output, grouparooType, destinationType);
-          })
+      mapping.map(([destinationType, output]) =>
+        test(`exporting ${grouparooType} to ${destinationType}`, () => {
+          testValues(
+            input,
+            output,
+            grouparooType,
+            destinationType as DestinationMappingOptionsResponseType
+          );
+        })
       );
     });
 
@@ -188,14 +195,15 @@ describe("models/destination", () => {
         ["date", null],
       ];
 
-      mapping.map(
-        ([destinationType, output]: [
-          DestinationMappingOptionsResponseTypes,
-          any
-        ]) =>
-          test(`exporting ${grouparooType} to ${destinationType}`, () => {
-            testValues(input, output, grouparooType, destinationType);
-          })
+      mapping.map(([destinationType, output]) =>
+        test(`exporting ${grouparooType} to ${destinationType}`, () => {
+          testValues(
+            input,
+            output,
+            grouparooType,
+            destinationType as DestinationMappingOptionsResponseType
+          );
+        })
       );
     });
 
@@ -214,14 +222,15 @@ describe("models/destination", () => {
         ["date", null],
       ];
 
-      mapping.map(
-        ([destinationType, output]: [
-          DestinationMappingOptionsResponseTypes,
-          any
-        ]) =>
-          test(`exporting ${grouparooType} to ${destinationType}`, () => {
-            testValues(input, output, grouparooType, destinationType);
-          })
+      mapping.map(([destinationType, output]) =>
+        test(`exporting ${grouparooType} to ${destinationType}`, () => {
+          testValues(
+            input,
+            output,
+            grouparooType,
+            destinationType as DestinationMappingOptionsResponseType
+          );
+        })
       );
     });
 
@@ -240,14 +249,15 @@ describe("models/destination", () => {
         ["date", null],
       ];
 
-      mapping.map(
-        ([destinationType, output]: [
-          DestinationMappingOptionsResponseTypes,
-          any
-        ]) =>
-          test(`exporting ${grouparooType} to ${destinationType}`, () => {
-            testValues(input, output, grouparooType, destinationType);
-          })
+      mapping.map(([destinationType, output]) =>
+        test(`exporting ${grouparooType} to ${destinationType}`, () => {
+          testValues(
+            input,
+            output,
+            grouparooType,
+            destinationType as DestinationMappingOptionsResponseType
+          );
+        })
       );
     });
 
@@ -266,14 +276,15 @@ describe("models/destination", () => {
         ["date", null],
       ];
 
-      mapping.map(
-        ([destinationType, output]: [
-          DestinationMappingOptionsResponseTypes,
-          any
-        ]) =>
-          test(`exporting ${grouparooType} to ${destinationType}`, () => {
-            testValues(input, output, grouparooType, destinationType);
-          })
+      mapping.map(([destinationType, output]) =>
+        test(`exporting ${grouparooType} to ${destinationType}`, () => {
+          testValues(
+            input,
+            output,
+            grouparooType,
+            destinationType as DestinationMappingOptionsResponseType
+          );
+        })
       );
     });
 
@@ -292,14 +303,15 @@ describe("models/destination", () => {
         ["date", null],
       ];
 
-      mapping.map(
-        ([destinationType, output]: [
-          DestinationMappingOptionsResponseTypes,
-          any
-        ]) =>
-          test(`exporting ${grouparooType} to ${destinationType}`, () => {
-            testValues(input, output, grouparooType, destinationType);
-          })
+      mapping.map(([destinationType, output]) =>
+        test(`exporting ${grouparooType} to ${destinationType}`, () => {
+          testValues(
+            input,
+            output,
+            grouparooType,
+            destinationType as DestinationMappingOptionsResponseType
+          );
+        })
       );
     });
 
@@ -318,14 +330,15 @@ describe("models/destination", () => {
         ["date", new Date(123)],
       ];
 
-      mapping.map(
-        ([destinationType, output]: [
-          DestinationMappingOptionsResponseTypes,
-          any
-        ]) =>
-          test(`exporting ${grouparooType} to ${destinationType}`, () => {
-            testValues(input, output, grouparooType, destinationType);
-          })
+      mapping.map(([destinationType, output]) =>
+        test(`exporting ${grouparooType} to ${destinationType}`, () => {
+          testValues(
+            input,
+            output,
+            grouparooType,
+            destinationType as DestinationMappingOptionsResponseType
+          );
+        })
       );
     });
 
@@ -513,11 +526,11 @@ describe("models/destination", () => {
       });
 
       beforeEach(async () => {
-        await destination.trackGroup(group);
+        await destination.updateTracking("group", group.id);
       });
 
       afterEach(async () => {
-        await destination.unTrackGroup();
+        await destination.updateTracking(null, null);
       });
 
       test("record properties will be converted to the type requested by the plugin", async () => {

--- a/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
+++ b/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
@@ -530,7 +530,7 @@ describe("models/destination", () => {
       });
 
       afterEach(async () => {
-        await destination.updateTracking(null, null);
+        await destination.updateTracking("none");
       });
 
       test("record properties will be converted to the type requested by the plugin", async () => {

--- a/core/__tests__/models/destination/plugins/exportRecord.ts
+++ b/core/__tests__/models/destination/plugins/exportRecord.ts
@@ -174,7 +174,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
     });
 
     afterEach(async () => {
-      await destination.unTrackGroup();
+      await destination.updateTracking(null);
       await destination.destroy();
     });
 
@@ -187,7 +187,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
       const groupA = await helper.factories.group();
       const groupB = await helper.factories.group();
 
-      await destination.trackGroup(groupA);
+      await destination.updateTracking("group", groupA.id);
 
       // modify the membership name
       const destinationGroupMemberships = {};
@@ -275,7 +275,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
 
       const groupA = await helper.factories.group();
 
-      await destination.trackGroup(groupA);
+      await destination.updateTracking("group", groupA.id);
 
       const record = await helper.factories.record();
       await record.addOrUpdateProperties({
@@ -327,7 +327,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
       });
 
       const groupA = await helper.factories.group();
-      await destination.trackGroup(groupA);
+      await destination.updateTracking("group", groupA.id);
 
       const record = await helper.factories.record();
       await record.addOrUpdateProperties({
@@ -391,7 +391,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
       await emailProp.update({ state: "deleted" });
 
       const groupA = await helper.factories.group();
-      await destination.trackGroup(groupA);
+      await destination.updateTracking("group", groupA.id);
 
       const record = await helper.factories.record();
       await record.addOrUpdateProperties({
@@ -425,7 +425,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
       });
 
       const group = await helper.factories.group();
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       const record = await helper.factories.record();
       await group.addRecord(record);
@@ -469,7 +469,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
       });
 
       const group = await helper.factories.group();
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       const record = await helper.factories.record();
       await group.addRecord(record);
@@ -590,7 +590,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
         id: oldExport.id,
       });
 
-      await destination.trackGroup(groupC);
+      await destination.updateTracking("group", groupC.id);
       await destination.exportRecord(record);
 
       await specHelper.runTask("export:enqueue", {});
@@ -645,7 +645,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
           id: oldExport.id,
         });
 
-        await destination.trackGroup(groupC);
+        await destination.updateTracking("group", groupC.id);
         await destination.exportRecord(record);
 
         await specHelper.runTask("export:enqueue", {});
@@ -670,7 +670,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
       const record = await helper.factories.record();
       const group = await helper.factories.group();
       await group.addRecord(record);
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       const oldExport = await Export.create({
         destinationId: destination.id,
@@ -709,7 +709,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
       const record = await helper.factories.record();
       const group = await helper.factories.group();
       await group.addRecord(record);
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       const oldExport = await Export.create({
         destinationId: destination.id,
@@ -751,7 +751,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
       });
       const group = await helper.factories.group();
       await group.addRecord(record);
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       await destination.setMapping({
         customer_email: "email",
@@ -794,7 +794,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
         });
         const group = await helper.factories.group();
         await group.addRecord(record);
-        await destination.trackGroup(group);
+        await destination.updateTracking("group", group.id);
 
         await destination.setMapping({
           customer_email: "email",

--- a/core/__tests__/models/destination/plugins/exportRecord.ts
+++ b/core/__tests__/models/destination/plugins/exportRecord.ts
@@ -174,7 +174,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
     });
 
     afterEach(async () => {
-      await destination.updateTracking(null);
+      await destination.updateTracking("none");
       await destination.destroy();
     });
 
@@ -574,7 +574,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
         id: oldExport.id,
       });
 
-      await destination.updateTracking(null);
+      await destination.updateTracking("none");
       await destination.exportRecord(record);
 
       await specHelper.runTask("export:enqueue", {});

--- a/core/__tests__/models/destination/plugins/exportRecords.ts
+++ b/core/__tests__/models/destination/plugins/exportRecords.ts
@@ -139,7 +139,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
     });
 
     afterEach(async () => {
-      await destination.updateTracking(null);
+      await destination.updateTracking("none");
       await destination.destroy();
     });
 
@@ -446,7 +446,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
         id: oldExport.id,
       });
 
-      await destination.updateTracking(null);
+      await destination.updateTracking("none");
       await destination.exportRecord(record);
 
       // there should be no export:send tasks

--- a/core/__tests__/models/destination/plugins/exportRecords.ts
+++ b/core/__tests__/models/destination/plugins/exportRecords.ts
@@ -139,7 +139,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
     });
 
     afterEach(async () => {
-      await destination.unTrackGroup();
+      await destination.updateTracking(null);
       await destination.destroy();
     });
 
@@ -152,7 +152,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
       const groupA = await helper.factories.group();
       const groupB = await helper.factories.group();
 
-      await destination.trackGroup(groupA);
+      await destination.updateTracking("group", groupA.id);
 
       const destinationGroupMemberships = {};
       // modify the membership name
@@ -249,8 +249,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
       });
 
       const groupA = await helper.factories.group();
-
-      await destination.trackGroup(groupA);
+      await destination.updateTracking("group", groupA.id);
 
       const record = await helper.factories.record();
       await record.addOrUpdateProperties({
@@ -309,7 +308,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
       });
 
       const groupA = await helper.factories.group();
-      await destination.trackGroup(groupA);
+      await destination.updateTracking("group", groupA.id);
 
       const record = await helper.factories.record();
       await record.addOrUpdateProperties({
@@ -459,7 +458,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
         id: oldExport.id,
       });
 
-      await destination.trackGroup(groupC);
+      await destination.updateTracking("group", groupC.id);
       await destination.exportRecord(record);
 
       // there should be no export:send tasks
@@ -524,7 +523,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
           id: oldExport.id,
         });
 
-        await destination.trackGroup(groupC);
+        await destination.updateTracking("group", groupC.id);
         await destination.exportRecord(record);
 
         // there should be no export:send tasks
@@ -558,7 +557,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
       const record = await helper.factories.record();
       const group = await helper.factories.group();
       await group.addRecord(record);
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       const oldExport = await Export.create({
         destinationId: destination.id,
@@ -600,7 +599,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
       const record = await helper.factories.record();
       const group = await helper.factories.group();
       await group.addRecord(record);
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       const oldExport = await Export.create({
         destinationId: destination.id,
@@ -645,7 +644,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
       });
       const group = await helper.factories.group();
       await group.addRecord(record);
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       await destination.setMapping({
         customer_email: "email",

--- a/core/__tests__/models/destination/plugins/processExportedProfiles.ts
+++ b/core/__tests__/models/destination/plugins/processExportedProfiles.ts
@@ -191,7 +191,7 @@ describe("models/destination - with custom processExportedRecords", () => {
 
     afterEach(async () => {
       await Export.truncate();
-      await destination.unTrackGroup();
+      await destination.updateTracking(null);
       await destination.destroy();
     });
 
@@ -202,7 +202,7 @@ describe("models/destination - with custom processExportedRecords", () => {
       });
 
       const groupA = await helper.factories.group();
-      await destination.trackGroup(groupA);
+      await destination.updateTracking("group", groupA.id);
 
       const record = await helper.factories.record();
       await record.addOrUpdateProperties({

--- a/core/__tests__/models/destination/plugins/processExportedProfiles.ts
+++ b/core/__tests__/models/destination/plugins/processExportedProfiles.ts
@@ -191,7 +191,7 @@ describe("models/destination - with custom processExportedRecords", () => {
 
     afterEach(async () => {
       await Export.truncate();
-      await destination.updateTracking(null);
+      await destination.updateTracking("none");
       await destination.destroy();
     });
 

--- a/core/__tests__/models/export.ts
+++ b/core/__tests__/models/export.ts
@@ -297,7 +297,7 @@ describe("models/export", () => {
 
     // cleanup
     await record.destroy();
-    await destination.updateTracking(null, null);
+    await destination.updateTracking("none");
     await group.destroy();
     await destination.destroy();
   });
@@ -352,7 +352,7 @@ describe("models/export", () => {
 
     // cleanup
     await record.destroy();
-    await destination.updateTracking(null, null);
+    await destination.updateTracking("none");
     await group.destroy();
     await destination.destroy();
   });

--- a/core/__tests__/models/export.ts
+++ b/core/__tests__/models/export.ts
@@ -250,7 +250,7 @@ describe("models/export", () => {
     await group.addRecord(record);
 
     const destination = await helper.factories.destination();
-    await destination.trackGroup(group);
+    await destination.updateTracking("group", group.id);
     await destination.setMapping({
       "primary-id": "userId",
       email: "email",
@@ -297,7 +297,7 @@ describe("models/export", () => {
 
     // cleanup
     await record.destroy();
-    await destination.unTrackGroup();
+    await destination.updateTracking(null, null);
     await group.destroy();
     await destination.destroy();
   });
@@ -321,7 +321,7 @@ describe("models/export", () => {
     await group.addRecord(record);
 
     const destination = await helper.factories.destination();
-    await destination.trackGroup(group);
+    await destination.updateTracking("group", group.id);
     await destination.setMapping({
       "primary-id": "userId",
       email: "email",
@@ -352,7 +352,7 @@ describe("models/export", () => {
 
     // cleanup
     await record.destroy();
-    await destination.unTrackGroup();
+    await destination.updateTracking(null, null);
     await group.destroy();
     await destination.destroy();
   });
@@ -361,7 +361,7 @@ describe("models/export", () => {
     await Export.destroy({ where: { destinationId: destination.id } });
     const group = await helper.factories.group();
     await group.addRecord(record);
-    await destination.trackGroup(group);
+    await destination.updateTracking("group", group.id);
 
     const oldExport = await Export.create({
       destinationId: destination.id,

--- a/core/__tests__/models/group/calculatedGroup.ts
+++ b/core/__tests__/models/group/calculatedGroup.ts
@@ -84,7 +84,7 @@ describe("models/group", () => {
 
       await run.reload();
       expect(run.state).toBe("complete");
-      expect(run.groupMethod).toBe("complete");
+      expect(run.method).toBe("complete");
 
       await group.reload();
       expect(group.state).toBe("ready");

--- a/core/__tests__/models/group/group.ts
+++ b/core/__tests__/models/group/group.ts
@@ -269,7 +269,7 @@ describe("models/group", () => {
           /this group still in use by 1 destinations, cannot delete/
         );
 
-        await destination.updateTracking(null, null);
+        await destination.updateTracking("none");
         await group.destroy(); // does not throw
       });
 
@@ -288,7 +288,7 @@ describe("models/group", () => {
           /this group still in use by 1 destinations, cannot delete/
         );
 
-        await destination.updateTracking(null, null);
+        await destination.updateTracking("none");
         await group.destroy(); // does not throw
       });
 
@@ -354,7 +354,7 @@ describe("models/group", () => {
         expect(runningRuns[0].force).toBe(false);
         expect(runningRuns[0].id).not.toBe(newRun.id);
 
-        await destination.updateTracking(null, null);
+        await destination.updateTracking("none");
         await trackedGroup.destroy();
         await taggedGroup.destroy();
       });

--- a/core/__tests__/models/group/group.ts
+++ b/core/__tests__/models/group/group.ts
@@ -262,14 +262,14 @@ describe("models/group", () => {
         });
 
         const destination = await helper.factories.destination();
-        await destination.trackGroup(group);
+        await destination.updateTracking("group", group.id);
         await destination.update({ state: "ready" });
 
         await expect(group.destroy()).rejects.toThrow(
           /this group still in use by 1 destinations, cannot delete/
         );
 
-        await destination.unTrackGroup();
+        await destination.updateTracking(null, null);
         await group.destroy(); // does not throw
       });
 
@@ -281,14 +281,14 @@ describe("models/group", () => {
         });
 
         const destination = await helper.factories.destination();
-        await destination.trackGroup(group);
+        await destination.updateTracking("group", group.id);
         await destination.update({ state: "deleted" });
 
         await expect(group.destroy()).rejects.toThrow(
           /this group still in use by 1 destinations, cannot delete/
         );
 
-        await destination.unTrackGroup();
+        await destination.updateTracking(null, null);
         await group.destroy(); // does not throw
       });
 
@@ -331,7 +331,10 @@ describe("models/group", () => {
         });
 
         const destination: Destination = await helper.factories.destination();
-        const run = await destination.trackGroup(trackedGroup);
+        const { newRun } = await destination.updateTracking(
+          "group",
+          trackedGroup.id
+        );
         const destinationGroupMemberships = {};
         destinationGroupMemberships[taggedGroup.id] = "remote-tagged-group";
         await destination.setDestinationGroupMemberships(
@@ -349,9 +352,9 @@ describe("models/group", () => {
         expect(runningRuns.length).toBe(1);
         expect(runningRuns[0].destinationId).toBe(destination.id);
         expect(runningRuns[0].force).toBe(false);
-        expect(runningRuns[0].id).not.toBe(run.id);
+        expect(runningRuns[0].id).not.toBe(newRun.id);
 
-        await destination.unTrackGroup();
+        await destination.updateTracking(null, null);
         await trackedGroup.destroy();
         await taggedGroup.destroy();
       });
@@ -372,7 +375,7 @@ describe("models/group", () => {
         });
 
         const destination = await helper.factories.destination();
-        const run = await destination.trackGroup(trackedGroup);
+        await destination.updateTracking("group", trackedGroup.id);
         const destinationGroupMemberships = {};
         destinationGroupMemberships[taggedGroup.id] = "remote-tagged-group";
         await destination.setDestinationGroupMemberships(

--- a/core/__tests__/models/record/snapshot-testing.ts
+++ b/core/__tests__/models/record/snapshot-testing.ts
@@ -65,7 +65,7 @@ describe("test grouparoo records", () => {
       await destination.setDestinationGroupMemberships({
         [group.id]: "remote_group_name",
       });
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       // make ready
       await group.update({ state: "ready" });

--- a/core/__tests__/models/record/sync.ts
+++ b/core/__tests__/models/record/sync.ts
@@ -90,7 +90,7 @@ describe("record sync", () => {
         { key: "firstName", match: "Mario", operation: { op: "eq" } },
       ]);
       await group.update({ state: "ready" });
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
     });
 
     test("syncing will create exports", async () => {
@@ -135,8 +135,10 @@ describe("record sync", () => {
         await otherGroup.setRules([
           { key: "grouparooId", match: "rec%", operation: { op: "like" } },
         ]);
+        await otherGroup.update({ state: "ready" });
         otherDestination = await helper.factories.destination();
-        await otherDestination.trackGroup(otherGroup);
+        await otherDestination.updateTracking("group", otherGroup.id);
+        await otherDestination.update({ state: "ready" });
       });
 
       test("record sync will create a toDelete export if the group's rules remove it from the group", async () => {
@@ -230,7 +232,7 @@ describe("record sync", () => {
         expect(groups.length).toBe(2);
 
         // change the destination
-        await destination.unTrackGroup();
+        await destination.updateTracking(null, null);
 
         // test
         let exports = await record.sync();
@@ -250,7 +252,7 @@ describe("record sync", () => {
         expect(exports[0].destinationId).toBe(otherDestination.id);
 
         // reset
-        await destination.trackGroup(group);
+        await destination.updateTracking("group", group.id);
       });
     });
   });

--- a/core/__tests__/models/record/sync.ts
+++ b/core/__tests__/models/record/sync.ts
@@ -232,7 +232,7 @@ describe("record sync", () => {
         expect(groups.length).toBe(2);
 
         // change the destination
-        await destination.updateTracking(null, null);
+        await destination.updateTracking("none");
 
         // test
         let exports = await record.sync();

--- a/core/__tests__/models/run/run.ts
+++ b/core/__tests__/models/run/run.ts
@@ -164,7 +164,7 @@ describe("models/run", () => {
           state: "running",
           creatorId: group.id,
           creatorType: "group",
-          groupMethod: "runAddGroupMembers",
+          method: "runAddGroupMembers",
         });
 
         // 0 members
@@ -182,7 +182,7 @@ describe("models/run", () => {
           state: "running",
           creatorId: group.id,
           creatorType: "group",
-          groupMethod: "runRemoveGroupMembers",
+          method: "runRemoveGroupMembers",
         });
 
         // 0 members
@@ -200,14 +200,14 @@ describe("models/run", () => {
           state: "running",
           creatorId: group.id,
           creatorType: "group",
-          groupMethod: "removePreviousRunGroupMembers",
+          method: "removePreviousRunGroupMembers",
         });
 
         run = await Run.create({
           state: "running",
           creatorId: group.id,
           creatorType: "group",
-          groupMethod: "runRemoveGroupMembers",
+          method: "runRemoveGroupMembers",
         });
 
         // 3 members
@@ -223,7 +223,7 @@ describe("models/run", () => {
           state: "running",
           creatorId: group.id,
           creatorType: "group",
-          groupMethod: "complete",
+          method: "complete",
         });
         await run.determinePercentComplete();
         expect(run.percentComplete).toBe(99);
@@ -244,7 +244,7 @@ describe("models/run", () => {
           state: "running",
           creatorId: group.id,
           creatorType: "group",
-          groupMethod: "runRemoveGroupMembers",
+          method: "runRemoveGroupMembers",
         });
 
         // 3 members left (manually added because group is deleted)

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -978,6 +978,7 @@ describe("modules/configWriter", () => {
         type,
         appId: app.getConfigId(),
         groupId: group.getConfigId(),
+        collection: "group",
         syncMode,
         options: Object.fromEntries(options.map((o) => [o.key, o.value])),
         mapping: { "primary-id": mappingProperty.getConfigId() },

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -949,7 +949,7 @@ describe("modules/configWriter", () => {
     test("destinations can provide their config objects", async () => {
       const destination: Destination = await helper.factories.destination(
         undefined,
-        { groupId: group.id }
+        { groupId: group.id, collection: "group" }
       );
       const app: App = await destination.$get("app");
 

--- a/core/__tests__/snapshots/snapshot-testing.ts
+++ b/core/__tests__/snapshots/snapshot-testing.ts
@@ -66,7 +66,7 @@ describe("test grouparoo records", () => {
       await destination.setDestinationGroupMemberships({
         [group.id]: "remote_group_name",
       });
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       // make ready
       await group.update({ state: "ready" });

--- a/core/__tests__/tasks/destination/destroy.ts
+++ b/core/__tests__/tasks/destination/destroy.ts
@@ -57,7 +57,7 @@ describe("tasks/destination:destroy", () => {
         luigi = await helper.factories.record();
         await group.addRecord(mario);
         await group.addRecord(luigi);
-        await destination.trackGroup(group);
+        await destination.updateTracking("group", group.id);
 
         await group.update({ state: groupState });
 
@@ -94,6 +94,9 @@ describe("tasks/destination:destroy", () => {
       });
 
       test("the destination will not be deleted yet (running run)", async () => {
+        destination = await Destination.findById(destination.id);
+        expect(destination.state).toBe("deleted");
+
         await utils.sleep(1000);
         await specHelper.runTask("destination:destroy", {
           destinationId: destination.id,

--- a/core/__tests__/tasks/export/send.ts
+++ b/core/__tests__/tasks/export/send.ts
@@ -56,7 +56,7 @@ describe("tasks/export:send", () => {
       await group.addRecord(record);
 
       destination = await helper.factories.destination();
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       await api.resque.queue.connection.redis.flushdb();
       await Run.truncate();
@@ -68,7 +68,7 @@ describe("tasks/export:send", () => {
       );
       await destination.update({ state: "ready" });
 
-      await destination.exportGroupMembers(true);
+      await destination.exportMembers(true);
 
       run = await Run.findOne({
         where: { creatorId: group.id },
@@ -199,7 +199,7 @@ describe("tasks/export:send", () => {
           modelId: model.id,
         });
         await destination.update({ state: "ready" });
-        await destination.trackGroup(group);
+        await destination.updateTracking("group", group.id);
       });
 
       beforeEach(async () => {

--- a/core/__tests__/tasks/export/sendBatch.ts
+++ b/core/__tests__/tasks/export/sendBatch.ts
@@ -58,7 +58,7 @@ describe("tasks/export:sendBatch", () => {
       destination = await helper.factories.destination(null, {
         type: "test-plugin-export-batch",
       });
-      await destination.trackGroup(group);
+      await destination.updateTracking("group", group.id);
 
       await api.resque.queue.connection.redis.flushdb();
       await Run.truncate();
@@ -70,7 +70,7 @@ describe("tasks/export:sendBatch", () => {
       );
       await destination.update({ state: "ready" });
 
-      await destination.exportGroupMembers(true);
+      await destination.exportMembers(true);
 
       run = await Run.findOne({
         where: { creatorId: group.id },
@@ -210,7 +210,7 @@ describe("tasks/export:sendBatch", () => {
           modelId: model.id,
         });
         await destination.update({ state: "ready" });
-        await destination.trackGroup(group);
+        await destination.updateTracking("group", group.id);
       });
 
       beforeEach(async () => {

--- a/core/__tests__/tasks/group/destroy.ts
+++ b/core/__tests__/tasks/group/destroy.ts
@@ -116,9 +116,9 @@ describe("tasks/group:destroy", () => {
 
       expect(run).toBeTruthy();
       expect(run.state).toBe("running");
-      expect(run.groupMemberLimit).toBe(100);
-      expect(run.groupMemberOffset).toBe(0);
-      expect(run.groupMethod).toBe("runRemoveGroupMembers");
+      expect(run.memberLimit).toBe(100);
+      expect(run.memberOffset).toBe(0);
+      expect(run.method).toBe("runRemoveGroupMembers");
     });
 
     it("will remove all members in a manual group and then delete the group", async () => {
@@ -153,9 +153,9 @@ describe("tasks/group:destroy", () => {
 
       expect(run).toBeTruthy();
       expect(run.state).toBe("running");
-      expect(run.groupMemberLimit).toBe(100);
-      expect(run.groupMemberOffset).toBe(0);
-      expect(run.groupMethod).toBe("runRemoveGroupMembers");
+      expect(run.memberLimit).toBe(100);
+      expect(run.memberOffset).toBe(0);
+      expect(run.method).toBe("runRemoveGroupMembers");
 
       // process the run
       await specHelper.runTask("group:run", { runId: run.id }); // runRemoveGroupMembers
@@ -216,9 +216,9 @@ describe("tasks/group:destroy", () => {
 
       expect(run).toBeTruthy();
       expect(run.state).toBe("running");
-      expect(run.groupMemberLimit).toBe(100);
-      expect(run.groupMemberOffset).toBe(0);
-      expect(run.groupMethod).toBe("runRemoveGroupMembers");
+      expect(run.memberLimit).toBe(100);
+      expect(run.memberOffset).toBe(0);
+      expect(run.method).toBe("runRemoveGroupMembers");
 
       // process the run
       await specHelper.runTask("group:run", { runId: run.id }); // runRemoveGroupMembers

--- a/core/__tests__/tasks/group/destroy.ts
+++ b/core/__tests__/tasks/group/destroy.ts
@@ -266,7 +266,7 @@ describe("tasks/group:destroy", () => {
         let reloadedGroup = await Group.findById(group.id);
         expect(reloadedGroup.state).toBe("deleted"); // still waiting
 
-        await destination.updateTracking(null, null);
+        await destination.updateTracking("none");
         await group.stopPreviousRuns();
 
         // try to delete again

--- a/core/__tests__/tasks/group/destroy.ts
+++ b/core/__tests__/tasks/group/destroy.ts
@@ -250,7 +250,7 @@ describe("tasks/group:destroy", () => {
         });
 
         const destination: Destination = await helper.factories.destination();
-        await destination.trackGroup(group);
+        await destination.updateTracking("group", group.id);
         await group.stopPreviousRuns();
 
         await destination.update({ state: destinationState });
@@ -266,7 +266,7 @@ describe("tasks/group:destroy", () => {
         let reloadedGroup = await Group.findById(group.id);
         expect(reloadedGroup.state).toBe("deleted"); // still waiting
 
-        await destination.unTrackGroup(true);
+        await destination.updateTracking(null, null);
         await group.stopPreviousRuns();
 
         // try to delete again

--- a/core/__tests__/tasks/group/run.ts
+++ b/core/__tests__/tasks/group/run.ts
@@ -107,21 +107,21 @@ describe("tasks/group:run", () => {
       await specHelper.runTask("group:run", { runId: run.id }); // adding records (some found, enqueue add again)
 
       await run.reload();
-      expect(run.groupMemberLimit).toBe(100);
-      expect(run.groupMemberOffset).toBe(0);
-      expect(run.groupMethod).toBe("runAddGroupMembers");
+      expect(run.memberLimit).toBe(100);
+      expect(run.memberOffset).toBe(0);
+      expect(run.method).toBe("runAddGroupMembers");
       await specHelper.runTask("group:run", { runId: run.id }); // adding records (none found, enqueue remove)
 
       await run.reload();
-      expect(run.groupMemberLimit).toBe(100);
-      expect(run.groupMemberOffset).toBe(0);
-      expect(run.groupMethod).toBe("runRemoveGroupMembers");
+      expect(run.memberLimit).toBe(100);
+      expect(run.memberOffset).toBe(0);
+      expect(run.method).toBe("runRemoveGroupMembers");
       await specHelper.runTask("group:run", { runId: run.id }); // remove records, (none found, enqueue removePreviousRunGroupMembers)
 
       await run.reload();
-      expect(run.groupMemberLimit).toBe(100);
-      expect(run.groupMemberOffset).toBe(0);
-      expect(run.groupMethod).toBe("removePreviousRunGroupMembers");
+      expect(run.memberLimit).toBe(100);
+      expect(run.memberOffset).toBe(0);
+      expect(run.method).toBe("removePreviousRunGroupMembers");
       expect(run.state).toBe("running");
       await specHelper.runTask("group:run", { runId: run.id }); // remove records, (none found)
 
@@ -141,7 +141,7 @@ describe("tasks/group:run", () => {
       await specHelper.runTask("group:run", { runId: run.id }); // run is complete, mark group as ready
 
       await run.reload();
-      expect(run.groupMethod).toBe("complete");
+      expect(run.method).toBe("complete");
       expect(run.state).toBe("complete");
       await group.reload();
       expect(group.state).toBe("ready");
@@ -173,20 +173,20 @@ describe("tasks/group:run", () => {
       await specHelper.runTask("group:run", { runId: run.id });
 
       await run.reload();
-      expect(run.groupMethod).toBe("runAddGroupMembers");
+      expect(run.method).toBe("runAddGroupMembers");
       await specHelper.runTask("group:run", { runId: run.id });
 
       await run.reload();
-      expect(run.groupMethod).toBe("runRemoveGroupMembers");
+      expect(run.method).toBe("runRemoveGroupMembers");
       await specHelper.runTask("group:run", { runId: run.id });
 
       await run.reload();
-      expect(run.groupMethod).toBe("runRemoveGroupMembers");
+      expect(run.method).toBe("runRemoveGroupMembers");
       expect(run.state).toBe("running");
       await specHelper.runTask("group:run", { runId: run.id });
 
       await run.reload();
-      expect(run.groupMethod).toBe("removePreviousRunGroupMembers");
+      expect(run.method).toBe("removePreviousRunGroupMembers");
       expect(run.state).toBe("running");
       await specHelper.runTask("group:run", { runId: run.id });
 
@@ -207,7 +207,7 @@ describe("tasks/group:run", () => {
       await specHelper.runTask("group:run", { runId: run.id }); // run is complete, mark group as ready
 
       await run.reload();
-      expect(run.groupMethod).toBe("complete");
+      expect(run.method).toBe("complete");
       expect(run.state).toBe("complete");
       await group.reload();
       expect(group.state).toBe("ready");
@@ -250,16 +250,16 @@ describe("tasks/group:run", () => {
       await specHelper.runTask("group:run", { runId: run.id });
 
       await run.reload();
-      expect(run.groupMethod).toBe("runRemoveGroupMembers");
+      expect(run.method).toBe("runRemoveGroupMembers");
       await specHelper.runTask("group:run", { runId: run.id });
 
       await run.reload();
-      expect(run.groupMethod).toBe("removePreviousRunGroupMembers");
+      expect(run.method).toBe("removePreviousRunGroupMembers");
       expect(run.state).toBe("running");
       await specHelper.runTask("group:run", { runId: run.id });
 
       await run.reload();
-      expect(run.groupMethod).toBe("removePreviousRunGroupMembers");
+      expect(run.method).toBe("removePreviousRunGroupMembers");
       expect(run.state).toBe("running");
       await specHelper.runTask("group:run", { runId: run.id });
 
@@ -273,7 +273,7 @@ describe("tasks/group:run", () => {
       await specHelper.runTask("group:run", { runId: run.id }); // run is complete, mark group as ready
 
       await run.reload();
-      expect(run.groupMethod).toBe("complete");
+      expect(run.method).toBe("complete");
       expect(run.state).toBe("complete");
       await group.reload();
       expect(group.state).toBe("ready");
@@ -303,7 +303,7 @@ describe("tasks/group:run", () => {
 
       expect(group.state).toBe("updating");
       expect(run.state).toBe("running");
-      expect(run.groupMethod).toBe("complete");
+      expect(run.method).toBe("complete");
 
       // check again
       await specHelper.runTask("group:run", { runId: run.id });
@@ -313,7 +313,7 @@ describe("tasks/group:run", () => {
 
       expect(group.state).toBe("updating");
       expect(run.state).toBe("running");
-      expect(run.groupMethod).toBe("complete");
+      expect(run.method).toBe("complete");
 
       // complete pending imports
       await ImportWorkflow();

--- a/core/__tests__/tasks/grouparooModel/destroy.ts
+++ b/core/__tests__/tasks/grouparooModel/destroy.ts
@@ -1,7 +1,7 @@
 import { helper } from "@grouparoo/spec-helper";
 import { api, task, specHelper } from "actionhero";
 import { Group } from "../../../dist";
-import { App, GrouparooModel, Destination, Source } from "./../../../src";
+import { App, GrouparooModel, Destination, Source } from "../../../src";
 
 describe("tasks/model:destroy", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });

--- a/core/__tests__/tasks/grouparooModel/run.ts
+++ b/core/__tests__/tasks/grouparooModel/run.ts
@@ -2,8 +2,13 @@ process.env.GROUPAROO_IMPORTS_BATCH_SIZE = "100";
 
 import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
 import { api, specHelper, task } from "actionhero";
-import { GrouparooModel } from "../../../dist";
-import { Import, GrouparooRecord, Run, RecordProperty } from "../../../src";
+import {
+  Import,
+  GrouparooRecord,
+  Run,
+  GrouparooModel,
+  RecordProperty,
+} from "../../..";
 
 describe("tasks/grouparooModel:run", () => {
   helper.grouparooTestServer({

--- a/core/__tests__/tasks/grouparooModel/run.ts
+++ b/core/__tests__/tasks/grouparooModel/run.ts
@@ -1,0 +1,133 @@
+process.env.GROUPAROO_IMPORTS_BATCH_SIZE = "100";
+
+import { helper, ImportWorkflow } from "@grouparoo/spec-helper";
+import { api, specHelper, task } from "actionhero";
+import { GrouparooModel } from "../../../dist";
+import { Import, GrouparooRecord, Run, RecordProperty } from "../../../src";
+
+describe("tasks/grouparooModel:run", () => {
+  helper.grouparooTestServer({
+    truncate: true,
+    enableTestPlugin: true,
+    resetSettings: true,
+  });
+
+  describe("grouparooModel:run", () => {
+    let model: GrouparooModel;
+    let mario: GrouparooRecord;
+    let luigi: GrouparooRecord;
+    let peach: GrouparooRecord;
+    let bowser: GrouparooRecord;
+
+    beforeEach(async () => {
+      await api.resque.queue.connection.redis.flushdb();
+      await Import.truncate();
+      await Run.truncate();
+      await RecordProperty.update({ startedAt: 0 }, { where: {} });
+    });
+
+    beforeAll(async () => {
+      await helper.factories.properties();
+      helper.disableTestPluginImport();
+      await GrouparooRecord.truncate();
+
+      model = await GrouparooModel.findOne();
+
+      mario = await GrouparooRecord.create({ modelId: "mod_profiles" });
+      luigi = await GrouparooRecord.create({ modelId: "mod_profiles" });
+      peach = await GrouparooRecord.create({ modelId: "mod_profiles" });
+
+      const otherModel = await helper.factories.model();
+      bowser = await GrouparooRecord.create({ modelId: otherModel.id });
+
+      await mario.addOrUpdateProperties({
+        userId: [1],
+        firstName: ["Mario"],
+        lastName: ["Mario"],
+        email: ["mario@example.com"],
+      });
+
+      await luigi.addOrUpdateProperties({
+        userId: [2],
+        firstName: ["Luigi"],
+        lastName: ["Mario"],
+        email: ["luigi@example.com"],
+      });
+
+      await peach.addOrUpdateProperties({
+        userId: [3],
+        firstName: ["Peach"],
+        lastName: ["Toadstool"],
+        email: ["peach@example.com"],
+      });
+
+      await RecordProperty.update({ state: "ready" }, { where: {} });
+      await GrouparooRecord.update({ state: "ready" }, { where: {} });
+    });
+
+    test("can be enqueued", async () => {
+      await task.enqueue("grouparooModel:run", { runId: "abc123" }); // does not throw
+    });
+
+    test("does not throw if the run cannot be found", async () => {
+      await specHelper.runTask("grouparooModel:run", {
+        runId: "missing",
+      });
+    });
+
+    it("can create imports for records which should be considered", async () => {
+      let imports = [];
+      await model.run();
+
+      const run = await Run.findOne({
+        where: { state: "running", creatorId: model.id },
+      });
+      expect(run.state).toBe("running");
+
+      await specHelper.runTask("grouparooModel:run", { runId: run.id });
+      await run.reload();
+      expect(run.state).toBe("running");
+      expect(run.groupMemberLimit).toBe(100);
+      expect(run.groupMemberOffset).toBe(3);
+
+      imports = await Import.findAll();
+      expect(imports.length).toBe(3);
+      expect(imports.map((e) => e.recordId).sort()).toEqual(
+        [mario, luigi, peach].map((p) => p.id).sort()
+      );
+
+      // complete pending imports
+      await ImportWorkflow();
+      await specHelper.runTask("grouparooModel:run", { runId: run.id }); // run is complete now
+
+      await run.reload();
+      expect(run.state).toBe("complete");
+    });
+
+    it("the model run will not complete until all imports are complete", async () => {
+      await model.run();
+
+      const run = await Run.findOne({
+        where: { state: "running", creatorId: model.id },
+      });
+
+      await specHelper.runTask("grouparooModel:run", { runId: run.id });
+      await run.reload();
+      expect(run.state).toBe("running");
+
+      await specHelper.runTask("grouparooModel:run", { runId: run.id });
+      await specHelper.runTask("grouparooModel:run", { runId: run.id });
+      await specHelper.runTask("grouparooModel:run", { runId: run.id });
+
+      await run.reload();
+      expect(run.state).toBe("running");
+
+      // complete pending imports
+      await ImportWorkflow();
+      await specHelper.runTask("grouparooModel:run", { runId: run.id });
+
+      await run.reload();
+      expect(run.state).toBe("complete");
+    });
+  });
+});

--- a/core/__tests__/tasks/grouparooModel/run.ts
+++ b/core/__tests__/tasks/grouparooModel/run.ts
@@ -42,7 +42,10 @@ describe("tasks/grouparooModel:run", () => {
       luigi = await GrouparooRecord.create({ modelId: "mod_profiles" });
       peach = await GrouparooRecord.create({ modelId: "mod_profiles" });
 
-      const otherModel = await helper.factories.model();
+      const otherModel = await helper.factories.model({
+        id: "other_model",
+        name: "Other Model",
+      });
       bowser = await GrouparooRecord.create({ modelId: otherModel.id });
 
       await mario.addOrUpdateProperties({

--- a/core/__tests__/tasks/grouparooModel/run.ts
+++ b/core/__tests__/tasks/grouparooModel/run.ts
@@ -8,7 +8,7 @@ import {
   Run,
   GrouparooModel,
   RecordProperty,
-} from "../../..";
+} from "../../../src";
 
 describe("tasks/grouparooModel:run", () => {
   helper.grouparooTestServer({

--- a/core/__tests__/tasks/grouparooModel/run.ts
+++ b/core/__tests__/tasks/grouparooModel/run.ts
@@ -95,8 +95,8 @@ describe("tasks/grouparooModel:run", () => {
       await specHelper.runTask("grouparooModel:run", { runId: run.id });
       await run.reload();
       expect(run.state).toBe("running");
-      expect(run.groupMemberLimit).toBe(100);
-      expect(run.groupMemberOffset).toBe(3);
+      expect(run.memberLimit).toBe(100);
+      expect(run.memberOffset).toBe(3);
 
       imports = await Import.findAll();
       expect(imports.length).toBe(3);

--- a/core/__tests__/tasks/record/destroy.ts
+++ b/core/__tests__/tasks/record/destroy.ts
@@ -74,7 +74,7 @@ describe("tasks/record:destroy", () => {
     );
     await record.update({ state: "ready" });
 
-    await destination.trackGroup(group);
+    await destination.updateTracking("group", group.id);
     const destinationGroupMemberships = {};
     destinationGroupMemberships[group.id] = group.name;
     await destination.setDestinationGroupMemberships(

--- a/core/__tests__/tasks/record/export.ts
+++ b/core/__tests__/tasks/record/export.ts
@@ -138,7 +138,7 @@ describe("tasks/record:export", () => {
           firstName: "firstName",
           lastName: "lastName",
         });
-        await destination.trackGroup(group);
+        await destination.updateTracking("group", group.id);
         const destinationGroupMemberships = {};
         destinationGroupMemberships[group.id] = group.name;
         await destination.setDestinationGroupMemberships(

--- a/core/__tests__/tasks/run/internalRun.ts
+++ b/core/__tests__/tasks/run/internalRun.ts
@@ -49,9 +49,9 @@ describe("tasks/run:internalRun", () => {
       await specHelper.runTask("run:internalRun", { runId: run.id });
 
       await run.reload();
-      expect(run.groupMemberLimit).toBe(100);
-      expect(run.groupMemberOffset).toBe(1);
-      expect(run.groupMethod).toBe("internalRun");
+      expect(run.memberLimit).toBe(100);
+      expect(run.memberOffset).toBe(1);
+      expect(run.method).toBe("internalRun");
 
       await record.reload({
         include: RecordProperty,
@@ -70,9 +70,9 @@ describe("tasks/run:internalRun", () => {
       await specHelper.runTask("run:internalRun", { runId: run.id });
 
       await run.reload();
-      expect(run.groupMemberLimit).toBe(100);
-      expect(run.groupMemberOffset).toBe(1);
-      expect(run.groupMethod).toBe("internalRun");
+      expect(run.memberLimit).toBe(100);
+      expect(run.memberOffset).toBe(1);
+      expect(run.method).toBe("internalRun");
 
       await record.reload({
         include: RecordProperty,

--- a/core/src/actions/destinations.ts
+++ b/core/src/actions/destinations.ts
@@ -360,7 +360,7 @@ export class DestinationRecordPreview extends AuthenticatedAction {
     let record: GrouparooRecord;
     if (params.recordId) {
       record = await GrouparooRecord.findById(params.recordId);
-    } else if (params.groupId && params.groupId !== "_none") {
+    } else if (params.groupId && params.groupId !== APIData.nullKey) {
       const group = await Group.findById(params.groupId);
       const groupMember = await GroupMember.findOne({
         where: { groupId: group.id },

--- a/core/src/actions/destinations.ts
+++ b/core/src/actions/destinations.ts
@@ -198,10 +198,20 @@ export class DestinationEdit extends AuthenticatedAction {
       syncMode: params.syncMode,
     });
 
-    const { oldRun, newRun } = await destination.updateTracking(
-      params.collection,
-      params.groupId
-    );
+    let oldRun: Run;
+    let newRun: Run;
+    if (params.collection !== undefined || params.groupId !== undefined) {
+      const updateResponse = await destination.updateTracking(
+        params.collection,
+        params.groupId
+      );
+      oldRun = updateResponse.oldRun;
+      newRun = updateResponse.newRun;
+    }
+
+    if (params.triggerExport && !newRun && !oldRun) {
+      newRun = await destination.exportMembers(true);
+    }
 
     await ConfigWriter.run();
 

--- a/core/src/actions/destinations.ts
+++ b/core/src/actions/destinations.ts
@@ -196,6 +196,7 @@ export class DestinationEdit extends AuthenticatedAction {
       type: params.type,
       modelId: params.modelId,
       appId: params.appId,
+      state: params.state,
       syncMode: params.syncMode,
       recordCollection: params.recordCollection,
     });

--- a/core/src/actions/destinations.ts
+++ b/core/src/actions/destinations.ts
@@ -13,7 +13,6 @@ import { destinationTypeConversions } from "../modules/destinationTypeConversion
 import { AsyncReturnType } from "type-fest";
 import { ConfigWriter } from "../modules/configWriter";
 import { APIData } from "../modules/apiData";
-import { NullKey } from "../modules/nullKey";
 
 export class DestinationsList extends AuthenticatedAction {
   constructor() {
@@ -344,6 +343,7 @@ export class DestinationRecordPreview extends AuthenticatedAction {
     this.permission = { topic: "destination", mode: "read" };
     this.inputs = {
       id: { required: true },
+      collection: { required: false },
       groupId: { required: false },
       modelId: { required: false },
       recordId: { required: false },
@@ -359,9 +359,11 @@ export class DestinationRecordPreview extends AuthenticatedAction {
     const destination = await Destination.findById(params.id);
 
     let record: GrouparooRecord;
+    const collection = params.collection ?? destination.collection;
+
     if (params.recordId) {
       record = await GrouparooRecord.findById(params.recordId);
-    } else if (params.groupId && params.groupId !== NullKey) {
+    } else if (collection === "group" && params.groupId) {
       const group = await Group.findById(params.groupId);
       const groupMember = await GroupMember.findOne({
         where: { groupId: group.id },

--- a/core/src/actions/destinations.ts
+++ b/core/src/actions/destinations.ts
@@ -360,7 +360,7 @@ export class DestinationRecordPreview extends AuthenticatedAction {
     let record: GrouparooRecord;
     if (params.recordId) {
       record = await GrouparooRecord.findById(params.recordId);
-    } else if (params.groupId && params.groupId !== APIData.nullKey) {
+    } else if (params.groupId && params.groupId !== APIData.NullKey) {
       const group = await Group.findById(params.groupId);
       const groupMember = await GroupMember.findOne({
         where: { groupId: group.id },

--- a/core/src/actions/destinations.ts
+++ b/core/src/actions/destinations.ts
@@ -13,6 +13,7 @@ import { destinationTypeConversions } from "../modules/destinationTypeConversion
 import { AsyncReturnType } from "type-fest";
 import { ConfigWriter } from "../modules/configWriter";
 import { APIData } from "../modules/apiData";
+import { NullKey } from "../modules/nullKey";
 
 export class DestinationsList extends AuthenticatedAction {
   constructor() {
@@ -360,7 +361,7 @@ export class DestinationRecordPreview extends AuthenticatedAction {
     let record: GrouparooRecord;
     if (params.recordId) {
       record = await GrouparooRecord.findById(params.recordId);
-    } else if (params.groupId && params.groupId !== APIData.NullKey) {
+    } else if (params.groupId && params.groupId !== NullKey) {
       const group = await Group.findById(params.groupId);
       const groupMember = await GroupMember.findOne({
         where: { groupId: group.id },

--- a/core/src/actions/destinations.ts
+++ b/core/src/actions/destinations.ts
@@ -189,7 +189,7 @@ export class DestinationEdit extends AuthenticatedAction {
       );
     }
 
-    // do not set groupId or collection here, that's handled within the track/unTrack methods
+    // do not set groupId or collection here, that's handled within the updateTracking method
     await destination.update({
       name: params.name,
       type: params.type,

--- a/core/src/actions/object.ts
+++ b/core/src/actions/object.ts
@@ -23,6 +23,7 @@ export class ObjectFind extends AuthenticatedAction {
       "files",
       "groups",
       "imports",
+      "models",
       "notifications",
       "records",
       "properties",

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -1,5 +1,8 @@
 import { ActionheroLogLevel, log } from "actionhero";
-import { DestinationSyncMode } from "../models/Destination";
+import {
+  DestinationCollection,
+  DestinationSyncMode,
+} from "../models/Destination";
 import { GroupRuleWithKey } from "../models/Group";
 import { PropertyFiltersWithKey } from "../models/Property";
 import { MustacheUtils } from "../modules/mustacheUtils";
@@ -50,6 +53,7 @@ export interface DestinationConfigurationObject extends ConfigurationObject {
   appId: string;
   modelId: string;
   syncMode: DestinationSyncMode;
+  collection: DestinationCollection;
   groupId?: string;
   options?: { [key: string]: any };
   mapping?: { [key: string]: any };

--- a/core/src/classes/plugin.ts
+++ b/core/src/classes/plugin.ts
@@ -573,7 +573,7 @@ export interface DestinationMappingOptionsMethod {
   }): Promise<DestinationMappingOptionsMethodResponse>;
 }
 
-export type DestinationMappingOptionsResponseTypes =
+export type DestinationMappingOptionsResponseType =
   | "any"
   | "boolean"
   | "date"
@@ -586,7 +586,7 @@ export type DestinationMappingOptionsResponseTypes =
   | "url";
 export interface DestinationMappingOptionsResponseProperty {
   key: string;
-  type: DestinationMappingOptionsResponseTypes;
+  type: DestinationMappingOptionsResponseType;
   important?: boolean;
 }
 export interface DestinationMappingOptionsResponseProperties {

--- a/core/src/migrations/000084-addDestinationRecordCollection.ts
+++ b/core/src/migrations/000084-addDestinationRecordCollection.ts
@@ -13,6 +13,11 @@ export default {
     await queryInterface.sequelize.query(
       `UPDATE "destinations" SET "recordCollection"='group' WHERE "groupId" IS NOT NULL`
     );
+
+    await queryInterface.changeColumn("destinations", "recordCollection", {
+      type: DataTypes.STRING(191),
+      allowNull: false,
+    });
   },
 
   down: async (queryInterface: Sequelize.QueryInterface) => {

--- a/core/src/migrations/000085-addDestinationRecordCollection.ts
+++ b/core/src/migrations/000085-addDestinationRecordCollection.ts
@@ -1,0 +1,21 @@
+import Sequelize from "sequelize";
+
+export default {
+  up: async (
+    queryInterface: Sequelize.QueryInterface,
+    DataTypes: typeof Sequelize
+  ) => {
+    await queryInterface.addColumn("destinations", "recordCollection", {
+      type: DataTypes.STRING(191),
+      allowNull: true,
+    });
+
+    await queryInterface.sequelize.query(
+      `UPDATE "destinations" SET "recordCollection"='group' WHERE "groupId" IS NOT NULL`
+    );
+  },
+
+  down: async (queryInterface: Sequelize.QueryInterface) => {
+    await queryInterface.removeColumn("destinations", "recordCollection");
+  },
+};

--- a/core/src/migrations/000086-addDestinationRecordCollection.ts
+++ b/core/src/migrations/000086-addDestinationRecordCollection.ts
@@ -14,9 +14,9 @@ export default {
       `UPDATE "destinations" SET "collection"='group' WHERE "groupId" IS NOT NULL AND state='ready'`
     );
 
-    await queryInterface.addColumn("runs", "collection", {
+    await queryInterface.changeColumn("destinations", "collection", {
       type: DataTypes.STRING(191),
-      allowNull: true,
+      allowNull: false,
     });
 
     await queryInterface.renameColumn(

--- a/core/src/migrations/000086-addDestinationRecordCollection.ts
+++ b/core/src/migrations/000086-addDestinationRecordCollection.ts
@@ -5,18 +5,18 @@ export default {
     queryInterface: Sequelize.QueryInterface,
     DataTypes: typeof Sequelize
   ) => {
-    await queryInterface.addColumn("destinations", "recordCollection", {
+    await queryInterface.addColumn("destinations", "collection", {
       type: DataTypes.STRING(191),
       allowNull: true,
     });
 
     await queryInterface.sequelize.query(
-      `UPDATE "destinations" SET "recordCollection"='group' WHERE "groupId" IS NOT NULL`
+      `UPDATE "destinations" SET "collection"='group' WHERE "groupId" IS NOT NULL AND state='ready'`
     );
 
-    await queryInterface.changeColumn("destinations", "recordCollection", {
+    await queryInterface.addColumn("runs", "collection", {
       type: DataTypes.STRING(191),
-      allowNull: false,
+      allowNull: true,
     });
   },
 

--- a/core/src/migrations/000086-addDestinationRecordCollection.ts
+++ b/core/src/migrations/000086-addDestinationRecordCollection.ts
@@ -7,11 +7,12 @@ export default {
   ) => {
     await queryInterface.addColumn("destinations", "collection", {
       type: DataTypes.STRING(191),
+      defaultValue: "none",
       allowNull: true,
     });
 
     await queryInterface.sequelize.query(
-      `UPDATE "destinations" SET "collection"='group' WHERE "groupId" IS NOT NULL AND state='ready'`
+      `UPDATE "destinations" SET "collection"='group' WHERE "groupId" IS NOT NULL`
     );
 
     await queryInterface.changeColumn("destinations", "collection", {
@@ -37,7 +38,7 @@ export default {
     queryInterface: Sequelize.QueryInterface,
     DataTypes: typeof Sequelize
   ) => {
-    await queryInterface.removeColumn("destinations", "recordCollection");
+    await queryInterface.removeColumn("destinations", "collection");
     await queryInterface.renameColumn(
       "runs",
       "memberLimit",

--- a/core/src/migrations/000086-addDestinationRecordCollection.ts
+++ b/core/src/migrations/000086-addDestinationRecordCollection.ts
@@ -18,9 +18,40 @@ export default {
       type: DataTypes.STRING(191),
       allowNull: true,
     });
+
+    await queryInterface.renameColumn(
+      "runs",
+      "groupMemberLimit",
+      "memberLimit"
+    );
+    await queryInterface.renameColumn(
+      "runs",
+      "groupMemberOffset",
+      "memberOffset"
+    );
+    await queryInterface.renameColumn("runs", "groupMethod", "method");
+    await queryInterface.removeColumn("runs", "groupHighWaterMark");
   },
 
-  down: async (queryInterface: Sequelize.QueryInterface) => {
+  down: async (
+    queryInterface: Sequelize.QueryInterface,
+    DataTypes: typeof Sequelize
+  ) => {
     await queryInterface.removeColumn("destinations", "recordCollection");
+    await queryInterface.renameColumn(
+      "runs",
+      "memberLimit",
+      "groupMemberLimit"
+    );
+    await queryInterface.renameColumn(
+      "runs",
+      "memberOffset",
+      "groupMemberOffset"
+    );
+    await queryInterface.renameColumn("runs", "groupMethod", "method");
+    await queryInterface.addColumn("runs", "groupHighWaterMark", {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    });
   },
 };

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -239,7 +239,7 @@ export class Destination extends LoggedModel<Destination> {
       mapping,
       options,
       connection: pluginConnection,
-      destinationGroup: group ? await group.apiData() : null,
+      group: group ? await group.apiData() : null,
       destinationGroupMemberships,
       createdAt: APIData.formatDate(this.createdAt),
       updatedAt: APIData.formatDate(this.updatedAt),

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -765,8 +765,6 @@ export class Destination extends LoggedModel<Destination> {
     oldGroups: Group[] = [],
     newGroups: Group[] = []
   ) {
-    // TODO How do we find previously relevant destinations?  There's no "old destination id"
-
     const combinedGroupIds = [...oldGroups, ...newGroups].map((g) => g.id);
     const relevantDestinations =
       combinedGroupIds.length > 0

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -339,8 +339,11 @@ export class Destination extends LoggedModel<Destination> {
     return DestinationOps.exportMembers(this, force);
   }
 
-  async updateTracking(collection: Destination["collection"], groupId: string) {
-    return DestinationOps.updateTracking(this, collection, groupId);
+  async updateTracking(
+    collection: Destination["collection"],
+    collectionId?: string
+  ) {
+    return DestinationOps.updateTracking(this, collection, collectionId);
   }
 
   async getSupportedSyncModes() {

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -168,6 +168,7 @@ export class Destination extends LoggedModel<Destination> {
   syncMode: DestinationSyncMode;
 
   @AllowNull(true)
+  @Default("group")
   @Column(DataType.ENUM(...RECORD_COLLECTIONS))
   recordCollection: DestinationRecordCollection;
 

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -755,14 +755,25 @@ export class Destination extends LoggedModel<Destination> {
   /**
    * Determine which destinations are interested in this record due to the groups they are tracking
    */
-  static async destinationsForGroups(
+  static async relevantFor(
+    record: GrouparooRecord,
     oldGroups: Group[] = [],
     newGroups: Group[] = []
   ) {
     const combinedGroupIds = [...oldGroups, ...newGroups].map((g) => g.id);
-    const relevantDestinations = await Destination.findAll({
-      where: { groupId: { [Op.in]: combinedGroupIds } },
-    });
+    const relevantDestinations =
+      combinedGroupIds.length > 0
+        ? await Destination.findAll({
+            where: {
+              [Op.or]: [
+                { collection: "model", modelId: record.modelId },
+                { collection: "group", groupId: { [Op.in]: combinedGroupIds } },
+              ],
+            },
+          })
+        : await Destination.findAll({
+            where: { collection: "model", modelId: record.modelId },
+          });
 
     return relevantDestinations;
   }

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -40,6 +40,7 @@ import { Run } from "./Run";
 import { Setting } from "./Setting";
 import { GrouparooModel } from "./GrouparooModel";
 import { Source } from "./Source";
+import { RunOps } from "../modules/ops/runs";
 
 export const GROUP_RULE_LIMIT = 10;
 const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -392,11 +393,11 @@ export class Group extends LoggedModel<Group> {
   }
 
   async run(force = false, destinationId?: string) {
-    return GroupOps.run(this, force, destinationId);
+    return RunOps.run(this, force, destinationId);
   }
 
   async stopPreviousRuns() {
-    return GroupOps.stopPreviousRuns(this);
+    return RunOps.stopPreviousRuns(this);
   }
 
   async addRecord(record: GrouparooRecord, force = true) {
@@ -808,9 +809,7 @@ export class Group extends LoggedModel<Group> {
       );
       await destinationGroupMemberships[i].destroy();
 
-      if (destination) {
-        await destination.exportGroupMembers(false);
-      }
+      if (destination) await destination.exportMembers(false);
     }
   }
 

--- a/core/src/models/GrouparooModel.ts
+++ b/core/src/models/GrouparooModel.ts
@@ -11,7 +11,6 @@ import {
   DefaultScope,
   Default,
 } from "sequelize-typescript";
-import * as uuid from "uuid";
 import { Source } from "./Source";
 import { ModelConfigurationObject } from "../classes/codeConfig";
 import { LoggedModel } from "../classes/loggedModel";
@@ -20,6 +19,7 @@ import { ConfigWriter } from "../modules/configWriter";
 import { LockableHelper } from "../modules/lockableHelper";
 import { Destination } from "./Destination";
 import { Group } from "./Group";
+import { RunOps } from "../modules/ops/runs";
 
 export const ModelTypes = ["profile"] as const;
 export type ModelType = typeof ModelTypes[number];
@@ -76,6 +76,14 @@ export class GrouparooModel extends LoggedModel<GrouparooModel> {
       default:
         throw new Error(`no icon for ${this.type} model`);
     }
+  }
+
+  async run(force = false, destinationId?: string) {
+    return RunOps.run(this, force, destinationId);
+  }
+
+  async stopPreviousRuns() {
+    return RunOps.stopPreviousRuns(this);
   }
 
   async apiData() {

--- a/core/src/models/Run.ts
+++ b/core/src/models/Run.ts
@@ -26,6 +26,7 @@ import { plugin } from "../modules/plugin";
 import Moment from "moment";
 import { APIData } from "../modules/apiData";
 import { CommonModel } from "../classes/commonModel";
+import { GrouparooModel } from "..";
 
 export interface HighWaterMark {
   [key: string]: string | number | Date;
@@ -35,6 +36,7 @@ const RUN_CREATORS = [
   "schedule",
   "property",
   "group",
+  "grouparooModel",
   "task",
   "teamMember",
 ] as const;
@@ -289,6 +291,9 @@ export class Run extends CommonModel<Run> {
       } else if (this.creatorType === "property") {
         const property = await Property.findById(this.creatorId);
         name = property.key;
+      } else if (this.creatorType === "grouparooModel") {
+        const model = await GrouparooModel.findById(this.creatorId);
+        name = model.name;
       } else if (this.creatorType === "schedule") {
         const schedule = await Schedule.findById(this.creatorId);
         const source = await schedule.$get("source", { scope: null });

--- a/core/src/models/Run.ts
+++ b/core/src/models/Run.ts
@@ -106,18 +106,14 @@ export class Run extends CommonModel<Run> {
 
   @Default(0)
   @Column
-  groupMemberLimit: number;
+  memberLimit: number;
 
   @Default(0)
   @Column
-  groupMemberOffset: number;
-
-  @Default(0)
-  @Column
-  groupHighWaterMark: number;
+  memberOffset: number;
 
   @Column
-  groupMethod: string;
+  method: string;
 
   @Default(0)
   @Column
@@ -269,10 +265,9 @@ export class Run extends CommonModel<Run> {
       error: this.error,
       highWaterMark: this.highWaterMark,
       sourceOffset: this.sourceOffset,
-      groupMemberLimit: this.groupMemberLimit,
-      groupMemberOffset: this.groupMemberOffset,
-      groupHighWaterMark: this.groupHighWaterMark,
-      groupMethod: this.groupMethod,
+      memberLimit: this.memberLimit,
+      memberOffset: this.memberOffset,
+      method: this.method,
       force: this.force,
       destinationId: this.destinationId,
       createdAt: APIData.formatDate(this.createdAt),
@@ -350,8 +345,8 @@ export class Run extends CommonModel<Run> {
     // we only need to broadcast at the end of each batch or on a state change, not as we increment values
     if (
       instance.changed("state") ||
-      instance.changed("groupMemberLimit") ||
-      instance.changed("groupMemberOffset") ||
+      instance.changed("memberLimit") ||
+      instance.changed("memberOffset") ||
       instance.changed("highWaterMark") ||
       instance.changed("sourceOffset") ||
       instance.changed("percentComplete")

--- a/core/src/models/Run.ts
+++ b/core/src/models/Run.ts
@@ -26,7 +26,7 @@ import { plugin } from "../modules/plugin";
 import Moment from "moment";
 import { APIData } from "../modules/apiData";
 import { CommonModel } from "../classes/commonModel";
-import { GrouparooModel } from "..";
+import { GrouparooModel } from "./GrouparooModel";
 
 export interface HighWaterMark {
   [key: string]: string | number | Date;

--- a/core/src/modules/apiData.ts
+++ b/core/src/modules/apiData.ts
@@ -54,4 +54,6 @@ export namespace APIData {
     else if (typeof date === "string") return new Date(date).getTime();
     else throw new Error(`${date} is not a date`);
   }
+
+  export const nullKey = "_none" as const;
 }

--- a/core/src/modules/apiData.ts
+++ b/core/src/modules/apiData.ts
@@ -55,5 +55,5 @@ export namespace APIData {
     else throw new Error(`${date} is not a date`);
   }
 
-  export const nullKey = "_none" as const;
+  export const NullKey = "_none" as const;
 }

--- a/core/src/modules/apiData.ts
+++ b/core/src/modules/apiData.ts
@@ -54,6 +54,4 @@ export namespace APIData {
     else if (typeof date === "string") return new Date(date).getTime();
     else throw new Error(`${date} is not a date`);
   }
-
-  export const NullKey = "_none" as const;
 }

--- a/core/src/modules/configLoaders/destination.ts
+++ b/core/src/modules/configLoaders/destination.ts
@@ -83,9 +83,10 @@ export async function loadDestination(
   }
   await destination.setDestinationGroupMemberships(destinationGroupMemberships);
 
-  if (group && destination.groupId !== group.id) {
-    await destination.trackGroup(group);
-  }
+  await destination.updateTracking(
+    configObject.collection,
+    configObject.groupId
+  );
 
   if (destination.state === "deleted") {
     // when bringing back deleted destinations, we need to be sure to trigger a new export even though options may be the same

--- a/core/src/modules/configLoaders/destination.ts
+++ b/core/src/modules/configLoaders/destination.ts
@@ -85,7 +85,7 @@ export async function loadDestination(
   await destination.setDestinationGroupMemberships(destinationGroupMemberships);
 
   await destination.updateTracking(
-    configObject.collection,
+    configObject.collection ?? "none", // allow a "null" collection in config to be treated as a "none" collection
     configObject.groupId
   );
 

--- a/core/src/modules/configLoaders/destination.ts
+++ b/core/src/modules/configLoaders/destination.ts
@@ -50,6 +50,7 @@ export async function loadDestination(
     group = await getParentByName(Group, configObject.groupId);
   }
 
+  // do not set groupId or collection here, that's handled within the updateTracking method
   await destination.update({
     name: configObject.name,
     type: configObject.type,

--- a/core/src/modules/configLoaders/destination.ts
+++ b/core/src/modules/configLoaders/destination.ts
@@ -89,7 +89,7 @@ export async function loadDestination(
 
   if (destination.state === "deleted") {
     // when bringing back deleted destinations, we need to be sure to trigger a new export even though options may be the same
-    await destination.exportGroupMembers(true);
+    await destination.exportMembers(true);
   }
 
   await destination.update({ state: "ready" });

--- a/core/src/modules/internalRun.ts
+++ b/core/src/modules/internalRun.ts
@@ -21,7 +21,7 @@ export async function internalRun(creatorType: string, creatorId: string) {
     creatorType,
     creatorId,
     state: "running",
-    groupMethod: "internalRun",
+    method: "internalRun",
   });
 
   return run;

--- a/core/src/modules/middleware/authentication.ts
+++ b/core/src/modules/middleware/authentication.ts
@@ -181,7 +181,7 @@ async function authenticateTeamMemberInRoom(
     process.env.GROUPAROO_RUN_MODE === "cli:config" &&
     env === "development"
   ) {
-    return; // TODO: What's the log in story for `grouparoo config`
+    return;
   }
 
   await CLS.wrap(async () => {

--- a/core/src/modules/nullKey.ts
+++ b/core/src/modules/nullKey.ts
@@ -1,1 +1,0 @@
-export const NullKey = "_none" as const;

--- a/core/src/modules/nullKey.ts
+++ b/core/src/modules/nullKey.ts
@@ -1,0 +1,1 @@
+export const NullKey = "_none" as const;

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -88,14 +88,7 @@ export namespace DestinationOps {
   ) {
     if (destination.collection === "group" && destination.groupId) {
       const group = await Group.findById(destination.groupId);
-      if (group) {
-        if (group.state === "deleted") {
-          throw new Error(
-            `Cannot track deleted Group "${group.name} (${group.id})"`
-          );
-        }
-        return RunOps.run(group, force, destination.id);
-      }
+      if (group) return RunOps.run(group, force, destination.id);
     } else if (destination.collection === "model") {
       const model = await GrouparooModel.findById(destination.modelId);
       if (model) return RunOps.run(model, force, destination.id);

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -346,8 +346,15 @@ export namespace DestinationOps {
       include: [{ model: GroupMember, where: { recordId: record.id } }],
     });
 
-    if (!newGroups.map((g) => g.id).includes(destination.groupId)) {
-      toDelete = true;
+    // do we need to delete this record from the destination?
+    if (destination.collection === "group") {
+      if (!destination.groupId) {
+        toDelete = true;
+      } else if (!newGroups.map((g) => g.id).includes(destination.groupId)) {
+        toDelete = true;
+      }
+    } else {
+      if (!destination.collection) toDelete = true;
     }
 
     let newRecordProperties = await record.getProperties();

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -1,4 +1,6 @@
 import Moment from "moment";
+import { config, cache } from "actionhero";
+import { deepStrictEqual } from "assert";
 import {
   Destination,
   DestinationSyncModeData,
@@ -9,7 +11,6 @@ import { GrouparooRecord } from "../../models/GrouparooRecord";
 import { Export, ExportRecordPropertiesWithType } from "../../models/Export";
 import { Group } from "../../models/Group";
 import { Property } from "../../models/Property";
-import { MappingHelper } from "../mappingHelper";
 import {
   ExportedRecord,
   ExportRecordsPluginMethod,
@@ -19,17 +20,16 @@ import {
   ProcessExportsForRecordIds,
   ExportRecordsPluginMethodResponse,
 } from "../../classes/plugin";
-import { config, cache } from "actionhero";
-import { deepStrictEqual } from "assert";
-import { RecordPropertyOps } from "./recordProperty";
 import { destinationTypeConversions } from "../destinationTypeConversions";
 import { GroupMember } from "../../models/GroupMember";
 import { ExportProcessor } from "../../models/ExportProcessor";
 import { GrouparooModel } from "../../models/GrouparooModel";
 import { Run } from "../../models/Run";
+import { MappingHelper } from "../mappingHelper";
+import { RecordPropertyOps } from "./recordProperty";
 import { Option } from "../../models/Option";
 import { RunOps } from "./runs";
-import { APIData } from "../apiData";
+import { NullKey } from "../nullKey";
 
 function deepStrictEqualBoolean(a: any, b: any): boolean {
   try {
@@ -58,7 +58,7 @@ export namespace DestinationOps {
 
   export async function updateTracking(
     destination: Destination,
-    collection: Destination["collection"] | typeof APIData.NullKey,
+    collection: Destination["collection"] | typeof NullKey,
     collectionId?: string
   ) {
     let oldRun: Run;
@@ -71,11 +71,7 @@ export namespace DestinationOps {
       return { oldRun, newRun }; // no changes
     }
 
-    if (
-      collection === "group" &&
-      collectionId &&
-      collectionId !== APIData.NullKey
-    ) {
+    if (collection === "group" && collectionId && collectionId !== NullKey) {
       const group = await Group.findById(collectionId);
       if (group.state === "deleted") {
         throw new Error(`cannot track deleted Group "${group.name}"`);
@@ -98,9 +94,9 @@ export namespace DestinationOps {
 
     oldRun = await runDestinationCollection(destination, false); // old collection
     await destination.update({
-      collection: collection === APIData.NullKey ? null : collection,
+      collection: collection === NullKey ? null : collection,
       groupId:
-        collectionId === APIData.NullKey || collection !== "group"
+        collectionId === NullKey || collection !== "group"
           ? null
           : collectionId,
     });

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -58,7 +58,7 @@ export namespace DestinationOps {
 
   export async function updateTracking(
     destination: Destination,
-    collection: Destination["collection"] | typeof APIData.nullKey,
+    collection: Destination["collection"] | typeof APIData.NullKey,
     collectionId?: string
   ) {
     let oldRun: Run;
@@ -74,7 +74,7 @@ export namespace DestinationOps {
     if (
       collection === "group" &&
       collectionId &&
-      collectionId !== APIData.nullKey
+      collectionId !== APIData.NullKey
     ) {
       const group = await Group.findById(collectionId);
       if (group.state === "deleted") {
@@ -98,9 +98,9 @@ export namespace DestinationOps {
 
     oldRun = await runDestinationCollection(destination, false); // old collection
     await destination.update({
-      collection: collection === APIData.nullKey ? null : collection,
+      collection: collection === APIData.NullKey ? null : collection,
       groupId:
-        collectionId === APIData.nullKey || collection !== "group"
+        collectionId === APIData.NullKey || collection !== "group"
           ? null
           : collectionId,
     });

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -73,6 +73,12 @@ export namespace DestinationOps {
     }
 
     // validations
+    if (collectionId && collection !== "group") {
+      throw new Error(
+        `cannot track ${collectionId} without destination collection being "group"`
+      );
+    }
+
     if (collection === "none") {
       // nothing to check
     } else if (collection === "group") {

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -40,12 +40,18 @@ export namespace DestinationOps {
   /**
    * Export all the Group Members of the Groups that this Destination is Tracking
    */
-  export async function exportGroupMembers(
-    destination: Destination,
-    force = false
-  ) {
-    const group = await destination.$get("group");
-    if (group) return group.run(force, destination.id);
+  export async function exportMembers(destination: Destination, force = false) {
+    if (destination.recordCollection === "group") {
+      const group = await destination.$get("group");
+      if (group) return group.run(force, destination.id);
+    } else if (destination.recordCollection === "model") {
+      const model = await destination.$get("model");
+      if (model) return model.run(force, destination.id);
+    } else {
+      throw new Error(
+        `cannot export members for a ${destination.recordCollection}`
+      );
+    }
   }
 
   /**

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -25,9 +25,10 @@ import { RecordPropertyOps } from "./recordProperty";
 import { destinationTypeConversions } from "../destinationTypeConversions";
 import { GroupMember } from "../../models/GroupMember";
 import { ExportProcessor } from "../../models/ExportProcessor";
+import { GrouparooModel } from "../../models/GrouparooModel";
+import { Run } from "../../models/Run";
 import { Option } from "../../models/Option";
 import { RunOps } from "./runs";
-import { GrouparooModel, Run } from "../..";
 
 function deepStrictEqualBoolean(a: any, b: any): boolean {
   try {

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -83,7 +83,9 @@ export namespace DestinationOps {
       }
     } else if (collection === "model") {
       const model = await GrouparooModel.findById(
-        collectionId ?? destination.modelId
+        !collectionId || collectionId === NullKey
+          ? destination.modelId
+          : collectionId
       );
       if (model.id !== destination.modelId) {
         throw new Error(

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -14,7 +14,7 @@ import {
   ExportedRecord,
   ExportRecordsPluginMethod,
   ErrorWithRecordId,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
   DestinationMappingOptionsMethodResponse,
   ProcessExportsForRecordIds,
   ExportRecordsPluginMethodResponse,
@@ -72,6 +72,18 @@ export namespace DestinationOps {
       return { oldRun, newRun }; // no changes
     }
 
+    if (groupId && groupId !== nullKey) {
+      const group = await Group.findById(groupId);
+      if (group.state === "deleted") {
+        throw new Error(`cannot track deleted Group "${group.name}"`);
+      }
+      if (destination.modelId !== group.modelId) {
+        throw new Error(
+          `destination ${destination.id} and group ${group.id} do not share the same modelId`
+        );
+      }
+    }
+
     oldRun = await runDestinationCollection(destination, false); // old collection
     await destination.update({
       collection: collection === nullKey ? null : collection,
@@ -118,7 +130,7 @@ export namespace DestinationOps {
 
       mappedRecordProperties[k] = collection;
 
-      let destinationType: DestinationMappingOptionsResponseTypes = "any";
+      let destinationType: DestinationMappingOptionsResponseType = "any";
       for (const j in destinationMappingOptions.properties.required) {
         const destinationProperty =
           destinationMappingOptions.properties.required[j];
@@ -952,7 +964,7 @@ export namespace DestinationOps {
     for (const k in rawProperties) {
       const type: string = rawProperties[k].type;
       const value = _export[key][k];
-      let destinationType: DestinationMappingOptionsResponseTypes = "any";
+      let destinationType: DestinationMappingOptionsResponseType = "any";
 
       for (const j in destinationMappingOptions.properties.required) {
         const destinationProperty =
@@ -991,7 +1003,7 @@ export namespace DestinationOps {
   export function formatOutgoingRecordProperties(
     value: any,
     grouparooType: string,
-    destinationType: DestinationMappingOptionsResponseTypes
+    destinationType: DestinationMappingOptionsResponseType
   ) {
     if (!grouparooType) return null;
     if (value === null || value === undefined) return value;

--- a/core/src/modules/ops/group.ts
+++ b/core/src/modules/ops/group.ts
@@ -10,50 +10,6 @@ import { RecordOps } from "./record";
 
 export namespace GroupOps {
   /**
-   * Create a Run for this Group
-   */
-  export async function run(
-    group: Group,
-    force = false,
-    destinationId?: string
-  ) {
-    if (process.env.GROUPAROO_RUN_MODE === "cli:validate") return;
-    if (process.env.GROUPAROO_RUN_MODE === "cli:config") return;
-
-    await group.stopPreviousRuns();
-
-    if (group.state !== "deleted") {
-      await group.update({ state: "updating" });
-    }
-
-    const run = await Run.create({
-      creatorId: group.id,
-      creatorType: "group",
-      state: "running",
-      destinationId,
-      force,
-    });
-
-    return run;
-  }
-
-  /**
-   * Stop previous Runs for this Group
-   */
-  export async function stopPreviousRuns(group: Group) {
-    const previousRuns = await Run.findAll({
-      where: {
-        creatorId: group.id,
-        state: "running",
-      },
-    });
-
-    for (const i in previousRuns) {
-      await previousRuns[i].stop();
-    }
-  }
-
-  /**
    * Given a GrouparooRecord, create an import to recalculate its Group Membership.  Optionally re-import all GrouparooRecord Properties with `force`
    */
   export async function updateRecords(

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -610,10 +610,11 @@ export namespace RecordOps {
   ) {
     const groups = await record.$get("groups");
 
-    const destinations = await Destination.destinationsForGroups([
-      ...oldGroups,
-      ...groups,
-    ]);
+    const destinations = await Destination.relevantFor(
+      record,
+      oldGroups,
+      groups
+    );
 
     // We want to find destinations which aren't in the above set and already have an Export for this GrouparooRecord.
     // That's a sign that the GrouparooRecord is about to get a toDelete export

--- a/core/src/modules/ops/runs.ts
+++ b/core/src/modules/ops/runs.ts
@@ -190,8 +190,8 @@ export namespace RunOps {
     if (run.state === "stopped") return 100;
 
     if (run.creatorType === "group") {
-      if (run.groupMethod === "complete") return 99;
-      if (!run.groupMethod) return 0; // we are exporting the group to CSV or not yet set
+      if (run.method === "complete") return 99;
+      if (!run.method) return 0; // we are exporting the group to CSV or not yet set
 
       const group = await Group.findById(run.creatorId);
       let totalGroupMembers =
@@ -230,7 +230,7 @@ export namespace RunOps {
               (totalGroupMembers > 0 ? totalGroupMembers : 1))
         );
 
-        if (!run.groupMethod.match(/remove/i)) {
+        if (!run.method.match(/remove/i)) {
           percentComplete = Math.floor(percentComplete / 2);
         } else {
           percentComplete = 49 + Math.floor(percentComplete / 2);

--- a/core/src/modules/statusReporters.ts
+++ b/core/src/modules/statusReporters.ts
@@ -241,7 +241,7 @@ export namespace StatusReporters {
         const percentComplete = run.percentComplete;
         const highWaterMark = run.highWaterMark
           ? Object.values(run.highWaterMark)[0]
-          : run.groupHighWaterMark;
+          : null;
 
         metrics.push({
           collection: "percentComplete",

--- a/core/src/tasks/destination/destroy.ts
+++ b/core/src/tasks/destination/destroy.ts
@@ -32,7 +32,7 @@ export class DestinationDestroy extends CLSTask {
       (destination.groupId && destination.collection === "group") ||
       destination.collection === "model"
     ) {
-      const unTrackResponse = await destination.updateTracking(null, null);
+      const unTrackResponse = await destination.updateTracking("none");
       run = unTrackResponse.oldRun;
     } else {
       run = await Run.scope(null).findOne({

--- a/core/src/tasks/destination/destroy.ts
+++ b/core/src/tasks/destination/destroy.ts
@@ -28,12 +28,15 @@ export class DestinationDestroy extends CLSTask {
     let run: Run;
     // untrack the group, if we are still tracking one
     // this will trigger a run to export all group members one last time
-    if (destination.groupId || destination.modelId) {
+    if (
+      (destination.groupId && destination.collection === "group") ||
+      destination.collection === "model"
+    ) {
       const unTrackResponse = await destination.updateTracking(null, null);
       run = unTrackResponse.oldRun;
     } else {
       run = await Run.scope(null).findOne({
-        where: { destinationId: params.destinationId },
+        where: { destinationId: destination.id },
         order: [["updatedAt", "desc"]],
         limit: 1,
       });

--- a/core/src/tasks/destination/destroy.ts
+++ b/core/src/tasks/destination/destroy.ts
@@ -3,7 +3,6 @@ import { Destination } from "../../models/Destination";
 import { Run } from "../../models/Run";
 import { Export } from "../../models/Export";
 import { CLSTask } from "../../classes/tasks/clsTask";
-import { CLS } from "../../modules/cls";
 
 export class DestinationDestroy extends CLSTask {
   constructor() {
@@ -29,8 +28,9 @@ export class DestinationDestroy extends CLSTask {
     let run: Run;
     // untrack the group, if we are still tracking one
     // this will trigger a run to export all group members one last time
-    if (destination.groupId) {
-      run = await destination.unTrackGroup();
+    if (destination.groupId || destination.modelId) {
+      const unTrackResponse = await destination.updateTracking(null, null);
+      run = unTrackResponse.oldRun;
     } else {
       run = await Run.scope(null).findOne({
         where: { destinationId: params.destinationId },

--- a/core/src/tasks/group/destroy.ts
+++ b/core/src/tasks/group/destroy.ts
@@ -48,9 +48,9 @@ export class GroupDestroy extends CLSTask {
         creatorId: group.id,
         creatorType: "group",
         state: "running",
-        groupMemberOffset: 0,
-        groupMemberLimit: limit,
-        groupMethod: "runRemoveGroupMembers",
+        memberOffset: 0,
+        memberLimit: limit,
+        method: "runRemoveGroupMembers",
       });
     }
 

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -34,10 +34,13 @@ export class RunGroup extends CLSTask {
 
     const force = run.force || false;
     const destinationId = run.destinationId;
-    const method = run.groupMethod || "runAddGroupMembers";
-    const highWaterMark: number = run.groupHighWaterMark || 0;
-    const offset: number = run.groupMemberOffset || 0;
-    const limit: number = run.groupMemberLimit || config.batchSize.imports;
+    const method = run.method || "runAddGroupMembers";
+    const highWaterMark: number =
+      run.highWaterMark && Object.values(run.highWaterMark)[0]
+        ? parseInt(Object.values(run.highWaterMark)[0] as string)
+        : 0;
+    const offset: number = run.memberOffset || 0;
+    const limit: number = run.memberLimit || config.batchSize.imports;
 
     let groupMembersCount = 0;
     let nextHighWaterMark = 0;
@@ -82,10 +85,10 @@ export class RunGroup extends CLSTask {
     }
 
     await run.update({
-      groupMemberLimit: limit,
-      groupMemberOffset: nextOffset,
-      groupHighWaterMark: nextHighWaterMark,
-      groupMethod: nextMethod,
+      memberLimit: limit,
+      memberOffset: nextOffset,
+      highWaterMark: { group: nextHighWaterMark },
+      method: nextMethod,
       force,
     });
 

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -100,9 +100,7 @@ export class RunGroup extends CLSTask {
       groupMembersCount === 0
     ) {
       await run.afterBatch("complete");
-      if (group.state !== "deleted") {
-        await group.update({ state: "ready" });
-      }
+      if (group.state !== "deleted") await group.update({ state: "ready" });
     } else {
       await run.afterBatch();
     }

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -67,7 +67,7 @@ export class RunGroup extends CLSTask {
     } else if (method === "complete") {
       // waiting for imports...
     } else {
-      throw new Error(`${method} is not now a known method`);
+      throw new Error(`${method} is not a known method`);
     }
 
     let nextMethod = method;

--- a/core/src/tasks/grouparooModel/run.ts
+++ b/core/src/tasks/grouparooModel/run.ts
@@ -82,7 +82,12 @@ export class RunInternalRun extends CLSTask {
       groupMemberOffset: offset + records.length,
     });
 
-    if (records.length === 0) {
+    const pendingImports = await run.$count("imports", {
+      where: { groupsUpdatedAt: null },
+    });
+
+    // we don't want to denote the group as ready until all the imports are imported
+    if (records.length === 0 && pendingImports === 0) {
       await run.afterBatch("complete");
     } else {
       await run.afterBatch();

--- a/core/src/tasks/grouparooModel/run.ts
+++ b/core/src/tasks/grouparooModel/run.ts
@@ -63,8 +63,13 @@ export class RunInternalRun extends CLSTask {
       for (const record of records) {
         const oldRecordProperties = await record.simplifiedProperties();
         const oldGroupIds = record.groupMembers.map((gm) => gm.groupId);
+        const data = run.destinationId
+          ? { _meta: { destinationId: run.destinationId } }
+          : {};
 
         bulkImports.push({
+          rawData: data,
+          data: data,
           recordId: record.id,
           recordAssociatedAt: now,
           oldRecordProperties,

--- a/core/src/tasks/grouparooModel/run.ts
+++ b/core/src/tasks/grouparooModel/run.ts
@@ -29,8 +29,8 @@ export class RunInternalRun extends CLSTask {
     if (!run) return;
     if (run.state === "stopped") return;
 
-    const offset: number = run.groupMemberOffset || 0;
-    const limit: number = run.groupMemberLimit || config.batchSize.imports;
+    const offset: number = run.memberOffset || 0;
+    const limit: number = run.memberLimit || config.batchSize.imports;
 
     const model = await GrouparooModel.findOne({
       where: { id: run.creatorId },
@@ -78,8 +78,8 @@ export class RunInternalRun extends CLSTask {
     }
 
     await run.update({
-      groupMemberLimit: limit,
-      groupMemberOffset: offset + records.length,
+      memberLimit: limit,
+      memberOffset: offset + records.length,
     });
 
     const pendingImports = await run.$count("imports", {

--- a/core/src/tasks/record/export.ts
+++ b/core/src/tasks/record/export.ts
@@ -56,7 +56,8 @@ export class RecordExport extends RetryableTask {
             })
           : [];
 
-      const destinations = await Destination.destinationsForGroups(
+      const destinations = await Destination.relevantFor(
+        record,
         oldGroups,
         newGroups
       );

--- a/core/src/tasks/run/internalRun.ts
+++ b/core/src/tasks/run/internalRun.ts
@@ -28,8 +28,8 @@ export class RunInternalRun extends CLSTask {
     if (!run) return;
     if (run.state === "stopped") return;
 
-    const offset: number = run.groupMemberOffset || 0;
-    const limit: number = run.groupMemberLimit || config.batchSize.imports;
+    const offset: number = run.memberOffset || 0;
+    const limit: number = run.memberLimit || config.batchSize.imports;
 
     const records = await GrouparooRecord.findAll({
       order: [["createdAt", "asc"]],
@@ -88,8 +88,8 @@ export class RunInternalRun extends CLSTask {
     }
 
     await run.update({
-      groupMemberLimit: limit,
-      groupMemberOffset: offset + records.length,
+      memberLimit: limit,
+      memberOffset: offset + records.length,
     });
 
     if (records.length === 0) {

--- a/core/src/tasks/run/tick.ts
+++ b/core/src/tasks/run/tick.ts
@@ -25,7 +25,7 @@ export class RunsTick extends CLSTask {
       const args = { runId: run.id };
       let taskName = "";
 
-      if (run.groupMethod === "internalRun") {
+      if (run.method === "internalRun") {
         taskName = "run:internalRun";
       } else if (run.creatorType === "group") {
         taskName = "group:run";

--- a/core/src/tasks/run/tick.ts
+++ b/core/src/tasks/run/tick.ts
@@ -21,9 +21,7 @@ export class RunsTick extends CLSTask {
     });
     let runsEnqueued = 0;
 
-    for (const i in runs) {
-      const run = runs[i];
-
+    for (const run of runs) {
       const args = { runId: run.id };
       let taskName = "";
 
@@ -33,6 +31,8 @@ export class RunsTick extends CLSTask {
         taskName = "group:run";
       } else if (run.creatorType === "schedule") {
         taskName = "schedule:run";
+      } else if (run.creatorType === "grouparooModel") {
+        taskName = "grouparooModel:run";
       } else {
         throw new Error(`cannot tick run ${run.id}`);
       }

--- a/plugins/@grouparoo/braze/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/braze/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "braze-export-users",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "braze_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/customerio/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/customerio/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "customerio-export-customers",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "customerio_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/eloqua/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/eloqua/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "eloqua-export-contacts",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "eloqua_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/eloqua/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/eloqua/src/lib/export/destinationMappingOptions.ts
@@ -1,6 +1,6 @@
 import {
   DestinationMappingOptionsMethod,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
 } from "@grouparoo/core";
 
 import { connect } from "../connect";
@@ -35,15 +35,15 @@ export const destinationMappingOptions: DestinationMappingOptionsMethod =
 const mapTypesToGrouparoo = (
   eloquaType: string,
   fieldName: string
-): DestinationMappingOptionsResponseTypes => {
-  const overrides: Record<string, DestinationMappingOptionsResponseTypes> = {
+): DestinationMappingOptionsResponseType => {
+  const overrides: Record<string, DestinationMappingOptionsResponseType> = {
     emailAddress: "email",
     businessPhone: "phoneNumber",
     mobilePhone: "phoneNumber",
   };
   if (overrides[fieldName]) return overrides[fieldName];
 
-  const map: Record<string, DestinationMappingOptionsResponseTypes> = {
+  const map: Record<string, DestinationMappingOptionsResponseType> = {
     string: "string",
     date: "date",
     number: "number",
@@ -57,7 +57,7 @@ const mapTypesToGrouparoo = (
 
 export const getRequiredFields = (): Array<{
   key: string;
-  type: DestinationMappingOptionsResponseTypes;
+  type: DestinationMappingOptionsResponseType;
 }> => {
   return [{ key: "emailAddress", type: "email" }];
 };
@@ -71,7 +71,7 @@ export const getContactFields = async (
 ): Promise<
   Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     statement: string;
     important?: boolean;
   }>
@@ -87,7 +87,7 @@ export const getAllContactFields = async (
 ): Promise<
   Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     statement: string;
     important?: boolean;
   }>
@@ -101,7 +101,7 @@ export const getAllContactFields = async (
       continue;
     }
     if (!field["hasReadOnlyConstraint"]) {
-      const type: DestinationMappingOptionsResponseTypes = mapTypesToGrouparoo(
+      const type: DestinationMappingOptionsResponseType = mapTypesToGrouparoo(
         field["dataType"],
         key
       );

--- a/plugins/@grouparoo/facebook/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/facebook/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "facebook-export-audiences-custom",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "facebookApp"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       syncMode: {{{syncMode}}}, // How should Grouparoo updateFacebook audiences? Options: "sync", "additive"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
 

--- a/plugins/@grouparoo/facebook/src/lib/export/fields.ts
+++ b/plugins/@grouparoo/facebook/src/lib/export/fields.ts
@@ -1,5 +1,5 @@
 import {
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
   DestinationOptionsMethodResponse,
 } from "@grouparoo/core";
 import { log } from "actionhero";
@@ -81,11 +81,11 @@ export const getMappingFields = (
 ): {
   required: Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
   }>;
   known: Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     important?: boolean;
   }>;
 } => {

--- a/plugins/@grouparoo/hubspot/__tests__/integration/hubspot-export.ts
+++ b/plugins/@grouparoo/hubspot/__tests__/integration/hubspot-export.ts
@@ -252,12 +252,13 @@ describe("integration/runs/hubspot", () => {
       csrfToken,
       id: destination.id,
       destinationGroupMemberships,
-      trackedGroupId: group.id,
+      groupId: group.id,
+      collection: "group",
     };
     const { error, destination: _destination } =
       await specHelper.runAction<DestinationEdit>("destination:edit", session);
     expect(error).toBeUndefined();
-    expect(_destination.destinationGroup.id).toBe(group.id);
+    expect(_destination.group.id).toBe(group.id);
     expect(_destination.destinationGroupMemberships).toEqual([
       {
         groupId: group.id,

--- a/plugins/@grouparoo/hubspot/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/hubspot/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "hubspot-export-contacts",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "hubspot_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/hubspot/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/export/destinationMappingOptions.ts
@@ -1,6 +1,6 @@
 import {
   DestinationMappingOptionsMethod,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
   SimpleAppOptions,
 } from "@grouparoo/core";
 import { connect } from "./../connect";
@@ -59,7 +59,7 @@ const mapTypesFromHubspotToGrouparoo = (fieldKey, hubspotType) => {
 
 export const getRequiredFields = (): Array<{
   key: string;
-  type: DestinationMappingOptionsResponseTypes;
+  type: DestinationMappingOptionsResponseType;
 }> => {
   return [{ key: "email", type: "email" }];
 };
@@ -74,7 +74,7 @@ export const getUserFields = async (
 ): Promise<
   Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     important?: boolean;
   }>
 > => {
@@ -82,7 +82,7 @@ export const getUserFields = async (
   const out = [];
   for (const field of fields) {
     if (field["name"] !== "email" && !field["readOnlyValue"]) {
-      const type: DestinationMappingOptionsResponseTypes =
+      const type: DestinationMappingOptionsResponseType =
         mapTypesFromHubspotToGrouparoo(field["name"], field["type"]);
       if (type) {
         out.push({

--- a/plugins/@grouparoo/intercom/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/intercom/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "intercom-export-contacts",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "intercom_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/intercom/src/lib/export-contacts/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/intercom/src/lib/export-contacts/destinationMappingOptions.ts
@@ -1,6 +1,6 @@
 import {
   DestinationMappingOptionsMethod,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
   objectCache,
   SimpleDestinationOptions,
 } from "@grouparoo/core";
@@ -59,7 +59,7 @@ const getRequiredFields = (
   destinationOptions: SimpleDestinationOptions
 ): Array<{
   key: string;
-  type: DestinationMappingOptionsResponseTypes;
+  type: DestinationMappingOptionsResponseType;
 }> => {
   const { creationMode } = destinationOptions;
   const required = [];
@@ -89,7 +89,7 @@ const getKnownAttributes = async (
 ): Promise<
   Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     important?: boolean;
   }>
 > => {
@@ -110,7 +110,7 @@ export const fetchKnownAttributes = async (
 ): Promise<
   Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     important?: boolean;
   }>
 > => {
@@ -134,7 +134,7 @@ export const fetchKnownAttributes = async (
       continue;
     }
     const important = field.custom || importantKeys.includes(key);
-    const type: DestinationMappingOptionsResponseTypes =
+    const type: DestinationMappingOptionsResponseType =
       mapTypesFromIntercomToGrouparoo(key, field.data_type);
     if (type) {
       out.push({ key, type, important });

--- a/plugins/@grouparoo/iterable/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/iterable/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "iterable-export-users",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "iterable_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/iterable/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/iterable/src/lib/export/destinationMappingOptions.ts
@@ -1,6 +1,6 @@
 import {
   DestinationMappingOptionsMethod,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
 } from "@grouparoo/core";
 import { connect } from "./../connect";
 
@@ -34,7 +34,7 @@ export const destinationMappingOptions: DestinationMappingOptionsMethod =
 
 export const getRequiredFields = (): Array<{
   key: string;
-  type: DestinationMappingOptionsResponseTypes;
+  type: DestinationMappingOptionsResponseType;
 }> => {
   return [{ key: "email", type: "email" }];
 };
@@ -67,7 +67,7 @@ export const getUserFields = async (
 ): Promise<
   Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     important?: boolean;
   }>
 > => {
@@ -76,7 +76,7 @@ export const getUserFields = async (
 
   for (const [key, value] of Object.entries(fields["fields"])) {
     if (value !== "object" && key !== "email") {
-      const type: DestinationMappingOptionsResponseTypes =
+      const type: DestinationMappingOptionsResponseType =
         mapTypesFromIterableToGrouparoo(key, value);
       if (type) {
         out.push({ key, type, important: isImportant(key) });

--- a/plugins/@grouparoo/logger/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/logger/public/templates/destination/{{{id}}}.js.template
@@ -7,7 +7,9 @@ exports.default = async function buildConfig() {
       type: "logger-export-records",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "iterable_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
+      syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.

--- a/plugins/@grouparoo/logger/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/logger/public/templates/destination/{{{id}}}.js.template
@@ -9,7 +9,6 @@ exports.default = async function buildConfig() {
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
       collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
-      syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
       // Mappings are how you choose which properties to export to this destination.
       // Keys are the name to display in the destination, values are the IDs of the Properties in Grouparoo.

--- a/plugins/@grouparoo/logger/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/logger/src/initializers/plugin.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { Initializer } from "actionhero";
-import { DestinationSyncMode, plugin } from "@grouparoo/core";
+import { plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
 import { appOptions } from "./../lib/appOptions";
@@ -22,9 +22,6 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
-    const defaultSyncMode: DestinationSyncMode = "sync";
-
     plugin.registerPlugin({
       name: packageJSON.name,
       icon: "/public/@grouparoo/logger/log.svg",
@@ -32,12 +29,9 @@ export class Plugins extends Initializer {
         new AppTemplate("logger", [
           path.join(templateRoot, "app", "*.template"),
         ]),
-        new DestinationTemplate(
-          "logger",
-          [path.join(templateRoot, "destination", "*.template")],
-          syncModes,
-          defaultSyncMode
-        ),
+        new DestinationTemplate("logger", [
+          path.join(templateRoot, "destination", "*.template"),
+        ]),
       ],
       apps: [
         {
@@ -70,7 +64,6 @@ export class Plugins extends Initializer {
           direction: "export",
           description: "Export Records to a log file as JSON.",
           app: "logger",
-          syncModes,
           options: [],
           methods: {
             exportRecords,

--- a/plugins/@grouparoo/logger/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/logger/src/initializers/plugin.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { Initializer } from "actionhero";
-import { plugin } from "@grouparoo/core";
+import { DestinationSyncMode, plugin } from "@grouparoo/core";
 
 import { test } from "./../lib/test";
 import { appOptions } from "./../lib/appOptions";
@@ -22,6 +22,9 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
+    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const defaultSyncMode: DestinationSyncMode = "sync";
+
     plugin.registerPlugin({
       name: packageJSON.name,
       icon: "/public/@grouparoo/logger/log.svg",
@@ -29,9 +32,12 @@ export class Plugins extends Initializer {
         new AppTemplate("logger", [
           path.join(templateRoot, "app", "*.template"),
         ]),
-        new DestinationTemplate("logger", [
-          path.join(templateRoot, "destination", "*.template"),
-        ]),
+        new DestinationTemplate(
+          "logger",
+          [path.join(templateRoot, "destination", "*.template")],
+          syncModes,
+          defaultSyncMode
+        ),
       ],
       apps: [
         {
@@ -64,6 +70,7 @@ export class Plugins extends Initializer {
           direction: "export",
           description: "Export Records to a log file as JSON.",
           app: "logger",
+          syncModes,
           options: [],
           methods: {
             exportRecords,

--- a/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-export-contacts-by-id.ts
+++ b/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-export-contacts-by-id.ts
@@ -277,12 +277,13 @@ describe("integration/runs/mailchimp-export-id", () => {
       csrfToken,
       id: destination.id,
       destinationGroupMemberships,
-      trackedGroupId: group.id,
+      groupId: group.id,
+      collection: "group",
     };
     const { error, destination: _destination } =
       await specHelper.runAction<DestinationEdit>("destination:edit", session);
     expect(error).toBeUndefined();
-    expect(_destination.destinationGroup.id).toBe(group.id);
+    expect(_destination.group.id).toBe(group.id);
     expect(_destination.destinationGroupMemberships).toEqual([
       {
         groupId: group.id,

--- a/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-export-contacts.ts
+++ b/plugins/@grouparoo/mailchimp/__tests__/integration/mailchimp-export-contacts.ts
@@ -262,12 +262,13 @@ describe("integration/runs/mailchimp-export-contacts", () => {
       csrfToken,
       id: destination.id,
       destinationGroupMemberships,
-      trackedGroupId: group.id,
+      groupId: group.id,
+      collection: "group",
     };
     const { error, destination: _destination } =
       await specHelper.runAction<DestinationEdit>("destination:edit", session);
     expect(error).toBeUndefined();
-    expect(_destination.destinationGroup.id).toBe(group.id);
+    expect(_destination.group.id).toBe(group.id);
     expect(_destination.destinationGroupMemberships).toEqual([
       {
         groupId: group.id,

--- a/plugins/@grouparoo/mailchimp/public/templates/destination/email/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/destination/email/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "mailchimp-export-contacts",
       appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "mailchimp_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/mailchimp/public/templates/destination/id/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailchimp/public/templates/destination/id/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "mailchimp-export-contacts-by-id",
       appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "mailchimp_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: only "enrich" is accepted.
 

--- a/plugins/@grouparoo/mailjet/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mailjet/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "mailjet-export-contacts",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "mailjet_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/mailjet/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/mailjet/src/lib/export/destinationMappingOptions.ts
@@ -1,6 +1,6 @@
 import {
   DestinationMappingOptionsMethod,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
   SimpleAppOptions,
 } from "@grouparoo/core";
 import { connect } from "./../connect";
@@ -53,7 +53,7 @@ const mapTypesFromMailjetToGrouparoo = (fieldKey, mailjetType) => {
 
 export const getRequiredFields = (): Array<{
   key: string;
-  type: DestinationMappingOptionsResponseTypes;
+  type: DestinationMappingOptionsResponseType;
 }> => {
   return [{ key: "Email", type: "email" }];
 };
@@ -67,14 +67,14 @@ export const getUserFields = async (
 ): Promise<
   Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     important?: boolean;
   }>
 > => {
   const fields = await client.getAllContactsProperties();
   const out = [];
   for (const field of fields) {
-    const type: DestinationMappingOptionsResponseTypes =
+    const type: DestinationMappingOptionsResponseType =
       mapTypesFromMailjetToGrouparoo(field["Name"], field["Datatype"]);
     if (type) {
       out.push({

--- a/plugins/@grouparoo/marketo/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/marketo/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "marketo-export-leads",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "marketo_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/marketo/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/marketo/src/lib/export/destinationMappingOptions.ts
@@ -1,6 +1,6 @@
 import {
   DestinationMappingOptionsMethod,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
 } from "@grouparoo/core";
 import { connect } from "./../connect";
 import { log } from "actionhero";
@@ -72,11 +72,11 @@ export const getFields = async (
 ): Promise<{
   required: Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
   }>;
   known: Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     important?: boolean;
   }>;
 }> => {

--- a/plugins/@grouparoo/mixpanel/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mixpanel/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "mixpanel-export-profiles",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "iterable_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -357,12 +357,13 @@ describe("integration/runs/mysql", () => {
       csrfToken,
       id: destination.id,
       destinationGroupMemberships,
-      trackedGroupId: group.id,
+      groupId: group.id,
+      collection: "group",
     };
     const { error, destination: _destination } =
       await specHelper.runAction<DestinationEdit>("destination:edit", session);
     expect(error).toBeUndefined();
-    expect(_destination.destinationGroup.id).toBe(group.id);
+    expect(_destination.group.id).toBe(group.id);
     expect(_destination.destinationGroupMemberships).toEqual([
       {
         groupId: group.id,

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -377,6 +377,7 @@ describe("integration/runs/mysql", () => {
     session.params = {
       csrfToken,
       id: destination.id,
+      syncMode: "sync",
       mapping: {
         id: "userId",
         customer_email: "email",

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-table-import.ts
@@ -377,7 +377,6 @@ describe("integration/runs/mysql", () => {
     session.params = {
       csrfToken,
       id: destination.id,
-      syncMode: "sync",
       mapping: {
         id: "userId",
         customer_email: "email",

--- a/plugins/@grouparoo/mysql/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mysql/public/templates/destination/{{{id}}}.js.template
@@ -9,7 +9,6 @@ exports.default = async function buildConfig() {
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
       collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
-      syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
       options: {
         table: 'users_export', // The table to write Records to

--- a/plugins/@grouparoo/mysql/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mysql/public/templates/destination/{{{id}}}.js.template
@@ -7,7 +7,9 @@ exports.default = async function buildConfig() {
       type: "mysql-export-records",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "data_warehouse"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
+      syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 
       options: {
         table: 'users_export', // The table to write Records to

--- a/plugins/@grouparoo/mysql/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mysql/src/initializers/plugin.ts
@@ -1,5 +1,5 @@
 import { Initializer } from "actionhero";
-import { plugin } from "@grouparoo/core";
+import { DestinationSyncMode, plugin } from "@grouparoo/core";
 import path from "path";
 
 import { test } from "./../lib/test";
@@ -38,6 +38,9 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
+    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const defaultSyncMode: DestinationSyncMode = "sync";
+
     plugin.registerPlugin({
       name: packageJSON.name,
       icon: "/public/@grouparoo/mysql/mysql.png",
@@ -49,9 +52,12 @@ export class Plugins extends Initializer {
         new TablePropertyTemplate("mysql"),
         new QuerySourceTemplate("mysql"),
         new QueryPropertyTemplate("mysql"),
-        new DestinationTemplate("mysql", [
-          path.join(templateRoot, "destination", "*.template"),
-        ]),
+        new DestinationTemplate(
+          "mysql",
+          [path.join(templateRoot, "destination", "*.template")],
+          syncModes,
+          defaultSyncMode
+        ),
       ],
       apps: [
         {
@@ -105,6 +111,7 @@ export class Plugins extends Initializer {
           description:
             "Export Records to a MySQL table.  Groups will be exported to a secondary table linked by a foreign key.",
           app: "mysql",
+          syncModes,
           options: [
             {
               key: "table",

--- a/plugins/@grouparoo/mysql/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mysql/src/initializers/plugin.ts
@@ -1,5 +1,5 @@
 import { Initializer } from "actionhero";
-import { DestinationSyncMode, plugin } from "@grouparoo/core";
+import { plugin } from "@grouparoo/core";
 import path from "path";
 
 import { test } from "./../lib/test";
@@ -38,9 +38,6 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
-    const defaultSyncMode: DestinationSyncMode = "sync";
-
     plugin.registerPlugin({
       name: packageJSON.name,
       icon: "/public/@grouparoo/mysql/mysql.png",
@@ -52,12 +49,9 @@ export class Plugins extends Initializer {
         new TablePropertyTemplate("mysql"),
         new QuerySourceTemplate("mysql"),
         new QueryPropertyTemplate("mysql"),
-        new DestinationTemplate(
-          "mysql",
-          [path.join(templateRoot, "destination", "*.template")],
-          syncModes,
-          defaultSyncMode
-        ),
+        new DestinationTemplate("mysql", [
+          path.join(templateRoot, "destination", "*.template"),
+        ]),
       ],
       apps: [
         {
@@ -111,7 +105,6 @@ export class Plugins extends Initializer {
           description:
             "Export Records to a MySQL table.  Groups will be exported to a secondary table linked by a foreign key.",
           app: "mysql",
-          syncModes,
           options: [
             {
               key: "table",

--- a/plugins/@grouparoo/mysql/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/mysql/src/lib/export/destinationMappingOptions.ts
@@ -1,6 +1,6 @@
 import {
   DestinationMappingOptionsMethod,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
 } from "@grouparoo/core";
 
 export const destinationMappingOptions: DestinationMappingOptionsMethod =
@@ -12,7 +12,7 @@ export const destinationMappingOptions: DestinationMappingOptionsMethod =
 
     const columns: Array<{
       key: string;
-      type: DestinationMappingOptionsResponseTypes;
+      type: DestinationMappingOptionsResponseType;
       important: boolean;
     }> = [];
     for (const i in rows) {

--- a/plugins/@grouparoo/onesignal/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/onesignal/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "onesignal-export-users",
       appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "onesignal_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "enrich"
 

--- a/plugins/@grouparoo/pardot/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/pardot/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "pardot-export-prospects",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "pardot_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/pardot/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/pardot/src/lib/export/destinationMappingOptions.ts
@@ -1,7 +1,7 @@
 import {
   DestinationMappingOptionsMethod,
   DestinationMappingOptionsResponseProperty,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
 } from "@grouparoo/core";
 
 import PardotClient from "../client";
@@ -66,7 +66,7 @@ export const destinationMappingOptions: DestinationMappingOptionsMethod =
 
 const mapTypesToGrouparoo = (
   pardotType: string
-): DestinationMappingOptionsResponseTypes => {
+): DestinationMappingOptionsResponseType => {
   // https://help.salesforce.com/articleView?id=sf.pardot_field_types.htm&type=5
 
   const map = {

--- a/plugins/@grouparoo/pipedrive/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/pipedrive/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "pipedrive-export-persons",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "pipedrive_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/pipedrive/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/pipedrive/src/lib/export/destinationMappingOptions.ts
@@ -1,6 +1,6 @@
 import {
   DestinationMappingOptionsMethod,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
   SimpleAppOptions,
   objectCache,
 } from "@grouparoo/core";
@@ -52,16 +52,16 @@ export const destinationMappingOptions: DestinationMappingOptionsMethod =
 const mapTypesToGrouparoo = (
   pipedriveType: string,
   fieldName: string
-): DestinationMappingOptionsResponseTypes => {
+): DestinationMappingOptionsResponseType => {
   // https://pipedrive.readme.io/docs/core-api-concepts-custom-fields#section-types-of-custom-fields
 
-  const overrides: Record<string, DestinationMappingOptionsResponseTypes> = {
+  const overrides: Record<string, DestinationMappingOptionsResponseType> = {
     Email: "email",
   };
 
   if (overrides[fieldName]) return overrides[fieldName];
 
-  const map: Record<string, DestinationMappingOptionsResponseTypes> = {
+  const map: Record<string, DestinationMappingOptionsResponseType> = {
     varchar: "string",
     varchar_auto: "string",
     text: "string",
@@ -93,7 +93,7 @@ const mapTypesToGrouparoo = (
 type KnownPersonField = {
   key: string;
   pipedriveKey: string;
-  type: DestinationMappingOptionsResponseTypes;
+  type: DestinationMappingOptionsResponseType;
   required: boolean;
   important: boolean;
   groupMembershipField: boolean;

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-table-import.ts
@@ -348,12 +348,13 @@ describe("integration/runs/postgres", () => {
       csrfToken,
       id: destination.id,
       destinationGroupMemberships,
-      trackedGroupId: group.id,
+      groupId: group.id,
+      collection: "group",
     };
     const { error, destination: _destination } =
       await specHelper.runAction<DestinationEdit>("destination:edit", session);
     expect(error).toBeUndefined();
-    expect(_destination.destinationGroup.id).toBe(group.id);
+    expect(_destination.group.id).toBe(group.id);
     expect(_destination.destinationGroupMemberships).toEqual([
       {
         groupId: group.id,

--- a/plugins/@grouparoo/postgres/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/postgres/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "postgres-export-records",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "data_warehouse"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/postgres/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/postgres/src/lib/export/destinationMappingOptions.ts
@@ -1,6 +1,6 @@
 import {
   DestinationMappingOptionsMethod,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
 } from "@grouparoo/core";
 import format from "pg-format";
 
@@ -17,7 +17,7 @@ export const destinationMappingOptions: DestinationMappingOptionsMethod =
 
     const columns: Array<{
       key: string;
-      type: DestinationMappingOptionsResponseTypes;
+      type: DestinationMappingOptionsResponseType;
       important: boolean;
     }> = [];
     for (const i in rows) {

--- a/plugins/@grouparoo/redshift/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/redshift/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "redshift-export-records",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "data_warehouse"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `appId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/sailthru/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/sailthru/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "sailthru-export-users",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "sailthru_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/salesforce/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/salesforce/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "salesforce-export-objects",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "salesforce_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/salesforce/src/lib/export/mapping.ts
+++ b/plugins/@grouparoo/salesforce/src/lib/export/mapping.ts
@@ -1,5 +1,5 @@
 import {
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
   SimpleAppOptions,
   DestinationMappingOptionsMethodResponse,
 } from "@grouparoo/core";
@@ -153,11 +153,11 @@ const extractFields = (
 ): {
   required: Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
   }>;
   known: Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     important?: boolean;
   }>;
 } => {
@@ -215,11 +215,11 @@ export const getFields = (
 ): {
   required: Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
   }>;
   known: Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     important?: boolean;
   }>;
 } => {

--- a/plugins/@grouparoo/sendgrid/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/sendgrid/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "sendgrid-export-marketing-contacts",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "sendgrid_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/sendgrid/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/sendgrid/src/lib/export/destinationMappingOptions.ts
@@ -1,6 +1,6 @@
 import {
   DestinationMappingOptionsMethod,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
   SimpleAppOptions,
 } from "@grouparoo/core";
 import { getFields } from "./fieldsMethods";
@@ -72,7 +72,7 @@ export const isReadOnlyField = (key): boolean => {
 
 export const getRequiredFields = (): Array<{
   key: string;
-  type: DestinationMappingOptionsResponseTypes;
+  type: DestinationMappingOptionsResponseType;
 }> => {
   return [{ key: "email", type: "email" }];
 };
@@ -105,7 +105,7 @@ export const getUserFields = async (
 ): Promise<
   Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     important?: boolean;
   }>
 > => {
@@ -114,7 +114,7 @@ export const getUserFields = async (
 
   for (const field of fields) {
     if (field["name"] !== "email" && !field["read_only"]) {
-      const type: DestinationMappingOptionsResponseTypes =
+      const type: DestinationMappingOptionsResponseType =
         mapTypesFromSendgridToGrouparoo(field["name"], field["field_type"]);
       if (type) {
         out.push({

--- a/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-table-import.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-table-import.ts
@@ -361,12 +361,13 @@ describe("integration/runs/sqlite", () => {
       csrfToken,
       id: destination.id,
       destinationGroupMemberships,
-      trackedGroupId: group.id,
+      groupId: group.id,
+      collection: "group",
     };
     const { error, destination: _destination } =
       await specHelper.runAction<DestinationEdit>("destination:edit", session);
     expect(error).toBeUndefined();
-    expect(_destination.destinationGroup.id).toBe(group.id);
+    expect(_destination.group.id).toBe(group.id);
     expect(_destination.destinationGroupMemberships).toEqual([
       {
         groupId: group.id,

--- a/plugins/@grouparoo/sqlite/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/sqlite/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "sqlite-export-records",
       appId: {{{appId}}}, // The ID of the App this Source uses - e.g. `appId: "data_warehouse"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/sqlite/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/export/destinationMappingOptions.ts
@@ -1,6 +1,6 @@
 import {
   DestinationMappingOptionsMethod,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
 } from "@grouparoo/core";
 
 export const destinationMappingOptions: DestinationMappingOptionsMethod =
@@ -10,7 +10,7 @@ export const destinationMappingOptions: DestinationMappingOptionsMethod =
 
     const columns: Array<{
       key: string;
-      type: DestinationMappingOptionsResponseTypes;
+      type: DestinationMappingOptionsResponseType;
       important: boolean;
     }> = [];
     for (const i in rows) {

--- a/plugins/@grouparoo/zendesk/public/templates/destination/{{{id}}}.js.template
+++ b/plugins/@grouparoo/zendesk/public/templates/destination/{{{id}}}.js.template
@@ -7,6 +7,7 @@ exports.default = async function buildConfig() {
       type: "zendesk-export-users",
       appId: {{{appId}}}, // The ID of the App this Destination uses - e.g. `appId: "zendesk_app"`
       modelId: "mod_profiles", // The ID of the Grouparoo Model that this Destination will send
+      collection: "group", // What collection of Records should be sent?  "group" requires a groupId below, and "model" will sync all Records from "modelId"
       groupId: "...", // The ID of the group whose members you want to export - e.g. `groupId: "high_value_customers"`
       syncMode: {{{syncMode}}}, // How should Grouparoo sync with this destination? Options: "sync", "additive", "enrich"
 

--- a/plugins/@grouparoo/zendesk/src/lib/export/destinationMappingOptions.ts
+++ b/plugins/@grouparoo/zendesk/src/lib/export/destinationMappingOptions.ts
@@ -1,6 +1,6 @@
 import {
   DestinationMappingOptionsMethod,
-  DestinationMappingOptionsResponseTypes,
+  DestinationMappingOptionsResponseType,
 } from "@grouparoo/core";
 import { connect } from "./../connect";
 
@@ -50,13 +50,13 @@ const mapTypesFromZendeskToGrouparoo = (zendeskType) => {
 
 export const getRequiredFields = (): Array<{
   key: string;
-  type: DestinationMappingOptionsResponseTypes;
+  type: DestinationMappingOptionsResponseType;
 }> => {
   return [{ key: "external_id", type: "string" }];
 };
 export const getBuiltInFields = (): Array<{
   key: string;
-  type: DestinationMappingOptionsResponseTypes;
+  type: DestinationMappingOptionsResponseType;
   important?: boolean;
 }> => {
   return [
@@ -80,14 +80,14 @@ export const getUserFields = async (
 ): Promise<
   Array<{
     key: string;
-    type: DestinationMappingOptionsResponseTypes;
+    type: DestinationMappingOptionsResponseType;
     important?: boolean;
   }>
 > => {
   const list = await client.userfields.list();
   const out = [];
   for (const field of list) {
-    const type: DestinationMappingOptionsResponseTypes =
+    const type: DestinationMappingOptionsResponseType =
       mapTypesFromZendeskToGrouparoo(field.type);
     const key = field.key;
     out.push({ key, type, important: true });

--- a/ui/ui-components/components/destination/recordPreview.tsx
+++ b/ui/ui-components/components/destination/recordPreview.tsx
@@ -10,14 +10,14 @@ export default function RecordPreview(props) {
   const {
     errorHandler,
     destination,
-    recordCollection,
+    collection,
     groupId,
     modelId,
     mappingOptions,
   }: {
     errorHandler: ErrorHandler;
     destination: Models.DestinationType;
-    recordCollection: Models.DestinationType["recordCollection"];
+    collection: Models.DestinationType["collection"] | "_none";
     groupId: string;
     modelId: string;
     mappingOptions: Actions.DestinationMappingOptions["options"];
@@ -49,6 +49,7 @@ export default function RecordPreview(props) {
   }, [
     destination.id,
     groupId,
+    collection,
     JSON.stringify(destination.destinationGroup),
     JSON.stringify(destination.mapping),
     JSON.stringify(destination.destinationGroupMemberships),
@@ -72,7 +73,11 @@ export default function RecordPreview(props) {
     setToHide(false);
     storeRecordPropertyId(_recordId);
 
-    if (groupId === "_none" && recordCollection === "group") {
+    if (
+      !collection ||
+      collection === "_none" ||
+      (collection === "group" && groupId === "_none")
+    ) {
       setToHide(true);
       return;
     }

--- a/ui/ui-components/components/destination/recordPreview.tsx
+++ b/ui/ui-components/components/destination/recordPreview.tsx
@@ -4,7 +4,8 @@ import { Card, ListGroup } from "react-bootstrap";
 import Loader from "../loader";
 import { useRouter } from "next/router";
 import { ErrorHandler } from "../../utils/errorHandler";
-import { Models, Actions, NullKey } from "../../utils/apiData";
+import { Models, Actions } from "../../utils/apiData";
+import { NullKey } from "../../utils/nullKey";
 
 export default function RecordPreview(props) {
   const {

--- a/ui/ui-components/components/destination/recordPreview.tsx
+++ b/ui/ui-components/components/destination/recordPreview.tsx
@@ -50,7 +50,7 @@ export default function RecordPreview(props) {
     destination.id,
     groupId,
     collection,
-    JSON.stringify(destination.destinationGroup),
+    JSON.stringify(destination.group),
     JSON.stringify(destination.mapping),
     JSON.stringify(destination.destinationGroupMemberships),
   ]);

--- a/ui/ui-components/components/destination/recordPreview.tsx
+++ b/ui/ui-components/components/destination/recordPreview.tsx
@@ -4,7 +4,7 @@ import { Card, ListGroup } from "react-bootstrap";
 import Loader from "../loader";
 import { useRouter } from "next/router";
 import { ErrorHandler } from "../../utils/errorHandler";
-import { Models, Actions } from "../../utils/apiData";
+import { Models, Actions, nullKey } from "../../utils/apiData";
 
 export default function RecordPreview(props) {
   const {
@@ -17,7 +17,7 @@ export default function RecordPreview(props) {
   }: {
     errorHandler: ErrorHandler;
     destination: Models.DestinationType;
-    collection: Models.DestinationType["collection"] | "_none";
+    collection: Models.DestinationType["collection"] | typeof nullKey;
     groupId: string;
     modelId: string;
     mappingOptions: Actions.DestinationMappingOptions["options"];
@@ -75,8 +75,8 @@ export default function RecordPreview(props) {
 
     if (
       !collection ||
-      collection === "_none" ||
-      (collection === "group" && groupId === "_none")
+      collection === nullKey ||
+      (collection === "group" && groupId === nullKey)
     ) {
       setToHide(true);
       return;

--- a/ui/ui-components/components/destination/recordPreview.tsx
+++ b/ui/ui-components/components/destination/recordPreview.tsx
@@ -10,12 +10,16 @@ export default function RecordPreview(props) {
   const {
     errorHandler,
     destination,
-    trackedGroupId,
+    recordCollection,
+    groupId,
+    modelId,
     mappingOptions,
   }: {
     errorHandler: ErrorHandler;
     destination: Models.DestinationType;
-    trackedGroupId: string;
+    recordCollection: Models.DestinationType["recordCollection"];
+    groupId: string;
+    modelId: string;
     mappingOptions: Actions.DestinationMappingOptions["options"];
   } = props;
   const router = useRouter();
@@ -44,7 +48,7 @@ export default function RecordPreview(props) {
     };
   }, [
     destination.id,
-    trackedGroupId,
+    groupId,
     JSON.stringify(destination.destinationGroup),
     JSON.stringify(destination.mapping),
     JSON.stringify(destination.destinationGroupMemberships),
@@ -68,7 +72,7 @@ export default function RecordPreview(props) {
     setToHide(false);
     storeRecordPropertyId(_recordId);
 
-    if (trackedGroupId === "_none") {
+    if (groupId === "_none" && recordCollection === "group") {
       setToHide(true);
       return;
     }
@@ -86,7 +90,8 @@ export default function RecordPreview(props) {
         "get",
         `/destination/${destination.id}/recordPreview`,
         {
-          groupId: trackedGroupId,
+          groupId: groupId,
+          modelId: modelId,
           mapping: destination.mapping,
           destinationGroupMemberships: destinationGroupMembershipsObject,
           recordId: _recordId !== "" ? _recordId : undefined,

--- a/ui/ui-components/components/destination/recordPreview.tsx
+++ b/ui/ui-components/components/destination/recordPreview.tsx
@@ -4,7 +4,7 @@ import { Card, ListGroup } from "react-bootstrap";
 import Loader from "../loader";
 import { useRouter } from "next/router";
 import { ErrorHandler } from "../../utils/errorHandler";
-import { Models, Actions, nullKey } from "../../utils/apiData";
+import { Models, Actions, NullKey } from "../../utils/apiData";
 
 export default function RecordPreview(props) {
   const {
@@ -17,7 +17,7 @@ export default function RecordPreview(props) {
   }: {
     errorHandler: ErrorHandler;
     destination: Models.DestinationType;
-    collection: Models.DestinationType["collection"] | typeof nullKey;
+    collection: Models.DestinationType["collection"] | typeof NullKey;
     groupId: string;
     modelId: string;
     mappingOptions: Actions.DestinationMappingOptions["options"];
@@ -75,8 +75,8 @@ export default function RecordPreview(props) {
 
     if (
       !collection ||
-      collection === nullKey ||
-      (collection === "group" && groupId === nullKey)
+      collection === NullKey ||
+      (collection === "group" && groupId === NullKey)
     ) {
       setToHide(true);
       return;

--- a/ui/ui-components/components/destination/recordPreview.tsx
+++ b/ui/ui-components/components/destination/recordPreview.tsx
@@ -5,7 +5,6 @@ import Loader from "../loader";
 import { useRouter } from "next/router";
 import { ErrorHandler } from "../../utils/errorHandler";
 import { Models, Actions } from "../../utils/apiData";
-import { NullKey } from "../../utils/nullKey";
 
 export default function RecordPreview(props) {
   const {
@@ -18,7 +17,7 @@ export default function RecordPreview(props) {
   }: {
     errorHandler: ErrorHandler;
     destination: Models.DestinationType;
-    collection: Models.DestinationType["collection"] | typeof NullKey;
+    collection: Models.DestinationType["collection"];
     groupId: string;
     modelId: string;
     mappingOptions: Actions.DestinationMappingOptions["options"];
@@ -74,11 +73,7 @@ export default function RecordPreview(props) {
     setToHide(false);
     storeRecordPropertyId(_recordId);
 
-    if (
-      !collection ||
-      collection === NullKey ||
-      (collection === "group" && groupId === NullKey)
-    ) {
+    if (collection === "none" || (collection === "group" && !groupId)) {
       setToHide(true);
       return;
     }

--- a/ui/ui-components/components/runs/list.tsx
+++ b/ui/ui-components/components/runs/list.tsx
@@ -216,19 +216,13 @@ export default function RunsList(props) {
                         {run.creatorType === "group" ||
                         run.creatorType === "grouparooModel" ? (
                           <>
-                            groupMemberLimit: {run.groupMemberLimit} <br />
+                            Member Limit: {run.memberLimit} <br />
                           </>
                         ) : null}
                         {run.creatorType === "group" ||
                         run.creatorType === "grouparooModel" ? (
                           <>
-                            groupMemberOffset: {run.groupMemberOffset} <br />
-                          </>
-                        ) : null}
-                        {run.creatorType === "group" ||
-                        run.creatorType === "grouparooModel" ? (
-                          <>
-                            groupHighWaterMark: {run.groupHighWaterMark} <br />
+                            Member Offset: {run.memberOffset} <br />
                           </>
                         ) : null}
                         {run.creatorType !== "group" ? (

--- a/ui/ui-components/components/runs/list.tsx
+++ b/ui/ui-components/components/runs/list.tsx
@@ -213,17 +213,20 @@ export default function RunsList(props) {
                     <td>
                       {/* <code>{JSON.stringify(run.filter)}</code> */}
                       <>
-                        {run.creatorType === "group" ? (
+                        {run.creatorType === "group" ||
+                        run.creatorType === "grouparooModel" ? (
                           <>
                             groupMemberLimit: {run.groupMemberLimit} <br />
                           </>
                         ) : null}
-                        {run.creatorType === "group" ? (
+                        {run.creatorType === "group" ||
+                        run.creatorType === "grouparooModel" ? (
                           <>
                             groupMemberOffset: {run.groupMemberOffset} <br />
                           </>
                         ) : null}
-                        {run.creatorType === "group" ? (
+                        {run.creatorType === "group" ||
+                        run.creatorType === "grouparooModel" ? (
                           <>
                             groupHighWaterMark: {run.groupHighWaterMark} <br />
                           </>

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -10,7 +10,7 @@ import LoadingButton from "../../../../../components/loadingButton";
 import StateBadge from "../../../../../components/badges/stateBadge";
 import LockedBadge from "../../../../../components/badges/lockedBadge";
 import PageHeader from "../../../../../components/pageHeader";
-import { Models, Actions } from "../../../../../utils/apiData";
+import { Models, Actions, nullKey } from "../../../../../utils/apiData";
 import { ErrorHandler } from "../../../../../utils/errorHandler";
 import { SuccessHandler } from "../../../../../utils/successHandler";
 import ModelBadge from "../../../../../components/badges/modelBadge";
@@ -44,7 +44,7 @@ export default function Page(props) {
     props.destination
   );
   const [groupId, setGroupId] = useState<string>(
-    destination.group?.id ?? "_none"
+    destination.group?.id ?? nullKey
   );
   const [collection, setCollection] = useState<
     Models.DestinationType["collection"]
@@ -78,7 +78,7 @@ export default function Page(props) {
 
     await execApi("put", `/destination/${destinationId}`, {
       mapping: filteredMapping,
-      groupId: groupId || "_none",
+      groupId: groupId || nullKey,
       collection,
       destinationGroupMemberships: destinationGroupMembershipsObject,
       triggerExport: true,
@@ -304,14 +304,14 @@ export default function Page(props) {
                     disabled={loading}
                     onChange={(e) => {
                       e.target.value === "__model"
-                        ? setGroupId("_none")
+                        ? setGroupId(nullKey)
                         : setGroupId(e.target.value);
                       e.target.value === "__model"
                         ? setCollection("model")
                         : setCollection("group");
                     }}
                   >
-                    <option value={"_none"}>No Group or Model</option>
+                    <option value={nullKey}>No Group or Model</option>
                     <option disabled>--- Models ---</option>
                     <option value="__model">
                       All Records in the {destination.modelName} Model

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -46,9 +46,9 @@ export default function Page(props) {
   const [groupId, setGroupId] = useState<string>(
     destination.destinationGroup?.id ?? "_none"
   );
-  const [recordCollection, setRecordCollection] = useState<
-    Models.DestinationType["recordCollection"]
-  >(destination.recordCollection);
+  const [collection, setCollection] = useState<
+    Models.DestinationType["collection"]
+  >(destination.collection);
 
   const [displayedDestinationProperties, setDisplayedDestinationProperties] =
     useState<string[]>([]);
@@ -79,7 +79,7 @@ export default function Page(props) {
     await execApi("put", `/destination/${destinationId}`, {
       mapping: filteredMapping,
       groupId: groupId || "_none",
-      recordCollection,
+      collection,
       destinationGroupMemberships: destinationGroupMembershipsObject,
       triggerExport: true,
     });
@@ -300,15 +300,15 @@ export default function Page(props) {
                   <Form.Control
                     as="select"
                     required={true}
-                    value={recordCollection === "model" ? "__model" : groupId}
+                    value={collection === "model" ? "__model" : groupId}
                     disabled={loading}
                     onChange={(e) => {
                       e.target.value === "__model"
                         ? setGroupId("_none")
                         : setGroupId(e.target.value);
                       e.target.value === "__model"
-                        ? setRecordCollection("model")
-                        : setRecordCollection("group");
+                        ? setCollection("model")
+                        : setCollection("group");
                     }}
                   >
                     <option value={"_none"}>No Group or Model</option>
@@ -812,7 +812,7 @@ export default function Page(props) {
             {...props}
             mappingOptions={mappingOptions}
             destination={destination}
-            recordCollection={recordCollection}
+            collection={collection}
             groups={groups}
             groupId={groupId}
             modelId={destination.modelId}

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -16,7 +16,6 @@ import { SuccessHandler } from "../../../../../utils/successHandler";
 import ModelBadge from "../../../../../components/badges/modelBadge";
 import { NextPageContext } from "next";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
-import { NullKey } from "../../../../../utils/nullKey";
 
 export default function Page(props) {
   const {
@@ -44,9 +43,7 @@ export default function Page(props) {
   const [destination, setDestination] = useState<Models.DestinationType>(
     props.destination
   );
-  const [groupId, setGroupId] = useState<string>(
-    destination.group?.id ?? NullKey
-  );
+  const [groupId, setGroupId] = useState<string>(destination.group?.id);
   const [collection, setCollection] = useState<
     Models.DestinationType["collection"]
   >(destination.collection);
@@ -79,8 +76,8 @@ export default function Page(props) {
 
     await execApi("put", `/destination/${destinationId}`, {
       mapping: filteredMapping,
-      groupId: groupId || NullKey,
       collection,
+      groupId,
       destinationGroupMemberships: destinationGroupMembershipsObject,
       triggerExport: true,
     });
@@ -304,15 +301,26 @@ export default function Page(props) {
                     value={collection === "model" ? "__model" : groupId}
                     disabled={loading}
                     onChange={(e) => {
-                      e.target.value === "__model"
-                        ? setGroupId(NullKey)
-                        : setGroupId(e.target.value);
-                      e.target.value === "__model"
-                        ? setCollection("model")
-                        : setCollection("group");
+                      switch (e.target.value) {
+                        case "__none": {
+                          setCollection("none");
+                          setGroupId(null);
+                          break;
+                        }
+                        case "__model": {
+                          setCollection("model");
+                          setGroupId(null);
+                          break;
+                        }
+                        default: {
+                          setCollection("group");
+                          setGroupId(e.target.value);
+                          break;
+                        }
+                      }
                     }}
                   >
-                    <option value={NullKey}>No Group or Model</option>
+                    <option value="__none">No Group or Model</option>
                     <option disabled>--- Models ---</option>
                     <option value="__model">
                       All Records in the {destination.modelName} Model

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -10,12 +10,13 @@ import LoadingButton from "../../../../../components/loadingButton";
 import StateBadge from "../../../../../components/badges/stateBadge";
 import LockedBadge from "../../../../../components/badges/lockedBadge";
 import PageHeader from "../../../../../components/pageHeader";
-import { Models, Actions, NullKey } from "../../../../../utils/apiData";
+import { Models, Actions } from "../../../../../utils/apiData";
 import { ErrorHandler } from "../../../../../utils/errorHandler";
 import { SuccessHandler } from "../../../../../utils/successHandler";
 import ModelBadge from "../../../../../components/badges/modelBadge";
 import { NextPageContext } from "next";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
+import { NullKey } from "../../../../../utils/nullKey";
 
 export default function Page(props) {
   const {

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -44,7 +44,7 @@ export default function Page(props) {
     props.destination
   );
   const [groupId, setGroupId] = useState<string>(
-    destination.destinationGroup?.id ?? "_none"
+    destination.group?.id ?? "_none"
   );
   const [collection, setCollection] = useState<
     Models.DestinationType["collection"]

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -10,7 +10,7 @@ import LoadingButton from "../../../../../components/loadingButton";
 import StateBadge from "../../../../../components/badges/stateBadge";
 import LockedBadge from "../../../../../components/badges/lockedBadge";
 import PageHeader from "../../../../../components/pageHeader";
-import { Models, Actions, nullKey } from "../../../../../utils/apiData";
+import { Models, Actions, NullKey } from "../../../../../utils/apiData";
 import { ErrorHandler } from "../../../../../utils/errorHandler";
 import { SuccessHandler } from "../../../../../utils/successHandler";
 import ModelBadge from "../../../../../components/badges/modelBadge";
@@ -44,7 +44,7 @@ export default function Page(props) {
     props.destination
   );
   const [groupId, setGroupId] = useState<string>(
-    destination.group?.id ?? nullKey
+    destination.group?.id ?? NullKey
   );
   const [collection, setCollection] = useState<
     Models.DestinationType["collection"]
@@ -78,7 +78,7 @@ export default function Page(props) {
 
     await execApi("put", `/destination/${destinationId}`, {
       mapping: filteredMapping,
-      groupId: groupId || nullKey,
+      groupId: groupId || NullKey,
       collection,
       destinationGroupMemberships: destinationGroupMembershipsObject,
       triggerExport: true,
@@ -304,14 +304,14 @@ export default function Page(props) {
                     disabled={loading}
                     onChange={(e) => {
                       e.target.value === "__model"
-                        ? setGroupId(nullKey)
+                        ? setGroupId(NullKey)
                         : setGroupId(e.target.value);
                       e.target.value === "__model"
                         ? setCollection("model")
                         : setCollection("group");
                     }}
                   >
-                    <option value={nullKey}>No Group or Model</option>
+                    <option value={NullKey}>No Group or Model</option>
                     <option disabled>--- Models ---</option>
                     <option value="__model">
                       All Records in the {destination.modelName} Model

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -40,12 +40,16 @@ export default function Page(props) {
   const { execApi } = UseApi(props, errorHandler);
   const router = useRouter();
   const [loading, setLoading] = useState(false);
-  const [trackedGroupId, settrackedGroupId] = useState(
-    props.trackedGroupId || "_none"
-  );
   const [destination, setDestination] = useState<Models.DestinationType>(
     props.destination
   );
+  const [groupId, setGroupId] = useState<string>(
+    destination.destinationGroup?.id ?? "_none"
+  );
+  const [recordCollection, setRecordCollection] = useState<
+    Models.DestinationType["recordCollection"]
+  >(destination.recordCollection);
+
   const [displayedDestinationProperties, setDisplayedDestinationProperties] =
     useState<string[]>([]);
   const displayedDestinationPropertiesAutocomleteRef = useRef(null);
@@ -74,7 +78,8 @@ export default function Page(props) {
 
     await execApi("put", `/destination/${destinationId}`, {
       mapping: filteredMapping,
-      trackedGroupId: trackedGroupId || "_none",
+      groupId: groupId || "_none",
+      recordCollection,
       destinationGroupMemberships: destinationGroupMembershipsObject,
       triggerExport: true,
     });
@@ -248,7 +253,7 @@ export default function Page(props) {
       return 0;
     })
     .sort((a, b) => {
-      if (a.id === trackedGroupId) return -1;
+      if (a.id === groupId) return -1;
       return 1;
     });
 
@@ -295,12 +300,23 @@ export default function Page(props) {
                   <Form.Control
                     as="select"
                     required={true}
-                    value={trackedGroupId}
+                    value={recordCollection === "model" ? "__model" : groupId}
                     disabled={loading}
-                    onChange={(e) => settrackedGroupId(e.target["value"])}
+                    onChange={(e) => {
+                      e.target.value === "__model"
+                        ? setGroupId("_none")
+                        : setGroupId(e.target.value);
+                      e.target.value === "__model"
+                        ? setRecordCollection("model")
+                        : setRecordCollection("group");
+                    }}
                   >
-                    <option value={"_none"}>No Group</option>
-                    <option disabled>---</option>
+                    <option value={"_none"}>No Group or Model</option>
+                    <option disabled>--- Models ---</option>
+                    <option value="__model">
+                      All Records in the {destination.modelName} Model
+                    </option>
+                    <option disabled>--- Groups ---</option>
                     {groups
                       .sort((a, b) => {
                         if (a.name >= b.name) {
@@ -796,8 +812,10 @@ export default function Page(props) {
             {...props}
             mappingOptions={mappingOptions}
             destination={destination}
+            recordCollection={recordCollection}
             groups={groups}
-            trackedGroupId={trackedGroupId}
+            groupId={groupId}
+            modelId={destination.modelId}
           />
         </Col>
       </Row>
@@ -847,7 +865,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
     mappingOptions,
     destinationTypeConversions,
     exportArrayProperties,
-    trackedGroupId: destination.destinationGroup?.id,
     groups: groups
       .filter((group) => group.state !== "draft")
       .filter((group) => group.state !== "deleted"),

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
@@ -56,15 +56,17 @@ export default function Page(props) {
 
   const onSubmit = async (event) => {
     event.preventDefault();
-    delete destination["mapping"];
-    delete destination["destinationGroupMemberships"];
-    delete destination["groups"];
 
     setLoading(true);
     const response: Actions.DestinationEdit = await execApi(
       "put",
       `/destination/${destinationId}`,
-      Object.assign({}, destination, { state: "ready" })
+      {
+        state: "ready",
+        name: destination.name,
+        syncMode: destination.syncMode,
+        options: destination.options,
+      }
     );
     if (response?.destination) {
       setDestination(response.destination);

--- a/ui/ui-components/pages/model/[modelId]/destinations.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destinations.tsx
@@ -129,12 +129,12 @@ export default function Page(props) {
                 </td>
                 <td>{destination.connection.displayName}</td>
                 <td>
-                  {destination.destinationGroup?.id ? (
+                  {destination.group?.id ? (
                     <EnterpriseLink
                       href="/model/[modelId]/group/[groupId]/edit"
-                      as={`/model/${destination.destinationGroup.modelId}/group/${destination.destinationGroup.id}/edit`}
+                      as={`/model/${destination.group.modelId}/group/${destination.group.id}/edit`}
                     >
-                      <a>{destination.destinationGroup.name}</a>
+                      <a>{destination.group.name}</a>
                     </EnterpriseLink>
                   ) : (
                     "None"

--- a/ui/ui-components/pages/run/[id]/edit.tsx
+++ b/ui/ui-components/pages/run/[id]/edit.tsx
@@ -105,11 +105,9 @@ export default function Page(props) {
               Records Imported: {run.recordsImported}
             </Col>
             <Col>
-              Group Member Limit: {run.groupMemberLimit}
+              Member Limit: {run.memberLimit}
               <br />
-              Group Member Offset: {run.groupMemberOffset}
-              <br />
-              Group Member High Water Mark: {run.groupHighWaterMark}
+              Member Offset: {run.memberOffset}
               <br />
               Source Offset: {run.sourceOffset}
               {run.highWaterMark ? (

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -739,3 +739,5 @@ export namespace Actions {
     typeof ObjectFind.prototype.runWithinTransaction
   >;
 }
+
+export const nullKey = "_none" as const;

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -739,5 +739,3 @@ export namespace Actions {
     typeof ObjectFind.prototype.runWithinTransaction
   >;
 }
-
-export const NullKey = "_none" as const;

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -740,4 +740,4 @@ export namespace Actions {
   >;
 }
 
-export const nullKey = "_none" as const;
+export const NullKey = "_none" as const;

--- a/ui/ui-components/utils/nullKey.ts
+++ b/ui/ui-components/utils/nullKey.ts
@@ -1,1 +1,0 @@
-export const NullKey = "_none" as const;

--- a/ui/ui-components/utils/nullKey.ts
+++ b/ui/ui-components/utils/nullKey.ts
@@ -1,0 +1,1 @@
+export const NullKey = "_none" as const;


### PR DESCRIPTION
This PR adds the ability for a Destination to track and export all Records in a Model, instead of the members of a Group.

<img width="1436" alt="Screen Shot 2021-09-30 at 10 42 33 AM" src="https://user-images.githubusercontent.com/303226/135504831-b3fd89ee-b2f8-4215-82c8-54c1c42a5dc4.png">

Code-wise, the previous destination tracking methods have all been replaced with a single utility method: `destination.updateTracking(type:string, id: string)`

```ts
// track a group
await destination.updateTracking('group, 'abc123')

// track a model
await destination.updateTracking('model')

// track nothing
await destination.updateTracking('none')
```

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

* Migration and backfill

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
