### PR TITLE
Don't crash when viewing an Import that has not yet been associated to a Record

### DIFF
--- a/core/__tests__/models/import.ts
+++ b/core/__tests__/models/import.ts
@@ -34,7 +34,7 @@ describe("models/import", () => {
   });
 
   test("an error can be set", async () => {
-    const _import: Import = await helper.factories.import();
+    const _import = await helper.factories.import();
     await _import.setError(new Error("oh no"), "associate");
     await _import.reload();
 
@@ -47,7 +47,7 @@ describe("models/import", () => {
     await run.afterBatch("complete");
     expect(run.error).toBeFalsy();
 
-    const _import: Import = await helper.factories.import(run);
+    const _import = await helper.factories.import(run);
     await _import.setError(new Error("oh no"), "associate");
 
     await run.reload();
@@ -75,5 +75,32 @@ describe("models/import", () => {
 
     const remaining = await Import.findAll();
     expect(remaining.length).toBe(0);
+  });
+
+  test("apiData works without a Record", async () => {
+    const _import = await Import.create({
+      data: { email: "mario@example.com" },
+      creatorType: "test",
+      creatorId: "",
+    });
+
+    const apiData = await _import.apiData();
+    expect(apiData.id).toEqual(_import.id);
+    expect(apiData.modelId).toBeFalsy();
+  });
+
+  test("apiData works with a Record", async () => {
+    const record = await helper.factories.record();
+
+    const _import = await Import.create({
+      data: { email: "mario@example.com" },
+      creatorType: "test",
+      creatorId: "",
+      recordId: record.id,
+    });
+
+    const apiData = await _import.apiData();
+    expect(apiData.id).toEqual(_import.id);
+    expect(apiData.modelId).toBe(record.modelId);
   });
 });

--- a/core/src/models/Import.ts
+++ b/core/src/models/Import.ts
@@ -162,7 +162,7 @@ export class Import extends CommonModel<Import> {
       creatorType: this.creatorType,
       creatorId: this.creatorId,
       recordId: this.recordId,
-      modelId: record.modelId,
+      modelId: record?.modelId,
 
       //data
       data,


### PR DESCRIPTION
Fixes an API bug which was trying to load the Import's Record's modelId... but the Import might not yet have a Model early in it's lifecyle

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
