### PR TITLE
dont try to export records after destroy

### DIFF
--- a/core/src/models/GrouparooRecord.ts
+++ b/core/src/models/GrouparooRecord.ts
@@ -279,11 +279,6 @@ export class GrouparooRecord extends LoggedModel<GrouparooRecord> {
   }
 
   @AfterDestroy
-  static async removeFromDestinations(instance: GrouparooRecord) {
-    await instance.export();
-  }
-
-  @AfterDestroy
   static async destroyRecordProperties(instance: GrouparooRecord) {
     await RecordProperty.destroy({
       where: { recordId: instance.id },

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
@@ -253,7 +253,7 @@ export default function Page(props) {
                       handleDelete();
                     }}
                   >
-                    Delete
+                    Remove Sample Record
                   </LoadingButton>
                 </>
               ) : null}


### PR DESCRIPTION
## Change description

In the normal record deletion workflow, the `record:destroy` task is already taking care of exporting the profile before destroying it. This hook only really had an effect in config ui when clicking the `delete` button. I don't quite understand why this was in an `@AfterDestroy` hook, since some of the export functions that are called later on require the record to be present, so it hasn't really been working, causing errors such as `Error: Errors returned without recordId - throw if unknown ` due to the record not existing.

This delete button on config ui should not export anyway, since we're just working with sample profiles and the intention of clicking that button probably means just remove the sample profile.

When checking this I did notice that the `record:destroy` task doesn't seem to be considering models, but that seems like another issue. Created a story on tracker https://www.pivotaltracker.com/story/show/179998326.

## Related issues

Does this PR fix a Github Issue?

No

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
