### PR TITLE
add invalid tags to records/properties in ui

### DIFF
--- a/ui/ui-components/components/badges/stateBadge.tsx
+++ b/ui/ui-components/components/badges/stateBadge.tsx
@@ -26,6 +26,8 @@ export default function StateBadge({
       break;
     case "deleted":
       variant = "danger";
+    case "invalid":
+      variant = "danger";
     case "failed":
       variant = "danger";
       break;

--- a/ui/ui-components/components/badges/stateBadge.tsx
+++ b/ui/ui-components/components/badges/stateBadge.tsx
@@ -51,7 +51,14 @@ export default function StateBadge({
   }
 
   return (
-    <Badge style={{ marginBottom: marginBottom ?? 20 }} variant={variant}>
+    <Badge
+      style={{
+        marginLeft: 3,
+        marginRight: 3,
+        marginBottom: marginBottom ?? 20,
+      }}
+      variant={variant}
+    >
       {state}
     </Badge>
   );

--- a/ui/ui-components/components/record/list.tsx
+++ b/ui/ui-components/components/record/list.tsx
@@ -353,6 +353,9 @@ export default function RecordsList(props) {
                 </td>
                 <td>
                   <StateBadge state={record.state} />
+                  {record.invalid === true ? (
+                    <StateBadge state="invalid" />
+                  ) : null}
                 </td>
                 <td>{formatTimestamp(record.createdAt)}</td>
                 <td>{formatTimestamp(record.updatedAt)}</td>

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
@@ -218,6 +218,7 @@ export default function Page(props) {
         badges={[
           <StateBadge state={record.state} />,
           <ModelBadge modelName={record.modelName} modelId={record.modelId} />,
+          record.invalid === true ? <StateBadge state="invalid" /> : null,
         ]}
       />
 
@@ -315,6 +316,9 @@ export default function Page(props) {
                       </td>
                       <td>
                         <StateBadge state={recordProperty.state} />
+                        {recordProperty.invalidReason ? (
+                          <StateBadge state="invalid" />
+                        ) : null}
                       </td>
                       <td>
                         {recordProperty.valueChangedAt


### PR DESCRIPTION
## Change description

Adds a `StateBadge` for invalid properties/records 

<img width="1152" alt="Screen Shot 2021-10-19 at 4 58 06 PM" src="https://user-images.githubusercontent.com/63751206/137989481-7cdd4075-9fea-4903-9c62-8692a9924877.png">

<img width="1172" alt="Screen Shot 2021-10-19 at 4 58 36 PM" src="https://user-images.githubusercontent.com/63751206/137989547-9ea16830-d756-4d06-93b2-2de19b5db4ad.png">

## Related issues

Does this PR fix a Github Issue?

no

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
