### PR TITLE
Prevent final Record export if Destination state is not ready

### DIFF
--- a/core/__tests__/models/record/export.ts
+++ b/core/__tests__/models/record/export.ts
@@ -1,22 +1,11 @@
 import { helper } from "@grouparoo/spec-helper";
-import { api } from "actionhero";
-import { group } from "console";
 import {
-  plugin,
   GrouparooRecord,
-  RecordProperty,
-  Property,
   Group,
-  GroupMember,
-  App,
-  Source,
-  Log,
   GrouparooModel,
   Destination,
 } from "../../../src";
 import { Op } from "sequelize";
-import { RecordOps } from "../../../src/modules/ops/record";
-import { not } from "sequelize/types/lib/operators";
 
 describe("models/record", () => {
   let model: GrouparooModel;

--- a/core/__tests__/models/record/export.ts
+++ b/core/__tests__/models/record/export.ts
@@ -1,0 +1,92 @@
+import { helper } from "@grouparoo/spec-helper";
+import { api } from "actionhero";
+import { group } from "console";
+import {
+  plugin,
+  GrouparooRecord,
+  RecordProperty,
+  Property,
+  Group,
+  GroupMember,
+  App,
+  Source,
+  Log,
+  GrouparooModel,
+  Destination,
+} from "../../../src";
+import { Op } from "sequelize";
+import { RecordOps } from "../../../src/modules/ops/record";
+import { not } from "sequelize/types/lib/operators";
+
+describe("models/record", () => {
+  let model: GrouparooModel;
+  let record: GrouparooRecord;
+  let group: Group;
+  let groupDestination: Destination;
+  let modelDestination: Destination;
+  let otherDestination: Destination;
+  let seenExportIds: string[] = [];
+
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
+  beforeAll(async () => {
+    ({ model } = await helper.factories.properties());
+    record = await helper.factories.record();
+    group = await helper.factories.group();
+    groupDestination = await helper.factories.destination();
+    modelDestination = await helper.factories.destination();
+    otherDestination = await helper.factories.destination();
+
+    await group.addRecord(record);
+    await groupDestination.updateTracking("group", group.id);
+    await modelDestination.updateTracking("model");
+  });
+
+  describe("export", () => {
+    test("export will find relevant destinations to export to", async () => {
+      await record.export();
+      const exports = await record.$get("exports");
+      expect(exports.length).toEqual(2);
+      const exportedDestinationIds = exports.map((e) => e.destinationId);
+      expect(exportedDestinationIds).toContain(groupDestination.id);
+      expect(exportedDestinationIds).toContain(modelDestination.id);
+      expect(exportedDestinationIds).not.toContain(otherDestination.id);
+
+      seenExportIds = seenExportIds.concat(exports.map((e) => e.id));
+    });
+
+    test("export will use previous exports to include a recently un-tracked destination", async () => {
+      await groupDestination.updateTracking("none");
+
+      await record.export();
+      const exports = await record.$get("exports", {
+        where: { id: { [Op.notIn]: seenExportIds } },
+      });
+
+      expect(exports.length).toEqual(2);
+      const exportedDestinationIds = exports.map((e) => e.destinationId);
+      expect(exportedDestinationIds).toContain(groupDestination.id);
+      expect(exportedDestinationIds).toContain(modelDestination.id);
+      expect(exportedDestinationIds).not.toContain(otherDestination.id);
+
+      seenExportIds = seenExportIds.concat(exports.map((e) => e.id));
+    });
+
+    test("export will not use previous exports to include a recently un-tracked destination that is now in the deleted state", async () => {
+      await groupDestination.update({ state: "deleted" });
+
+      await record.export();
+      const exports = await record.$get("exports", {
+        where: { id: { [Op.notIn]: seenExportIds } },
+      });
+
+      expect(exports.length).toEqual(1);
+      const exportedDestinationIds = exports.map((e) => e.destinationId);
+      expect(exportedDestinationIds).not.toContain(groupDestination.id);
+      expect(exportedDestinationIds).toContain(modelDestination.id);
+      expect(exportedDestinationIds).not.toContain(otherDestination.id);
+
+      seenExportIds = seenExportIds.concat(exports.map((e) => e.id));
+    });
+  });
+});

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -644,7 +644,7 @@ export namespace RecordOps {
     for (const _export of existingExportNotDeleted) {
       if (!destinations.map((d) => d.id).includes(_export.destinationId)) {
         const destination = await Destination.findById(_export.destinationId);
-        destinations.push(destination);
+        if (destination.state === "ready") destinations.push(destination);
       }
     }
 


### PR DESCRIPTION
Prevents exports from being created when a Record is destroyed, against a previously exported Destination, that itself is also in the deleted state.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
