### PR TITLE
Set `RecordProperty.startedAt` to null after import

### DIFF
--- a/core/__tests__/tasks/recordProperty/importRecordProperty.ts
+++ b/core/__tests__/tasks/recordProperty/importRecordProperty.ts
@@ -67,7 +67,7 @@ describe("tasks/recordProperty:importRecordProperty", () => {
       const recordProperty = await RecordProperty.findOne({
         where: { rawValue: "old@example.com" },
       });
-      await recordProperty.update({ state: "pending" });
+      await recordProperty.update({ state: "pending", startedAt: new Date() });
 
       await specHelper.runTask("recordProperty:importRecordProperty", {
         recordId: record.id,
@@ -78,6 +78,7 @@ describe("tasks/recordProperty:importRecordProperty", () => {
       await recordProperty.reload();
       expect(recordProperty.state).toBe("ready");
       expect(recordProperty.rawValue).toBe(`${record.id}@example.com`);
+      expect(recordProperty.startedAt).toBe(null);
     });
 
     test("will not crash with invalidValues and they will be set on the recordProperties", async () => {
@@ -97,7 +98,7 @@ describe("tasks/recordProperty:importRecordProperty", () => {
       const recordProperty = await RecordProperty.findOne({
         where: { rawValue: "a@example.com" },
       });
-      await recordProperty.update({ state: "pending" });
+      await recordProperty.update({ state: "pending", startedAt: new Date() });
 
       await specHelper.runTask("recordProperty:importRecordProperty", {
         recordId: record.id,
@@ -108,6 +109,7 @@ describe("tasks/recordProperty:importRecordProperty", () => {
       expect(recordProperty.state).toBe("ready");
       expect(recordProperty.rawValue).toBe(null);
       expect(recordProperty.invalidValue).toBe("not-an-email");
+      expect(recordProperty.startedAt).toBe(null);
 
       await record.destroy();
 
@@ -129,7 +131,7 @@ describe("tasks/recordProperty:importRecordProperty", () => {
       const recordPropertyB = await RecordProperty.findOne({
         where: { propertyId: "email", recordId: recordB.id },
       });
-      await recordPropertyB.update({ state: "pending" });
+      await recordPropertyB.update({ state: "pending", startedAt: new Date() });
 
       await specHelper.runTask("recordProperty:importRecordProperty", {
         recordId: recordB.id,
@@ -140,6 +142,7 @@ describe("tasks/recordProperty:importRecordProperty", () => {
       expect(recordPropertyB.state).toBe("ready");
       expect(recordPropertyB.rawValue).toBe(null);
       expect(recordPropertyB.invalidValue).toBe("mario@example.com");
+      expect(recordPropertyB.startedAt).toBe(null);
 
       await recordA.destroy();
       await recordB.destroy();
@@ -158,7 +161,7 @@ describe("tasks/recordProperty:importRecordProperty", () => {
       const recordProperty = await RecordProperty.findOne({
         where: { propertyId: "email", recordId: record.id },
       });
-      await recordProperty.update({ state: "pending" });
+      await recordProperty.update({ state: "pending", startedAt: new Date() });
 
       await expect(
         specHelper.runTask("recordProperty:importRecordProperty", {
@@ -171,6 +174,7 @@ describe("tasks/recordProperty:importRecordProperty", () => {
       expect(recordProperty.state).toBe("pending");
       expect(recordProperty.rawValue).toBe(null);
       expect(recordProperty.invalidValue).toBe(null);
+      expect(recordProperty.startedAt).not.toBe(null);
 
       await record.destroy();
 
@@ -190,7 +194,7 @@ describe("tasks/recordProperty:importRecordProperty", () => {
       const recordProperty = await RecordProperty.findOne({
         where: { rawValue: "someoldemail@example.com", recordId: record.id },
       });
-      await recordProperty.update({ state: "pending" });
+      await recordProperty.update({ state: "pending", startedAt: new Date() });
 
       await specHelper.runTask("recordProperty:importRecordProperty", {
         recordId: record.id,
@@ -201,6 +205,7 @@ describe("tasks/recordProperty:importRecordProperty", () => {
       await recordProperty.reload();
       expect(recordProperty.state).toBe("ready");
       expect(recordProperty.rawValue).toBe(null);
+      expect(recordProperty.startedAt).toBe(null);
 
       spy.mockRestore();
 
@@ -220,7 +225,7 @@ describe("tasks/recordProperty:importRecordProperty", () => {
       const recordProperty = await RecordProperty.findOne({
         where: { rawValue: "old@example.com" },
       });
-      await recordProperty.update({ state: "pending" });
+      await recordProperty.update({ state: "pending", startedAt: new Date() });
 
       const userIdRecordProperty = await RecordProperty.findOne({
         where: {
@@ -239,6 +244,7 @@ describe("tasks/recordProperty:importRecordProperty", () => {
       await recordProperty.reload();
       expect(recordProperty.state).toBe("pending");
       expect(recordProperty.rawValue).toBe(`old@example.com`);
+      expect(recordProperty.startedAt).not.toBe(null);
 
       // sendAt is slightly in the future from (now - 5 minutes) to try again soon
       expect(recordProperty.startedAt.getTime()).toBeGreaterThan(

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -265,6 +265,7 @@ export namespace RecordOps {
       unique: boolean;
       stateChangedAt: Date;
       confirmedAt: Date;
+      startedAt: Date;
       valueChangedAt: Date;
     }> = [];
     const bulkDeletes = { where: { id: [] as string[] } };
@@ -341,6 +342,7 @@ export namespace RecordOps {
               state: "ready",
               stateChangedAt: now,
               confirmedAt: now,
+              startedAt: null,
               valueChangedAt:
                 !existingRecordProperty ||
                 !existingRecordProperty.valueChangedAt ||
@@ -377,6 +379,7 @@ export namespace RecordOps {
               "stateChangedAt",
               "confirmedAt",
               "valueChangedAt",
+              "startedAt",
               "rawValue",
               "invalidValue",
               "updatedAt",
@@ -399,6 +402,7 @@ export namespace RecordOps {
                     invalidValue: `${attemptedRecordProperty.rawValue}`,
                     stateChangedAt: new Date(),
                     confirmedAt: new Date(),
+                    startedAt: null,
                   },
                   {
                     transaction,

--- a/core/src/tasks/recordProperty/importRecordProperties.ts
+++ b/core/src/tasks/recordProperty/importRecordProperties.ts
@@ -138,6 +138,7 @@ export class ImportRecordProperties extends RetryableTask {
           rawValue: null,
           stateChangedAt: new Date(),
           confirmedAt: new Date(),
+          startedAt: null,
         },
         {
           where: {

--- a/core/src/tasks/recordProperty/importRecordProperty.ts
+++ b/core/src/tasks/recordProperty/importRecordProperty.ts
@@ -83,6 +83,7 @@ export class ImportRecordProperty extends RetryableTask {
           rawValue: null,
           stateChangedAt: new Date(),
           confirmedAt: new Date(),
+          startedAt: null,
         },
         {
           where: {


### PR DESCRIPTION
We use `RecordProperty.startedAt` to ensure that we only retry an import for a RecordProperty every 5 minutes (as defined by `RecordPropertyOps.processPendingRecordProperties()`.  This is good, because it helps us more evenly find recordProperties that need to be imported (https://github.com/grouparoo/grouparoo/pull/1566). 

Prior to this PR, after a successful import, we weren't resting `RecordProperty.startedAt`.  This means that if there was a legitimate reason import the record/property again, you would need to wait 5 minutes.  This situation occurs when you add a group to a destination to a group (or remove one) soon after an import occurred. 

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
