### PR TITLE
fix: only keep params in new path when switching models

### DIFF
--- a/ui/ui-components/components/navigation.tsx
+++ b/ui/ui-components/components/navigation.tsx
@@ -18,6 +18,7 @@ import { SetupStepHandler } from "../utils/setupStepsHandler";
 import { SessionHandler } from "../utils/sessionHandler";
 import { StatusHandler } from "../utils/statusHandler";
 import { truncate } from "../utils/truncate";
+import { onChangeModelId } from "../utils/modelHelper";
 
 export const navLiStyle = { marginTop: 20, marginBottom: 20 };
 
@@ -35,7 +36,6 @@ export const iconConstrainedStyle = { width: 20 };
 
 export default function Navigation(props) {
   const {
-    onChangeModelId,
     navigationModel,
     navigationMode,
     navigation,
@@ -51,7 +51,6 @@ export default function Navigation(props) {
     navigation: Actions.NavigationList["navigation"];
     clusterName: { value: string; default: boolean };
     navigationModel: Actions.NavigationList["navigationModel"];
-    onChangeModelId: (id: string) => Promise<void>;
     navExpanded: boolean;
     toggleNavExpanded: () => {};
     errorHandler: ErrorHandler;

--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -1,6 +1,6 @@
 import App from "next/app";
-import Cookies from "universal-cookie";
-import { plural } from "pluralize";
+import { AxiosError } from "axios";
+import type { AppContext } from "next/app";
 
 import { UseApi } from "../hooks/useApi";
 
@@ -9,8 +9,6 @@ import Layout from "../components/layouts/main";
 import PageTransition from "../components/pageTransition";
 import StatusSubscription from "../components/statusSubscription";
 import "../components/icons";
-
-import { AxiosError } from "axios";
 
 import { Actions } from "../utils/apiData";
 
@@ -30,8 +28,7 @@ import { SourceHandler } from "../utils/sourceHandler";
 import { TeamHandler } from "../utils/teamHandler";
 import { TeamMemberHandler } from "../utils/teamMembersHandler";
 import { UploadHandler } from "../utils/uploadHandler";
-import { AppContext } from "next/app";
-import router from "next/router";
+import { getModelFromUrlOrCookie } from "../utils/modelHelper";
 
 const successHandler = new SuccessHandler();
 const errorHandler = new ErrorHandler();
@@ -53,50 +50,11 @@ const uploadHandler = new UploadHandler();
 export default function GrouparooWebApp(props) {
   const { Component, pageProps, err, hydrationError } = props;
 
-  const onChangeModelId = async (newModelId: string) => {
-    const cookies = new Cookies();
-    cookies.set("grouparooModelId", newModelId, { path: "/" });
-
-    if (router.pathname.match(/^\/model\//)) {
-      const pathParts = router.pathname.split("/");
-      let newPath = router.pathname;
-
-      if (pathParts.length >= 5 && pathParts[4] !== "new") {
-        // redirect /model/old/source/abc to /model/new/sources
-        const topic = pathParts[3];
-        newPath = `/model/[modelId]/${plural(topic)}`;
-      }
-
-      // only keep path params for new url
-      const newQuery: typeof router.query = Object.keys(router.query).reduce(
-        (query, paramName) => {
-          if (newPath.includes(`[${paramName}]`)) {
-            query[paramName] = router.query[paramName];
-          }
-          return query;
-        },
-        {}
-      );
-
-      newQuery.modelId = newModelId;
-
-      router.push({
-        query: newQuery,
-        pathname: newPath,
-      });
-    } else {
-      // model is not in url,
-      // but we should still refresh to update nav menu
-      router.reload();
-    }
-  };
-
   const combinedProps = Object.assign({}, pageProps || {}, {
     navigation: props.navigation,
     navigationMode: props.navigationMode,
     navigationModel: props.navigationModel,
     clusterName: props.clusterName,
-    onChangeModelId,
     currentTeamMember: props.currentTeamMember,
     successHandler,
     errorHandler,
@@ -138,13 +96,7 @@ GrouparooWebApp.getInitialProps = async (appContext: AppContext) => {
     id: null,
   };
 
-  let modelId: string;
-  if (appContext.ctx.pathname.match("/model/")) {
-    modelId = appContext.ctx.query.modelId as string;
-  } else {
-    const cookies = new Cookies(appContext.ctx.req?.headers.cookie);
-    modelId = cookies.get("grouparooModelId");
-  }
+  const modelId = getModelFromUrlOrCookie(appContext.ctx);
 
   try {
     const navigationResponse: Actions.NavigationList = await execApi(

--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -67,12 +67,22 @@ export default function GrouparooWebApp(props) {
         newPath = `/model/[modelId]/${plural(topic)}`;
       }
 
-      router.push({
-        pathname: newPath,
-        query: {
-          modelId: newModelId,
-          appId: router.query.appId,
+      // only keep path params for new url
+      const newQuery: typeof router.query = Object.keys(router.query).reduce(
+        (query, paramName) => {
+          if (newPath.includes(`[${paramName}]`)) {
+            query[paramName] = router.query[paramName];
+          }
+          return query;
         },
+        {}
+      );
+
+      newQuery.modelId = newModelId;
+
+      router.push({
+        query: newQuery,
+        pathname: newPath,
       });
     } else {
       // model is not in url,

--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -70,8 +70,8 @@ export default function GrouparooWebApp(props) {
       router.push({
         pathname: newPath,
         query: {
-          ...router.query,
           modelId: newModelId,
+          appId: router.query.appId,
         },
       });
     } else {

--- a/ui/ui-components/utils/modelHelper.ts
+++ b/ui/ui-components/utils/modelHelper.ts
@@ -1,0 +1,54 @@
+import Cookies from "universal-cookie";
+import router from "next/router";
+import { plural } from "pluralize";
+import { NextPageContext } from "next";
+
+export const onChangeModelId = async (newModelId: string) => {
+  const cookies = new Cookies();
+  cookies.set("grouparooModelId", newModelId, { path: "/" });
+
+  if (router.pathname.match(/^\/model\//)) {
+    const pathParts = router.pathname.split("/");
+    let newPath = router.pathname;
+
+    if (pathParts.length >= 5 && pathParts[4] !== "new") {
+      // redirect /model/old/source/abc to /model/new/sources
+      const topic = pathParts[3];
+      newPath = `/model/[modelId]/${plural(topic)}`;
+    }
+
+    // only keep path params for new url
+    const newQuery: typeof router.query = Object.keys(router.query).reduce(
+      (query, paramName) => {
+        if (newPath.includes(`[${paramName}]`)) {
+          query[paramName] = router.query[paramName];
+        }
+        return query;
+      },
+      {}
+    );
+
+    newQuery.modelId = newModelId;
+
+    router.push({
+      query: newQuery,
+      pathname: newPath,
+    });
+  } else {
+    // model is not in url,
+    // but we should still refresh to update nav menu
+    router.reload();
+  }
+};
+
+export const getModelFromUrlOrCookie = (ctx: NextPageContext) => {
+  let modelId: string;
+  if (ctx.pathname.match("/model/")) {
+    modelId = String(ctx.query.modelId);
+  } else {
+    const cookies = new Cookies(ctx.req?.headers.cookie);
+    modelId = cookies.get("grouparooModelId");
+  }
+
+  return modelId;
+};

--- a/ui/ui-components/utils/modelHelper.ts
+++ b/ui/ui-components/utils/modelHelper.ts
@@ -42,13 +42,10 @@ export const onChangeModelId = async (newModelId: string) => {
 };
 
 export const getModelFromUrlOrCookie = (ctx: NextPageContext) => {
-  let modelId: string;
   if (ctx.pathname.match("/model/")) {
-    modelId = String(ctx.query.modelId);
-  } else {
-    const cookies = new Cookies(ctx.req?.headers.cookie);
-    modelId = cookies.get("grouparooModelId");
+    return String(ctx.query.modelId);
   }
 
-  return modelId;
+  const cookies = new Cookies(ctx.req?.headers.cookie);
+  return cookies.get("grouparooModelId") as string;
 };


### PR DESCRIPTION
## Change description

We were always keeping the params from the old route when switching to a new model, which may or may not be required. For example, `/model/admins/record/rec_6a0c9714-d18b-4fde-8f5d-879f819fc72f/edit` took you to `/model/users/records?recordId=rec_6a0c9714-d18b-4fde-8f5d-879f819fc72f` after switching because the param was kept. 

This filters out the params to only include those that are present in the new route. 

## Related issues

Does this PR fix a Github Issue?

No

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
