### PR TITLE
fix: dont get modelId from url in /model/new

### DIFF
--- a/ui/ui-components/__tests__/utils/modelHelper.ts
+++ b/ui/ui-components/__tests__/utils/modelHelper.ts
@@ -1,0 +1,122 @@
+import type { NextPageContext } from "next";
+import Cookies from "universal-cookie";
+import {
+  getModelFromUrlOrCookie,
+  setModelCookie,
+} from "../../utils/modelHelper";
+
+describe("modelHelper", () => {
+  describe("#setModelCookie", () => {
+    test("Sets cookie header when running server-side", () => {
+      let headerVal: string;
+      const fakeCtx = {
+        res: {
+          setHeader: (name, value: string) => {
+            if (name === "set-cookie") {
+              headerVal = value;
+            }
+            return null;
+          },
+        },
+      } as NextPageContext;
+
+      setModelCookie("myModelId", fakeCtx);
+      expect(headerVal).toBe("grouparooModelId=myModelId; Path=/");
+    });
+
+    test("Sets cookie directly when running client-side", () => {
+      let cookieVal: string;
+      const cookieMock = jest
+        .spyOn(Cookies.prototype, "set")
+        .mockImplementation((name, value: string) => {
+          if (name === "grouparooModelId") {
+            cookieVal = value;
+          }
+        });
+
+      setModelCookie("someModelId");
+      expect(cookieVal).toBe("someModelId");
+
+      cookieMock.mockRestore();
+    });
+  });
+
+  describe("#getModelFromUrlOrCookie", () => {
+    let modelCookieValue: string;
+    let cookieMock: jest.SpyInstance;
+
+    beforeAll(() => {
+      cookieMock = jest
+        .spyOn(Cookies.prototype, "get")
+        .mockImplementation((name) => {
+          if (name === "grouparooModelId") return modelCookieValue;
+          return null;
+        });
+    });
+
+    afterAll(() => {
+      cookieMock.mockRestore();
+    });
+
+    test("Gets from URL when in subpage within /model/[modelId]/topic", () => {
+      const ctx: NextPageContext = {
+        pathname: "/model/[modelId]/records",
+        query: { modelId: "profiles" },
+        AppTree: null,
+      };
+
+      const modelId = getModelFromUrlOrCookie(ctx);
+      expect(modelId).toBe("profiles");
+    });
+
+    test("Gets from URL when in deeply nested subpage within /model/[modelId]/topic", () => {
+      const ctx: NextPageContext = {
+        pathname: "/model/[modelId]/sources/[sourceId]/schedule",
+        query: { modelId: "admins", sourceId: "abcd123" },
+        AppTree: null,
+      };
+
+      const modelId = getModelFromUrlOrCookie(ctx);
+      expect(modelId).toBe("admins");
+    });
+
+    test("Gets from Cookie when in non-model-scoped page", () => {
+      const ctx: NextPageContext = {
+        pathname: "/settings",
+        query: {},
+        AppTree: null,
+      };
+
+      modelCookieValue = "someModelId";
+
+      const modelId = getModelFromUrlOrCookie(ctx);
+      expect(modelId).toBe("someModelId");
+    });
+
+    test("Gets from Cookie when in direct model page", () => {
+      const ctx: NextPageContext = {
+        pathname: "/model/[modelId]",
+        query: { modelId: "users" },
+        AppTree: null,
+      };
+
+      modelCookieValue = "profiles";
+
+      const modelId = getModelFromUrlOrCookie(ctx);
+      expect(modelId).toBe("profiles");
+    });
+
+    test("Gets from Cookie when in new page", () => {
+      const ctx: NextPageContext = {
+        pathname: "/model/new",
+        query: {},
+        AppTree: null,
+      };
+
+      modelCookieValue = "drivers";
+
+      const modelId = getModelFromUrlOrCookie(ctx);
+      expect(modelId).toBe("drivers");
+    });
+  });
+});

--- a/ui/ui-components/__tests__/utils/modelHelper.ts
+++ b/ui/ui-components/__tests__/utils/modelHelper.ts
@@ -58,7 +58,7 @@ describe("modelHelper", () => {
       cookieMock.mockRestore();
     });
 
