### PR TITLE
Use `displayNames` in UI App Selector Cards

### DIFF
--- a/core/__tests__/actions/apps.ts
+++ b/core/__tests__/actions/apps.ts
@@ -72,6 +72,8 @@ describe("actions/apps", () => {
       expect(types.length).toBeGreaterThanOrEqual(1);
       const names = types.map((t) => t.name);
       expect(names).toContain("test-plugin-app");
+      const displayNames = types.map((t) => t.displayName);
+      expect(displayNames).toContain("test-plugin-app");
 
       const pluginTestAppType = types.find((t) => t.name === "test-plugin-app");
       expect(pluginTestAppType.options).toEqual([

--- a/core/src/actions/apps.ts
+++ b/core/src/actions/apps.ts
@@ -61,6 +61,7 @@ export class AppOptions extends AuthenticatedAction {
   async runWithinTransaction() {
     const types: Array<{
       name: string;
+      displayName: string;
       maxInstances: number;
       minInstances: number;
       addible: boolean;
@@ -98,6 +99,7 @@ export class AppOptions extends AuthenticatedAction {
 
           types.push({
             name: app.name,
+            displayName: app.displayName,
             maxInstances: app.maxInstances,
             minInstances: app.minInstances,
             addible,

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -198,7 +198,6 @@ export class App extends LoggedModel<App> {
       name: this.name,
       icon,
       type: this.type,
-      typeDisplayName: pluginApp.displayName,
       state: this.state,
       locked: this.locked,
       options,

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -198,6 +198,7 @@ export class App extends LoggedModel<App> {
       name: this.name,
       icon,
       type: this.type,
+      typeDisplayName: pluginApp.displayName,
       state: this.state,
       locked: this.locked,
       options,

--- a/core/src/modules/plugins.ts
+++ b/core/src/modules/plugins.ts
@@ -42,6 +42,17 @@ export namespace Plugins {
     };
   }
 
+  export type GrouparooManifestPackage = {
+    name: string;
+    description: string;
+    imageUrl: string;
+    packageName: string;
+    source: boolean;
+    destination: boolean;
+    npmUrl?: string;
+    docsUrl?: string;
+  };
+
   export async function installedPluginVersions() {
     const pluginManifest = getPluginManifest();
     const coreVersion = getCoreVersion();
@@ -87,7 +98,9 @@ export namespace Plugins {
 
   export async function availableGrouparooPlugins() {
     const pluginManifestUrl = config.pluginManifestUrl;
-    const pluginManifest = await fetch(pluginManifestUrl).then((r) => r.json());
+    const pluginManifest: GrouparooManifestPackage[] = await fetch(
+      pluginManifestUrl
+    ).then((r) => r.json());
     return pluginManifest;
   }
 

--- a/ui/ui-components/components/appSelectorList.tsx
+++ b/ui/ui-components/components/appSelectorList.tsx
@@ -10,24 +10,12 @@ type SelectableSource =
 type SelectableDestination =
   Actions.DestinationConnectionApps["connectionApps"][number]["app"];
 
-function isSelectableApp(
-  item:
-    | SelectableApp
-    | SelectablePackage
-    | SelectableSource
-    | SelectableDestination
-): item is SelectableApp {
-  return (item as SelectableApp).plugin !== undefined;
+function isSelectableApp(item: any): item is SelectableApp {
+  return item.plugin !== undefined;
 }
 
-function isSelectablePackage(
-  item:
-    | SelectableApp
-    | SelectablePackage
-    | SelectableSource
-    | SelectableDestination
-): item is SelectablePackage {
-  return (item as SelectablePackage).npmUrl !== undefined;
+function isSelectablePackage(item: any): item is SelectablePackage {
+  return item.npmUrl !== undefined;
 }
 
 export default function AppSelectorList({

--- a/ui/ui-components/components/appSelectorList.tsx
+++ b/ui/ui-components/components/appSelectorList.tsx
@@ -113,7 +113,7 @@ export default function AppSelectorList({
           } else {
             // these are apps extracted from connectionApps
             src = item.icon;
-            title = item.typeDisplayName;
+            title = item.pluginApp.displayName;
             subheading = item.type;
             className =
               item.id === selectedItem.id


### PR DESCRIPTION
This PR continues https://github.com/grouparoo/grouparoo/pull/2342, and uses the displayNames in the App Selector cards in the UI

<img width="1553" alt="Screen Shot 2021-09-30 at 3 08 09 PM" src="https://user-images.githubusercontent.com/303226/135536758-12829098-754c-4a65-bb1f-9e60e28bf959.png">

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

N/A

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
