### PR TITLE
Set collection to none for demo destinations

### DIFF
--- a/plugins/@grouparoo/demo/config/mailchimp/users/destinations/mailchimp.json
+++ b/plugins/@grouparoo/demo/config/mailchimp/users/destinations/mailchimp.json
@@ -5,7 +5,7 @@
   "name": "Mailchimp",
   "type": "mailchimp-export-contacts",
   "appId": "mailchimpapp",
-  "groupId": "nobody",
+  "collection": "none",
   "syncMode": "sync",
   "options": {
     "listId": "MAILCHIMP_DESTINATION_LIST_ID"

--- a/plugins/@grouparoo/demo/config/salesforce/users/destinations/salesforce.json
+++ b/plugins/@grouparoo/demo/config/salesforce/users/destinations/salesforce.json
@@ -5,7 +5,7 @@
   "name": "Salesforce",
   "type": "salesforce-export-objects",
   "appId": "salesforce",
-  "groupId": "nobody",
+  "collection": "none",
   "syncMode": "sync",
   "options": {
     "groupNameField": "Name",


### PR DESCRIPTION
From the new changes for model/group collections, we need to update the JSON for the seeded demo destinations.