### PR TITLE
Add `modelId` input to action schedules:list

### DIFF
--- a/core/__tests__/actions/schedules.ts
+++ b/core/__tests__/actions/schedules.ts
@@ -1,6 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { specHelper, api } from "actionhero";
-import { Run, Schedule, Source } from "../../src";
+import { GrouparooModel, Run, Schedule, Source } from "../../src";
 import { SessionCreate } from "../../src/actions/session";
 import {
   ScheduleCreate,
@@ -16,7 +16,9 @@ import {
 describe("actions/schedules", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
   let id: string;
+  let model: GrouparooModel;
   let source: Source;
+  let source2: Source;
 
   beforeAll(async () => {
     await helper.factories.properties();
@@ -43,10 +45,30 @@ describe("actions/schedules", () => {
       );
       csrfToken = sessionResponse.csrfToken;
 
+      model = await helper.factories.model();
+      //default model
       source = await helper.factories.source();
       await source.setOptions({ table: "test table" });
       await source.setMapping({ id: "userId" });
       await source.update({ state: "ready" });
+      //new model
+      source2 = await helper.factories.source(null, {
+        modelId: model.id,
+      });
+
+      await source2.setOptions({ table: "test table2" });
+
+      const newProperty = await helper.factories.property(
+        source2,
+        {
+          unique: true,
+          key: "prp_9a8c4ac0-c3d8-443e-b0a7-017c4fa3bc26",
+        },
+        { column: "email" }
+      );
+      newProperty.update({ state: "ready" });
+      await source2.setMapping({ id: newProperty.id });
+      await source2.update({ state: "ready" });
     });
 
     test("an administrator can create a new schedule", async () => {
@@ -62,6 +84,7 @@ describe("actions/schedules", () => {
         "schedule:create",
         connection
       );
+
       expect(error).toBeUndefined();
       expect(schedule.id).toBeTruthy();
       expect(schedule.name).toBe("test schedule");
@@ -71,6 +94,21 @@ describe("actions/schedules", () => {
     });
 
     describe("with schedule", () => {
+      beforeAll(async () => {
+        connection.params = {
+          csrfToken,
+          name: "test schedule 2",
+          type: "test-plugin-import",
+          sourceId: source2.id,
+          recurring: false,
+          confirmRecords: true,
+        };
+        const schedule2 = await specHelper.runAction<ScheduleCreate>(
+          "schedule:create",
+          connection
+        );
+      });
+
       test("an administrator can list all the schedules", async () => {
         connection.params = {
           csrfToken,
@@ -80,6 +118,24 @@ describe("actions/schedules", () => {
             "schedules:list",
             connection
           );
+
+        expect(error).toBeUndefined();
+        expect(schedules.length).toBe(2);
+        expect(schedules[0].name).toBe("test schedule 2");
+        expect(total).toBe(2);
+      });
+
+      test("an administrator can list all schedules by model id", async () => {
+        connection.params = {
+          csrfToken,
+          modelId: "mod_profiles",
+        };
+        const { error, schedules, total } =
+          await specHelper.runAction<SchedulesList>(
+            "schedules:list",
+            connection
+          );
+
         expect(error).toBeUndefined();
         expect(schedules.length).toBe(1);
         expect(schedules[0].name).toBe("test schedule");

--- a/core/__tests__/actions/schedules.ts
+++ b/core/__tests__/actions/schedules.ts
@@ -46,18 +46,18 @@ describe("actions/schedules", () => {
       csrfToken = sessionResponse.csrfToken;
 
       model = await helper.factories.model();
-      //default model
+      //source using default model
       source = await helper.factories.source();
       await source.setOptions({ table: "test table" });
       await source.setMapping({ id: "userId" });
       await source.update({ state: "ready" });
-      //new model
+
+      //source using new model
       source2 = await helper.factories.source(null, {
         modelId: model.id,
       });
 
       await source2.setOptions({ table: "test table2" });
-
       const newProperty = await helper.factories.property(
         source2,
         {
@@ -67,7 +67,6 @@ describe("actions/schedules", () => {
         { column: "email" }
       );
       newProperty.update({ state: "ready" });
-
       await source2.setMapping({ id: newProperty.key });
       await source2.update({ state: "ready" });
     });
@@ -96,20 +95,7 @@ describe("actions/schedules", () => {
 
     describe("with schedule", () => {
       beforeAll(async () => {
-        connection.params = {
-          csrfToken,
-          name: "test schedule",
-          type: "test-plugin-import",
-          sourceId: source.id,
-          recurring: false,
-          confirmRecords: true,
-        };
-
-        const { error, schedule } = await specHelper.runAction<ScheduleCreate>(
-          "schedule:create",
-          connection
-        );
-
+        //schedule with created model's source
         connection.params = {
           csrfToken,
           name: "test schedule 2",
@@ -150,6 +136,8 @@ describe("actions/schedules", () => {
             "schedules:list",
             connection
           );
+
+        console.log(JSON.stringify(error));
 
         expect(error).toBeUndefined();
         expect(schedules.length).toBe(1);

--- a/core/__tests__/actions/schedules.ts
+++ b/core/__tests__/actions/schedules.ts
@@ -1,6 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { specHelper, api } from "actionhero";
-import { GrouparooModel, Run, Schedule, Source } from "../../src";
+import { GrouparooModel, Run, Source } from "../../src";
 import { SessionCreate } from "../../src/actions/session";
 import {
   ScheduleCreate,
@@ -136,8 +136,6 @@ describe("actions/schedules", () => {
             "schedules:list",
             connection
           );
-
-        console.log(JSON.stringify(error));
 
         expect(error).toBeUndefined();
         expect(schedules.length).toBe(1);

--- a/core/__tests__/actions/schedules.ts
+++ b/core/__tests__/actions/schedules.ts
@@ -62,12 +62,13 @@ describe("actions/schedules", () => {
         source2,
         {
           unique: true,
-          key: "prp_9a8c4ac0-c3d8-443e-b0a7-017c4fa3bc26",
+          key: "newProperty",
         },
         { column: "email" }
       );
       newProperty.update({ state: "ready" });
-      await source2.setMapping({ id: newProperty.id });
+
+      await source2.setMapping({ id: newProperty.key });
       await source2.update({ state: "ready" });
     });
 
@@ -95,6 +96,20 @@ describe("actions/schedules", () => {
 
     describe("with schedule", () => {
       beforeAll(async () => {
+        connection.params = {
+          csrfToken,
+          name: "test schedule",
+          type: "test-plugin-import",
+          sourceId: source.id,
+          recurring: false,
+          confirmRecords: true,
+        };
+
+        const { error, schedule } = await specHelper.runAction<ScheduleCreate>(
+          "schedule:create",
+          connection
+        );
+
         connection.params = {
           csrfToken,
           name: "test schedule 2",

--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -5,7 +5,7 @@ import { ConfigWriter } from "../modules/configWriter";
 import { FilterHelper } from "../modules/filterHelper";
 import { APIData } from "../modules/apiData";
 import { Op } from "sequelize";
-import { Source } from "..";
+import { Source } from "../models/Source";
 
 export class SchedulesList extends AuthenticatedAction {
   constructor() {

--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -46,7 +46,7 @@ export class SchedulesList extends AuthenticatedAction {
         sourceIds.push(source.id);
       }
 
-      where["sourceId"] = `[Op.in]: ${sourceIds}`;
+      where["sourceId"] = { [Op.in]: sourceIds };
     }
     const schedules = await Schedule.scope(null).findAll({
       where,

--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -32,7 +32,7 @@ export class SchedulesList extends AuthenticatedAction {
 
   async runWithinTransaction({ params }) {
     const where = {};
-    const sourceIds = [];
+    const sourceIds: string[] = [];
     if (params.state) where["state"] = params.state;
 
     if (params.modelId) {

--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -5,6 +5,7 @@ import { ConfigWriter } from "../modules/configWriter";
 import { FilterHelper } from "../modules/filterHelper";
 import { APIData } from "../modules/apiData";
 import { Op } from "sequelize";
+import { Source } from "..";
 
 export class SchedulesList extends AuthenticatedAction {
   constructor() {
@@ -14,6 +15,7 @@ export class SchedulesList extends AuthenticatedAction {
     this.outputExample = {};
     this.permission = { topic: "source", mode: "read" };
     this.inputs = {
+      modelId: { required: false },
       limit: { required: true, default: 100, formatter: APIData.ensureNumber },
       offset: { required: true, default: 0, formatter: APIData.ensureNumber },
       state: { required: false },
@@ -30,8 +32,22 @@ export class SchedulesList extends AuthenticatedAction {
 
   async runWithinTransaction({ params }) {
     const where = {};
+    const sourceIds = [];
     if (params.state) where["state"] = params.state;
 
+    if (params.modelId) {
+      const sources = await Source.scope(null).findAll({
+        where: {
+          modelId: params.modelId,
+        },
+      });
+
+      for (const source of sources) {
+        sourceIds.push(source.id);
+      }
+
+      where["sourceId"] = `[Op.in]: ${sourceIds}`;
+    }
     const schedules = await Schedule.scope(null).findAll({
       where,
       limit: params.limit,

--- a/ui/ui-components/pages/source/[id]/mapping.tsx
+++ b/ui/ui-components/pages/source/[id]/mapping.tsx
@@ -408,11 +408,12 @@ Page.getInitialProps = async (ctx) => {
     { includeExamples: true, state: "ready", modelId: source?.modelId }
   );
   const { types } = await execApi("get", `/propertyOptions`);
-  const { total: scheduleCount } = await execApi("get", `/schedules`);
 
+  const { total: scheduleCount } = await execApi("get", `/schedules`, {
+    modelId: source?.modelId,
+  });
   let preview;
   let hydrationError: Error;
-
   try {
     if (source.previewAvailable) {
       const previewResponse = await execApi("get", `/source/${id}/preview`);


### PR DESCRIPTION
## Change description

> **Original story:** When creating the first source for a model, users should be prompted to create a schedule.

> **Solution:** I've added an input on the "schedule:list" action that takes an optional modelId, finds all associated sources, and only returns schedules associated with those sources (and thus the given model).  The source mapping page now uses this input and redirects to the create schedule page if no schedule exists for the given model.

## Related issues

Does this PR fix a Github Issue?

> no

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

> n/a

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
