### PR TITLE
dont redirect to `new` page for sources and destinations

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/destinations.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destinations.tsx
@@ -59,13 +59,6 @@ export default function Page(props) {
     if (response?.destinations) {
       setDestinations(response.destinations);
       setTotal(response.total);
-
-      if (response.total === 0) {
-        router.push(
-          "/model/[modelId]/destination/new",
-          `/model/${modelId}/destination/new`
-        );
-      }
     }
   }
 

--- a/ui/ui-components/pages/model/[modelId]/sources.tsx
+++ b/ui/ui-components/pages/model/[modelId]/sources.tsx
@@ -64,13 +64,6 @@ export default function Page(props) {
       setSources(response.sources);
       setTotal(response.total);
       setRuns(_runs);
-
-      if (response.total === 0) {
-        router.push(
-          "/model/[modelId]/source/new",
-          `/model/${router.query.modelId}/source/new`
-        );
-      }
     }
   }
 


### PR DESCRIPTION
## Change description

This was causing inconsistent behavior (going directly to the page you would see an empty list, but if the model changed you would see the `new` page.  I'm not entirely sure why these redirects were in there, since before this model change you would never really hit it- it was only checking for empty results when updating the offset and limit params, which wouldnt normally cause a `length 0` 🤔 

We could've also just matched the behavior in `getIntitialProps` and redirect from there if the total was 0, but this doesn't really match what the other list pages do anyway, and might be confusing imo.

## Related issues

Does this PR fix a Github Issue?

No

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