-    test("Gets from URL when in subpage within /model/[modelId]/topic", () => {
+    test("Gets from URL when in subpage within /model/[modelId]", () => {
       const ctx: NextPageContext = {
         pathname: "/model/[modelId]/records",
         query: { modelId: "profiles" },
@@ -69,7 +69,7 @@ describe("modelHelper", () => {
       expect(modelId).toBe("profiles");
     });
 
-    test("Gets from URL when in deeply nested subpage within /model/[modelId]/topic", () => {
+    test("Gets from URL when in subpage within /model/[modelId]/topic", () => {
       const ctx: NextPageContext = {
         pathname: "/model/[modelId]/sources/[sourceId]/schedule",
         query: { modelId: "admins", sourceId: "abcd123" },
@@ -91,19 +91,6 @@ describe("modelHelper", () => {
 
       const modelId = getModelFromUrlOrCookie(ctx);
       expect(modelId).toBe("someModelId");
-    });
-
-    test("Gets from Cookie when in direct model page", () => {
-      const ctx: NextPageContext = {
-        pathname: "/model/[modelId]",
-        query: { modelId: "users" },
-        AppTree: null,
-      };
-
-      modelCookieValue = "profiles";
-
-      const modelId = getModelFromUrlOrCookie(ctx);
-      expect(modelId).toBe("profiles");
     });
 
     test("Gets from Cookie when in new page", () => {

--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -28,7 +28,7 @@ import { SourceHandler } from "../utils/sourceHandler";
 import { TeamHandler } from "../utils/teamHandler";
 import { TeamMemberHandler } from "../utils/teamMembersHandler";
 import { UploadHandler } from "../utils/uploadHandler";
-import { getModelFromUrlOrCookie } from "../utils/modelHelper";
+import { getModelFromUrlOrCookie, setModelCookie } from "../utils/modelHelper";
 
 const successHandler = new SuccessHandler();
 const errorHandler = new ErrorHandler();
@@ -109,11 +109,8 @@ GrouparooWebApp.getInitialProps = async (appContext: AppContext) => {
       currentTeamMember = navigationResponse.teamMember;
     }
 
-    if (navigationResponse.navigationModel.value && appContext.ctx.res) {
-      appContext.ctx.res.setHeader(
-        "set-cookie",
-        `grouparooModelId=${navigationResponse.navigationModel.value}; Path=/`
-      );
+    if (navigationResponse.navigationModel.value) {
+      setModelCookie(navigationResponse.navigationModel.value, appContext.ctx);
     }
 
     // render page-specific getInitialProps

--- a/ui/ui-components/utils/modelHelper.ts
+++ b/ui/ui-components/utils/modelHelper.ts
@@ -4,8 +4,7 @@ import { plural } from "pluralize";
 import { NextPageContext } from "next";
 
 export const onChangeModelId = async (newModelId: string) => {
-  const cookies = new Cookies();
-  cookies.set("grouparooModelId", newModelId, { path: "/" });
+  setModelCookie(newModelId);
 
   if (router.pathname.match(/^\/model\//)) {
     const pathParts = router.pathname.split("/");
@@ -42,10 +41,24 @@ export const onChangeModelId = async (newModelId: string) => {
 };
 
 export const getModelFromUrlOrCookie = (ctx: NextPageContext) => {
-  if (ctx.pathname.match("/model/")) {
+  const pathParts = ctx.pathname.split("/");
+  if (
+    pathParts.length > 3 &&
+    pathParts[1] === "model" &&
+    pathParts[2] === "[modelId]"
+  ) {
     return String(ctx.query.modelId);
   }
 
   const cookies = new Cookies(ctx.req?.headers.cookie);
-  return cookies.get("grouparooModelId") as string;
+  return String(cookies.get("grouparooModelId"));
+};
+
+export const setModelCookie = (modelId: string, ctx?: NextPageContext) => {
+  if (ctx?.res) {
+    ctx.res.setHeader("set-cookie", `grouparooModelId=${modelId}; Path=/`);
+  } else {
+    const cookies = new Cookies();
+    cookies.set("grouparooModelId", modelId, { path: "/" });
+  }
 };


### PR DESCRIPTION
## Change description

When going to `/model/new` to add a new model, the currently selected model was getting reset to the first one.

## Related issues

Does this PR fix a Github Issue?

No

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
