### PR TITLE
fix: filter sample record properties by model

### DIFF
--- a/ui/ui-config/pages/model/[modelId]/record/new.tsx
+++ b/ui/ui-config/pages/model/[modelId]/record/new.tsx
@@ -7,6 +7,7 @@ import { Form, Button, Alert } from "react-bootstrap";
 import LoadingButton from "@grouparoo/ui-components/components/loadingButton";
 import { Actions } from "@grouparoo/ui-components/utils/apiData";
 import { ErrorHandler } from "@grouparoo/ui-components/utils/errorHandler";
+import { NextPageContext } from "next";
 
 export default function NewRecord(props) {
   const {
@@ -108,11 +109,13 @@ export default function NewRecord(props) {
   );
 }
 
-NewRecord.getInitialProps = async (ctx) => {
+NewRecord.getInitialProps = async (ctx: NextPageContext) => {
   const { execApi } = UseApi(ctx);
+  const { modelId } = ctx.query;
   const { properties }: Actions.PropertiesList = await execApi(
     "get",
-    `/properties`
+    `/properties`,
+    { modelId }
   );
 
   return { properties };


### PR DESCRIPTION
## Change description

The properties you could create a sample record from in config-ui is now filtered by the currently selected model. This was causing an error to be thrown when selecting a property from another model.

## Related issues

Does this PR fix a Github Issue?

No

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
