### PR TITLE
Do not use Sequelize's rename column method

### DIFF
--- a/core/src/migrations/000053-removeCompoundindex.ts
+++ b/core/src/migrations/000053-removeCompoundindex.ts
@@ -6,7 +6,7 @@ export default {
     queryInterface: Sequelize.QueryInterface,
     DataTypes: typeof Sequelize
   ) => {
-    const dialect = await MigrationUtils.getDialect(queryInterface);
+    const dialect = MigrationUtils.getDialect(queryInterface);
 
     if (dialect === "sqlite") {
       await queryInterface.removeIndex(

--- a/core/src/migrations/000053-removeCompoundindex.ts
+++ b/core/src/migrations/000053-removeCompoundindex.ts
@@ -1,5 +1,3 @@
-import { config } from "actionhero";
-
 import Sequelize from "sequelize";
 
 export default {
@@ -7,7 +5,9 @@ export default {
     queryInterface: Sequelize.QueryInterface,
     DataTypes: typeof Sequelize
   ) => {
-    if (config.sequelize?.dialect === "sqlite") {
+    const dialect: string = queryInterface.sequelize["options"].dialect;
+
+    if (dialect === "sqlite") {
       await queryInterface.removeIndex(
         "groupMembers",
         ["profileGuid", "groupGuid"],

--- a/core/src/migrations/000053-removeCompoundindex.ts
+++ b/core/src/migrations/000053-removeCompoundindex.ts
@@ -1,11 +1,12 @@
 import Sequelize from "sequelize";
+import { MigrationUtils } from "../utils/migration";
 
 export default {
   up: async (
     queryInterface: Sequelize.QueryInterface,
     DataTypes: typeof Sequelize
   ) => {
-    const dialect: string = queryInterface.sequelize["options"].dialect;
+    const dialect = await MigrationUtils.getDialect(queryInterface);
 
     if (dialect === "sqlite") {
       await queryInterface.removeIndex(

--- a/core/src/migrations/000065-lengthen-id-columns.ts
+++ b/core/src/migrations/000065-lengthen-id-columns.ts
@@ -1,4 +1,5 @@
-import { config } from "actionhero";
+import Sequelize from "sequelize";
+import { MigrationUtils } from "../utils/migration";
 
 const tables = {
   apiKeys: ["apiKey"],
@@ -41,7 +42,7 @@ const runMigration = async ({
   queryInterface: Sequelize.QueryInterface;
   DataTypes: typeof Sequelize;
 }) => {
-  const dialect: string = queryInterface.sequelize["options"].dialect;
+  const dialect = await MigrationUtils.getDialect(queryInterface);
 
   const changeColumn = async (tableName, columnName) => {
     if (dialect !== "sqlite") {
@@ -61,8 +62,6 @@ const runMigration = async ({
     }
   }
 };
-
-import Sequelize from "sequelize";
 
 export default {
   up: async (

--- a/core/src/migrations/000065-lengthen-id-columns.ts
+++ b/core/src/migrations/000065-lengthen-id-columns.ts
@@ -41,8 +41,10 @@ const runMigration = async ({
   queryInterface: Sequelize.QueryInterface;
   DataTypes: typeof Sequelize;
 }) => {
+  const dialect: string = queryInterface.sequelize["options"].dialect;
+
   const changeColumn = async (tableName, columnName) => {
-    if (config.sequelize?.dialect !== "sqlite") {
+    if (dialect !== "sqlite") {
       const query = `ALTER TABLE "${tableName}" ALTER COLUMN "${columnName}" SET DATA TYPE varchar(${maxIdLength}); `;
       await queryInterface.sequelize.query(query);
     } else {

--- a/core/src/migrations/000065-lengthen-id-columns.ts
+++ b/core/src/migrations/000065-lengthen-id-columns.ts
@@ -42,7 +42,7 @@ const runMigration = async ({
   queryInterface: Sequelize.QueryInterface;
   DataTypes: typeof Sequelize;
 }) => {
-  const dialect = await MigrationUtils.getDialect(queryInterface);
+  const dialect = MigrationUtils.getDialect(queryInterface);
 
   const changeColumn = async (tableName, columnName) => {
     if (dialect !== "sqlite") {

--- a/core/src/migrations/000068-profilePropertyCompositeUniqueIndex.ts
+++ b/core/src/migrations/000068-profilePropertyCompositeUniqueIndex.ts
@@ -53,16 +53,6 @@ export default {
         where: { unique: true },
       }
     );
-
-    // All previous SQLite indexes had been removed (migration 000053), but we need to manually apply the per-profile position/value lock
-    // We cannot use Sequelize to apply the second index as it clobbers the first (https://github.com/sequelize/sequelize/issues/12823)
-    // MOVED TO MIGRATION 000081
-    //
-    // if (config.sequelize?.dialect === "sqlite") {
-    //   await queryInterface.sequelize.query(
-    //     "CREATE UNIQUE INDEX `profile_properties_profile_guid_profile_property_rule_guid_posi` ON `profileProperties` (`profileId`, `propertyId`, `position`)"
-    //   );
-    // }
   },
 
   down: async (queryInterface: Sequelize.QueryInterface) => {

--- a/core/src/migrations/000081-profilesToRecords.ts
+++ b/core/src/migrations/000081-profilesToRecords.ts
@@ -1,4 +1,5 @@
 import Sequelize from "sequelize";
+import { MigrationUtils } from "../utils/migration";
 
 const renames: { [table: string]: [string, string][] } = {
   exports: [
@@ -29,12 +30,18 @@ export default {
     queryInterface: Sequelize.QueryInterface,
     DataTypes: typeof Sequelize
   ) => {
-    const dialect: string = queryInterface.sequelize["options"].dialect;
+    const dialect = MigrationUtils.getDialect(queryInterface);
 
     if (dialect === "sqlite") {
       // All previous SQLite indexes had been removed (migration 000053), but we need to manually remove and re-add those special indexes for the recordProperties table.
       // Continued below at end of migration
       // See https://github.com/sequelize/sequelize/issues/12823
+
+      await MigrationUtils.ensureSQLiteTableEmpty(
+        queryInterface,
+        "profileProperties"
+      );
+
       await queryInterface.removeIndex(
         "profileProperties",
         ["profileId", "propertyId", "position"],

--- a/core/src/migrations/000081-profilesToRecords.ts
+++ b/core/src/migrations/000081-profilesToRecords.ts
@@ -66,8 +66,11 @@ export default {
     for (const [table, collection] of Object.entries(renames)) {
       for (const batch of collection) {
         const [oldName, newName] = batch;
+        console.log(
+          `ALTER TABLE "${table}" RENAME COLUMN "${oldName}" TO "${newName}";`
+        );
         await queryInterface.sequelize.query(
-          `ALTER TABLE "${table}" RENAME COLUMN '${oldName}' TO '${newName}';`
+          `ALTER TABLE "${table}" RENAME COLUMN "${oldName}" TO "${newName}";`
         );
       }
     }

--- a/core/src/migrations/000081-profilesToRecords.ts
+++ b/core/src/migrations/000081-profilesToRecords.ts
@@ -66,9 +66,6 @@ export default {
     for (const [table, collection] of Object.entries(renames)) {
       for (const batch of collection) {
         const [oldName, newName] = batch;
-        console.log(
-          `ALTER TABLE "${table}" RENAME COLUMN "${oldName}" TO "${newName}";`
-        );
         await queryInterface.sequelize.query(
           `ALTER TABLE "${table}" RENAME COLUMN "${oldName}" TO "${newName}";`
         );

--- a/core/src/utils/migration.ts
+++ b/core/src/utils/migration.ts
@@ -1,0 +1,31 @@
+import Sequelize from "sequelize";
+
+export namespace MigrationUtils {
+  export function getDialect(queryInterface: Sequelize.QueryInterface) {
+    const dialect: Sequelize.Dialect =
+      queryInterface.sequelize["options"].dialect;
+    return dialect;
+  }
+
+  export async function countRows(
+    queryInterface: Sequelize.QueryInterface,
+    table: string
+  ) {
+    const [rows] = await queryInterface.sequelize.query(
+      `SELECT COUNT(*) as c FROM "${table}"`
+    );
+    return parseInt(rows[0]["c"]);
+  }
+
+  export async function ensureSQLiteTableEmpty(
+    queryInterface: Sequelize.QueryInterface,
+    table: string
+  ) {
+    if (getDialect(queryInterface) !== "sqlite") return;
+    const count = await countRows(queryInterface, table);
+    if (count > 0)
+      throw new Error(
+        `[ migration ] Cannot proceed with migration - table ${table} is not empty.  Please remove your SQLite database at ${queryInterface.sequelize["options"].storage} and retry the migration.  See https://www.grouparoo.com/docs/support/upgrading-grouparoo/v06-v07 for more information.`
+      );
+  }
+}

--- a/core/src/utils/migration.ts
+++ b/core/src/utils/migration.ts
@@ -25,7 +25,7 @@ export namespace MigrationUtils {
     const count = await countRows(queryInterface, table);
     if (count > 0)
       throw new Error(
-        `[ migration ] Cannot proceed with migration - table ${table} is not empty.  Please remove your SQLite database at ${queryInterface.sequelize["options"].storage} and retry the migration.  See https://www.grouparoo.com/docs/support/upgrading-grouparoo/v06-v07 for more information.`
+        `[ migration ] Cannot proceed with migration - table ${table} is not empty.  Please remove your SQLite database at ${queryInterface.sequelize["options"].storage} and retry the migration.  See https://github.com/grouparoo/grouparoo/discussions/2428 for more information.`
       );
   }
 }


### PR DESCRIPTION
This PR makes it clear that Grouparoo will not be migrating SQLite database that have Records and Properties already.  SQLite users are to delete their database and re-start the application. 
  https://github.com/grouparoo/grouparoo/discussions/2428 explains more.

This PR includes a number of migration utilities for the future.


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
