### PR TITLE
redirect to list page when switching model

### DIFF
--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -1,5 +1,6 @@
 import App from "next/app";
 import Cookies from "universal-cookie";
+import { plural } from "pluralize";
 
 import { UseApi } from "../hooks/useApi";
 
@@ -57,14 +58,25 @@ export default function GrouparooWebApp(props) {
     cookies.set("grouparooModelId", newModelId, { path: "/" });
 
     if (router.pathname.match(/^\/model\//)) {
+      const pathParts = router.pathname.split("/");
+      let newPath = router.pathname;
+
+      if (pathParts.length > 4) {
+        // redirect /model/old/source/abc to /model/new/sources
+        const topic = pathParts[3];
+        newPath = `/model/[modelId]/${plural(topic)}`;
+      }
+
       router.push({
-        pathname: router.pathname,
+        pathname: newPath,
         query: {
           ...router.query,
           modelId: newModelId,
         },
       });
     } else {
+      // model is not in url,
+      // but we should still refresh to update nav menu
       router.reload();
     }
   };

--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -61,7 +61,7 @@ export default function GrouparooWebApp(props) {
       const pathParts = router.pathname.split("/");
       let newPath = router.pathname;
 
-      if (pathParts.length > 4) {
+      if (pathParts.length >= 5 && pathParts[4] !== "new") {
         // redirect /model/old/source/abc to /model/new/sources
         const topic = pathParts[3];
         newPath = `/model/[modelId]/${plural(topic)}`;


### PR DESCRIPTION
## Change description

In most cases, any page scoped by `/model/[modelId]/topic` will not be valid after switching the model. Instead of just switching the model in the path for anything within `/model/`, this PR redirects further subpages to the topic's list. 

For example:
- `/model/users/property/propertyId` -> `/model/admins/properties` 
- `/model/users/sources/sourceId/runs` -> `/model/admins/sources`
- `/model/users/groups` -> `/model/users/groups`

`new` is an exception:
- `/model/users/group/new` -> `/model/admins/group/new`
- `/model/users/destination/new/postgres` -> `/model/admins/destination/new/postgres`

## Related issues

Does this PR fix a Github Issue?

No

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
