### PR TITLE
Model scoping on Groups, model state in UI

### DIFF
--- a/core/__tests__/models/group/group.ts
+++ b/core/__tests__/models/group/group.ts
@@ -57,7 +57,9 @@ describe("models/group", () => {
       modelId: model.id,
     });
 
-    expect(group.save()).rejects.toThrow(/cannot find ready model with id/);
+    await expect(group.save()).rejects.toThrow(
+      /cannot find ready model with id/
+    );
 
     await model.update({ state: "ready" });
   });

--- a/core/__tests__/models/group/group.ts
+++ b/core/__tests__/models/group/group.ts
@@ -62,7 +62,7 @@ describe("models/group", () => {
     await model.update({ state: "ready" });
   });
 
-  test("a group can be saved with a deleted state model", async () => {
+  test("a deleted group can be saved with a deleted state model", async () => {
     const group = new Group({
       name: "test group",
       type: "manual",
@@ -72,7 +72,7 @@ describe("models/group", () => {
     await group.save();
 
     await model.update({ state: "deleted" });
-    await group.update({ name: "abc" });
+    await group.update({ name: "abc", state: "deleted" });
     expect(group.name).toBe("abc");
 
     await model.update({ state: "ready" });

--- a/core/__tests__/models/group/group.ts
+++ b/core/__tests__/models/group/group.ts
@@ -14,11 +14,9 @@ import { GroupOps } from "../../../src/modules/ops/group";
 describe("models/group", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
   let model: GrouparooModel;
-  let secondModel: GrouparooModel;
 
   beforeAll(async () => {
     model = await helper.factories.model();
-    // secondModel = await helper.factories.model();
   });
 
   test("a group can be created", async () => {
@@ -72,11 +70,9 @@ describe("models/group", () => {
     });
 
     await group.save();
-
     await model.update({ state: "deleted" });
     await group.update({ name: "abc", state: "deleted" });
     expect(group.name).toBe("abc");
-
     await model.update({ state: "ready" });
   });
 

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -729,9 +729,18 @@ export class Group extends LoggedModel<Group> {
   }
 
   @BeforeCreate
+  static async ensureModelNotDeleted(instance: Destination) {
+    const model = await GrouparooModel.findOne({
+      where: { id: instance.modelId },
+    });
+    if (!model) {
+      throw new Error(`cannot find model with id ${instance.modelId}`);
+    }
+  }
+
   @BeforeSave
   static async ensureModel(instance: Destination) {
-    const model = await GrouparooModel.findOne({
+    const model = await GrouparooModel.scope(null).findOne({
       where: { id: instance.modelId },
     });
     if (!model) {

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -729,7 +729,7 @@ export class Group extends LoggedModel<Group> {
   }
 
   @BeforeCreate
-  static async ensureModelNotDeleted(instance: Destination) {
+  static async ensureModelNotDeleted(instance: Group) {
     const model = await GrouparooModel.findOne({
       where: { id: instance.modelId },
     });
@@ -739,12 +739,21 @@ export class Group extends LoggedModel<Group> {
   }
 
   @BeforeSave
-  static async ensureModel(instance: Destination) {
-    const model = await GrouparooModel.scope(null).findOne({
-      where: { id: instance.modelId },
-    });
-    if (!model) {
-      throw new Error(`cannot find model with id ${instance.modelId}`);
+  static async ensureModel(instance: Group) {
+    if (instance.state === "deleted") {
+      const model = await GrouparooModel.scope(null).findOne({
+        where: { id: instance.modelId },
+      });
+      if (!model) {
+        throw new Error(`cannot find model with id ${instance.modelId}`);
+      }
+    } else {
+      const model = await GrouparooModel.findOne({
+        where: { id: instance.modelId },
+      });
+      if (!model) {
+        throw new Error(`cannot find ready model with id ${instance.modelId}`);
+      }
     }
   }
 

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -734,7 +734,7 @@ export class Group extends LoggedModel<Group> {
       where: { id: instance.modelId },
     });
     if (!model) {
-      throw new Error(`cannot find model with id ${instance.modelId}`);
+      throw new Error(`cannot find ready model with id ${instance.modelId}`);
     }
   }
 

--- a/ui/ui-components/pages/models.tsx
+++ b/ui/ui-components/pages/models.tsx
@@ -12,6 +12,7 @@ import { Models, Actions } from "../utils/apiData";
 import { formatTimestamp } from "../utils/formatTimestamp";
 import { ErrorHandler } from "../utils/errorHandler";
 import EnterpriseLink from "../components/enterpriseLink";
+import StateBadge from "../components/badges/stateBadge";
 
 export default function Page(props) {
   const { errorHandler }: { errorHandler: ErrorHandler } = props;
@@ -67,6 +68,7 @@ export default function Page(props) {
             <th></th>
             <th>Name</th>
             <th>Type</th>
+            <th>State</th>
             <th>Created At</th>
             <th>Updated At</th>
           </tr>
@@ -89,6 +91,9 @@ export default function Page(props) {
                   </EnterpriseLink>
                 </td>
                 <td>{model.type}</td>
+                <td>
+                  <StateBadge state={model.state} />
+                </td>
                 <td>{formatTimestamp(model.createdAt)}</td>
                 <td>{formatTimestamp(model.updatedAt)}</td>
               </tr>


### PR DESCRIPTION
## Change description

Fixes a bug introduced by #2398 where the search for models in the `@BeforeCreate`/`@BeforeSave` hook for Groups wasn't properly scoped.  It caused crashes when deleting a group because the group is updated/saved during the deletion process -- when its model may or may not also be in "deleted" state.  To solve this, I've split out the logic because I don't think they should be the same hook.

- When creating a Group, its Models can only be in `"ready"` state
- When saving a Group, if the Group is in the `"deleted"` state, then its Model may be in the `"deleted"` state.  This is required for final runs to process correctly for deletion.

Also adds a "state" column to `/models` in the ui.

## Related issues

Does this PR fix a Github Issue?

no

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
