### PR TITLE
`CLSTasks` include the `QueueLock` Middleware

### DIFF
--- a/core/__tests__/tasks/recordProperty/enqueue/enqueue.ts
+++ b/core/__tests__/tasks/recordProperty/enqueue/enqueue.ts
@@ -51,6 +51,16 @@ describe("tasks/recordProperties:enqueue", () => {
         await App.truncate();
       });
 
+      // this test is really testing CLSTask in general
+      it("cannot be enqueued more than once due to the QueueLock middleware", async () => {
+        await task.enqueue("recordProperties:enqueue", {});
+        await task.enqueue("recordProperties:enqueue", {});
+        const foundTasks = await specHelper.findEnqueuedTasks(
+          "recordProperties:enqueue"
+        );
+        expect(foundTasks.length).toEqual(1);
+      });
+
       it("will not crash when there is a property without a ready source", async () => {
         const source = await helper.factories.source();
         const property = await source.bootstrapUniqueProperty(

--- a/core/src/classes/tasks/clsTask.ts
+++ b/core/src/classes/tasks/clsTask.ts
@@ -7,6 +7,7 @@ import { CLS } from "../../modules/cls";
 export abstract class CLSTask extends Task {
   constructor() {
     super();
+    this.plugins = ["QueueLock"];
   }
 
   async run(

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -10,7 +10,6 @@ export class RunGroup extends CLSTask {
     this.description =
       "calculate the groups members and create imports to update them all";
     this.frequency = 0;
-    this.plugins = ["QueueLock"];
     this.queue = "groups";
     this.inputs = {
       runId: { required: true },

--- a/core/src/tasks/system/status/statusSample.ts
+++ b/core/src/tasks/system/status/statusSample.ts
@@ -9,7 +9,6 @@ export class StatusSample extends CLSTask {
     this.description = "Calculate and set one of the status samples";
     this.frequency = 0;
     this.queue = "system";
-    this.plugins = ["QueueLock"];
     this.inputs = {
       index: { required: true },
     };


### PR DESCRIPTION
Most of Grouparoo's tasks that do not talk to an external system extend `CLSTask` rather than `RetryableTask`.  until this PR, `CLSTask` did not include any middleware.  However, we always want to include the `QueueLock` Middleware, which will prevent the same task with the same args being enqueued more than once.   This prevents double-enqueuing when more than one node boots up, things retry, etc.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
