### PR TITLE
add calculated-property to staging-config

### DIFF
--- a/apps/staging-config/package.json
+++ b/apps/staging-config/package.json
@@ -9,6 +9,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
+    "@grouparoo/calculated-property": "0.7.0-alpha.15",
     "@grouparoo/core": "0.7.0-alpha.15",
     "@grouparoo/demo": "0.7.0-alpha.15",
     "@grouparoo/postgres": "0.7.0-alpha.15",
@@ -28,6 +29,7 @@
   "grouparoo": {
     "grouparoo_monorepo_app": "staging-config",
     "plugins": [
+      "@grouparoo/calculated-property",
       "@grouparoo/demo",
       "@grouparoo/postgres",
       "@grouparoo/sqlite"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,7 @@ importers:
 
   apps/staging-config:
     specifiers:
+      '@grouparoo/calculated-property': 0.7.0-alpha.15
       '@grouparoo/core': 0.7.0-alpha.15
       '@grouparoo/demo': 0.7.0-alpha.15
       '@grouparoo/postgres': 0.7.0-alpha.15
@@ -108,6 +109,7 @@ importers:
       grouparoo: 0.7.0-alpha.15
       jest: 27.1.0
     dependencies:
+      '@grouparoo/calculated-property': link:../../plugins/@grouparoo/calculated-property
       '@grouparoo/core': link:../../core
       '@grouparoo/demo': link:../../plugins/@grouparoo/demo
       '@grouparoo/postgres': link:../../plugins/@grouparoo/postgres


### PR DESCRIPTION
## Change description

The default demo data from `grouparoo demo -c` includes calculated properties, but it was not pre-installed on this staging app, so running it with the demo data caused can error that prevented it from booting up:

```
2021-10-19T20:10:34.826Z - warning: [ config ] error with App `Demo Calculated Property App` (demo_calculated_property_app): Cannot find a "calculated-property" connection available within the installed plugins. Current connections installed are: postgres-export-records, postgres-import-query, postgres-import-table, sqlite-export-records, sqlite-import-query, sqlite-import-table. Use `grouparoo install` to add new plugins if necessary. 
```

## Related issues

Does this PR fix a Github Issue?

No

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [ ] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
