### PR TITLE
changes to gh pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,6 @@
 ## Change description
 
-> Description here
-
-## Related issues
-
-Does this PR fix a Github Issue?
-
-> Fix [#1]()
+Description here
 
 ## Checklists
 
@@ -22,8 +16,6 @@ Does this PR fix a Github Issue?
 - [ ] Possible migration needs considered (model migrations, config migrations, etc.)
 
 Please explain any security, performance, migration, or other impacts if relevant:
-
->
 
 ### Code review
 


### PR DESCRIPTION
## Change description
Removes the "github issue" prompt from the template and turns off the default of making descriptions a blockquote.  Our PRs are not usually associated with an issue, and the blockquoting makes the description more difficult to read.

## Related issues

Does this PR fix a Github Issue?

no

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

>

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
