### PR TITLE
Deleting a Destination will not remove Records previously exported

### DIFF
--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -185,22 +185,6 @@ describe("models/destination", () => {
       expect(latestLog).toBeTruthy();
     });
 
-    test("a destination tracking a group cannot be deleted", async () => {
-      const group = await helper.factories.group();
-      destination = await Destination.create({
-        name: "bye destination",
-        type: "test-plugin-export",
-        appId: app.id,
-        modelId: model.id,
-      });
-      await destination.updateTracking("group", group.id);
-      await expect(destination.destroy()).rejects.toThrow(
-        /cannot delete a destination that is tracking a group/
-      );
-      await group.destroy();
-      await destination.destroy(); // does not throw
-    });
-
     test("deleting a destination deletes related models", async () => {
       const group = await helper.factories.group();
       destination = await Destination.create({

--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -1,5 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { cache } from "actionhero";
+import { DestinationOps } from "../../../src/modules/ops/destination";
 import {
   App,
   Destination,
@@ -1019,7 +1020,7 @@ describe("models/destination", () => {
 
           // before the destinations are ready
           await destination.updateTracking("group", group.id);
-          let destinations = await Destination.relevantFor(
+          let destinations = await DestinationOps.relevantFor(
             record,
             await record.$get("groups")
           );
@@ -1032,7 +1033,7 @@ describe("models/destination", () => {
           await otherGroupDestination.updateTracking("group", group.id);
           await modelDestination.updateTracking("model");
 
-          destinations = await Destination.relevantFor(
+          destinations = await DestinationOps.relevantFor(
             record,
             await record.$get("groups")
           );

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -663,7 +663,6 @@ describe("modules/codeConfig", () => {
 
   describe("bring it all back", () => {
     let previousGroupRun: Run;
-    let previousDestinationRun: Run;
 
     beforeAll(async () => {
       // fake that runs are still being executed for deleted group
@@ -711,16 +710,6 @@ describe("modules/codeConfig", () => {
         where: { id: "test_destination", state: "deleted" },
       });
       expect(destination).toBeTruthy();
-
-      await specHelper.runTask("destination:destroy", {
-        destinationId: destination.id,
-      });
-
-      previousDestinationRun = await Run.scope(null).findOne({
-        where: { destinationId: destination.id, state: "running" },
-      });
-      expect(previousDestinationRun).toBeTruthy();
-      expect(previousDestinationRun.creatorId).toBe("email_group");
     });
 
     beforeAll(async () => {
@@ -926,10 +915,6 @@ describe("modules/codeConfig", () => {
       expect(destinations[0].locked).toBe("config:code");
       const options = await destinations[0].getOptions();
       expect(options).toEqual({ table: "output" });
-
-      // previous run stopped
-      await previousDestinationRun.reload();
-      expect(previousDestinationRun.state).toBe("stopped");
 
       // new run kicked off
       const runs = await Run.findAll({

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -778,30 +778,4 @@ export class Destination extends LoggedModel<Destination> {
       where: { destinationId: instance.id },
     });
   }
-
-  /**
-   * Determine which destinations are interested in this record due to the groups they are tracking
-   */
-  static async relevantFor(
-    record: GrouparooRecord,
-    oldGroups: Group[] = [],
-    newGroups: Group[] = []
-  ) {
-    const combinedGroupIds = [...oldGroups, ...newGroups].map((g) => g.id);
-    const relevantDestinations =
-      combinedGroupIds.length > 0
-        ? await Destination.findAll({
-            where: {
-              [Op.or]: [
-                { collection: "model", modelId: record.modelId },
-                { collection: "group", groupId: { [Op.in]: combinedGroupIds } },
-              ],
-            },
-          })
-        : await Destination.findAll({
-            where: { collection: "model", modelId: record.modelId },
-          });
-
-    return relevantDestinations;
-  }
 }

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -727,19 +727,6 @@ export class Destination extends LoggedModel<Destination> {
   }
 
   @BeforeDestroy
-  static async cannotDeleteDestinationWithTrackedGroup(instance: Destination) {
-    if (process.env.GROUPAROO_RUN_MODE === "cli:config") return;
-    if (instance.groupId) {
-      const group = await Group.scope("notDraft").findOne({
-        where: { id: instance.groupId },
-      });
-      if (group) {
-        throw new Error("cannot delete a destination that is tracking a group");
-      }
-    }
-  }
-
-  @BeforeDestroy
   static async waitForPendingExports(instance: Destination) {
     const pendingExportCount = await instance.$count("exports", {
       where: { state: ["pending", "processing"] },

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -24,6 +24,7 @@ import { Mapping } from "../../models/Mapping";
 import { SourceOps } from "./source";
 import { GrouparooModel } from "../../models/GrouparooModel";
 import { CLS } from "../cls";
+import { DestinationOps } from "./destination";
 
 export interface RecordPropertyType {
   [key: string]: {
@@ -610,7 +611,7 @@ export namespace RecordOps {
   ) {
     const groups = await record.$get("groups");
 
-    const destinations = await Destination.relevantFor(
+    const destinations = await DestinationOps.relevantFor(
       record,
       oldGroups,
       groups

--- a/core/src/tasks/destination/destroy.ts
+++ b/core/src/tasks/destination/destroy.ts
@@ -25,22 +25,11 @@ export class DestinationDestroy extends CLSTask {
     // the destination may have been force-deleted
     if (!destination) return;
 
-    let run: Run;
-    // untrack the group, if we are still tracking one
-    // this will trigger a run to export all group members one last time
-    if (
-      (destination.groupId && destination.collection === "group") ||
-      destination.collection === "model"
-    ) {
-      const unTrackResponse = await destination.updateTracking("none");
-      run = unTrackResponse.oldRun;
-    } else {
-      run = await Run.scope(null).findOne({
-        where: { destinationId: destination.id },
-        order: [["updatedAt", "desc"]],
-        limit: 1,
-      });
-    }
+    const run = await Run.scope(null).findOne({
+      where: { destinationId: destination.id },
+      order: [["updatedAt", "desc"]],
+      limit: 1,
+    });
 
     // the run is not yet complete
     if (run && (run.state === "running" || run.state === "draft")) {
@@ -81,7 +70,7 @@ export class DestinationDestroy extends CLSTask {
       }
     }
 
-    // the run is done (complete or stopped) or there was not a tracked group for this destination
+    // the run is done (complete or stopped) or there was nothing tracked for this destination
     await destination.destroy();
   }
 }

--- a/core/src/tasks/record/export.ts
+++ b/core/src/tasks/record/export.ts
@@ -5,6 +5,7 @@ import { Destination } from "../../models/Destination";
 import { Group } from "../../models/Group";
 import { RetryableTask } from "../../classes/tasks/retryableTask";
 import { env, log } from "actionhero";
+import { DestinationOps } from "../../modules/ops/destination";
 
 export class RecordExport extends RetryableTask {
   constructor() {
@@ -56,7 +57,7 @@ export class RecordExport extends RetryableTask {
             })
           : [];
 
-      const destinations = await Destination.relevantFor(
+      const destinations = await DestinationOps.relevantFor(
         record,
         oldGroups,
         newGroups


### PR DESCRIPTION
When a Destination is deleted, we no longer attempt to remove all the Records that were previously exported.  Now, we just delete the Destination.

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
