### PR TITLE
appRefreshQuery Task

### DIFF
--- a/core/__tests__/models/appRefreshQuery.ts
+++ b/core/__tests__/models/appRefreshQuery.ts
@@ -125,9 +125,9 @@ describe("appRefreshQuery", () => {
       const runs = await Run.findAll({
         where: { creatorType: "schedule", state: "running" },
       });
-      console.log(runs);
 
       expect(runs.length).toBe(1);
+      expect(runs[0].creatorId).toBe(schedule.id);
     });
 
     test("an appRefreshQuery in the draft state will not run its query", async () => {

--- a/core/__tests__/models/appRefreshQuery.ts
+++ b/core/__tests__/models/appRefreshQuery.ts
@@ -62,7 +62,7 @@ describe("appRefreshQuery", () => {
       });
       await appRefreshQuery.save();
 
-      const spy = jest.spyOn(AppRefreshQueryOps, "checkDataRefreshValue");
+      const spy = jest.spyOn(AppRefreshQueryOps, "checkRefreshQueryValue");
       await appRefreshQuery.update({
         refreshQuery: "SELECT 'hi' AS name;",
       });
@@ -71,7 +71,7 @@ describe("appRefreshQuery", () => {
       spy.mockRestore();
     });
 
-    test("schedules are enqueued if a new 'value' is found from the query", async () => {
+    test("schedules marked refreshEnabled are enqueued if a new 'value' is found from the query", async () => {
       let model;
       ({ model } = await helper.factories.properties());
       const source = await Source.create({
@@ -83,10 +83,37 @@ describe("appRefreshQuery", () => {
       await source.setOptions({ table: "test table" });
       await source.setMapping({ id: "userId" });
       await source.update({ state: "ready" });
+      const source2 = await Source.create({
+        name: "test source 2",
+        type: "test-plugin-import",
+        appId: app.id,
+        modelId: model.id,
+      });
+
+      await source2.setOptions({ table: "test table" });
+      await source2.setMapping({ id: "userId" });
+      await source2.update({ state: "ready" });
+
+      //two schedules, only one has refreshEnabled
       const schedule = await helper.factories.schedule(source);
+      await schedule.update({
+        recurring: "true",
+        recurringFrequency: 6000000,
+      });
+      const schedule2 = await helper.factories.schedule(source2);
+      await schedule2.update({
+        recurring: "true",
+        recurringFrequency: 6000000,
+        refreshEnabled: false,
+      });
 
-      await schedule.update({ recurring: "true", recurringFrequency: 6000000 });
+      //stop their initial runs
+      const runsToStop = await Run.findAll({
+        where: { creatorType: "schedule", state: "running" },
+      });
+      for (const run of runsToStop) run.stop();
 
+      //make an appRefreshQuery
       const appRefreshQuery = new AppRefreshQuery({
         appId: app.id,
         refreshQuery: "SELECT * FROM test;",
@@ -94,15 +121,15 @@ describe("appRefreshQuery", () => {
       });
       await appRefreshQuery.save();
 
-      await appRefreshQuery.update({
-        refreshQuery: "SELECT 'hi' AS name;",
-      });
-
+      //only one should have started a run
       const runs = await Run.findAll({
         where: { creatorType: "schedule", state: "running" },
       });
+      console.log(runs);
+
       expect(runs.length).toBe(1);
     });
+
     test("an appRefreshQuery in the draft state will not run its query", async () => {
       const spy = jest.spyOn(AppRefreshQueryOps, "triggerSchedules");
 

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -459,7 +459,7 @@ describe("modules/codeConfig", () => {
       expect(apiKeys[0].apiKey).toBe("def456");
     });
 
-    test("an updated refreshQuery will trigger a checkDataRefreshValue", async () => {
+    test("an updated refreshQuery will trigger a checkRefreshQueryValue", async () => {
       const appRefreshQuery = await AppRefreshQuery.findOne();
       expect(appRefreshQuery.refreshQuery).toBe(
         "SELECT MAX(stamp) FROM users;"

--- a/core/__tests__/tasks/appRefreshQuery/check.ts
+++ b/core/__tests__/tasks/appRefreshQuery/check.ts
@@ -1,0 +1,73 @@
+import { helper } from "@grouparoo/spec-helper";
+import { api, task, specHelper } from "actionhero";
+import {
+  Source,
+  Schedule,
+  App,
+  Run,
+  plugin,
+  GrouparooModel,
+  AppRefreshQuery,
+} from "../../../src";
+
+describe("tasks/appRefreshQuery:check", () => {
+  let model: GrouparooModel;
+  let source: Source;
+  let schedule: Schedule;
+
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+  beforeEach(async () => await api.resque.queue.connection.redis.flushdb());
+
+  beforeAll(async () => {});
+
+  describe("appRefreshQuery:run", () => {
+    let model: GrouparooModel;
+    let app: App;
+    let source: Source;
+    let schedule: Schedule;
+    let appRefreshQuery: AppRefreshQuery;
+
+    beforeAll(async () => {
+      ({ model } = await helper.factories.properties());
+      app = await helper.factories.app(model);
+      source = await helper.factories.source();
+      await source.setOptions({ table: "test table" });
+      await source.setMapping({ id: "userId" });
+      await source.update({ state: "ready" });
+
+      schedule = await helper.factories.schedule(source);
+      await schedule.update({ state: "ready" });
+
+      appRefreshQuery = new AppRefreshQuery({
+        appId: app.id,
+        refreshQuery: "SELECT 'hi' AS name;",
+        state: "ready",
+      });
+      await appRefreshQuery.save();
+    });
+
+    test("can be enqueued", async () => {
+      await task.enqueue("appRefreshQuery:check", {}); //does not throw
+    });
+
+    test("does not throw if no appRefreshQueries found", async () => {
+      appRefreshQuery.destroy();
+
+      await task.enqueue("appRefreshQuery:check", {}); //does not throw
+    });
+
+    test("does not throw if no app or schedules ready for appRefreshQuery", async () => {
+      const anotherApp = await helper.factories.app();
+      await anotherApp.update({ state: "deleted" });
+
+      const anotherAppRefreshQuery = new AppRefreshQuery({
+        appId: app.id,
+        refreshQuery: "SELECT 'hi' AS name;",
+        state: "ready",
+      });
+      await appRefreshQuery.save();
+
+      await task.enqueue("appRefreshQuery:check", {});
+    });
+  });
+});

--- a/core/src/models/AppRefreshQuery.ts
+++ b/core/src/models/AppRefreshQuery.ts
@@ -105,7 +105,7 @@ export class AppRefreshQuery extends LoggedModel<AppRefreshQuery> {
       !instance.changed("lastConfirmedAt") &&
       instance.state === "ready"
     ) {
-      const isUpdated = await AppRefreshQueryOps.checkDataRefreshValue(
+      const isUpdated = await AppRefreshQueryOps.checkRefreshQueryValue(
         instance
       );
       if (isUpdated === true) {

--- a/core/src/modules/ops/appRefreshQuery.ts
+++ b/core/src/modules/ops/appRefreshQuery.ts
@@ -55,7 +55,6 @@ export namespace AppRefreshQueryOps {
           },
         }))
       );
-      console.log(schedulesToRun);
     }
 
     for (const schedule of schedulesToRun) {

--- a/core/src/modules/ops/appRefreshQuery.ts
+++ b/core/src/modules/ops/appRefreshQuery.ts
@@ -4,7 +4,7 @@ import { Schedule } from "../../models/Schedule";
 import { Run } from "../../models/Run";
 
 export namespace AppRefreshQueryOps {
-  export async function checkDataRefreshValue(
+  export async function checkRefreshQueryValue(
     appRefreshQuery: AppRefreshQuery
   ) {
     const app = await appRefreshQuery.$get("app");
@@ -48,9 +48,14 @@ export namespace AppRefreshQueryOps {
     for (const source of sources) {
       schedulesToRun.push(
         ...(await Schedule.findAll({
-          where: { sourceId: source.id, refreshEnabled: true, state: "ready" },
+          where: {
+            sourceId: source.id,
+            refreshEnabled: true,
+            state: "ready",
+          },
         }))
       );
+      console.log(schedulesToRun);
     }
 
     for (const schedule of schedulesToRun) {

--- a/core/src/tasks/appRefreshQuery/check.ts
+++ b/core/src/tasks/appRefreshQuery/check.ts
@@ -1,0 +1,30 @@
+import { CLSTask } from "../../classes/tasks/clsTask";
+import { App, AppRefreshQuery } from "../..";
+import { AppRefreshQueryOps } from "../../modules/ops/appRefreshQuery";
+
+export class AppRefreshQueryCheck extends CLSTask {
+  constructor() {
+    super();
+    this.name = "appRefreshQuery:check";
+    this.description = "check all appRefreshQueries and run them if it is time";
+    this.frequency =
+      process.env.GROUPAROO_RUN_MODE === "cli:run" ? 0 : 1000 * 60 * 5; // Run every 5 minutes
+    this.queue = "appRefreshQueries";
+    this.inputs = {};
+  }
+
+  async runWithinTransaction(params) {
+    0;
+    const appRefreshQueries = await AppRefreshQuery.findAll();
+    for (const appRefreshQuery of appRefreshQueries) {
+      const app = await App.findOne({
+        where: { id: appRefreshQuery.appId, state: "ready" },
+      });
+      if (app) {
+        const isUpdated =
+          AppRefreshQueryOps.checkRefreshQueryValue(appRefreshQuery);
+        if (isUpdated) AppRefreshQueryOps.triggerSchedules(appRefreshQuery);
+      }
+    }
+  }
+}

--- a/core/src/tasks/appRefreshQuery/check.ts
+++ b/core/src/tasks/appRefreshQuery/check.ts
@@ -1,5 +1,6 @@
 import { CLSTask } from "../../classes/tasks/clsTask";
-import { App, AppRefreshQuery } from "../..";
+import { App } from "../../models/App";
+import { AppRefreshQuery } from "../../models/AppRefreshQuery";
 import { AppRefreshQueryOps } from "../../modules/ops/appRefreshQuery";
 
 export class AppRefreshQueryCheck extends CLSTask {
@@ -13,17 +14,20 @@ export class AppRefreshQueryCheck extends CLSTask {
     this.inputs = {};
   }
 
-  async runWithinTransaction(params) {
-    0;
+  async runWithinTransaction() {
     const appRefreshQueries = await AppRefreshQuery.findAll();
+
     for (const appRefreshQuery of appRefreshQueries) {
       const app = await App.findOne({
         where: { id: appRefreshQuery.appId, state: "ready" },
       });
+
       if (app) {
-        const isUpdated =
-          AppRefreshQueryOps.checkRefreshQueryValue(appRefreshQuery);
-        if (isUpdated) AppRefreshQueryOps.triggerSchedules(appRefreshQuery);
+        const isUpdated = await AppRefreshQueryOps.checkRefreshQueryValue(
+          appRefreshQuery
+        );
+        if (isUpdated)
+          await AppRefreshQueryOps.triggerSchedules(appRefreshQuery);
       }
     }
   }


### PR DESCRIPTION
## Change description

Adds a periodic (currently every 5 minutes) task to run `appRefreshQuery` checks and triggers.

Also added onto an earlier test to ensure that _only_ schedules where `refreshEnabled=true` are being enqueued in `AppRefreshQueryOps.triggerSchedules()`

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
