### PR TITLE
Strings can be mapped to any Destination type

### DIFF
--- a/core/__tests__/actions/destinations.ts
+++ b/core/__tests__/actions/destinations.ts
@@ -207,7 +207,18 @@ describe("actions/destinations", () => {
         float: ["any", "float", "string", "number"],
         integer: ["any", "float", "integer", "string", "number"],
         phoneNumber: ["any", "string", "phoneNumber"],
-        string: ["any", "string"],
+        string: [
+          "any",
+          "string",
+          "url",
+          "email",
+          "boolean",
+          "date",
+          "float",
+          "integer",
+          "number",
+          "phoneNumber",
+        ],
         url: ["any", "string", "url"],
       });
     });

--- a/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
+++ b/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
@@ -157,15 +157,15 @@ describe("models/destination", () => {
       const grouparooType = "string";
       const input = "hello";
       const mapping = [
-        ["float", null],
-        ["integer", null],
+        ["float", input],
+        ["integer", input],
         ["string", input],
-        ["email", null],
-        ["phoneNumber", null],
-        ["boolean", null],
-        ["url", null],
-        ["number", null],
-        ["date", null],
+        ["email", input],
+        ["phoneNumber", input],
+        ["boolean", input],
+        ["url", input],
+        ["number", input],
+        ["date", input],
       ];
 
       mapping.map(([destinationType, output]) =>
@@ -496,9 +496,9 @@ describe("models/destination", () => {
       required = [{ key: "remote-id", type: "integer" }];
 
       await expect(
-        destination.setMapping({ "remote-id": "firstName" })
+        destination.setMapping({ "remote-id": "email" })
       ).rejects.toThrow(
-        "remote-id requires a property of type integer, but a string (firstName) was mapped"
+        "remote-id requires a property of type integer, but a email (email) was mapped"
       );
     });
 

--- a/core/src/modules/destinationTypeConversions.ts
+++ b/core/src/modules/destinationTypeConversions.ts
@@ -23,6 +23,14 @@ export const destinationTypeConversions = {
   string: {
     any: (v: string) => v,
     string: (v: string) => v,
+    url: (v: string) => v,
+    email: (v: string) => v,
+    boolean: (v: string) => v,
+    date: (v: string) => v,
+    float: (v: string) => v,
+    integer: (v: string) => v,
+    number: (v: string) => v,
+    phoneNumber: (v: string) => v,
   },
 
   url: {


### PR DESCRIPTION
## Change description

Strings can now be mapped to: `url`, `email`, `boolean`, `date`, `float`, `integer`, `number` and `phoneNumber` destination types. Note that no conversion is being done for these strings - it is left up to the destination to interpret whether it's actually valid or not.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
