### PR TITLE
Store config files generated in navigation test in `/tmp`

### DIFF
--- a/core/__tests__/actions/navigation.ts
+++ b/core/__tests__/actions/navigation.ts
@@ -1,3 +1,4 @@
+import os from "os";
 import { helper } from "@grouparoo/spec-helper";
 import { specHelper } from "actionhero";
 import { ConfigUserCreate } from "../../src/actions/config";
@@ -79,7 +80,11 @@ describe("actions/navigation", () => {
         password: "P@ssw0rd!",
         email: "peach@example.com",
       });
+
       process.env.GROUPAROO_RUN_MODE = "cli:config";
+      process.env.GROUPAROO_CONFIG_DIR = `${os.tmpdir()}/test/${
+        process.env.JEST_WORKER_ID
+      }/config/navigation`;
     });
 
     test("the navigation includes Models and Apps if authenticated in config mode", async () => {
@@ -108,6 +113,7 @@ describe("actions/navigation", () => {
       expect(navigation.navigationItems[0].title).toEqual("Apps");
       expect(navigation.navigationItems[1].title).toEqual("Models");
     });
+
     test("the navigation does not include Platform items if in config mode", async () => {
       const connection = await specHelper.buildConnection();
       connection.params = {


### PR DESCRIPTION
Fixes a bug added in https://github.com/grouparoo/grouparoo/pull/2349 that tests our `navigation` action when running `grouparoo config`, but neglected to move the config directory.  Prevents config files from appearing in `core` when running the test suite

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
