### PR TITLE
A few fixes for when Records and Models are deleted

### DIFF
--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -514,9 +514,17 @@ export class Destination extends LoggedModel<Destination> {
     record: GrouparooRecord,
     sync = false,
     force = false,
-    saveExports = true
+    saveExports = true,
+    toDelete?: boolean
   ) {
-    return DestinationOps.exportRecord(this, record, sync, force, saveExports);
+    return DestinationOps.exportRecord(
+      this,
+      record,
+      sync,
+      force,
+      saveExports,
+      toDelete
+    );
   }
 
   async sendExport(_export: Export, sync = false) {

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -210,7 +210,7 @@ export class Destination extends LoggedModel<Destination> {
       group = await this.$get("group", { scope: null, include: [GroupRule] });
     }
 
-    const model = await this.$get("model");
+    const model = await this.$get("model", { scope: null });
     const mapping = await this.getMapping();
     const options = await this.getOptions(null);
     const destinationGroupMemberships =

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -294,7 +294,7 @@ export class Group extends LoggedModel<Group> {
   }
 
   async apiData() {
-    const model = await this.$get("model");
+    const model = await this.$get("model", { scope: null });
     const recordsCount = await this.recordsCount(null);
     const rules = await this.getRules();
     const nextCalculatedAt = await this.nextCalculatedAt();

--- a/core/src/models/GrouparooRecord.ts
+++ b/core/src/models/GrouparooRecord.ts
@@ -87,7 +87,7 @@ export class GrouparooRecord extends LoggedModel<GrouparooRecord> {
   exports: Export[];
 
   async apiData() {
-    const model = await this.$get("model");
+    const model = await this.$get("model", { scope: null });
     const properties = await this.getProperties();
 
     return {
@@ -266,7 +266,6 @@ export class GrouparooRecord extends LoggedModel<GrouparooRecord> {
   }
 
   @BeforeCreate
-  @BeforeSave
   static async ensureModel(instance: GrouparooRecord) {
     const model = await GrouparooModel.findOne({
       where: { id: instance.modelId },

--- a/core/src/models/GrouparooRecord.ts
+++ b/core/src/models/GrouparooRecord.ts
@@ -179,9 +179,17 @@ export class GrouparooRecord extends LoggedModel<GrouparooRecord> {
     force = false,
     oldGroupsOverride?: Group[],
     saveExports = true,
-    sync = true
+    sync = true,
+    toDelete?: boolean
   ) {
-    return RecordOps._export(this, force, oldGroupsOverride, saveExports, sync);
+    return RecordOps._export(
+      this,
+      force,
+      oldGroupsOverride,
+      saveExports,
+      sync,
+      toDelete
+    );
   }
 
   async logMessage(verb: "create" | "update" | "destroy") {

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -196,7 +196,7 @@ export class Source extends LoggedModel<Source> {
   }
 
   async apiData() {
-    const model = await this.$get("model");
+    const model = await this.$get("model", { scope: null });
     const app = await this.$get("app", { scope: null, include: [Option] });
     const schedule = await this.$get("schedule", { scope: null });
 

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -328,7 +328,8 @@ export namespace DestinationOps {
     record: GrouparooRecord,
     synchronous = false,
     force = false,
-    saveExports = true
+    saveExports = true,
+    toDelete?: boolean
   ) {
     if (destination.modelId !== record.modelId) {
       throw new Error(
@@ -351,20 +352,23 @@ export namespace DestinationOps {
     let mappedNewRecordProperties: ExportRecordPropertiesWithType = {};
     let oldGroupNames: string[] = [];
     let newGroupNames: string[] = [];
-    let toDelete = false;
 
     let newGroups = await Group.findAll({
       include: [{ model: GroupMember, where: { recordId: record.id } }],
     });
 
-    // do we need to delete this record from the destination?
-    if (destination.collection === "none") {
-      toDelete = true;
-    } else if (destination.collection === "group") {
-      if (!destination.groupId) {
+    // Do we need to delete this record from the destination?
+    // If toDelete was not provided explicitly, determine what to do
+    if (toDelete !== true && toDelete !== false) {
+      toDelete = false;
+      if (destination.collection === "none") {
         toDelete = true;
-      } else if (!newGroups.map((g) => g.id).includes(destination.groupId)) {
-        toDelete = true;
+      } else if (destination.collection === "group") {
+        if (!destination.groupId) {
+          toDelete = true;
+        } else if (!newGroups.map((g) => g.id).includes(destination.groupId)) {
+          toDelete = true;
+        }
       }
     }
 

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -403,7 +403,13 @@ export namespace DestinationOps {
 
     for (const k in mapping) {
       const property = properties.find((r) => r.key === mapping[k]);
-      if (!property) throw new Error(`cannot find rule for ${mapping[k]}`);
+      if (!property) {
+        if (destination.state === "ready") {
+          throw new Error(`cannot find rule for ${mapping[k]}`);
+        } else {
+          continue;
+        }
+      }
       const { type } = property;
 
       if (forceOldPropertyValues) {

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -606,7 +606,8 @@ export namespace RecordOps {
     force = false,
     oldGroups: Group[] = [],
     saveExports = true,
-    sync = true
+    sync = true,
+    toDelete?: boolean
   ) {
     const groups = await record.$get("groups");
 
@@ -652,7 +653,8 @@ export namespace RecordOps {
           record,
           sync, // sync = true -> do the export in-line
           force, // force = true -> do the export even if it looks like the data hasn't changed
-          saveExports // saveExports = true -> should we really save these exports, or do we just want examples for the next export?
+          saveExports, // saveExports = true -> should we really save these exports, or do we just want examples for the next export?
+          toDelete // are we deleting this record and should we ensure that all exports are toDelete=true?
         )
       )
     );

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -847,7 +847,7 @@ export namespace RecordOps {
     }
 
     // Also search all records for a "null" value in the directly mapped property
-    recordsToDestroy = recordsToDestroy.concat(
+    return recordsToDestroy.concat(
       await api.sequelize.query(
         `
     SELECT "id" FROM "records"
@@ -866,8 +866,6 @@ export namespace RecordOps {
         }
       )
     );
-
-    return recordsToDestroy;
   }
 
   /**
@@ -1056,7 +1054,7 @@ export namespace RecordOps {
         id: { [Op.in]: recordIds },
       },
       include: [
-        { model: RecordProperty, required: false },
+        { model: RecordProperty, required: true },
         { model: Import, required: false, where: { recordUpdatedAt: null } },
       ],
     });

--- a/core/src/tasks/grouparooModel/run.ts
+++ b/core/src/tasks/grouparooModel/run.ts
@@ -32,7 +32,7 @@ export class RunInternalRun extends CLSTask {
     const offset: number = run.memberOffset || 0;
     const limit: number = run.memberLimit || config.batchSize.imports;
 
-    const model = await GrouparooModel.findOne({
+    const model = await GrouparooModel.scope(null).findOne({
       where: { id: run.creatorId },
     });
     if (!model) return;
@@ -46,10 +46,12 @@ export class RunInternalRun extends CLSTask {
     });
 
     if (records.length > 0) {
-      await RecordProperty.update(
-        { state: "pending" },
-        { where: { recordId: { [Op.in]: records.map((p) => p.id) } } }
-      );
+      if (model.state === "ready") {
+        await RecordProperty.update(
+          { state: "pending" },
+          { where: { recordId: { [Op.in]: records.map((p) => p.id) } } }
+        );
+      }
 
       await GrouparooRecord.update(
         { state: "pending" },

--- a/core/src/tasks/record/destroy.ts
+++ b/core/src/tasks/record/destroy.ts
@@ -34,7 +34,7 @@ export class RecordDestroy extends CLSTask {
       // clear groups and export
       // when the export is done, this task will be enqueued again to destroy it
       await GrouparooRecord.destroyGroupMembers(record);
-      await record.export(false, oldGroups, true, false);
+      await record.export(false, oldGroups, true, false, true);
     } else {
       // use "destroy" to clean up related models
       await record.destroy();


### PR DESCRIPTION
A few fixes for when Records and Models are deleted:

* When a Record is destroyed, any final Exports will explicitly set `toDelete=true`
* Implement GrouparooModel state machine
* Prevent situations where we delete a model (and source, properties, etc) from prematurely deleting Grouparoo's local data before sending the final export to any destination that had previously been tracking the model

## TODO:
- [ ] Test all the new behavior
- [ ] Sort out why the final export's properties aren't getting the right data on that last export.  
   * Or, maybe the mailchimp plugin doesn't know what to do when there's no new email but there is an old one?
- [ ] It's time to refactor DestinationOps

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [ ] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
