### PR TITLE
fix: recordPreview gets record from correct model

### DIFF
--- a/core/__tests__/actions/properties.ts
+++ b/core/__tests__/actions/properties.ts
@@ -417,7 +417,9 @@ describe("actions/properties", () => {
       });
 
       test("record preview will select a record from the property's model", async () => {
-        const foreignRecord = await helper.factories.record();
+        const foreignRecord = await helper.factories.record({
+          modelId: model.id,
+        });
         await foreignRecord.addOrUpdateProperties({ userId: [1001] });
 
         const _record = await helper.factories.record({ modelId: model2.id });

--- a/core/__tests__/actions/properties.ts
+++ b/core/__tests__/actions/properties.ts
@@ -402,6 +402,51 @@ describe("actions/properties", () => {
       expect(success).toBe(true);
     });
 
+    describe("with multiple models", () => {
+      let model2: GrouparooModel;
+      let source2: Source;
+
+      beforeAll(async () => {
+        model2 = await helper.factories.model({ name: "admins" });
+
+        source2 = await helper.factories.source(null, { modelId: model2.id });
+        await source2.setOptions({ table: "test table" });
+        await source2.bootstrapUniqueProperty("adminId", "integer", "id");
+        await source2.setMapping({ id: "adminId" });
+        await source2.update({ state: "ready" });
+      });
+
+      test("record preview will select a record from the property's model", async () => {
+        const foreignRecord = await helper.factories.record();
+        await foreignRecord.addOrUpdateProperties({ userId: [1001] });
+
+        const _record = await helper.factories.record({ modelId: model2.id });
+        await _record.addOrUpdateProperties({ adminId: [1001] });
+
+        const property = await helper.factories.property(
+          source2,
+          { key: "adminEmail" },
+          { column: "email" }
+        );
+
+        connection.params = {
+          csrfToken,
+          id: property.id,
+        };
+        const { error, record } =
+          await specHelper.runAction<PropertyRecordPreview>(
+            "property:recordPreview",
+            connection
+          );
+        expect(error).toBeUndefined();
+        expect(record.id).toBe(_record.id);
+        expect(record.modelId).toBe(source2.modelId);
+
+        await _record.destroy();
+        await foreignRecord.destroy();
+      });
+    });
+
     describe("dynamic property options", () => {
       let app: App;
       let source: Source;

--- a/core/src/actions/properties.ts
+++ b/core/src/actions/properties.ts
@@ -352,18 +352,21 @@ export class PropertyRecordPreview extends AuthenticatedAction {
     let record: GrouparooRecord;
 
     const property = await Property.findById(params.id);
+    const source = await property.$get("source", { scope: null });
 
     if (params.recordId) {
       record = await GrouparooRecord.findById(params.recordId);
     } else {
-      record = await GrouparooRecord.findOne({ order: [["id", "asc"]] });
+      record = await GrouparooRecord.findOne({
+        where: { modelId: source.modelId },
+        order: [["id", "asc"]],
+      });
       if (!record) {
         return { errorMessage: "No records found" };
       }
     }
 
     const apiData = await record.apiData();
-    const source = await property.$get("source", { scope: null });
 
     let newPropertyValues: Array<string | number | boolean | Date> = [];
     let errorMessage: string;


### PR DESCRIPTION
## Change description

Get record from the relevant model when previewing. This was causing a crash in the UI.

## Related issues

Does this PR fix a Github Issue?

No

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
