### PR TITLE
limit node versions to under 17

### DIFF
--- a/apps/staging-community/package.json
+++ b/apps/staging-community/package.json
@@ -6,7 +6,7 @@
   "license": "MPL-2.0",
   "private": true,
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "dependencies": {
     "@grouparoo/bigquery": "0.7.0-alpha.15",

--- a/apps/staging-config/package.json
+++ b/apps/staging-config/package.json
@@ -6,7 +6,7 @@
   "license": "MPL-2.0",
   "private": true,
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "dependencies": {
     "@grouparoo/calculated-property": "0.7.0-alpha.15",

--- a/apps/staging-enterprise/package.json
+++ b/apps/staging-enterprise/package.json
@@ -6,7 +6,7 @@
   "license": "unlicensed",
   "private": true,
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "dependencies": {
     "@grouparoo/bigquery": "0.7.0-alpha.15",

--- a/cli/package.json
+++ b/cli/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "bin": {
     "grouparoo": "dist/grouparoo.js"

--- a/cli/templates/package.json
+++ b/cli/templates/package.json
@@ -6,7 +6,7 @@
   "license": "MPL-2.0",
   "private": true,
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "dependencies": {
     "@grouparoo/core": "~~VERSION~~",

--- a/core/package.json
+++ b/core/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "SEE LICENSE IN LICENSE.txt",
   "private": true,
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "description": "The main Grouparoo Application. Learn more at www.grouparoo.com.",
   "repository": {

--- a/plugins/@grouparoo/app-templates/package.json
+++ b/plugins/@grouparoo/app-templates/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/bigquery/package.json
+++ b/plugins/@grouparoo/bigquery/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/braze/package.json
+++ b/plugins/@grouparoo/braze/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/calculated-property/package.json
+++ b/plugins/@grouparoo/calculated-property/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/cloudwatch/package.json
+++ b/plugins/@grouparoo/cloudwatch/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/csv/package.json
+++ b/plugins/@grouparoo/csv/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/customerio/package.json
+++ b/plugins/@grouparoo/customerio/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/dbt/package.json
+++ b/plugins/@grouparoo/dbt/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/demo/package.json
+++ b/plugins/@grouparoo/demo/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/eloqua/package.json
+++ b/plugins/@grouparoo/eloqua/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/facebook/package.json
+++ b/plugins/@grouparoo/facebook/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/google-sheets/package.json
+++ b/plugins/@grouparoo/google-sheets/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/hubspot/package.json
+++ b/plugins/@grouparoo/hubspot/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/intercom/package.json
+++ b/plugins/@grouparoo/intercom/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/iterable/package.json
+++ b/plugins/@grouparoo/iterable/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/logger/package.json
+++ b/plugins/@grouparoo/logger/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/mailchimp/package.json
+++ b/plugins/@grouparoo/mailchimp/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/mailjet/package.json
+++ b/plugins/@grouparoo/mailjet/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/marketo/package.json
+++ b/plugins/@grouparoo/marketo/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/mixpanel/package.json
+++ b/plugins/@grouparoo/mixpanel/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/mongo/package.json
+++ b/plugins/@grouparoo/mongo/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/mysql/package.json
+++ b/plugins/@grouparoo/mysql/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/newrelic/package.json
+++ b/plugins/@grouparoo/newrelic/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/onesignal/package.json
+++ b/plugins/@grouparoo/onesignal/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/pardot/package.json
+++ b/plugins/@grouparoo/pardot/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/pipedrive/package.json
+++ b/plugins/@grouparoo/pipedrive/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/postgres/package.json
+++ b/plugins/@grouparoo/postgres/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/prometheus/package.json
+++ b/plugins/@grouparoo/prometheus/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "scripts": {
     "lint": "prettier --check src __tests__",

--- a/plugins/@grouparoo/redshift/package.json
+++ b/plugins/@grouparoo/redshift/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/sailthru/package.json
+++ b/plugins/@grouparoo/sailthru/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/salesforce/package.json
+++ b/plugins/@grouparoo/salesforce/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/sendgrid/package.json
+++ b/plugins/@grouparoo/sendgrid/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/sentry/package.json
+++ b/plugins/@grouparoo/sentry/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/snowflake/package.json
+++ b/plugins/@grouparoo/snowflake/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/spec-helper/package.json
+++ b/plugins/@grouparoo/spec-helper/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "main": "dist/index",
   "homepage": "https://www.grouparoo.com",

--- a/plugins/@grouparoo/sqlite/package.json
+++ b/plugins/@grouparoo/sqlite/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/plugins/@grouparoo/zendesk/package.json
+++ b/plugins/@grouparoo/zendesk/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/tools/merger/package.json
+++ b/tools/merger/package.json
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "private": true,
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "dependencies": {
     "glob": "7.1.7",

--- a/ui/ui-community/package.json
+++ b/ui/ui-community/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/ui/ui-components/package.json
+++ b/ui/ui-components/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/ui/ui-config/package.json
+++ b/ui/ui-config/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {

--- a/ui/ui-enterprise/package.json
+++ b/ui/ui-enterprise/package.json
@@ -9,7 +9,7 @@
     "access": "restricted"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.0.0 <17.0.0"
   },
   "homepage": "https://www.grouparoo.com",
   "bugs": {


### PR DESCRIPTION
## Change description

There is at least one known issue with our setup being compatible with Node17 ([related Github issue](https://github.com/webpack/webpack/issues/14532#issuecomment-947525539) pertaining to webpack's hashing function).  Limiting our Node version to <17.0.0 until our setup is compatible.

## Related issues

Does this PR fix a Github Issue?

No.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
