### PR TITLE
Use GitHub Apps to authenticate Omnibus notification

### DIFF
--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -1,0 +1,14 @@
+# Repository secrets
+
+The following secrets are required to run the various GitHub Action workflows in this repository:
+
+- `BOT_NPM_TOKEN`: NPM token that will be used to publish packages.
+- `GROUPAROO_TIMED_RUN_SENTRY_DSN`: Sentry DSN used when running Grouparoo for timed runs.
+- `OMNIBUS_NOTIFIER_APP_ID`: GitHub App ID for authenticating to the GitHub API when notifying infra-apps that there's a new image available.
+- `OMNIBUS_NOTIFIER_APP_PRIVATE_KEY`: GitHub App Private Key for authenticating to the GitHub API when notifying infra-apps that there's a new image available.
+
+### Notifier GitHub App
+
+This app requires Read/Write access on the `Actions` permission for the repository that will be notified. A new GitHub App can be created [here](https://github.com/organizations/grouparoo/settings/apps/new).
+
+To sign requests, the app's private key is required. Instructions for generating a private key can be found [here](https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps). The contents of the key will need to be copied into the `OMNIBUS_NOTIFIER_APP_PRIVATE_KEY` GitHub secret.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.BOT_GITHUB_PAT }}
           fetch-depth: 0
       - name: Update ENV
         if: github.event.inputs.release_type != ''
@@ -34,7 +35,7 @@ jobs:
       - name: publish
         run: ./bin/publish $RELEASE_TYPE
         env:
-          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_AUTH: ${{ secrets.BOT_GITHUB_PAT }}
           NPM_TOKEN: ${{ secrets.BOT_NPM_TOKEN }}
 
   update-lockfile:
@@ -45,6 +46,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           ref: main
+          token: ${{ secrets.BOT_GITHUB_PAT }}
       - name: Update PNPM lockfile
         run: |
           cd tools/merger && ./lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/checkout@master
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.BOT_GITHUB_PAT }}
           fetch-depth: 0
       - name: Update ENV
         if: github.event.inputs.release_type != ''
@@ -35,7 +34,7 @@ jobs:
       - name: publish
         run: ./bin/publish $RELEASE_TYPE
         env:
-          GITHUB_AUTH: ${{ secrets.BOT_GITHUB_PAT }}
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.BOT_NPM_TOKEN }}
 
   update-lockfile:
@@ -46,7 +45,6 @@ jobs:
       - uses: actions/checkout@master
         with:
           ref: main
-          token: ${{ secrets.BOT_GITHUB_PAT }}
       - name: Update PNPM lockfile
         run: |
           cd tools/merger && ./lockfile
@@ -65,11 +63,17 @@ jobs:
     steps:
       - name: Sleep
         run: sleep 60
+      - name: Notifier auth
+        uses: getsentry/action-github-app-token@v1
+        id: notifier_auth
+        with:
+          app_id: ${{ secrets.OMNIBUS_NOTIFIER_APP_ID }}
+          private_key: ${{ secrets.OMNIBUS_NOTIFIER_APP_PRIVATE_KEY }}
       - name: Notify
         run: >-
           curl
           -X POST
-          -u "${{secrets.BOT_GITHUB_USERNAME}}:${{secrets.BOT_GITHUB_PAT}}"
+          -H "Authorization: token ${{ steps.notifier_auth.outputs.token }}"
           -H "Accept: application/vnd.github.everest-preview+json"
           -H "Content-Type: application/json"
           https://api.github.com/repos/grouparoo/omnibus/actions/workflows/update.yml/dispatches

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.BOT_GITHUB_PAT }}
       - name: Update PNPM lockfile
         run: |
           cd tools/merger && ./lockfile

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/checkout@master
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.BOT_GITHUB_PAT }}
       - name: Update PNPM lockfile
         run: |
           cd tools/merger && ./lockfile


### PR DESCRIPTION
## Change description

The default token passed to actions has the necessary permissions to do everything for the current repository, but cannot run actions in another repository (such as when notifying omnibus of a new release). For this, we need to add a GitHub app that's installed on the `grouparoo/omnibus` repo with the `Read/write actions` permission.

Two new repository secrets will need to be added:
- `OMNIBUS_NOTIFIER_APP_ID`: the GitHub App ID that has access to the omnibus repo
- `OMNIBUS_NOTIFIER_APP_PRIVATE_KEY`: contents of the secret key generated by the GitHub app

## Related issues

Does this PR fix a Github Issue?

No

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
