### PR TITLE
Do not show Group Labels in UI if not present in plugin

### DIFF
--- a/core/src/classes/plugin.ts
+++ b/core/src/classes/plugin.ts
@@ -601,7 +601,7 @@ export interface DestinationMappingOptionsMethodResponse {
       singular: string; // merge var
       plural: string; // merge vars
     };
-    group: {
+    group?: {
       singular: string; // mailchimp tag
       plural: string; // mailchimp tags
     };

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -669,134 +669,137 @@ export default function Page(props) {
                       <br />
                     </>
                   ) : null}
-
                   <br />
 
-                  <h6>{mappingOptions?.labels?.group.plural}</h6>
+                  {mappingOptions?.labels?.group && (
+                    <>
+                      <h6>{mappingOptions?.labels?.group.plural}</h6>
 
-                  <Table size="sm">
-                    <thead>
-                      <tr>
-                        <th>Grouparoo Group</th>
-                        <th />
-                        <th>{mappingOptions?.labels?.group.singular}</th>
-                        <th />
-                        <th />
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {destination.destinationGroupMemberships.map(
-                        ({ groupName, groupId, remoteKey }, idx) => (
-                          <tr key={`optional-mapping-${idx}`}>
-                            <td>
-                              <Form.Control
-                                as="select"
-                                required={false}
-                                value={groupId}
-                                disabled={loading}
-                                onChange={(e) =>
-                                  updateDestinationGroupMembership(
-                                    e.target["value"],
-                                    null,
-                                    groupId
-                                  )
-                                }
-                              >
-                                <option disabled value={""}>
-                                  choose a group
-                                </option>
-                                {groups.map((group) => (
-                                  <option
-                                    value={group.id}
-                                    key={`group-remote-mapping-${group.id}`}
-                                  >
-                                    {group.name}
-                                  </option>
-                                ))}
-                              </Form.Control>
-                            </td>
-                            <td style={{ textAlign: "center" }}>→</td>
-                            <td>
-                              <Form.Control
-                                required
-                                type="text"
-                                disabled={!unlockedGroups.includes(groupId)}
-                                value={remoteKey}
-                                onChange={(e) =>
-                                  updateDestinationGroupMembership(
-                                    groupId,
-                                    e.target["value"]
-                                  )
-                                }
-                              />
-                              <Form.Control.Feedback type="invalid">
-                                {mappingOptions?.labels?.group.singular} is
-                                required
-                              </Form.Control.Feedback>
-                            </td>
-                            <td>
-                              <Button
-                                size="sm"
-                                variant="light"
-                                onClick={() => toggleUnlockedGroup(groupId)}
-                              >
-                                ✏️
-                              </Button>
-                            </td>
-                            <td>
-                              <Button
-                                size="sm"
-                                variant="danger"
-                                onClick={() => {
-                                  updateDestinationGroupMembership(
-                                    null,
-                                    null,
-                                    groupId
-                                  );
-                                }}
-                              >
-                                X
-                              </Button>
-                            </td>
+                      <Table size="sm">
+                        <thead>
+                          <tr>
+                            <th>Grouparoo Group</th>
+                            <th />
+                            <th>{mappingOptions?.labels?.group.singular}</th>
+                            <th />
+                            <th />
                           </tr>
-                        )
-                      )}
-                    </tbody>
-                  </Table>
-
-                  <Alert variant="light">
-                    <Form.Group as={Row}>
-                      <Form.Label column sm={3}>
-                        <strong>Send Group:</strong>
-                      </Form.Label>
-                      <Col>
-                        <Typeahead
-                          id="taggedGroup"
-                          ref={taggedGroupRef}
-                          disabled={
-                            groupsAvailalbeForDestinationGroupMemberships.length ===
-                            0
-                          }
-                          placeholder={`Choose a group...`}
-                          onChange={(selected) => {
-                            taggedGroupRef.current.clear();
-                            const chosenGroup =
-                              groupsAvailalbeForDestinationGroupMemberships.filter(
-                                (g) => g.name === selected[0]
-                              )[0];
-
-                            updateDestinationGroupMembership(
-                              chosenGroup.id,
-                              chosenGroup.name
-                            );
-                          }}
-                          options={groupsAvailalbeForDestinationGroupMemberships.map(
-                            ({ name }) => name
+                        </thead>
+                        <tbody>
+                          {destination.destinationGroupMemberships.map(
+                            ({ groupName, groupId, remoteKey }, idx) => (
+                              <tr key={`optional-mapping-${idx}`}>
+                                <td>
+                                  <Form.Control
+                                    as="select"
+                                    required={false}
+                                    value={groupId}
+                                    disabled={loading}
+                                    onChange={(e) =>
+                                      updateDestinationGroupMembership(
+                                        e.target["value"],
+                                        null,
+                                        groupId
+                                      )
+                                    }
+                                  >
+                                    <option disabled value={""}>
+                                      choose a group
+                                    </option>
+                                    {groups.map((group) => (
+                                      <option
+                                        value={group.id}
+                                        key={`group-remote-mapping-${group.id}`}
+                                      >
+                                        {group.name}
+                                      </option>
+                                    ))}
+                                  </Form.Control>
+                                </td>
+                                <td style={{ textAlign: "center" }}>→</td>
+                                <td>
+                                  <Form.Control
+                                    required
+                                    type="text"
+                                    disabled={!unlockedGroups.includes(groupId)}
+                                    value={remoteKey}
+                                    onChange={(e) =>
+                                      updateDestinationGroupMembership(
+                                        groupId,
+                                        e.target["value"]
+                                      )
+                                    }
+                                  />
+                                  <Form.Control.Feedback type="invalid">
+                                    {mappingOptions?.labels?.group.singular} is
+                                    required
+                                  </Form.Control.Feedback>
+                                </td>
+                                <td>
+                                  <Button
+                                    size="sm"
+                                    variant="light"
+                                    onClick={() => toggleUnlockedGroup(groupId)}
+                                  >
+                                    ✏️
+                                  </Button>
+                                </td>
+                                <td>
+                                  <Button
+                                    size="sm"
+                                    variant="danger"
+                                    onClick={() => {
+                                      updateDestinationGroupMembership(
+                                        null,
+                                        null,
+                                        groupId
+                                      );
+                                    }}
+                                  >
+                                    X
+                                  </Button>
+                                </td>
+                              </tr>
+                            )
                           )}
-                        />
-                      </Col>
-                    </Form.Group>
-                  </Alert>
+                        </tbody>
+                      </Table>
+
+                      <Alert variant="light">
+                        <Form.Group as={Row}>
+                          <Form.Label column sm={3}>
+                            <strong>Send Group:</strong>
+                          </Form.Label>
+                          <Col>
+                            <Typeahead
+                              id="taggedGroup"
+                              ref={taggedGroupRef}
+                              disabled={
+                                groupsAvailalbeForDestinationGroupMemberships.length ===
+                                0
+                              }
+                              placeholder={`Choose a group...`}
+                              onChange={(selected) => {
+                                taggedGroupRef.current.clear();
+                                const chosenGroup =
+                                  groupsAvailalbeForDestinationGroupMemberships.filter(
+                                    (g) => g.name === selected[0]
+                                  )[0];
+
+                                updateDestinationGroupMembership(
+                                  chosenGroup.id,
+                                  chosenGroup.name
+                                );
+                              }}
+                              options={groupsAvailalbeForDestinationGroupMemberships.map(
+                                ({ name }) => name
+                              )}
+                            />
+                          </Col>
+                        </Form.Group>
+                      </Alert>
+                    </>
+                  )}
                 </Col>
               </Row>
 


### PR DESCRIPTION
Allows the labels a Destination Plugin provides not to include the "groups" collection.  If these labels are excluded, the UI for mapping Groups to tags/lists/etc will not be shown.

This PR does not remove the group labels from any of the plugins.

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
