### PR TITLE
reload model edit page when selected model changes

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/edit.tsx
@@ -29,20 +29,8 @@ export default function Page(props) {
   const { modelId } = router.query;
 
   useEffect(() => {
-    load();
+    setModel(props.model);
   }, [modelId]);
-
-  async function load() {
-    setLoading(true);
-    const response: Actions.ModelView = await execApi(
-      "get",
-      `/model/${modelId}`
-    );
-    setLoading(false);
-    if (response?.model) {
-      setModel(response.model);
-    }
-  }
 
   async function edit(event) {
     event.preventDefault();

--- a/ui/ui-components/pages/model/[modelId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/edit.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { UseApi } from "../../../hooks/useApi";
 import { Row, Col, Form } from "react-bootstrap";
 import { useRouter } from "next/router";
@@ -27,6 +27,22 @@ export default function Page(props) {
   const [model, setModel] = useState<Models.GrouparooModelType>(props.model);
   const [loading, setLoading] = useState(false);
   const { modelId } = router.query;
+
+  useEffect(() => {
+    load();
+  }, [modelId]);
+
+  async function load() {
+    setLoading(true);
+    const response: Actions.ModelView = await execApi(
+      "get",
+      `/model/${modelId}`
+    );
+    setLoading(false);
+    if (response?.model) {
+      setModel(response.model);
+    }
+  }
 
   async function edit(event) {
     event.preventDefault();


### PR DESCRIPTION
## Change description

When on the model edit page, if we used the global model selection dropdown to change to another model, the url would be updated but the model we were looking at was still the old one.

Honestly I think the core issue is actually that in many places throughout the app we are initializing state from props, which gets us into issues with not updating things if props change after the page is rendered. But changing this is a greater refactor and also affects how we're using uncontrolled components in forms.

## Related issues

Does this PR fix a Github Issue?

> Fix [#1]()

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
