### PR TITLE
Remove previously sync'd Records from Destinations when they are deleted

### DIFF
--- a/core/__tests__/tasks/grouparooModel/destroy.ts
+++ b/core/__tests__/tasks/grouparooModel/destroy.ts
@@ -1,7 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { api, task, specHelper } from "actionhero";
-import { Group } from "../../../dist";
-import { App, GrouparooModel, Destination, Source } from "../../../src";
+import { GrouparooModel, Destination } from "../../../src";
 
 describe("tasks/model:destroy", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -19,7 +18,7 @@ describe("tasks/model:destroy", () => {
     });
 
     test("will delete model immediately if it's not being used", async () => {
-      const model: GrouparooModel = await helper.factories.model();
+      const model = await helper.factories.model();
 
       await model.update({ state: "deleted" });
       await task.enqueue("model:destroy", { modelId: model.id });
@@ -33,9 +32,9 @@ describe("tasks/model:destroy", () => {
     });
 
     test("will wait for source to be deleted if it uses the model", async () => {
-      const model: GrouparooModel = await helper.factories.model();
-      const app: App = await helper.factories.app();
-      const source: Source = await helper.factories.source(app, {
+      const model = await helper.factories.model();
+      const app = await helper.factories.app();
+      const source = await helper.factories.source(app, {
         modelId: model.id,
       });
       await model.update({ state: "deleted" });
@@ -57,8 +56,8 @@ describe("tasks/model:destroy", () => {
     });
 
     test("will wait for destination to be deleted if it uses the model", async () => {
-      const model: GrouparooModel = await helper.factories.model();
-      const app: App = await helper.factories.app();
+      const model = await helper.factories.model();
+      const app = await helper.factories.app();
       const destination: Destination = await helper.factories.destination(app, {
         modelId: model.id,
       });
@@ -81,8 +80,8 @@ describe("tasks/model:destroy", () => {
     });
 
     test("will wait for group to be deleted if it uses the model", async () => {
-      const model: GrouparooModel = await helper.factories.model();
-      const group: Group = await helper.factories.group();
+      const model = await helper.factories.model();
+      const group = await helper.factories.group();
       await group.update({ modelId: model.id });
 
       await model.update({ state: "deleted" });
@@ -97,6 +96,28 @@ describe("tasks/model:destroy", () => {
 
       // remove group
       await group.destroy();
+
+      // run it again
+      await specHelper.runTask("model:destroy", foundTasks[0].args[0]);
+      await expect(model.reload()).rejects.toThrow(/does not exist anymore/);
+    });
+
+    test("will wait for record to be deleted if it uses the model", async () => {
+      const model = await helper.factories.model();
+      const record = await helper.factories.record({ modelId: model.id });
+
+      await model.update({ state: "deleted" });
+      await task.enqueue("model:destroy", { modelId: model.id });
+
+      const foundTasks = await specHelper.findEnqueuedTasks("model:destroy");
+      expect(foundTasks.length).toBe(1);
+      await specHelper.runTask("model:destroy", foundTasks[0].args[0]);
+
+      const reloadedModel = await GrouparooModel.findById(model.id);
+      expect(reloadedModel.state).toBe("deleted");
+
+      // remove group
+      await record.destroy();
 
       // run it again
       await specHelper.runTask("model:destroy", foundTasks[0].args[0]);

--- a/core/__tests__/tasks/grouparooModel/destroy.ts
+++ b/core/__tests__/tasks/grouparooModel/destroy.ts
@@ -116,7 +116,7 @@ describe("tasks/model:destroy", () => {
       const reloadedModel = await GrouparooModel.findById(model.id);
       expect(reloadedModel.state).toBe("deleted");
 
-      // remove group
+      // remove record
       await record.destroy();
 
       // run it again

--- a/core/__tests__/tasks/record/destroy.ts
+++ b/core/__tests__/tasks/record/destroy.ts
@@ -47,7 +47,7 @@ describe("tasks/record:destroy", () => {
 
     await specHelper.runTask("record:destroy", { recordId: record.id });
     await record.reload();
-    expect(record.state).toBe("deleted");
+    expect(record.state).toBe("pending"); // no change
 
     // make it ready
     await RecordProperty.update(

--- a/core/__tests__/tasks/record/destroy.ts
+++ b/core/__tests__/tasks/record/destroy.ts
@@ -5,7 +5,6 @@ import {
   Property,
   RecordProperty,
   GrouparooRecord,
-  Destination,
   Group,
   Export,
   Import,
@@ -43,28 +42,28 @@ describe("tasks/record:destroy", () => {
   });
 
   test("does not delete records that aren't ready", async () => {
-    const record: GrouparooRecord = await helper.factories.record();
+    const record = await helper.factories.record();
     await record.update({ state: "pending" });
 
     await specHelper.runTask("record:destroy", { recordId: record.id });
     await record.reload();
-    expect(record.state).toBe("pending");
+    expect(record.state).toBe("deleted");
 
     // make it ready
     await RecordProperty.update(
       { state: "ready" },
       { where: { recordId: record.id } }
     );
-    await record.update({ state: "ready" });
+    await record.update({ state: "deleted" });
 
     await specHelper.runTask("record:destroy", { recordId: record.id });
     await expect(record.reload()).rejects.toThrow(/does not exist anymore/);
   });
 
-  test("exports records and removes them from groups before destroying", async () => {
-    const record: GrouparooRecord = await helper.factories.record();
+  test("exports records and removes them from groups before destroying (group destination)", async () => {
+    const record = await helper.factories.record();
 
-    const destination: Destination = await helper.factories.destination();
+    const destination = await helper.factories.destination();
     const group: Group = await helper.factories.group();
 
     await group.addRecord(record);
@@ -105,7 +104,7 @@ describe("tasks/record:destroy", () => {
 
     // record is still there, but is now being exported
     await record.reload();
-    expect(record.state).toBe("ready");
+    expect(record.state).toBe("deleted");
 
     recordGroups = await record.$get("groups");
     expect(recordGroups.length).toBe(0); // removed from groups
@@ -120,7 +119,7 @@ describe("tasks/record:destroy", () => {
 
     // does nothing, there's an export being processed
     await record.reload();
-    expect(record.state).toBe("ready");
+    expect(record.state).toBe("deleted");
     exportCount = await Export.count({
       where: { recordId: record.id, state: { [Op.ne]: "complete" } },
     });
@@ -144,14 +143,82 @@ describe("tasks/record:destroy", () => {
     await expect(record.reload()).rejects.toThrow(/does not exist anymore/);
   });
 
+  test("exports records and removes them from groups before destroying (model destination)", async () => {
+    const record = await helper.factories.record();
+
+    const destination = await helper.factories.destination();
+
+    await RecordProperty.update(
+      { state: "ready" },
+      { where: { recordId: record.id } }
+    );
+    await record.update({ state: "ready" });
+
+    await destination.updateTracking("model");
+    await destination.exportRecord(record);
+
+    await specHelper.runTask("export:enqueue", {});
+    let foundTasks = await specHelper.findEnqueuedTasks("export:send");
+    expect(foundTasks.length).toBe(1);
+    for (const i in foundTasks) {
+      await specHelper.runTask("export:send", foundTasks[i].args[0]);
+    }
+    await api.resque.queue.connection.redis.flushdb();
+
+    let exportCount = await Export.count({
+      where: { recordId: record.id, state: { [Op.ne]: "complete" } },
+    });
+    expect(exportCount).toBe(0);
+    await record.reload();
+    expect(record.state).toBe("ready");
+
+    // try to delete
+    await specHelper.runTask("record:destroy", { recordId: record.id });
+
+    // record is still there, but is now being exported
+    await record.reload();
+    expect(record.state).toBe("deleted");
+
+    exportCount = await Export.count({
+      where: { recordId: record.id, state: { [Op.ne]: "complete" } },
+    });
+    expect(exportCount).toBe(1);
+
+    // try to delete
+    await specHelper.runTask("record:destroy", { recordId: record.id });
+
+    // does nothing, there's an export being processed
+    await record.reload();
+    expect(record.state).toBe("deleted");
+    exportCount = await Export.count({
+      where: { recordId: record.id, state: { [Op.ne]: "complete" } },
+    });
+    expect(exportCount).toBe(1); // still only 1
+
+    // process the export
+    await specHelper.runTask("export:enqueue", {});
+    foundTasks = await specHelper.findEnqueuedTasks("export:send");
+    expect(foundTasks.length).toBe(1);
+    for (const i in foundTasks) {
+      await specHelper.runTask("export:send", foundTasks[i].args[0]);
+    }
+
+    const finalExport = await Export.findById(foundTasks[0].args[0].exportId);
+    expect(finalExport.toDelete).toBe(true);
+
+    // now we can destroy
+    await specHelper.runTask("record:destroy", { recordId: record.id });
+    await expect(record.reload()).rejects.toThrow(/does not exist anymore/);
+  });
+
   test("all related models are cleaned up", async () => {
-    const record: GrouparooRecord = await helper.factories.record();
-    const _import: Import = await helper.factories.import(
+    const record = await helper.factories.record();
+    const _import = await helper.factories.import(
       undefined,
       undefined,
       record.id
     );
-    const _export: Export = await helper.factories.export(record);
+    const _export = await helper.factories.export(record);
     await _export.update({ state: "complete" });
 
     await record.addOrUpdateProperties({
@@ -164,9 +231,10 @@ describe("tasks/record:destroy", () => {
       { state: "ready" },
       { where: { recordId: record.id } }
     );
-    await record.update({ state: "ready" });
+    await record.update({ state: "deleted" });
 
     await specHelper.runTask("record:destroy", { recordId: record.id });
+    await expect(record.reload()).rejects.toThrow(/does not exist anymore/);
 
     const properties = await RecordProperty.findAll({
       where: { recordId: record.id },

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -514,9 +514,17 @@ export class Destination extends LoggedModel<Destination> {
     record: GrouparooRecord,
     sync = false,
     force = false,
-    saveExports = true
+    saveExports = true,
+    toDelete?: boolean
   ) {
-    return DestinationOps.exportRecord(this, record, sync, force, saveExports);
+    return DestinationOps.exportRecord(
+      this,
+      record,
+      sync,
+      force,
+      saveExports,
+      toDelete
+    );
   }
 
   async sendExport(_export: Export, sync = false) {

--- a/core/src/models/GrouparooRecord.ts
+++ b/core/src/models/GrouparooRecord.ts
@@ -143,11 +143,9 @@ export class GrouparooRecord extends LoggedModel<GrouparooRecord> {
   }
 
   async buildNullProperties(state: GrouparooRecord["state"] = "pending") {
-    if (state === "deleted") {
-      throw new Error("cannot build null properties when in the deleted state");
+    if (state !== "deleted") {
+      return RecordOps.buildNullProperties([this], state);
     }
-
-    return RecordOps.buildNullProperties([this], state);
   }
 
   async markPending() {

--- a/core/src/modules/ops/destination.ts
+++ b/core/src/modules/ops/destination.ts
@@ -29,7 +29,6 @@ import { MappingHelper } from "../mappingHelper";
 import { RecordPropertyOps } from "./recordProperty";
 import { Option } from "../../models/Option";
 import { RunOps } from "./runs";
-import { boolean } from "webidl-conversions";
 
 function deepStrictEqualBoolean(a: any, b: any): boolean {
   try {

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -839,7 +839,7 @@ export namespace RecordOps {
       // It's safe to assume that if there are no Properties, we aren't exporting
       recordsToDestroy = await GrouparooRecord.findAll({
         attributes: ["id"],
-        where: { state: "ready", modelId: modelId },
+        where: { state: ["ready", "deleted"], modelId: modelId },
         limit,
       });
     }
@@ -849,7 +849,7 @@ export namespace RecordOps {
       await api.sequelize.query(
         `
     SELECT "id" FROM "records"
-    WHERE "state"='ready'
+    WHERE "state" IN ('ready', 'deleted')
     AND "id" IN (
       SELECT DISTINCT("recordId") FROM "recordProperties"
       JOIN properties ON "properties"."id"="recordProperties"."propertyId"

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -606,7 +606,8 @@ export namespace RecordOps {
     force = false,
     oldGroups: Group[] = [],
     saveExports = true,
-    sync = true
+    sync = true,
+    toDelete?: boolean
   ) {
     const groups = await record.$get("groups");
 
@@ -652,7 +653,8 @@ export namespace RecordOps {
           record,
           sync, // sync = true -> do the export in-line
           force, // force = true -> do the export even if it looks like the data hasn't changed
-          saveExports // saveExports = true -> should we really save these exports, or do we just want examples for the next export?
+          saveExports, // saveExports = true -> should we really save these exports, or do we just want examples for the next export?
+          toDelete // are we deleting this record and should we ensure that all exports are toDelete=true?
         )
       )
     );
@@ -983,7 +985,7 @@ export namespace RecordOps {
         },
       }
     );
-    // Update records to invalid if any assocaited properties are invalid.
+    // Update records to invalid if any associated properties are invalid.
     await api.sequelize.query(`
       UPDATE
         "records"

--- a/core/src/tasks/record/destroy.ts
+++ b/core/src/tasks/record/destroy.ts
@@ -16,9 +16,7 @@ export class RecordDestroy extends CLSTask {
   }
 
   async runWithinTransaction({ recordId }: { recordId: string }) {
-    const record = await GrouparooRecord.findOne({
-      where: { id: recordId, state: "ready" },
-    });
+    const record = await GrouparooRecord.findOne({ where: { id: recordId } });
     if (!record) return;
 
     const pendingExports = await Export.count({
@@ -29,12 +27,13 @@ export class RecordDestroy extends CLSTask {
     });
     if (pendingExports > 0) return;
 
-    const oldGroups = await record.$get("groups");
-    if (oldGroups.length > 0) {
+    if (["draft", "pending", "ready"].includes(record.state)) {
       // clear groups and export
       // when the export is done, this task will be enqueued again to destroy it
+      const oldGroups = await record.$get("groups");
       await GrouparooRecord.destroyGroupMembers(record);
-      await record.export(false, oldGroups, true, false);
+      await record.update({ state: "deleted" });
+      await record.export(false, oldGroups, true, false, true);
     } else {
       // use "destroy" to clean up related models
       await record.destroy();

--- a/core/src/tasks/record/destroy.ts
+++ b/core/src/tasks/record/destroy.ts
@@ -16,7 +16,9 @@ export class RecordDestroy extends CLSTask {
   }
 
   async runWithinTransaction({ recordId }: { recordId: string }) {
-    const record = await GrouparooRecord.findOne({ where: { id: recordId } });
+    const record = await GrouparooRecord.findOne({
+      where: { id: recordId, state: ["ready", "deleted"] },
+    });
     if (!record) return;
 
     const pendingExports = await Export.count({

--- a/core/src/tasks/record/destroy.ts
+++ b/core/src/tasks/record/destroy.ts
@@ -27,7 +27,7 @@ export class RecordDestroy extends CLSTask {
     });
     if (pendingExports > 0) return;
 
-    if (["draft", "pending", "ready"].includes(record.state)) {
+    if (record.state === "ready") {
       // clear groups and export
       // when the export is done, this task will be enqueued again to destroy it
       const oldGroups = await record.$get("groups");


### PR DESCRIPTION
Updates GrouparooRecords to have a `deleted` state.  This allows the `record:destroy` task to enqueue one final export for any Destinations that this Record had been previously synced too.  These final exports will be `toDelete=true` explicitly.

This PR also locks in that GrouparooModels cannot be destroyed if there are still GrouparooRecords that use the model.

More or less replaces https://github.com/grouparoo/grouparoo/pull/2441

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
