### PR TITLE
`timed_run` test runs `grouparoo demo -c` (no purchases)

### DIFF
--- a/bin/timed_run
+++ b/bin/timed_run
@@ -39,7 +39,7 @@ echo ""
 echo "-----> REBUILDING CONFIG FROM DEMO"
 echo ""
 
-$ROO demo purchases -c --scale $SCALE
+$ROO demo -c --scale $SCALE
 
 echo ""
 echo "-----> STARTING TEST"


### PR DESCRIPTION
This PR fixes our `timed_run` performance test, which previously used `grouparoo demo -c purchases`.  The `purchases` flag was removed in https://github.com/grouparoo/grouparoo/pull/2351.

When this is merged in, we should manually re-run the failing timed-run test @ https://github.com/grouparoo/grouparoo/runs/3762811975?check_suite_focus=true

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
