### PR TITLE
Share `ensureModel` checks with ModelGuard helper

### DIFF
--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -230,7 +230,21 @@ describe("models/destination", () => {
           appId: app.id,
           modelId: "foo",
         })
-      ).rejects.toThrow(/cannot find ready model with id foo/);
+      ).rejects.toThrow(/cannot find model with id "foo"/);
+    });
+
+    test("destinations cannot change models", async () => {
+      destination = await Destination.create({
+        name: "bye destination",
+        type: "test-plugin-export",
+        appId: app.id,
+        modelId: model.id,
+      });
+      await expect(destination.update({ modelId: "foo" })).rejects.toThrow(
+        /cannot change models/
+      );
+
+      await destination.destroy();
     });
 
     test("deleting a destination does not delete options for other models with the same id", async () => {

--- a/core/__tests__/models/group/group.ts
+++ b/core/__tests__/models/group/group.ts
@@ -112,7 +112,20 @@ describe("models/group", () => {
         type: "manual",
         modelId: "foo",
       })
-    ).rejects.toThrow(/cannot find ready model with id foo/);
+    ).rejects.toThrow(/cannot find model with id "foo"/);
+  });
+
+  test("groups cannot change models", async () => {
+    const group = await Group.create({
+      name: "doomed group",
+      type: "manual",
+      modelId: model.id,
+    });
+    await expect(group.update({ modelId: "foo" })).rejects.toThrow(
+      /cannot change models/
+    );
+
+    await group.destroy();
   });
 
   describe("run()", () => {

--- a/core/__tests__/models/record/record.ts
+++ b/core/__tests__/models/record/record.ts
@@ -63,8 +63,17 @@ describe("models/record", () => {
   test("records require a valid modelId", async () => {
     expect(GrouparooRecord.create()).rejects.toThrow(/modelId cannot be null/);
     expect(GrouparooRecord.create({ modelId: "foo" })).rejects.toThrow(
-      /cannot find model with id foo/
+      /cannot find model with id "foo"/
     );
+  });
+
+  test("records cannot change models", async () => {
+    const record = await GrouparooRecord.create({ modelId: model.id });
+    await expect(record.update({ modelId: "foo" })).rejects.toThrow(
+      /cannot change models/
+    );
+
+    await record.destroy();
   });
 
   describe("findOrCreateByUniqueRecordProperties", () => {

--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -100,7 +100,21 @@ describe("models/source", () => {
           appId: app.id,
           modelId: "foo",
         })
-      ).rejects.toThrow(/cannot find model with id foo/);
+      ).rejects.toThrow(/cannot find model with id "foo"/);
+    });
+
+    test("sources cannot change models", async () => {
+      const source = await Source.create({
+        type: "test-plugin-import",
+        name: "test source",
+        appId: app.id,
+        modelId: model.id,
+      });
+      await expect(source.update({ modelId: "foo" })).rejects.toThrow(
+        /cannot change models/
+      );
+
+      await source.destroy();
     });
 
     test("a new source will have a '' name", async () => {

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -40,6 +40,7 @@ import { Mapping } from "./Mapping";
 import { Option } from "./Option";
 import { Property } from "./Property";
 import { GrouparooModel } from "./GrouparooModel";
+import { ModelGuard } from "../modules/modelGuard";
 
 export interface DestinationMapping extends MappingHelper.Mappings {}
 export interface SimpleDestinationGroupMembership {
@@ -627,32 +628,9 @@ export class Destination extends LoggedModel<Destination> {
   }
 
   @BeforeCreate
-  static async ensureModelNotDeleted(instance: Destination) {
-    const model = await GrouparooModel.findOne({
-      where: { id: instance.modelId },
-    });
-    if (!model) {
-      throw new Error(`cannot find ready model with id ${instance.modelId}`);
-    }
-  }
-
   @BeforeSave
   static async ensureModel(instance: Destination) {
-    if (instance.state === "deleted") {
-      const model = await GrouparooModel.scope(null).findOne({
-        where: { id: instance.modelId },
-      });
-      if (!model) {
-        throw new Error(`cannot find model with id ${instance.modelId}`);
-      }
-    } else {
-      const model = await GrouparooModel.findOne({
-        where: { id: instance.modelId },
-      });
-      if (!model) {
-        throw new Error(`cannot find ready model with id ${instance.modelId}`);
-      }
-    }
+    return ModelGuard.check(instance);
   }
 
   @BeforeCreate

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -41,6 +41,7 @@ import { Setting } from "./Setting";
 import { GrouparooModel } from "./GrouparooModel";
 import { Source } from "./Source";
 import { RunOps } from "../modules/ops/runs";
+import { ModelGuard } from "../modules/modelGuard";
 
 export const GROUP_RULE_LIMIT = 10;
 const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -733,32 +734,9 @@ export class Group extends LoggedModel<Group> {
   }
 
   @BeforeCreate
-  static async ensureModelNotDeleted(instance: Group) {
-    const model = await GrouparooModel.findOne({
-      where: { id: instance.modelId },
-    });
-    if (!model) {
-      throw new Error(`cannot find ready model with id ${instance.modelId}`);
-    }
-  }
-
   @BeforeSave
   static async ensureModel(instance: Group) {
-    if (instance.state === "deleted") {
-      const model = await GrouparooModel.scope(null).findOne({
-        where: { id: instance.modelId },
-      });
-      if (!model) {
-        throw new Error(`cannot find model with id ${instance.modelId}`);
-      }
-    } else {
-      const model = await GrouparooModel.findOne({
-        where: { id: instance.modelId },
-      });
-      if (!model) {
-        throw new Error(`cannot find ready model with id ${instance.modelId}`);
-      }
-    }
+    return ModelGuard.check(instance);
   }
 
   @BeforeSave

--- a/core/src/models/GrouparooRecord.ts
+++ b/core/src/models/GrouparooRecord.ts
@@ -271,7 +271,6 @@ export class GrouparooRecord extends LoggedModel<GrouparooRecord> {
   }
 
   @BeforeCreate
-  @BeforeSave
   static async ensureModel(instance: GrouparooRecord) {
     const model = await GrouparooModel.findOne({
       where: { id: instance.modelId },

--- a/core/src/models/GrouparooRecord.ts
+++ b/core/src/models/GrouparooRecord.ts
@@ -27,6 +27,7 @@ import { GroupRule } from "./GroupRule";
 import { RecordConfigurationObject } from "../classes/codeConfig";
 import { Source } from "./Source";
 import { GrouparooModel } from "./GrouparooModel";
+import { ModelGuard } from "../modules/modelGuard";
 
 const STATES = ["draft", "pending", "ready", "deleted"] as const;
 
@@ -271,13 +272,9 @@ export class GrouparooRecord extends LoggedModel<GrouparooRecord> {
   }
 
   @BeforeCreate
+  @BeforeSave
   static async ensureModel(instance: GrouparooRecord) {
-    const model = await GrouparooModel.findOne({
-      where: { id: instance.modelId },
-    });
-    if (!model) {
-      throw new Error(`cannot find model with id ${instance.modelId}`);
-    }
+    return ModelGuard.check(instance);
   }
 
   @BeforeSave

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -43,6 +43,7 @@ import {
 } from "./Property";
 import { Run } from "./Run";
 import { GrouparooModel } from "./GrouparooModel";
+import { ModelGuard } from "../modules/modelGuard";
 
 export interface SimpleSourceOptions extends OptionHelper.SimpleOptions {}
 export interface SourceMapping extends MappingHelper.Mappings {}
@@ -386,12 +387,7 @@ export class Source extends LoggedModel<Source> {
   @BeforeCreate
   @BeforeSave
   static async ensureModel(instance: Source) {
-    const model = await GrouparooModel.findOne({
-      where: { id: instance.modelId },
-    });
-    if (!model) {
-      throw new Error(`cannot find model with id ${instance.modelId}`);
-    }
+    return ModelGuard.check(instance);
   }
 
   @BeforeCreate

--- a/core/src/modules/modelGuard.ts
+++ b/core/src/modules/modelGuard.ts
@@ -1,0 +1,35 @@
+import { GrouparooModel } from "../models/GrouparooModel";
+import { GrouparooRecord } from "../models/GrouparooRecord";
+import { Source } from "../models/Source";
+import { Destination } from "../models/Destination";
+import { Group } from "../models/Group";
+
+export namespace ModelGuard {
+  export async function check(
+    instance: GrouparooRecord | Source | Destination | Group
+  ) {
+    if (instance.isNewRecord) {
+      // we are creating a new instance
+      const model = await GrouparooModel.scope(null).findOne({
+        where: { id: instance.modelId },
+      });
+
+      if (!model) {
+        throw new Error(`cannot find model with id "${instance.modelId}"`);
+      }
+
+      if (instance.state !== "deleted" && model.state === "deleted") {
+        throw new Error(
+          `cannot find ready model with id "${instance.modelId}"`
+        );
+      }
+    } else {
+      // we are updating an existing record
+      const changes = instance.changed();
+      if (!changes) return;
+      if (changes.includes("modelId")) {
+        throw new Error("cannot change models");
+      }
+    }
+  }
+}

--- a/core/src/modules/modelGuard.ts
+++ b/core/src/modules/modelGuard.ts
@@ -24,7 +24,7 @@ export namespace ModelGuard {
         );
       }
     } else {
-      // we are updating an existing record
+      // we are updating an existing instance
       const changes = instance.changed();
       if (!changes) return;
       if (changes.includes("modelId")) {


### PR DESCRIPTION
Standardize model checking behavior with a new `ModelGuard` utility.
* New instances check if the model exists and is ready
* Existing instances ensure that modelId hasn't changed

There's no reason to re-check the model when updating an existing instance.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
