### PR TITLE
Use `router.replace` to update URL with Sample Records

### DIFF
--- a/ui/ui-components/components/destination/recordPreview.tsx
+++ b/ui/ui-components/components/destination/recordPreview.tsx
@@ -58,14 +58,11 @@ export default function RecordPreview(props) {
   function storeRecordPropertyId(recordId: string = "") {
     setRecordId(recordId);
     let url = `${window.location.pathname}?`;
+    if (recordId) url += `recordId=${recordId}&`;
 
-    if (recordId !== "") {
-      url += `recordId=${recordId}&`;
+    if (url !== `${window.location.pathname}?`) {
+      router.replace(router.route, url, { shallow: true });
     }
-
-    const routerMethod =
-      url === `${window.location.pathname}?` ? "replace" : "push";
-    router[routerMethod](router.route, url, { shallow: true });
   }
 
   async function load(_recordId = "", _sleep = sleep) {

--- a/ui/ui-components/components/destination/recordPreview.tsx
+++ b/ui/ui-components/components/destination/recordPreview.tsx
@@ -55,7 +55,7 @@ export default function RecordPreview(props) {
     JSON.stringify(destination.destinationGroupMemberships),
   ]);
 
-  function storeRecordPropertyId(recordId: string = "") {
+  function storeRecordPropertyId(recordId = "") {
     setRecordId(recordId);
     let url = `${window.location.pathname}?`;
     if (recordId) url += `recordId=${recordId}&`;

--- a/ui/ui-components/components/property/recordPreview.tsx
+++ b/ui/ui-components/components/property/recordPreview.tsx
@@ -50,7 +50,7 @@ export default function RecordPreview(props) {
     JSON.stringify(localFilters),
   ]);
 
-  function storeRecordPropertyId(recordId: string) {
+  function storeRecordPropertyId(recordId = "") {
     setRecordId(recordId);
     let url = `${window.location.pathname}?`;
     if (recordId) url += `recordId=${recordId}&`;

--- a/ui/ui-components/components/property/recordPreview.tsx
+++ b/ui/ui-components/components/property/recordPreview.tsx
@@ -53,11 +53,11 @@ export default function RecordPreview(props) {
   function storeRecordPropertyId(recordId: string) {
     setRecordId(recordId);
     let url = `${window.location.pathname}?`;
-    url += `recordId=${recordId}&`;
+    if (recordId) url += `recordId=${recordId}&`;
 
-    const routerMethod =
-      url === `${window.location.pathname}?` ? "replace" : "push";
-    router[routerMethod](router.route, url, { shallow: true });
+    if (url !== `${window.location.pathname}?`) {
+      router.replace(router.route, url, { shallow: true });
+    }
   }
 
   async function load(


### PR DESCRIPTION
Prevents a "back" entry from appearing in your browser when Grouparoo updates the URL of the page to add the sample property. 

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
