### PR TITLE
Fixup UI `Link`, `LinkButtons`, and `LoadingButtons`

### DIFF
--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -78,6 +78,12 @@ export class ScheduleRun extends AuthenticatedAction {
 
   async runWithinTransaction({ params }) {
     const schedule = await Schedule.findById(params.id);
+
+    const runningRun = await Run.findOne({
+      where: { creatorId: schedule.id, state: "running" },
+    });
+    if (runningRun) await runningRun.stop();
+
     const run = await schedule.enqueueRun();
     return { run: await run.apiData() };
   }

--- a/ui/ui-components/components/badges/appBadge.tsx
+++ b/ui/ui-components/components/badges/appBadge.tsx
@@ -12,7 +12,7 @@ export default function AppBadge({
 }) {
   return (
     <Badge style={{ marginBottom: marginBottom ?? 20 }} variant="secondary">
-      <EnterpriseLink href="/app/[id]/edit" as={`/app/${appId}/edit`}>
+      <EnterpriseLink href={`/app/${appId}/edit`}>
         <a style={{ color: "white" }}>{appName}</a>
       </EnterpriseLink>
     </Badge>

--- a/ui/ui-components/components/badges/appBadge.tsx
+++ b/ui/ui-components/components/badges/appBadge.tsx
@@ -1,5 +1,5 @@
 import { Badge } from "react-bootstrap";
-import EnterpriseLink from "../enterpriseLink";
+import EnterpriseLink from "../grouparooLink";
 
 export default function AppBadge({
   appName,

--- a/ui/ui-components/components/badges/modelBadge.tsx
+++ b/ui/ui-components/components/badges/modelBadge.tsx
@@ -1,5 +1,5 @@
 import { Badge } from "react-bootstrap";
-import EnterpriseLink from "../enterpriseLink";
+import EnterpriseLink from "../grouparooLink";
 
 export default function ModelBadge({
   modelName,

--- a/ui/ui-components/components/badges/modelBadge.tsx
+++ b/ui/ui-components/components/badges/modelBadge.tsx
@@ -12,10 +12,7 @@ export default function ModelBadge({
 }) {
   return (
     <Badge style={{ marginBottom: marginBottom ?? 20 }} variant="primary">
-      <EnterpriseLink
-        href="/model/[modelId]/edit"
-        as={`/model/${modelId}/edit`}
-      >
+      <EnterpriseLink href={`/model/${modelId}/edit`}>
         <a style={{ color: "white" }}>{modelName}</a>
       </EnterpriseLink>
     </Badge>

--- a/ui/ui-components/components/enterpriseLink.tsx
+++ b/ui/ui-components/components/enterpriseLink.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { grouparooUiEdition } from "../utils/uiEdition";
 
 const EnterpriseLink = Link;
 
@@ -6,7 +7,7 @@ const CommunityLink = function ({ children }) {
   return <span>{children}</span>;
 };
 
-export default process.env.GROUPAROO_UI_EDITION === "enterprise" ||
-process.env.GROUPAROO_UI_EDITION === "config"
+export default grouparooUiEdition === "enterprise" ||
+grouparooUiEdition === "config"
   ? EnterpriseLink
   : CommunityLink;

--- a/ui/ui-components/components/enterpriseLink.tsx
+++ b/ui/ui-components/components/enterpriseLink.tsx
@@ -7,7 +7,7 @@ const CommunityLink = function ({ children }) {
   return <span>{children}</span>;
 };
 
-export default grouparooUiEdition === "enterprise" ||
-grouparooUiEdition === "config"
+export default grouparooUiEdition() === "enterprise" ||
+grouparooUiEdition() === "config"
   ? EnterpriseLink
   : CommunityLink;

--- a/ui/ui-components/components/export/diff.tsx
+++ b/ui/ui-components/components/export/diff.tsx
@@ -108,10 +108,7 @@ function groupLink(groups: Models.GroupType[], groupName: string) {
 
   if (group) {
     return (
-      <Link
-        href="/model/[modelId]/group/[groupId]/edit"
-        as={`/model/${group.modelId}/group/${group.id}/edit`}
-      >
+      <Link href={`/model/${group.modelId}/group/${group.id}/edit`}>
         <a>{group.name}</a>
       </Link>
     );

--- a/ui/ui-components/components/export/list.tsx
+++ b/ui/ui-components/components/export/list.tsx
@@ -5,7 +5,7 @@ import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
 import Link from "next/link";
 import EnterpriseLink from "../enterpriseLink";
 import { useRouter } from "next/router";
-import { Row, Col, ButtonGroup, Button, Badge, Alert } from "react-bootstrap";
+import { Row, Col, ButtonGroup, Badge, Alert } from "react-bootstrap";
 import Pagination from "../pagination";
 import LoadingTable from "../loadingTable";
 import { Models, Actions } from "../../utils/apiData";
@@ -15,6 +15,7 @@ import { capitalize } from "../../utils/languageHelper";
 import { formatTimestamp } from "../../utils/formatTimestamp";
 import StateBadge from "../badges/stateBadge";
 import { DurationTime } from "../durationTime";
+import LoadingButton from "../loadingButton";
 
 const states = [
   "all",
@@ -108,13 +109,14 @@ export default function ExportsList(props) {
             {states.map((_state) => {
               return (
                 <Fragment key={`export-state-button-${_state}`}>
-                  <Button
+                  <LoadingButton
                     size="sm"
+                    disabled={loading}
                     variant={state === _state ? "secondary" : "info"}
                     onClick={() => setState(_state)}
                   >
                     {capitalize(_state)}
-                  </Button>
+                  </LoadingButton>
                 </Fragment>
               );
             })}

--- a/ui/ui-components/components/export/list.tsx
+++ b/ui/ui-components/components/export/list.tsx
@@ -3,7 +3,7 @@ import { UseApi } from "../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../hooks/URLParams";
 import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
 import Link from "next/link";
-import EnterpriseLink from "../enterpriseLink";
+import EnterpriseLink from "../grouparooLink";
 import { useRouter } from "next/router";
 import { Row, Col, Button, ButtonGroup, Badge, Alert } from "react-bootstrap";
 import Pagination from "../pagination";

--- a/ui/ui-components/components/export/list.tsx
+++ b/ui/ui-components/components/export/list.tsx
@@ -5,7 +5,7 @@ import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
 import Link from "next/link";
 import EnterpriseLink from "../enterpriseLink";
 import { useRouter } from "next/router";
-import { Row, Col, ButtonGroup, Badge, Alert } from "react-bootstrap";
+import { Row, Col, Button, ButtonGroup, Badge, Alert } from "react-bootstrap";
 import Pagination from "../pagination";
 import LoadingTable from "../loadingTable";
 import { Models, Actions } from "../../utils/apiData";
@@ -15,7 +15,6 @@ import { capitalize } from "../../utils/languageHelper";
 import { formatTimestamp } from "../../utils/formatTimestamp";
 import StateBadge from "../badges/stateBadge";
 import { DurationTime } from "../durationTime";
-import LoadingButton from "../loadingButton";
 
 const states = [
   "all",
@@ -109,14 +108,14 @@ export default function ExportsList(props) {
             {states.map((_state) => {
               return (
                 <Fragment key={`export-state-button-${_state}`}>
-                  <LoadingButton
+                  <Button
                     size="sm"
                     disabled={loading}
                     variant={state === _state ? "secondary" : "info"}
                     onClick={() => setState(_state)}
                   >
                     {capitalize(_state)}
-                  </LoadingButton>
+                  </Button>
                 </Fragment>
               );
             })}

--- a/ui/ui-components/components/export/list.tsx
+++ b/ui/ui-components/components/export/list.tsx
@@ -150,10 +150,7 @@ export default function ExportsList(props) {
                 <tr>
                   <td>
                     <span>Id</span>:{" "}
-                    <Link
-                      href="/export/[id]/edit"
-                      as={`/export/${_export.id}/edit`}
-                    >
+                    <Link href={`/export/${_export.id}/edit`}>
                       <a>{_export.id}</a>
                     </Link>
                     <br />
@@ -164,8 +161,7 @@ export default function ExportsList(props) {
                       <>
                         <span>Processor</span>:{" "}
                         <Link
-                          href="/exportProcessor/[id]/edit"
-                          as={`/exportProcessor/${_export.exportProcessorId}/edit`}
+                          href={`/exportProcessor/${_export.exportProcessorId}/edit`}
                         >
                           <a>{_export.exportProcessorId}</a>
                         </Link>
@@ -174,24 +170,21 @@ export default function ExportsList(props) {
                     ) : null}
                     Record:{" "}
                     <Link
-                      href="/model/[modelId]/record/[recordId]/edit"
-                      as={`/model/${_export.destination.modelId}/record/${_export.recordId}/edit`}
+                      href={`/model/${_export.destination.modelId}/record/${_export.recordId}/edit`}
                     >
                       <a>{_export.recordId}</a>
                     </Link>
                     <br />
                     Destination:{" "}
                     <EnterpriseLink
-                      href="/model/[modelId]/destination/[destinationId]/edit"
-                      as={`/model/${_export.destination.modelId}/destination/${_export.destination.id}/edit`}
+                      href={`/model/${_export.destination.modelId}/destination/${_export.destination.id}/edit`}
                     >
                       <a>{_export.destination.name}</a>
                     </EnterpriseLink>
                     <br />
                     Model:{" "}
                     <EnterpriseLink
-                      href="/model/[modelId]/edit"
-                      as={`/model/${_export.destination.modelId}/edit`}
+                      href={`/model/${_export.destination.modelId}/edit`}
                     >
                       <a>{_export.destination.modelId}</a>
                     </EnterpriseLink>

--- a/ui/ui-components/components/grouparooLink.tsx
+++ b/ui/ui-components/components/grouparooLink.tsx
@@ -7,7 +7,8 @@ const CommunityLink = function ({ children }) {
   return <span>{children}</span>;
 };
 
-export default grouparooUiEdition() === "enterprise" ||
-grouparooUiEdition() === "config"
+const GrouparooLink = ["enterprise", "config"].includes(grouparooUiEdition())
   ? EnterpriseLink
   : CommunityLink;
+
+export default GrouparooLink;

--- a/ui/ui-components/components/import/diff.tsx
+++ b/ui/ui-components/components/import/diff.tsx
@@ -143,10 +143,7 @@ function groupLink(groups: Models.GroupType[], groupId: string) {
 
   if (group) {
     return (
-      <EnterpriseLink
-        href="/model/[modelId]/group/[groupId]/edit"
-        as={`/model/${group.modelId}/group/${group.id}/edit`}
-      >
+      <EnterpriseLink href={`/model/${group.modelId}/group/${group.id}/edit`}>
         <a>{group.name}</a>
       </EnterpriseLink>
     );

--- a/ui/ui-components/components/import/diff.tsx
+++ b/ui/ui-components/components/import/diff.tsx
@@ -1,5 +1,5 @@
 import { Badge } from "react-bootstrap";
-import EnterpriseLink from "../enterpriseLink";
+import EnterpriseLink from "../grouparooLink";
 import { Models } from "../../utils/apiData";
 
 function onlyUnique(value, index, self) {

--- a/ui/ui-components/components/import/list.tsx
+++ b/ui/ui-components/components/import/list.tsx
@@ -87,18 +87,12 @@ export default function ImportList(props) {
                 <tr>
                   <td>
                     id:
-                    <Link
-                      href="/import/[id]/edit"
-                      as={`/import/${_import.id}/edit`}
-                    >
+                    <Link href={`/import/${_import.id}/edit`}>
                       <a> {_import.id}</a>
                     </Link>
                     <br /> Record:{" "}
                     {_import.recordId ? (
-                      <Link
-                        href="/object/[id]"
-                        as={`/object/${_import.recordId}`}
-                      >
+                      <Link href={`/object/${_import.recordId}`}>
                         <a>{_import.recordId}</a>
                       </Link>
                     ) : (
@@ -106,19 +100,13 @@ export default function ImportList(props) {
                     )}
                     <br />
                     Model:{" "}
-                    <Link
-                      href="/model/[modelId]/edit"
-                      as={`/model/${_import.modelId}/edit`}
-                    >
+                    <Link href={`/model/${_import.modelId}/edit`}>
                       <a>{_import.modelId}</a>
                     </Link>
                     <br />
                     Creator:{" "}
                     {_import.creatorType === "run" ? (
-                      <Link
-                        href="/run/[id]/edit"
-                        as={`/run/${_import.creatorId}/edit`}
-                      >
+                      <Link href={`/run/${_import.creatorId}/edit`}>
                         <a>{_import.creatorId}</a>
                       </Link>
                     ) : (

--- a/ui/ui-components/components/linkButton.tsx
+++ b/ui/ui-components/components/linkButton.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { Button, ButtonProps } from "react-bootstrap";
+import { grouparooUiEdition, GrouparooUIEdition } from "../utils/uiEdition";
+
+export default function LinkButton(
+  props: ButtonProps & {
+    href: string;
+    as?: string;
+    target?: string;
+    displayOn?: Array<GrouparooUIEdition>;
+    hideOn?: Array<GrouparooUIEdition>;
+  }
+) {
+  const { children, href, as, target, displayOn, hideOn, ...buttonProps } =
+    props;
+
+  if (displayOn && !displayOn.includes(grouparooUiEdition)) {
+    return null;
+  }
+
+  if (hideOn && hideOn.includes(grouparooUiEdition)) {
+    return null;
+  }
+
+  return (
+    <Link href={href} as={as}>
+      <a target={target}>
+        <Button {...buttonProps}>{children}</Button>
+      </a>
+    </Link>
+  );
+}

--- a/ui/ui-components/components/linkButton.tsx
+++ b/ui/ui-components/components/linkButton.tsx
@@ -5,7 +5,6 @@ import { grouparooUiEdition, GrouparooUIEdition } from "../utils/uiEdition";
 export default function LinkButton(
   props: ButtonProps & {
     href: string;
-    as?: string;
     target?: string;
     displayOn?: Array<GrouparooUIEdition>;
     hideOn?: Array<GrouparooUIEdition>;
@@ -14,16 +13,18 @@ export default function LinkButton(
   const { children, href, as, target, displayOn, hideOn, ...buttonProps } =
     props;
 
-  if (displayOn && !displayOn.includes(grouparooUiEdition)) {
+  if (displayOn && !displayOn.includes(grouparooUiEdition())) {
     return null;
   }
 
-  if (hideOn && hideOn.includes(grouparooUiEdition)) {
+  if (hideOn && hideOn.includes(grouparooUiEdition())) {
     return null;
   }
+
+  if (!href) return <>{children}</>;
 
   return (
-    <Link href={href} as={as}>
+    <Link href={href}>
       <a target={target}>
         <Button {...buttonProps}>{children}</Button>
       </a>

--- a/ui/ui-components/components/linkButton.tsx
+++ b/ui/ui-components/components/linkButton.tsx
@@ -2,17 +2,20 @@ import Link from "next/link";
 import { Button, ButtonProps } from "react-bootstrap";
 import { grouparooUiEdition, GrouparooUIEdition } from "../utils/uiEdition";
 
-export default function LinkButton(
-  props: ButtonProps & {
-    href: string;
-    target?: string;
-    displayOn?: Array<GrouparooUIEdition>;
-    hideOn?: Array<GrouparooUIEdition>;
-  }
-) {
-  const { children, href, as, target, displayOn, hideOn, ...buttonProps } =
-    props;
-
+export default function LinkButton({
+  children,
+  href,
+  as,
+  target,
+  displayOn,
+  hideOn,
+  ...buttonProps
+}: ButtonProps & {
+  href: string;
+  target?: string;
+  displayOn?: GrouparooUIEdition[];
+  hideOn?: GrouparooUIEdition[];
+}) {
   if (displayOn && !displayOn.includes(grouparooUiEdition())) {
     return null;
   }

--- a/ui/ui-components/components/loadingButton.tsx
+++ b/ui/ui-components/components/loadingButton.tsx
@@ -10,11 +10,11 @@ export default function LoadingButton(
 ) {
   const { children, displayOn, hideOn, ...buttonProps } = props;
 
-  if (displayOn && !displayOn.includes(grouparooUiEdition)) {
+  if (displayOn && !displayOn.includes(grouparooUiEdition())) {
     return null;
   }
 
-  if (hideOn && hideOn.includes(grouparooUiEdition)) {
+  if (hideOn && hideOn.includes(grouparooUiEdition())) {
     return null;
   }
 

--- a/ui/ui-components/components/loadingButton.tsx
+++ b/ui/ui-components/components/loadingButton.tsx
@@ -1,12 +1,23 @@
-import { Button } from "react-bootstrap";
+import { Button, ButtonProps } from "react-bootstrap";
+import { GrouparooUIEdition, grouparooUiEdition } from "../utils/uiEdition";
 import Loader from "./loader";
 
-export default function LoadingButton(props) {
-  const message = props.disabled ? (
-    <Loader size="sm" />
-  ) : (
-    props.children || "Submit"
-  );
+export default function LoadingButton(
+  props: ButtonProps & {
+    displayOn?: Array<GrouparooUIEdition>;
+    hideOn?: Array<GrouparooUIEdition>;
+  }
+) {
+  const { children, displayOn, hideOn, ...buttonProps } = props;
 
-  return <Button {...props}>{message}</Button>;
+  if (displayOn && !displayOn.includes(grouparooUiEdition)) {
+    return null;
+  }
+
+  if (hideOn && hideOn.includes(grouparooUiEdition)) {
+    return null;
+  }
+
+  const message = props.disabled ? <Loader size="sm" /> : children || "Submit";
+  return <Button {...buttonProps}>{message}</Button>;
 }

--- a/ui/ui-components/components/loadingButton.tsx
+++ b/ui/ui-components/components/loadingButton.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { Button } from "react-bootstrap";
 import Loader from "./loader";
 

--- a/ui/ui-components/components/loadingButton.tsx
+++ b/ui/ui-components/components/loadingButton.tsx
@@ -4,8 +4,8 @@ import Loader from "./loader";
 
 export default function LoadingButton(
   props: ButtonProps & {
-    displayOn?: Array<GrouparooUIEdition>;
-    hideOn?: Array<GrouparooUIEdition>;
+    displayOn?: GrouparooUIEdition[];
+    hideOn?: GrouparooUIEdition[];
   }
 ) {
   const { children, displayOn, hideOn, ...buttonProps } = props;

--- a/ui/ui-components/components/log/list.tsx
+++ b/ui/ui-components/components/log/list.tsx
@@ -85,11 +85,7 @@ export default function LogsList(props) {
 
     if (ownerId) {
       return [
-        <EnterpriseLink
-          href="/object/[id]"
-          as={`/object/${ownerId}`}
-          prefetch={false}
-        >
+        <EnterpriseLink href={`/object/${ownerId}`} prefetch={false}>
           <a>{`${topic}`}</a>
         </EnterpriseLink>,
       ];
@@ -189,10 +185,7 @@ export default function LogsList(props) {
                   {log.ownerId ? (
                     <>
                       <br />
-                      <EnterpriseLink
-                        href="/object/[id]"
-                        as={`/object/${log.ownerId}`}
-                      >
+                      <EnterpriseLink href={`/object/${log.ownerId}`}>
                         <a className="text-muted">{log.ownerId}</a>
                       </EnterpriseLink>
                     </>

--- a/ui/ui-components/components/log/list.tsx
+++ b/ui/ui-components/components/log/list.tsx
@@ -5,12 +5,13 @@ import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
 import { useRealtimeStream } from "../../hooks/useRealtimeStream";
 import EnterpriseLink from "../enterpriseLink";
 import { useRouter } from "next/router";
-import { ButtonGroup, Button, Alert } from "react-bootstrap";
+import { ButtonGroup, Alert } from "react-bootstrap";
 import Pagination from "../pagination";
 import LoadingTable from "../loadingTable";
 import { Models, Actions } from "../../utils/apiData";
 import { ErrorHandler } from "../../utils/errorHandler";
 import { NextPageContext } from "next";
+import LoadingButton from "../loadingButton";
 
 const getOwnerId = (query: { [key: string]: string | string[] }) => {
   const { id, recordId, propertyId, sourceId, destinationId, groupId } = query;
@@ -115,8 +116,9 @@ export default function LogsList(props) {
       <strong>Topics:</strong>
       <br />
       <ButtonGroup id="log-types">
-        <Button
+        <LoadingButton
           size="sm"
+          disabled={loading}
           variant={topic ? "info" : "secondary"}
           onClick={() => {
             setTopic(null);
@@ -124,13 +126,14 @@ export default function LogsList(props) {
           }}
         >
           All
-        </Button>
+        </LoadingButton>
         {topics.map((t) => {
           const variant = t === topic ? "secondary" : "info";
           return (
-            <Button
+            <LoadingButton
               key={`topic-${t}`}
               size="sm"
+              disabled={loading}
               variant={variant}
               onClick={() => {
                 setTopic(t);
@@ -138,7 +141,7 @@ export default function LogsList(props) {
               }}
             >
               {t}
-            </Button>
+            </LoadingButton>
           );
         })}
       </ButtonGroup>
@@ -160,9 +163,9 @@ export default function LogsList(props) {
       {newLogs > 0 ? (
         <Alert variant="secondary">
           {newLogs} new logs.{" "}
-          <Button size="sm" onClick={load}>
+          <LoadingButton size="sm" onClick={load} disabled={loading}>
             Load
-          </Button>
+          </LoadingButton>
         </Alert>
       ) : null}
 

--- a/ui/ui-components/components/log/list.tsx
+++ b/ui/ui-components/components/log/list.tsx
@@ -3,7 +3,7 @@ import { UseApi } from "../../hooks/useApi";
 import { updateURLParams, useOffset } from "../../hooks/URLParams";
 import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
 import { useRealtimeStream } from "../../hooks/useRealtimeStream";
-import EnterpriseLink from "../enterpriseLink";
+import EnterpriseLink from "../grouparooLink";
 import { useRouter } from "next/router";
 import { ButtonGroup, Button, Alert } from "react-bootstrap";
 import Pagination from "../pagination";

--- a/ui/ui-components/components/log/list.tsx
+++ b/ui/ui-components/components/log/list.tsx
@@ -5,7 +5,7 @@ import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
 import { useRealtimeStream } from "../../hooks/useRealtimeStream";
 import EnterpriseLink from "../enterpriseLink";
 import { useRouter } from "next/router";
-import { ButtonGroup, Alert } from "react-bootstrap";
+import { ButtonGroup, Button, Alert } from "react-bootstrap";
 import Pagination from "../pagination";
 import LoadingTable from "../loadingTable";
 import { Models, Actions } from "../../utils/apiData";
@@ -112,7 +112,7 @@ export default function LogsList(props) {
       <strong>Topics:</strong>
       <br />
       <ButtonGroup id="log-types">
-        <LoadingButton
+        <Button
           size="sm"
           disabled={loading}
           variant={topic ? "info" : "secondary"}
@@ -122,11 +122,11 @@ export default function LogsList(props) {
           }}
         >
           All
-        </LoadingButton>
+        </Button>
         {topics.map((t) => {
           const variant = t === topic ? "secondary" : "info";
           return (
-            <LoadingButton
+            <Button
               key={`topic-${t}`}
               size="sm"
               disabled={loading}
@@ -137,7 +137,7 @@ export default function LogsList(props) {
               }}
             >
               {t}
-            </LoadingButton>
+            </Button>
           );
         })}
       </ButtonGroup>

--- a/ui/ui-components/components/navigation.tsx
+++ b/ui/ui-components/components/navigation.tsx
@@ -122,7 +122,7 @@ export default function Navigation(props) {
 
   if (!navExpanded && !hasBeenCollapsed) setHasBeenCollapsed(true);
 
-  const uiPlugin = `@grouparoo/ui-${grouparooUiEdition}`;
+  const uiPlugin = `@grouparoo/ui-${grouparooUiEdition()}`;
   return (
     <div
       id="navigation"

--- a/ui/ui-components/components/navigation.tsx
+++ b/ui/ui-components/components/navigation.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState, useEffect } from "react";
 import { useRouter } from "next/router";
-import { Image, Accordion, Button, Badge, Form, Col } from "react-bootstrap";
+import { Image, Accordion, Button, Badge, Form } from "react-bootstrap";
 import Link from "next/link";
 import {
   FontAwesomeIcon,
@@ -19,6 +19,8 @@ import { SessionHandler } from "../utils/sessionHandler";
 import { StatusHandler } from "../utils/statusHandler";
 import { truncate } from "../utils/truncate";
 import { onChangeModelId } from "../utils/modelHelper";
+import LinkButton from "./linkButton";
+import { grouparooUiEdition } from "../utils/uiEdition";
 
 export const navLiStyle = { marginTop: 20, marginBottom: 20 };
 
@@ -120,7 +122,7 @@ export default function Navigation(props) {
 
   if (!navExpanded && !hasBeenCollapsed) setHasBeenCollapsed(true);
 
-  const uiPlugin = `@grouparoo/ui-${process.env.GROUPAROO_UI_EDITION}`;
+  const uiPlugin = `@grouparoo/ui-${grouparooUiEdition}`;
   return (
     <div
       id="navigation"
@@ -350,11 +352,7 @@ export default function Navigation(props) {
           </ul>
         </div>
       </div>
-      <div
-        className={
-          process.env.GROUPAROO_UI_EDITION === "config" ? "mb-5" : null
-        }
-      >
+      <div className={grouparooUiEdition === "config" ? "mb-5" : null}>
         <div
           id="bottomNavigationMenuCTA"
           style={{
@@ -364,7 +362,7 @@ export default function Navigation(props) {
           }}
           className="mx-auto px-3"
         >
-          <Button
+          <LinkButton
             style={{ color: "white" }}
             variant="outline-light"
             href="https://www.grouparoo.com/chat"
@@ -377,7 +375,7 @@ export default function Navigation(props) {
               size="1x"
             />{" "}
             Join us on Slack
-          </Button>
+          </LinkButton>
         </div>
 
         {navigation?.bottomMenuItems?.length > 0 ? (

--- a/ui/ui-components/components/navigation.tsx
+++ b/ui/ui-components/components/navigation.tsx
@@ -178,7 +178,7 @@ export default function Navigation(props) {
                 {truncate(clusterName.value, 30)}
               </Badge>
             ) : (
-              <Link href="/settings/[tab]" as="/settings/core">
+              <Link href="/settings/core">
                 <a>
                   <Badge variant="secondary">
                     {clusterName
@@ -352,7 +352,7 @@ export default function Navigation(props) {
           </ul>
         </div>
       </div>
-      <div className={grouparooUiEdition === "config" ? "mb-5" : null}>
+      <div className={grouparooUiEdition() === "config" ? "mb-5" : null}>
         <div
           id="bottomNavigationMenuCTA"
           style={{

--- a/ui/ui-components/components/record/list.tsx
+++ b/ui/ui-components/components/record/list.tsx
@@ -4,7 +4,6 @@ import { Form, Row, Col, Badge, Button, ButtonGroup } from "react-bootstrap";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import type { NextPageContext } from "next";
-
 import { UseApi } from "../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../hooks/URLParams";
 import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
@@ -222,7 +221,7 @@ export default function RecordsList(props) {
         <Col>
           States:{" "}
           <ButtonGroup id="record-states">
-            <LoadingButton
+            <Button
               size="sm"
               disabled={loading}
               variant={state ? "info" : "secondary"}
@@ -232,11 +231,11 @@ export default function RecordsList(props) {
               }}
             >
               All
-            </LoadingButton>
+            </Button>
             {states.map((t) => {
               const variant = t === state ? "secondary" : "info";
               return (
-                <LoadingButton
+                <Button
                   key={`state-${t}`}
                   size="sm"
                   disabled={loading}
@@ -247,7 +246,7 @@ export default function RecordsList(props) {
                   }}
                 >
                   {t}
-                </LoadingButton>
+                </Button>
               );
             })}
           </ButtonGroup>

--- a/ui/ui-components/components/record/list.tsx
+++ b/ui/ui-components/components/record/list.tsx
@@ -222,8 +222,9 @@ export default function RecordsList(props) {
         <Col>
           States:{" "}
           <ButtonGroup id="record-states">
-            <Button
+            <LoadingButton
               size="sm"
+              disabled={loading}
               variant={state ? "info" : "secondary"}
               onClick={() => {
                 setState(null);
@@ -231,13 +232,14 @@ export default function RecordsList(props) {
               }}
             >
               All
-            </Button>
+            </LoadingButton>
             {states.map((t) => {
               const variant = t === state ? "secondary" : "info";
               return (
-                <Button
+                <LoadingButton
                   key={`state-${t}`}
                   size="sm"
+                  disabled={loading}
                   variant={variant}
                   onClick={() => {
                     setState(t);
@@ -245,7 +247,7 @@ export default function RecordsList(props) {
                   }}
                 >
                   {t}
-                </Button>
+                </LoadingButton>
               );
             })}
           </ButtonGroup>

--- a/ui/ui-components/components/record/list.tsx
+++ b/ui/ui-components/components/record/list.tsx
@@ -291,8 +291,7 @@ export default function RecordsList(props) {
               <tr key={`record-${record.id}`}>
                 <td>
                   <Link
-                    href="/model/[modelId]/record/[recordId]/edit"
-                    as={`/model/${record.modelId}/record/${record.id}/edit`}
+                    href={`/model/${record.modelId}/record/${record.id}/edit`}
                   >
                     <a className="text-muted">
                       {identifyingRecordProperty?.key &&

--- a/ui/ui-components/components/runs/list.tsx
+++ b/ui/ui-components/components/runs/list.tsx
@@ -197,7 +197,7 @@ export default function RunsList(props) {
                   <tr>
                     <td>
                       id:{" "}
-                      <Link href="/run/[id]/edit" as={`/run/${run.id}/edit`}>
+                      <Link href={`/run/${run.id}/edit`}>
                         <a>{run.id}</a>
                       </Link>
                     </td>
@@ -263,10 +263,7 @@ export default function RunsList(props) {
                       ) : null}
                     </td>
                     <td>
-                      <Link
-                        href="/imports/[creatorId]"
-                        as={`/imports/${run.id}`}
-                      >
+                      <Link href={`/imports/${run.id}`}>
                         <a>Imports Created: {run.importsCreated}</a>
                       </Link>
                       <br />

--- a/ui/ui-components/components/runs/list.tsx
+++ b/ui/ui-components/components/runs/list.tsx
@@ -2,7 +2,7 @@ import { UseApi } from "../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../hooks/URLParams";
 import { Fragment, useEffect, useState } from "react";
 import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
-import { Row, Col, ButtonGroup, Alert, Card } from "react-bootstrap";
+import { Row, Col, Button, ButtonGroup, Alert, Card } from "react-bootstrap";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import EnterpriseLink from "../enterpriseLink";
@@ -15,7 +15,6 @@ import { ErrorHandler } from "../../utils/errorHandler";
 import { RunsHandler } from "../../utils/runsHandler";
 import { DurationTime } from "../durationTime";
 import { NextPageContext } from "next";
-import LoadingButton from "../loadingButton";
 
 export default function RunsList(props) {
   const {
@@ -91,67 +90,67 @@ export default function RunsList(props) {
         <Col>
           State:{" "}
           <ButtonGroup>
-            <LoadingButton
+            <Button
               size="sm"
               disabled={loading}
               variant={stateFilter === "" ? "secondary" : "info"}
               onClick={() => setFilter({ stateFilter: "" })}
             >
               All
-            </LoadingButton>
-            <LoadingButton
+            </Button>
+            <Button
               size="sm"
               disabled={loading}
               variant={stateFilter === "running" ? "secondary" : "info"}
               onClick={() => setFilter({ stateFilter: "running" })}
             >
               Running
-            </LoadingButton>
-            <LoadingButton
+            </Button>
+            <Button
               size="sm"
               disabled={loading}
               variant={stateFilter === "complete" ? "secondary" : "info"}
               onClick={() => setFilter({ stateFilter: "complete" })}
             >
               Complete
-            </LoadingButton>
-            <LoadingButton
+            </Button>
+            <Button
               size="sm"
               disabled={loading}
               variant={stateFilter === "stopped" ? "secondary" : "info"}
               onClick={() => setFilter({ stateFilter: "stopped" })}
             >
               Stopped
-            </LoadingButton>
+            </Button>
           </ButtonGroup>
         </Col>
         <Col>
           Has Error:{" "}
           <ButtonGroup>
-            <LoadingButton
+            <Button
               size="sm"
               disabled={loading}
               variant={errorFilter === "" ? "secondary" : "info"}
               onClick={() => setFilter({ errorFilter: "" })}
             >
               All
-            </LoadingButton>
-            <LoadingButton
+            </Button>
+            <Button
               size="sm"
               disabled={loading}
               variant={errorFilter === "true" ? "secondary" : "info"}
               onClick={() => setFilter({ errorFilter: "true" })}
             >
               True
-            </LoadingButton>
-            <LoadingButton
+            </Button>
+            <Button
               size="sm"
               disabled={loading}
               variant={errorFilter === "false" ? "secondary" : "info"}
               onClick={() => setFilter({ errorFilter: "false" })}
             >
               False
-            </LoadingButton>
+            </Button>
           </ButtonGroup>
         </Col>
       </Row>

--- a/ui/ui-components/components/runs/list.tsx
+++ b/ui/ui-components/components/runs/list.tsx
@@ -1,8 +1,8 @@
 import { UseApi } from "../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../hooks/URLParams";
-import { Fragment, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
-import { Row, Col, ButtonGroup, Button, Alert, Card } from "react-bootstrap";
+import { Row, Col, ButtonGroup, Alert, Card } from "react-bootstrap";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import EnterpriseLink from "../enterpriseLink";
@@ -12,11 +12,17 @@ import RunDurationChart from "../visualizations/runDurations";
 import { Models, Actions } from "../../utils/apiData";
 import { formatTimestamp } from "../../utils/formatTimestamp";
 import { ErrorHandler } from "../../utils/errorHandler";
+import { RunsHandler } from "../../utils/runsHandler";
 import { DurationTime } from "../durationTime";
 import { NextPageContext } from "next";
+import LoadingButton from "../loadingButton";
 
 export default function RunsList(props) {
-  const { errorHandler, topic }: { errorHandler: ErrorHandler; topic: string } =
+  const {
+    errorHandler,
+    runsHandler,
+    topic,
+  }: { errorHandler: ErrorHandler; runsHandler: RunsHandler; topic: string } =
     props;
   const router = useRouter();
   const { execApi } = UseApi(props, errorHandler);
@@ -33,6 +39,13 @@ export default function RunsList(props) {
   // pagination
   const limit = 100;
   const { offset, setOffset } = useOffset();
+
+  useEffect(() => {
+    runsHandler.subscribe("runs-list", () => load());
+    return () => {
+      runsHandler.unsubscribe("runs-list");
+    };
+  }, []);
 
   useSecondaryEffect(() => {
     load();
@@ -78,60 +91,67 @@ export default function RunsList(props) {
         <Col>
           State:{" "}
           <ButtonGroup>
-            <Button
+            <LoadingButton
               size="sm"
+              disabled={loading}
               variant={stateFilter === "" ? "secondary" : "info"}
               onClick={() => setFilter({ stateFilter: "" })}
             >
               All
-            </Button>
-            <Button
+            </LoadingButton>
+            <LoadingButton
               size="sm"
+              disabled={loading}
               variant={stateFilter === "running" ? "secondary" : "info"}
               onClick={() => setFilter({ stateFilter: "running" })}
             >
               Running
-            </Button>
-            <Button
+            </LoadingButton>
+            <LoadingButton
               size="sm"
+              disabled={loading}
               variant={stateFilter === "complete" ? "secondary" : "info"}
               onClick={() => setFilter({ stateFilter: "complete" })}
             >
               Complete
-            </Button>
-            <Button
+            </LoadingButton>
+            <LoadingButton
               size="sm"
+              disabled={loading}
               variant={stateFilter === "stopped" ? "secondary" : "info"}
               onClick={() => setFilter({ stateFilter: "stopped" })}
             >
               Stopped
-            </Button>
+            </LoadingButton>
           </ButtonGroup>
         </Col>
         <Col>
           Has Error:{" "}
           <ButtonGroup>
-            <Button
+            <LoadingButton
               size="sm"
+              disabled={loading}
               variant={errorFilter === "" ? "secondary" : "info"}
               onClick={() => setFilter({ errorFilter: "" })}
             >
               All
-            </Button>
-            <Button
+            </LoadingButton>
+            <LoadingButton
               size="sm"
+              disabled={loading}
               variant={errorFilter === "true" ? "secondary" : "info"}
               onClick={() => setFilter({ errorFilter: "true" })}
             >
               True
-            </Button>
-            <Button
+            </LoadingButton>
+            <LoadingButton
               size="sm"
+              disabled={loading}
               variant={errorFilter === "false" ? "secondary" : "info"}
               onClick={() => setFilter({ errorFilter: "false" })}
             >
               False
-            </Button>
+            </LoadingButton>
           </ButtonGroup>
         </Col>
       </Row>

--- a/ui/ui-components/components/runs/list.tsx
+++ b/ui/ui-components/components/runs/list.tsx
@@ -5,7 +5,7 @@ import { useSecondaryEffect } from "../../hooks/useSecondaryEffect";
 import { Row, Col, Button, ButtonGroup, Alert, Card } from "react-bootstrap";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import EnterpriseLink from "../enterpriseLink";
+import EnterpriseLink from "../grouparooLink";
 import Pagination from "../pagination";
 import LoadingTable from "../loadingTable";
 import RunDurationChart from "../visualizations/runDurations";

--- a/ui/ui-components/components/setupSteps/setupStepCard.tsx
+++ b/ui/ui-components/components/setupSteps/setupStepCard.tsx
@@ -81,7 +81,7 @@ export default function SetupStepCard({
                       Learn More
                     </LinkButton>
                     &nbsp;&nbsp;
-                    {(grouparooUiEdition !== "community" ||
+                    {(grouparooUiEdition() !== "community" ||
                       step.showCtaOnCommunity) &&
                       step.cta && (
                         <LinkButton
@@ -94,7 +94,7 @@ export default function SetupStepCard({
                         </LinkButton>
                       )}
                   </Col>
-                  {grouparooUiEdition === "config" ? null : (
+                  {grouparooUiEdition() === "config" ? null : (
                     <Col md={6} style={{ textAlign: "right" }}>
                       {step.skipped ? (
                         <LoadingButton

--- a/ui/ui-components/components/setupSteps/setupStepCard.tsx
+++ b/ui/ui-components/components/setupSteps/setupStepCard.tsx
@@ -24,8 +24,13 @@ export default function SetupStepCard({
     await execApi("put", `/setupStep/${step.id}`, {
       skipped: !step.skipped,
     });
-    await reload();
-    setLoading(false);
+
+    try {
+      await reload();
+    } finally {
+      setLoading(false);
+    }
+
     setActiveKey(step.skipped ? "0" : null);
   }
 

--- a/ui/ui-components/components/setupSteps/setupStepCard.tsx
+++ b/ui/ui-components/components/setupSteps/setupStepCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Models } from "../../utils/apiData";
 import { Accordion, Card, Row, Col, Button, Badge } from "react-bootstrap";
+import LoadingButton from "../loadingButton";
 
 export default function SetupStepCard({
   setupStep: step,
@@ -11,15 +12,18 @@ export default function SetupStepCard({
   execApi: Function;
   reload: Function;
 }) {
+  const [loading, setLoading] = useState(false);
   const [activeKey, setActiveKey] = useState(
     step.skipped || step.complete ? null : "0"
   );
 
   async function skip() {
+    setLoading(true);
     await execApi("put", `/setupStep/${step.id}`, {
       skipped: !step.skipped,
     });
-    reload();
+    await reload();
+    setLoading(false);
     setActiveKey(step.skipped ? "0" : null);
   }
 
@@ -91,23 +95,25 @@ export default function SetupStepCard({
                   {process.env.GROUPAROO_UI_EDITION === "config" ? null : (
                     <Col md={6} style={{ textAlign: "right" }}>
                       {step.skipped ? (
-                        <Button
+                        <LoadingButton
                           size="sm"
+                          disabled={loading}
                           className="m-1"
                           variant="outline-dark"
                           onClick={() => skip()}
                         >
                           un-skip
-                        </Button>
+                        </LoadingButton>
                       ) : (
-                        <Button
+                        <LoadingButton
                           size="sm"
+                          disabled={loading}
                           className="m-1"
                           variant="outline-dark"
                           onClick={() => skip()}
                         >
                           skip
-                        </Button>
+                        </LoadingButton>
                       )}
                     </Col>
                   )}

--- a/ui/ui-components/components/setupSteps/setupStepCard.tsx
+++ b/ui/ui-components/components/setupSteps/setupStepCard.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { Models } from "../../utils/apiData";
 import { Accordion, Card, Row, Col, Button, Badge } from "react-bootstrap";
 import LoadingButton from "../loadingButton";
+import LinkButton from "../linkButton";
+import { grouparooUiEdition } from "../../utils/uiEdition";
 
 export default function SetupStepCard({
   setupStep: step,
@@ -69,7 +71,7 @@ export default function SetupStepCard({
               {step.complete ? null : (
                 <Row>
                   <Col md={6}>
-                    <Button
+                    <LinkButton
                       variant="outline-primary"
                       size="sm"
                       className="m-1"
@@ -77,22 +79,22 @@ export default function SetupStepCard({
                       href={step.helpLink}
                     >
                       Learn More
-                    </Button>
+                    </LinkButton>
                     &nbsp;&nbsp;
-                    {(process.env.GROUPAROO_UI_EDITION !== "community" ||
+                    {(grouparooUiEdition !== "community" ||
                       step.showCtaOnCommunity) &&
                       step.cta && (
-                        <Button
+                        <LinkButton
                           size="sm"
                           className="m-1"
                           href={step.href}
                           disabled={step.disabled}
                         >
                           {step.cta}
-                        </Button>
+                        </LinkButton>
                       )}
                   </Col>
-                  {process.env.GROUPAROO_UI_EDITION === "config" ? null : (
+                  {grouparooUiEdition === "config" ? null : (
                     <Col md={6} style={{ textAlign: "right" }}>
                       {step.skipped ? (
                         <LoadingButton

--- a/ui/ui-components/components/tabs.tsx
+++ b/ui/ui-components/components/tabs.tsx
@@ -41,10 +41,7 @@ export default function GrouparooTabs({
           </Link>
         </li>
         <li className="breadcrumb-item">
-          <Link
-            href={`${pathnameScope}/${topic}/${pathnameId}/${defaultTab}`}
-            as={`${scope}/${topic}/${id}/${defaultTab}`}
-          >
+          <Link href={`${scope}/${topic}/${id}/${defaultTab}`}>
             <a>
               {name !== ""
                 ? name

--- a/ui/ui-components/components/tabs/destination.tsx
+++ b/ui/ui-components/components/tabs/destination.tsx
@@ -1,5 +1,6 @@
 import Tabs from "../tabs";
 import { Models } from "../../utils/apiData";
+import { grouparooUiEdition } from "../../utils/uiEdition";
 
 export default function DestinationTabs({
   destination,
@@ -7,7 +8,7 @@ export default function DestinationTabs({
   destination: Models.DestinationType;
 }) {
   let tabs = [];
-  switch (process.env.GROUPAROO_UI_EDITION) {
+  switch (grouparooUiEdition) {
     case "enterprise":
       tabs.push("edit");
       if (destination.state !== "draft") tabs.push("data");

--- a/ui/ui-components/components/tabs/destination.tsx
+++ b/ui/ui-components/components/tabs/destination.tsx
@@ -8,7 +8,7 @@ export default function DestinationTabs({
   destination: Models.DestinationType;
 }) {
   let tabs = [];
-  switch (grouparooUiEdition) {
+  switch (grouparooUiEdition()) {
     case "enterprise":
       tabs.push("edit");
       if (destination.state !== "draft") tabs.push("data");

--- a/ui/ui-components/components/tabs/group.tsx
+++ b/ui/ui-components/components/tabs/group.tsx
@@ -1,10 +1,11 @@
 import Tabs from "../tabs";
 import { Models } from "../../utils/apiData";
+import { grouparooUiEdition } from "../../utils/uiEdition";
 
 export default function GroupTabs({ group }: { group: Models.GroupType }) {
   let tabs = ["edit", "rules"];
 
-  if (process.env.GROUPAROO_UI_EDITION === "enterprise") {
+  if (grouparooUiEdition === "enterprise") {
     tabs.push("members", "destinations", "runs", "logs");
   }
 

--- a/ui/ui-components/components/tabs/group.tsx
+++ b/ui/ui-components/components/tabs/group.tsx
@@ -5,7 +5,7 @@ import { grouparooUiEdition } from "../../utils/uiEdition";
 export default function GroupTabs({ group }: { group: Models.GroupType }) {
   let tabs = ["edit", "rules"];
 
-  if (grouparooUiEdition === "enterprise") {
+  if (grouparooUiEdition() === "enterprise") {
     tabs.push("members", "destinations", "runs", "logs");
   }
 

--- a/ui/ui-components/components/tabs/property.tsx
+++ b/ui/ui-components/components/tabs/property.tsx
@@ -11,7 +11,7 @@ export default function PropertyTabs({
 }) {
   let tabs = ["edit"];
 
-  if (grouparooUiEdition === "enterprise") {
+  if (grouparooUiEdition() === "enterprise") {
     tabs.push("records", "groups", "runs", "logs");
   }
 

--- a/ui/ui-components/components/tabs/property.tsx
+++ b/ui/ui-components/components/tabs/property.tsx
@@ -1,5 +1,6 @@
 import Tabs from "../tabs";
 import { Models } from "../../utils/apiData";
+import { grouparooUiEdition } from "../../utils/uiEdition";
 
 export default function PropertyTabs({
   property,
@@ -10,7 +11,7 @@ export default function PropertyTabs({
 }) {
   let tabs = ["edit"];
 
-  if (process.env.GROUPAROO_UI_EDITION === "enterprise") {
+  if (grouparooUiEdition === "enterprise") {
     tabs.push("records", "groups", "runs", "logs");
   }
 

--- a/ui/ui-components/components/tabs/record.tsx
+++ b/ui/ui-components/components/tabs/record.tsx
@@ -1,6 +1,7 @@
 import Tabs from "../tabs";
 import { Models } from "../../utils/apiData";
 import { getRecordDisplayName } from "../record/getRecordDisplayName";
+import { grouparooUiEdition } from "../../utils/uiEdition";
 
 export default function RecordTabs({
   record,
@@ -9,7 +10,7 @@ export default function RecordTabs({
 }) {
   const tabs = ["edit", "imports", "exports", "logs"];
 
-  if (process.env.GROUPAROO_UI_EDITION === "config") {
+  if (grouparooUiEdition === "config") {
     tabs.splice(tabs.indexOf("imports"), 1);
   }
 

--- a/ui/ui-components/components/tabs/record.tsx
+++ b/ui/ui-components/components/tabs/record.tsx
@@ -10,7 +10,7 @@ export default function RecordTabs({
 }) {
   const tabs = ["edit", "imports", "exports", "logs"];
 
-  if (grouparooUiEdition === "config") {
+  if (grouparooUiEdition() === "config") {
     tabs.splice(tabs.indexOf("imports"), 1);
   }
 

--- a/ui/ui-components/components/tabs/source.tsx
+++ b/ui/ui-components/components/tabs/source.tsx
@@ -1,5 +1,6 @@
 import Tabs from "../tabs";
 import { Models } from "../../utils/apiData";
+import { grouparooUiEdition } from "../../utils/uiEdition";
 
 export default function SourceTabs({ source }: { source: Models.SourceType }) {
   const tabs = ["overview", "edit"];
@@ -10,7 +11,7 @@ export default function SourceTabs({ source }: { source: Models.SourceType }) {
 
   if (source.schedule) {
     tabs.push("schedule");
-    if (process.env.GROUPAROO_UI_EDITION === "enterprise") tabs.push("runs");
+    if (grouparooUiEdition === "enterprise") tabs.push("runs");
   }
 
   return <Tabs name={source.name} draftType={source.type} tabs={tabs} />;

--- a/ui/ui-components/components/tabs/source.tsx
+++ b/ui/ui-components/components/tabs/source.tsx
@@ -11,7 +11,7 @@ export default function SourceTabs({ source }: { source: Models.SourceType }) {
 
   if (source.schedule) {
     tabs.push("schedule");
-    if (grouparooUiEdition === "enterprise") tabs.push("runs");
+    if (grouparooUiEdition() === "enterprise") tabs.push("runs");
   }
 
   return <Tabs name={source.name} draftType={source.type} tabs={tabs} />;

--- a/ui/ui-components/components/visualizations/homepageWidgets.tsx
+++ b/ui/ui-components/components/visualizations/homepageWidgets.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
-import EnterpriseLink from "../enterpriseLink";
+import EnterpriseLink from "../grouparooLink";
 import { Card, Table, ProgressBar } from "react-bootstrap";
 import { Misc, Models } from "../../utils/apiData";
 import Moment from "react-moment";

--- a/ui/ui-components/components/visualizations/homepageWidgets.tsx
+++ b/ui/ui-components/components/visualizations/homepageWidgets.tsx
@@ -122,10 +122,7 @@ export function GroupsByNewestMember({
               return (
                 <tr key={`group-${group.id}`}>
                   <td>
-                    <EnterpriseLink
-                      href="/object/[id]"
-                      as={`/object/${group.id}`}
-                    >
+                    <EnterpriseLink href={`/object/${group.id}`}>
                       <a>{group.name}</a>
                     </EnterpriseLink>
                   </td>
@@ -224,7 +221,7 @@ export function RunningRuns({
               return (
                 <tr key={`run-${run.id}`}>
                   <td>
-                    <Link href="/run/[id]/edit" as={`/run/${run.id}/edit`}>
+                    <Link href={`/run/${run.id}/edit`}>
                       <a>{run.creatorName}</a>
                     </Link>
                   </td>
@@ -317,10 +314,7 @@ export function ScheduleRuns({
               return (
                 <tr key={`source-${sourceSchedule.id}`}>
                   <td>
-                    <EnterpriseLink
-                      href="/object/[id]"
-                      as={`/object/${sourceSchedule.id}`}
-                    >
+                    <EnterpriseLink href={`/object/${sourceSchedule.id}`}>
                       <a>{sourceSchedule.name}</a>
                     </EnterpriseLink>
                   </td>

--- a/ui/ui-components/pages/about.tsx
+++ b/ui/ui-components/pages/about.tsx
@@ -1,8 +1,9 @@
 import Head from "next/head";
 import { client } from "../hooks/useApi";
-import { Table, Badge, Alert, Button } from "react-bootstrap";
+import { Table, Badge, Alert } from "react-bootstrap";
 import { UseApi } from "../hooks/useApi";
 import { Actions } from "../utils/apiData";
+import LinkButton from "../components/linkButton";
 
 const upgradeHelpPage =
   "https://www.grouparoo.com/docs/support/upgrading-grouparoo";
@@ -60,14 +61,14 @@ export default function Page({
           date.
           <br />
           <br />
-          <Button
+          <LinkButton
             variant="warning"
             size="sm"
             href={upgradeHelpPage}
             target="_new"
           >
             Learn about upgrading your Grouparoo cluster
-          </Button>
+          </LinkButton>
         </Alert>
       ) : null}
 

--- a/ui/ui-components/pages/apiKeys.tsx
+++ b/ui/ui-components/pages/apiKeys.tsx
@@ -4,7 +4,7 @@ import { UseApi } from "../hooks/useApi";
 import { useOffset, updateURLParams } from "../hooks/URLParams";
 import { useState } from "react";
 import { useSecondaryEffect } from "../hooks/useSecondaryEffect";
-import Link from "../components/enterpriseLink";
+import GrouparooLink from "../components/grouparooLink";
 import Pagination from "../components/pagination";
 import LoadingTable from "../components/loadingTable";
 import { Models, Actions } from "../utils/apiData";
@@ -72,11 +72,11 @@ export default function Page(props) {
             return (
               <tr key={`apiKey-${apiKey.id}`}>
                 <td>
-                  <Link href={`/apiKey/${apiKey.id}/edit`}>
+                  <GrouparooLink href={`/apiKey/${apiKey.id}/edit`}>
                     <a>
                       <strong>{apiKey.name}</strong>
                     </a>
-                  </Link>
+                  </GrouparooLink>
                 </td>
                 <td>
                   <code>{apiKey.apiKey}</code>

--- a/ui/ui-components/pages/apiKeys.tsx
+++ b/ui/ui-components/pages/apiKeys.tsx
@@ -1,5 +1,4 @@
 import Head from "next/head";
-import { Button } from "react-bootstrap";
 import { useRouter } from "next/router";
 import { UseApi } from "../hooks/useApi";
 import { useOffset, updateURLParams } from "../hooks/URLParams";
@@ -11,6 +10,7 @@ import LoadingTable from "../components/loadingTable";
 import { Models, Actions } from "../utils/apiData";
 import { formatTimestamp } from "../utils/formatTimestamp";
 import { ErrorHandler } from "../utils/errorHandler";
+import LinkButton from "../components/linkButton";
 
 export default function Page(props) {
   const { errorHandler }: { errorHandler: ErrorHandler } = props;
@@ -98,16 +98,13 @@ export default function Page(props) {
         onPress={setOffset}
       />
 
-      {process.env.GROUPAROO_UI_EDITION === "enterprise" ? (
-        <Button
-          variant="primary"
-          onClick={() => {
-            router.push("/apiKey/new");
-          }}
-        >
-          Add API Key
-        </Button>
-      ) : null}
+      <LinkButton
+        variant="primary"
+        href="/apiKey/new"
+        displayOn={["enterprise"]}
+      >
+        Add API Key
+      </LinkButton>
     </>
   );
 }

--- a/ui/ui-components/pages/apiKeys.tsx
+++ b/ui/ui-components/pages/apiKeys.tsx
@@ -72,10 +72,7 @@ export default function Page(props) {
             return (
               <tr key={`apiKey-${apiKey.id}`}>
                 <td>
-                  <Link
-                    href="/apiKey/[id]/edit"
-                    as={`/apiKey/${apiKey.id}/edit`}
-                  >
+                  <Link href={`/apiKey/${apiKey.id}/edit`}>
                     <a>
                       <strong>{apiKey.name}</strong>
                     </a>

--- a/ui/ui-components/pages/app/[id]/edit.tsx
+++ b/ui/ui-components/pages/app/[id]/edit.tsx
@@ -192,7 +192,7 @@ export default function Page(props) {
                         ))}
                       </p>
                     )}
-                    {grouparooUiEdition === "config" && (
+                    {grouparooUiEdition() === "config" && (
                       <p className="mb-0">
                         <a
                           target="_blank"

--- a/ui/ui-components/pages/app/[id]/edit.tsx
+++ b/ui/ui-components/pages/app/[id]/edit.tsx
@@ -12,11 +12,11 @@ import AppTabs from "../../../components/tabs/app";
 import Loader from "../../../components/loader";
 import LoadingButton from "../../../components/loadingButton";
 import LockedBadge from "../../../components/badges/lockedBadge";
-
 import { Actions, Models } from "../../../utils/apiData";
 import { ErrorHandler } from "../../../utils/errorHandler";
 import { SuccessHandler } from "../../../utils/successHandler";
 import { AppHandler } from "../../../utils/appHandler";
+import { grouparooUiEdition } from "../../../utils/uiEdition";
 
 export default function Page(props) {
   const {
@@ -192,7 +192,7 @@ export default function Page(props) {
                         ))}
                       </p>
                     )}
-                    {process.env.GROUPAROO_UI_EDITION === "config" && (
+                    {grouparooUiEdition === "config" && (
                       <p className="mb-0">
                         <a
                           target="_blank"

--- a/ui/ui-components/pages/apps.tsx
+++ b/ui/ui-components/pages/apps.tsx
@@ -9,10 +9,10 @@ import Pagination from "../components/pagination";
 import LoadingTable from "../components/loadingTable";
 import AppIcon from "../components/appIcon";
 import StateBadge from "../components/badges/stateBadge";
-import { Button } from "react-bootstrap";
 import { Models, Actions } from "../utils/apiData";
 import { formatTimestamp } from "../utils/formatTimestamp";
 import { ErrorHandler } from "../utils/errorHandler";
+import LinkButton from "../components/linkButton";
 
 export default function Page(props) {
   const { errorHandler }: { errorHandler: ErrorHandler } = props;
@@ -117,16 +117,9 @@ export default function Page(props) {
 
       <br />
 
-      {process.env.GROUPAROO_UI_EDITION !== "community" ? (
-        <Button
-          variant="primary"
-          onClick={() => {
-            router.push("/app/new");
-          }}
-        >
-          Add App
-        </Button>
-      ) : null}
+      <LinkButton variant="primary" href="/app/new" hideOn={["community"]}>
+        Add App
+      </LinkButton>
     </>
   );
 }

--- a/ui/ui-components/pages/apps.tsx
+++ b/ui/ui-components/pages/apps.tsx
@@ -4,7 +4,7 @@ import { useOffset, updateURLParams } from "../hooks/URLParams";
 import { useSecondaryEffect } from "../hooks/useSecondaryEffect";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import Link from "../components/enterpriseLink";
+import Link from "../components/grouparooLink";
 import Pagination from "../components/pagination";
 import LoadingTable from "../components/loadingTable";
 import AppIcon from "../components/appIcon";

--- a/ui/ui-components/pages/apps.tsx
+++ b/ui/ui-components/pages/apps.tsx
@@ -83,7 +83,7 @@ export default function Page(props) {
                   <AppIcon src={app.icon} />
                 </td>
                 <td>
-                  <Link href="/app/[id]/edit" as={`/app/${app.id}/edit`}>
+                  <Link href={`/app/${app.id}/edit`}>
                     <a>
                       <strong>
                         {app.name ||

--- a/ui/ui-components/pages/export/[id]/edit.tsx
+++ b/ui/ui-components/pages/export/[id]/edit.tsx
@@ -38,8 +38,7 @@ export default function Page({
             <br />
             Destination:{" "}
             <EnterpriseLink
-              href="/model/[modelId]/destination/[destinationId]/edit"
-              as={`/model/${_export.destination.modelId}/destination/${_export.destination.id}/edit`}
+              href={`/model/${_export.destination.modelId}/destination/${_export.destination.id}/edit`}
             >
               <a>{_export.destination.name}</a>
             </EnterpriseLink>
@@ -48,8 +47,7 @@ export default function Page({
               <>
                 <span>Processor</span>:{" "}
                 <Link
-                  href="/exportProcessor/[id]/edit"
-                  as={`/exportProcessor/${_export.exportProcessorId}/edit`}
+                  href={`/exportProcessor/${_export.exportProcessorId}/edit`}
                 >
                   <a>{_export.exportProcessorId}</a>
                 </Link>
@@ -58,8 +56,7 @@ export default function Page({
             ) : null}
             Record:{" "}
             <Link
-              href="/model/[modelId]/record/[recordId]/edit"
-              as={`/model/${_export.destination.modelId}/record/${_export.recordId}/edit`}
+              href={`/model/${_export.destination.modelId}/record/${_export.recordId}/edit`}
             >
               <a>{_export.recordId}</a>
             </Link>

--- a/ui/ui-components/pages/export/[id]/edit.tsx
+++ b/ui/ui-components/pages/export/[id]/edit.tsx
@@ -1,7 +1,7 @@
 import { UseApi } from "../../../hooks/useApi";
 import { Row, Col, Table, Alert, Card, Badge } from "react-bootstrap";
 import Link from "next/link";
-import EnterpriseLink from "../../../components/enterpriseLink";
+import EnterpriseLink from "../../../components/grouparooLink";
 import Head from "next/head";
 import ExportTabs from "../../../components/tabs/export";
 import { Models } from "../../../utils/apiData";

--- a/ui/ui-components/pages/exportProcessor/[id]/edit.tsx
+++ b/ui/ui-components/pages/exportProcessor/[id]/edit.tsx
@@ -1,6 +1,6 @@
 import { UseApi } from "../../../hooks/useApi";
 import { Table, Alert, Card } from "react-bootstrap";
-import EnterpriseLink from "../../../components/enterpriseLink";
+import EnterpriseLink from "../../../components/grouparooLink";
 import Head from "next/head";
 import ExportProcessorTabs from "../../../components/tabs/exportProcessor";
 import { Models } from "../../../utils/apiData";

--- a/ui/ui-components/pages/exportProcessor/[id]/edit.tsx
+++ b/ui/ui-components/pages/exportProcessor/[id]/edit.tsx
@@ -31,8 +31,7 @@ export default function Page({
             <br />
             Destination:{" "}
             <EnterpriseLink
-              href="/model/[modelId]/destination/[destinationId]/edit"
-              as={`/model/${exportProcessor.destination.modelId}/destination/${exportProcessor.destination.id}/edit`}
+              href={`/model/${exportProcessor.destination.modelId}/destination/${exportProcessor.destination.id}/edit`}
             >
               <a>{exportProcessor.destination.name}</a>
             </EnterpriseLink>

--- a/ui/ui-components/pages/exportProcessors.tsx
+++ b/ui/ui-components/pages/exportProcessors.tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { Fragment, useState } from "react";
-import { Alert, Button, ButtonGroup, Col, Row } from "react-bootstrap";
+import { Alert, ButtonGroup, Col, Row } from "react-bootstrap";
 import StateBadge from "../components/badges/stateBadge";
 import LoadingTable from "../components/loadingTable";
 import Pagination from "../components/pagination";
@@ -15,6 +15,7 @@ import { ErrorHandler } from "../utils/errorHandler";
 import { capitalize } from "../utils/languageHelper";
 import { formatTimestamp } from "../utils/formatTimestamp";
 import { DurationTime } from "../components/durationTime";
+import LoadingButton from "../components/loadingButton";
 
 const states = ["all", "pending", "failed", "complete"];
 
@@ -98,13 +99,14 @@ export default function Page(props) {
             {states.map((_state) => {
               return (
                 <Fragment key={`export-processor-state-button-${_state}`}>
-                  <Button
+                  <LoadingButton
                     size="sm"
+                    disabled={loading}
                     variant={state === _state ? "secondary" : "info"}
                     onClick={() => setState(_state)}
                   >
                     {capitalize(_state)}
-                  </Button>
+                  </LoadingButton>
                 </Fragment>
               );
             })}

--- a/ui/ui-components/pages/exportProcessors.tsx
+++ b/ui/ui-components/pages/exportProcessors.tsx
@@ -6,7 +6,7 @@ import { Alert, Button, ButtonGroup, Col, Row } from "react-bootstrap";
 import StateBadge from "../components/badges/stateBadge";
 import LoadingTable from "../components/loadingTable";
 import Pagination from "../components/pagination";
-import EnterpriseLink from "../components/enterpriseLink";
+import EnterpriseLink from "../components/grouparooLink";
 import { useOffset, updateURLParams } from "../hooks/URLParams";
 import { UseApi } from "../hooks/useApi";
 import { useSecondaryEffect } from "../hooks/useSecondaryEffect";

--- a/ui/ui-components/pages/exportProcessors.tsx
+++ b/ui/ui-components/pages/exportProcessors.tsx
@@ -140,17 +140,13 @@ export default function Page(props) {
                 <tr>
                   <td>
                     <span>Id</span>:{" "}
-                    <Link
-                      href="/exportProcessor/[id]/edit"
-                      as={`/exportProcessor/${exportProcessor.id}/edit`}
-                    >
+                    <Link href={`/exportProcessor/${exportProcessor.id}/edit`}>
                       <a>{exportProcessor.id}</a>
                     </Link>
                     <br />
                     Destination:{" "}
                     <EnterpriseLink
-                      href="/model/[modelId]/destination/[destinationId]/edit"
-                      as={`/model/${exportProcessor.destination.modelId}/destination/${exportProcessor.destination.id}/edit`}
+                      href={`/model/${exportProcessor.destination.modelId}/destination/${exportProcessor.destination.id}/edit`}
                     >
                       <a>{exportProcessor.destination.name}</a>
                     </EnterpriseLink>

--- a/ui/ui-components/pages/exportProcessors.tsx
+++ b/ui/ui-components/pages/exportProcessors.tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { Fragment, useState } from "react";
-import { Alert, ButtonGroup, Col, Row } from "react-bootstrap";
+import { Alert, Button, ButtonGroup, Col, Row } from "react-bootstrap";
 import StateBadge from "../components/badges/stateBadge";
 import LoadingTable from "../components/loadingTable";
 import Pagination from "../components/pagination";
@@ -15,7 +15,6 @@ import { ErrorHandler } from "../utils/errorHandler";
 import { capitalize } from "../utils/languageHelper";
 import { formatTimestamp } from "../utils/formatTimestamp";
 import { DurationTime } from "../components/durationTime";
-import LoadingButton from "../components/loadingButton";
 
 const states = ["all", "pending", "failed", "complete"];
 
@@ -99,14 +98,14 @@ export default function Page(props) {
             {states.map((_state) => {
               return (
                 <Fragment key={`export-processor-state-button-${_state}`}>
-                  <LoadingButton
+                  <Button
                     size="sm"
                     disabled={loading}
                     variant={state === _state ? "secondary" : "info"}
                     onClick={() => setState(_state)}
                   >
                     {capitalize(_state)}
-                  </LoadingButton>
+                  </Button>
                 </Fragment>
               );
             })}

--- a/ui/ui-components/pages/help.tsx
+++ b/ui/ui-components/pages/help.tsx
@@ -1,5 +1,6 @@
 import Head from "next/head";
-import { Row, Col, Alert, Button } from "react-bootstrap";
+import { Row, Col, Alert } from "react-bootstrap";
+import LinkButton from "../components/linkButton";
 
 export default function Page() {
   const supportPageURL = "https://www.grouparoo.com/support";
@@ -28,44 +29,44 @@ export default function Page() {
       <br />
       <Row style={{ textAlign: "center" }}>
         <Col>
-          <Button
+          <LinkButton
             size="sm"
             variant="outline-primary"
             href="https://www.grouparoo.com/docs"
             target="_blank"
           >
             Documentation
-          </Button>
+          </LinkButton>
         </Col>
         <Col>
-          <Button
+          <LinkButton
             size="sm"
             variant="outline-primary"
             href="https://github.com/grouparoo/grouparoo/issues/new/choose"
             target="_blank"
           >
             Github Issue
-          </Button>
+          </LinkButton>
         </Col>
         <Col>
-          <Button
+          <LinkButton
             size="sm"
             variant="outline-primary"
             href="https://github.com/grouparoo/grouparoo/discussions"
             target="_blank"
           >
             Forum
-          </Button>
+          </LinkButton>
         </Col>
         <Col>
-          <Button
+          <LinkButton
             size="sm"
             variant="outline-primary"
             href="https://www.grouparoo.com/docs/community"
             target="_blank"
           >
             Grouparoo Community
-          </Button>
+          </LinkButton>
         </Col>
       </Row>
       <br /> <br />

--- a/ui/ui-components/pages/import/[id]/edit.tsx
+++ b/ui/ui-components/pages/import/[id]/edit.tsx
@@ -45,7 +45,7 @@ export default function Page(props) {
             <br />
             Creator:{" "}
             {_import.creatorType === "run" ? (
-              <Link href="/run/[id]/edit" as={`/run/${_import.creatorId}/edit`}>
+              <Link href={`/run/${_import.creatorId}/edit`}>
                 <a>{_import.creatorId}</a>
               </Link>
             ) : (
@@ -53,7 +53,7 @@ export default function Page(props) {
             )}
             <br />
             Record:{" "}
-            <Link href="/object/[id]" as={`/object/${_import.recordId}`}>
+            <Link href={`/object/${_import.recordId}`}>
               <a>{_import.recordId}</a>
             </Link>
           </p>

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -86,7 +86,7 @@ export default function Page(props) {
     setLoading(false);
     successHandler.set({
       message:
-        grouparooUiEdition === "config"
+        grouparooUiEdition() === "config"
           ? "Destination Updated"
           : "Destination Updated and Records Exporting...",
     });

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -338,7 +338,7 @@ export default function Page(props) {
                       .map((group) => (
                         <option key={`grp-${group.id}`} value={group.id}>
                           {group.name}
-                          {grouparooUiEdition !== "config" &&
+                          {grouparooUiEdition() !== "config" &&
                             ` (${group.recordsCount} members)`}
                         </option>
                       ))}

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -16,6 +16,7 @@ import { SuccessHandler } from "../../../../../utils/successHandler";
 import ModelBadge from "../../../../../components/badges/modelBadge";
 import { NextPageContext } from "next";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
+import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 
 export default function Page(props) {
   const {
@@ -85,7 +86,7 @@ export default function Page(props) {
     setLoading(false);
     successHandler.set({
       message:
-        process.env.GROUPAROO_UI_EDITION === "config"
+        grouparooUiEdition === "config"
           ? "Destination Updated"
           : "Destination Updated and Records Exporting...",
     });
@@ -337,7 +338,7 @@ export default function Page(props) {
                       .map((group) => (
                         <option key={`grp-${group.id}`} value={group.id}>
                           {group.name}
-                          {process.env.GROUPAROO_UI_EDITION !== "config" &&
+                          {grouparooUiEdition !== "config" &&
                             ` (${group.recordsCount} members)`}
                         </option>
                       ))}

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
@@ -206,7 +206,7 @@ export default function Page(props) {
 
               <p>
                 <strong>App</strong>:{" "}
-                <Link href="/app/[id]" as={`/app/${destination.app.id}`}>
+                <Link href={`/app/${destination.app.id}`}>
                   <a>{destination.app.name}</a>
                 </Link>
                 <br />
@@ -419,7 +419,7 @@ export default function Page(props) {
                 size="sm"
                 disabled={loading}
                 onClick={() => {
-                  handleDelete(grouparooUiEdition === "config");
+                  handleDelete(grouparooUiEdition() === "config");
                 }}
               >
                 Delete

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
@@ -18,6 +18,7 @@ import { DestinationHandler } from "../../../../../utils/destinationHandler";
 import ModelBadge from "../../../../../components/badges/modelBadge";
 import { NextPageContext } from "next";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
+import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 
 export default function Page(props) {
   const {
@@ -418,7 +419,7 @@ export default function Page(props) {
                 size="sm"
                 disabled={loading}
                 onClick={() => {
-                  handleDelete(process.env.GROUPAROO_UI_EDITION === "config");
+                  handleDelete(grouparooUiEdition === "config");
                 }}
               >
                 Delete

--- a/ui/ui-components/pages/model/[modelId]/destination/new/index.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/new/index.tsx
@@ -1,10 +1,11 @@
 import Head from "next/head";
 import { useState } from "react";
 import { UseApi } from "../../../../../hooks/useApi";
-import { Form, Alert, Button } from "react-bootstrap";
+import { Form, Alert } from "react-bootstrap";
 import AppSelectorList from "../../../../../components/appSelectorList";
 import { useRouter } from "next/router";
 import { Actions } from "../../../../../utils/apiData";
+import LinkButton from "../../../../../components/linkButton";
 
 export default function Page(props) {
   const {
@@ -38,9 +39,9 @@ export default function Page(props) {
           There are no Apps in the ready state yet.
           <br />
           <br />
-          <Button size="sm" href="/apps">
+          <LinkButton size="sm" href="/apps">
             Add an App
-          </Button>
+          </LinkButton>
         </Alert>
       </>
     );

--- a/ui/ui-components/pages/model/[modelId]/destinations.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destinations.tsx
@@ -2,9 +2,8 @@ import { useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Button, Badge } from "react-bootstrap";
+import { Badge } from "react-bootstrap";
 import type { NextPageContext } from "next";
-
 import { UseApi } from "../../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../../hooks/URLParams";
 import { useSecondaryEffect } from "../../../hooks/useSecondaryEffect";
@@ -16,6 +15,8 @@ import StateBadge from "../../../components/badges/stateBadge";
 import { Models, Actions } from "../../../utils/apiData";
 import { formatTimestamp } from "../../../utils/formatTimestamp";
 import { ErrorHandler } from "../../../utils/errorHandler";
+import LinkButton from "../../../components/linkButton";
+import { grouparooUiEdition } from "../../../utils/uiEdition";
 
 export default function Page(props) {
   const {
@@ -142,16 +143,13 @@ export default function Page(props) {
 
       <br />
 
-      {process.env.GROUPAROO_UI_EDITION !== "community" ? (
-        <Button
-          variant="primary"
-          onClick={() => {
-            router.push(`/model/${modelId}/destination/new`);
-          }}
-        >
-          Add new Destination
-        </Button>
-      ) : null}
+      <LinkButton
+        variant="primary"
+        href={`/model/${modelId}/destination/new`}
+        hideOn={["community"]}
+      >
+        Add new Destination
+      </LinkButton>
     </>
   );
 }
@@ -186,12 +184,11 @@ const AppDisplay = ({
       new Date(destination.createdAt).toLocaleString().split(",")[0]
     }`;
 
-  switch (process.env.GROUPAROO_UI_EDITION) {
+  switch (grouparooUiEdition) {
     case "community": {
       return (
         <Link
-          href="/model/[modelId]/destination/[destinationId]/exports"
-          as={`/model/${destination.modelId}/destination/${destination.id}/exports`}
+          href={`/model/${destination.modelId}/destination/${destination.id}/exports`}
         >
           <a>
             <strong>{formattedDestinationName}</strong>
@@ -202,8 +199,7 @@ const AppDisplay = ({
     default: {
       return (
         <EnterpriseLink
-          href="/model/[modelId]/destination/[destinationId]/edit"
-          as={`/model/${destination.modelId}/destination/${destination.id}/edit`}
+          href={`/model/${destination.modelId}/destination/${destination.id}/edit`}
         >
           <a>
             <strong>{formattedDestinationName}</strong>
@@ -223,8 +219,7 @@ const CollectionDisplay = ({
     case "group": {
       return (
         <EnterpriseLink
-          href="/model/[modelId]/group/[groupId]/edit"
-          as={`/model/${destination.group.modelId}/group/${destination.group.id}/edit`}
+          href={`/model/${destination.group.modelId}/group/${destination.group.id}/edit`}
         >
           <a>{destination.group.name}</a>
         </EnterpriseLink>
@@ -232,10 +227,7 @@ const CollectionDisplay = ({
     }
     case "model": {
       return (
-        <EnterpriseLink
-          href="/model/[modelId]/edit"
-          as={`/model/${destination.modelId}/edit`}
-        >
+        <EnterpriseLink href={`/model/${destination.modelId}/edit`}>
           <a>{destination.modelName}</a>
         </EnterpriseLink>
       );

--- a/ui/ui-components/pages/model/[modelId]/destinations.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destinations.tsx
@@ -7,7 +7,7 @@ import type { NextPageContext } from "next";
 import { UseApi } from "../../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../../hooks/URLParams";
 import { useSecondaryEffect } from "../../../hooks/useSecondaryEffect";
-import EnterpriseLink from "../../../components/enterpriseLink";
+import EnterpriseLink from "../../../components/grouparooLink";
 import Pagination from "../../../components/pagination";
 import LoadingTable from "../../../components/loadingTable";
 import AppIcon from "../../../components/appIcon";

--- a/ui/ui-components/pages/model/[modelId]/destinations.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destinations.tsx
@@ -110,10 +110,7 @@ export default function Page(props) {
                   <CollectionDisplay destination={destination} />
                 </td>
                 <td>
-                  <EnterpriseLink
-                    href="/app/[id]/edit"
-                    as={`/app/${destination.app.id}/edit`}
-                  >
+                  <EnterpriseLink href={`/app/${destination.app.id}/edit`}>
                     <a>
                       <strong>{destination.app.name}</strong>
                     </a>
@@ -184,7 +181,7 @@ const AppDisplay = ({
       new Date(destination.createdAt).toLocaleString().split(",")[0]
     }`;
 
-  switch (grouparooUiEdition) {
+  switch (grouparooUiEdition()) {
     case "community": {
       return (
         <Link

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
@@ -106,7 +106,7 @@ export default function Page(props) {
         ]}
       />
 
-      {group.type === "calculated" && grouparooUiEdition() !== "config" ? (
+      {group.type === "calculated" && grouparooUiEdition() !== "config" && (
         <Row>
           <Col>
             <strong>Last Member Calculation</strong>:{" "}
@@ -126,7 +126,7 @@ export default function Page(props) {
             <br />
           </Col>
         </Row>
-      ) : null}
+      )}
       <Row>
         <Col>
           <Form id="form" onSubmit={submit} autoComplete="off">

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
@@ -7,7 +7,6 @@ import { useRouter } from "next/router";
 import Head from "next/head";
 import GroupTabs from "../../../../../components/tabs/group";
 import LoadingButton from "../../../../../components/loadingButton";
-
 import { Models, Actions } from "../../../../../utils/apiData";
 import { formatTimestamp } from "../../../../../utils/formatTimestamp";
 import { ErrorHandler } from "../../../../../utils/errorHandler";
@@ -17,6 +16,7 @@ import PageHeader from "../../../../../components/pageHeader";
 import ModelBadge from "../../../../../components/badges/modelBadge";
 import { NextPageContext } from "next";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
+import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 
 export default function Page(props) {
   const {
@@ -106,8 +106,7 @@ export default function Page(props) {
         ]}
       />
 
-      {group.type === "calculated" &&
-      process.env.GROUPAROO_UI_EDITION !== "config" ? (
+      {group.type === "calculated" && grouparooUiEdition !== "config" ? (
         <Row>
           <Col>
             <strong>Last Member Calculation</strong>:{" "}
@@ -208,7 +207,7 @@ export default function Page(props) {
                   disabled={loading}
                   size="sm"
                   onClick={() => {
-                    handleDelete(process.env.GROUPAROO_UI_EDITION === "config");
+                    handleDelete(grouparooUiEdition === "config");
                   }}
                 >
                   Delete

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
@@ -106,7 +106,7 @@ export default function Page(props) {
         ]}
       />
 
-      {group.type === "calculated" && grouparooUiEdition !== "config" ? (
+      {group.type === "calculated" && grouparooUiEdition() !== "config" ? (
         <Row>
           <Col>
             <strong>Last Member Calculation</strong>:{" "}
@@ -207,7 +207,7 @@ export default function Page(props) {
                   disabled={loading}
                   size="sm"
                   onClick={() => {
-                    handleDelete(grouparooUiEdition === "config");
+                    handleDelete(grouparooUiEdition() === "config");
                   }}
                 >
                   Delete

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -173,7 +173,7 @@ export default function Page(props) {
         ]}
       />
 
-      {grouparooUiEdition !== "config" && (
+      {grouparooUiEdition()! == "config" && (
         <p>
           Total Records in this group: &nbsp;
           <Badge style={{ fontSize: 16 }} variant="info">
@@ -198,7 +198,7 @@ export default function Page(props) {
                 <th>
                   <strong>Operation</strong>
                 </th>
-                {grouparooUiEdition !== "config" && (
+                {grouparooUiEdition() !== "config" && (
                   <th>
                     <strong># of Records</strong>
                   </th>
@@ -455,7 +455,7 @@ export default function Page(props) {
                       </Form.Group>
                     </td>
 
-                    {grouparooUiEdition !== "config" && (
+                    {grouparooUiEdition() !== "config" && (
                       <td>
                         <Badge variant="info">{componentCounts[idx]}</Badge>
                       </td>

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -491,9 +491,7 @@ export default function Page(props) {
             variant="outline-dark"
             size="sm"
             hideOn={["config"]}
-            onClick={async () => {
-              await getCounts(false);
-            }}
+            onClick={() => getCounts(false)}
           >
             Count Potential Group Members
           </LoadingButton>

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -16,6 +16,7 @@ import PageHeader from "../../../../../components/pageHeader";
 import ModelBadge from "../../../../../components/badges/modelBadge";
 import { NextPageContext } from "next";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
+import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 
 export default function Page(props) {
   const {
@@ -172,7 +173,7 @@ export default function Page(props) {
         ]}
       />
 
-      {process.env.GROUPAROO_UI_EDITION !== "config" && (
+      {grouparooUiEdition !== "config" && (
         <p>
           Total Records in this group: &nbsp;
           <Badge style={{ fontSize: 16 }} variant="info">
@@ -197,7 +198,7 @@ export default function Page(props) {
                 <th>
                   <strong>Operation</strong>
                 </th>
-                {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                {grouparooUiEdition !== "config" && (
                   <th>
                     <strong># of Records</strong>
                   </th>
@@ -454,7 +455,7 @@ export default function Page(props) {
                       </Form.Group>
                     </td>
 
-                    {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                    {grouparooUiEdition !== "config" && (
                       <td>
                         <Badge variant="info">{componentCounts[idx]}</Badge>
                       </td>
@@ -485,18 +486,17 @@ export default function Page(props) {
             Add Rule
           </Button>
           &nbsp;
-          {process.env.GROUPAROO_UI_EDITION !== "config" && (
-            <LoadingButton
-              disabled={loading}
-              variant="outline-dark"
-              size="sm"
-              onClick={async () => {
-                await getCounts(false);
-              }}
-            >
-              Count Potential Group Members
-            </LoadingButton>
-          )}
+          <LoadingButton
+            disabled={loading}
+            variant="outline-dark"
+            size="sm"
+            hideOn={["config"]}
+            onClick={async () => {
+              await getCounts(false);
+            }}
+          >
+            Count Potential Group Members
+          </LoadingButton>
           <br />
           <br />{" "}
           {group.locked ? (

--- a/ui/ui-components/pages/model/[modelId]/groups.tsx
+++ b/ui/ui-components/pages/model/[modelId]/groups.tsx
@@ -1,9 +1,7 @@
 import Head from "next/head";
-import { Button } from "react-bootstrap";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import type { NextPageContext } from "next";
-
 import { UseApi } from "../../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../../hooks/URLParams";
 import { useSecondaryEffect } from "../../../hooks/useSecondaryEffect";
@@ -14,6 +12,8 @@ import StateBadge from "../../../components/badges/stateBadge";
 import { Models, Actions } from "../../../utils/apiData";
 import { formatTimestamp } from "../../../utils/formatTimestamp";
 import { ErrorHandler } from "../../../utils/errorHandler";
+import LinkButton from "../../../components/linkButton";
+import { grouparooUiEdition } from "../../../utils/uiEdition";
 
 export default function Page(props) {
   const {
@@ -75,11 +75,9 @@ export default function Page(props) {
           <tr>
             <th>Name</th>
             <th>Type</th>
-            {process.env.GROUPAROO_UI_EDITION !== "config" && <th>Records</th>}
+            {grouparooUiEdition !== "config" && <th>Records</th>}
             <th>State</th>
-            {process.env.GROUPAROO_UI_EDITION !== "config" && (
-              <th>Calculated At</th>
-            )}
+            {grouparooUiEdition !== "config" && <th>Calculated At</th>}
             <th>Created At</th>
             <th>Updated At</th>
           </tr>
@@ -106,13 +104,13 @@ export default function Page(props) {
                   )}
                 </td>
                 <td>{group.type}</td>
-                {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                {grouparooUiEdition !== "config" && (
                   <td>{group.recordsCount}</td>
                 )}
                 <td>
                   <StateBadge state={group.state} />
                 </td>
-                {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                {grouparooUiEdition !== "config" && (
                   <td>
                     {group.calculatedAt
                       ? formatTimestamp(group.calculatedAt)
@@ -134,19 +132,13 @@ export default function Page(props) {
         onPress={setOffset}
       />
 
-      {process.env.GROUPAROO_UI_EDITION !== "community" ? (
-        <Button
-          variant="primary"
-          onClick={() => {
-            router.push(
-              "/model/[modelId]/group/new",
-              `/model/${router.query.modelId}/group/new`
-            );
-          }}
-        >
-          Add Group
-        </Button>
-      ) : null}
+      <LinkButton
+        variant="primary"
+        href={`/model/${router.query.modelId}/group/new`}
+        hideOn={["community"]}
+      >
+        Add Group
+      </LinkButton>
     </>
   );
 }

--- a/ui/ui-components/pages/model/[modelId]/groups.tsx
+++ b/ui/ui-components/pages/model/[modelId]/groups.tsx
@@ -5,7 +5,7 @@ import type { NextPageContext } from "next";
 import { UseApi } from "../../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../../hooks/URLParams";
 import { useSecondaryEffect } from "../../../hooks/useSecondaryEffect";
-import Link from "../../../components/enterpriseLink";
+import Link from "../../../components/grouparooLink";
 import Pagination from "../../../components/pagination";
 import LoadingTable from "../../../components/loadingTable";
 import StateBadge from "../../../components/badges/stateBadge";

--- a/ui/ui-components/pages/model/[modelId]/groups.tsx
+++ b/ui/ui-components/pages/model/[modelId]/groups.tsx
@@ -75,9 +75,9 @@ export default function Page(props) {
           <tr>
             <th>Name</th>
             <th>Type</th>
-            {grouparooUiEdition !== "config" && <th>Records</th>}
+            {grouparooUiEdition() !== "config" && <th>Records</th>}
             <th>State</th>
-            {grouparooUiEdition !== "config" && <th>Calculated At</th>}
+            {grouparooUiEdition() !== "config" && <th>Calculated At</th>}
             <th>Created At</th>
             <th>Updated At</th>
           </tr>
@@ -89,28 +89,26 @@ export default function Page(props) {
                 <td>
                   {group.type === "calculated" ? (
                     <Link
-                      href="/model/[modelId]/group/[groupId]/rules"
-                      as={`/model/${group.modelId}/group/${group.id}/rules`}
+                      href={`/model/${group.modelId}/group/${group.id}/rules`}
                     >
                       <a>{group.name}</a>
                     </Link>
                   ) : (
                     <Link
-                      href="/model/[modelId]/group/[groupId]/edit"
-                      as={`/model/${group.modelId}/group/${group.id}/edit`}
+                      href={`/model/${group.modelId}/group/${group.id}/edit`}
                     >
                       <a>{group.name}</a>
                     </Link>
                   )}
                 </td>
                 <td>{group.type}</td>
-                {grouparooUiEdition !== "config" && (
+                {grouparooUiEdition() !== "config" && (
                   <td>{group.recordsCount}</td>
                 )}
                 <td>
                   <StateBadge state={group.state} />
                 </td>
-                {grouparooUiEdition !== "config" && (
+                {grouparooUiEdition() !== "config" && (
                   <td>
                     {group.calculatedAt
                       ? formatTimestamp(group.calculatedAt)

--- a/ui/ui-components/pages/model/[modelId]/properties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/properties.tsx
@@ -2,8 +2,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { Fragment, useState } from "react";
 import { NextPageContext } from "next";
-import { Button, Alert } from "react-bootstrap";
-
+import { Alert } from "react-bootstrap";
 import { UseApi } from "../../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../../hooks/URLParams";
 import { useSecondaryEffect } from "../../../hooks/useSecondaryEffect";
@@ -14,6 +13,7 @@ import StateBadge from "../../../components/badges/stateBadge";
 import { Models, Actions } from "../../../utils/apiData";
 import { ErrorHandler } from "../../../utils/errorHandler";
 import { formatTimestamp } from "../../../utils/formatTimestamp";
+import LinkButton from "../../../components/linkButton";
 
 export default function Page(props) {
   const {
@@ -89,9 +89,9 @@ export default function Page(props) {
           There are no Sources yet.
           <br />
           <br />
-          <Button size="sm" href={`/model/${router.query.modelId}/sources`}>
+          <LinkButton size="sm" href={`/model/${router.query.modelId}/sources`}>
             Add Source
-          </Button>
+          </LinkButton>
         </Alert>
       </>
     );

--- a/ui/ui-components/pages/model/[modelId]/properties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/properties.tsx
@@ -134,8 +134,7 @@ export default function Page(props) {
               <tr key={`property-${rule.id}`}>
                 <td>
                   <Link
-                    href="/model/[modelId]/property/[propertyId]/edit"
-                    as={`/model/${source.modelId}/property/${rule.id}/edit`}
+                    href={`/model/${source.modelId}/property/${rule.id}/edit`}
                   >
                     <a>
                       <strong>
@@ -154,8 +153,7 @@ export default function Page(props) {
                 <td>{rule.isArray ? "✅" : null}</td>
                 <td>
                   <Link
-                    href="/model/[modelId]/source/[sourceId]/overview"
-                    as={`/model/${source.modelId}/source/${source.id}/overview`}
+                    href={`/model/${source.modelId}/source/${source.id}/overview`}
                   >
                     <a>{source.name}</a>
                   </Link>

--- a/ui/ui-components/pages/model/[modelId]/properties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/properties.tsx
@@ -6,7 +6,7 @@ import { Alert } from "react-bootstrap";
 import { UseApi } from "../../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../../hooks/URLParams";
 import { useSecondaryEffect } from "../../../hooks/useSecondaryEffect";
-import Link from "../../../components/enterpriseLink";
+import GrouparooLink from "../../../components/grouparooLink";
 import Pagination from "../../../components/pagination";
 import LoadingTable from "../../../components/loadingTable";
 import StateBadge from "../../../components/badges/stateBadge";
@@ -133,7 +133,7 @@ export default function Page(props) {
             return (
               <tr key={`property-${rule.id}`}>
                 <td>
-                  <Link
+                  <GrouparooLink
                     href={`/model/${source.modelId}/property/${rule.id}/edit`}
                   >
                     <a>
@@ -146,17 +146,17 @@ export default function Page(props) {
                           }`}
                       </strong>
                     </a>
-                  </Link>
+                  </GrouparooLink>
                 </td>
                 <td>{rule.type}</td>
                 <td>{rule.unique ? "✅" : null}</td>
                 <td>{rule.isArray ? "✅" : null}</td>
                 <td>
-                  <Link
+                  <GrouparooLink
                     href={`/model/${source.modelId}/source/${source.id}/overview`}
                   >
                     <a>{source.name}</a>
-                  </Link>
+                  </GrouparooLink>
                 </td>
                 <td>
                   <StateBadge state={rule.state} />

--- a/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
@@ -230,8 +230,7 @@ export default function Page(props) {
                 <p>
                   <strong>Source</strong>:{" "}
                   <Link
-                    href="/model/[modelId]/source/[sourceId]/overview"
-                    as={`/model/${source.modelId}/source/${source.id}/overview`}
+                    href={`/model/${source.modelId}/source/${source.id}/overview`}
                   >
                     <a>{source.name}</a>
                   </Link>

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
@@ -247,7 +247,7 @@ export default function Page(props) {
               >
                 Export
               </LoadingButton>
-              {grouparooUiEdition() === "config" ? (
+              {grouparooUiEdition() === "config" && (
                 <>
                   {" "}
                   <LoadingButton
@@ -260,7 +260,7 @@ export default function Page(props) {
                     Remove Sample Record
                   </LoadingButton>
                 </>
-              ) : null}
+              )}
             </Col>
           </Row>
         </Col>
@@ -378,7 +378,7 @@ export default function Page(props) {
           </ListGroup>
 
           <hr />
-          {grouparooUiEdition() === "config" ? null : (
+          {grouparooUiEdition() !== "config" && (
             <Form onSubmit={(event) => handleAdd(event)} autoComplete="off">
               <Row>
                 <Col md={9}>

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import EnterpriseLink from "../../../../../components/enterpriseLink";
+import EnterpriseLink from "../../../../../components/grouparooLink";
 import RecordTabs from "../../../../../components/tabs/record";
 import { useState, useEffect } from "react";
 import { UseApi } from "../../../../../hooks/useApi";

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
@@ -247,7 +247,7 @@ export default function Page(props) {
               >
                 Export
               </LoadingButton>
-              {grouparooUiEdition === "config" ? (
+              {grouparooUiEdition() === "config" ? (
                 <>
                   {" "}
                   <LoadingButton
@@ -364,10 +364,9 @@ export default function Page(props) {
                     &nbsp; &nbsp;
                   </>
                 ) : null}
-                {grouparooUiEdition !== "config" ? (
+                {grouparooUiEdition() !== "config" ? (
                   <EnterpriseLink
-                    href="/model/[modelId]/group/[groupId]/members"
-                    as={`/model/${group.modelId}/group/${group.id}/members`}
+                    href={`/model/${group.modelId}/group/${group.id}/members`}
                   >
                     <a>{group.name}</a>
                   </EnterpriseLink>
@@ -379,7 +378,7 @@ export default function Page(props) {
           </ListGroup>
 
           <hr />
-          {grouparooUiEdition === "config" ? null : (
+          {grouparooUiEdition() === "config" ? null : (
             <Form onSubmit={(event) => handleAdd(event)} autoComplete="off">
               <Row>
                 <Col md={9}>

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
@@ -19,6 +19,8 @@ import ModelBadge from "../../../../../components/badges/modelBadge";
 import PageHeader from "../../../../../components/pageHeader";
 import { NextPageContext } from "next";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
+import LinkButton from "../../../../../components/linkButton";
+import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 
 export default function Page(props) {
   const {
@@ -173,9 +175,12 @@ export default function Page(props) {
           There are no Properties added yet.
           <br />
           <br />
-          <Button size="sm" href={`/model/${router.query.modelId}/properties`}>
+          <LinkButton
+            size="sm"
+            href={`/model/${router.query.modelId}/properties`}
+          >
             Add a Property
-          </Button>
+          </LinkButton>
         </Alert>
       </>
     );
@@ -242,7 +247,7 @@ export default function Page(props) {
               >
                 Export
               </LoadingButton>
-              {process.env.GROUPAROO_UI_EDITION === "config" ? (
+              {grouparooUiEdition === "config" ? (
                 <>
                   {" "}
                   <LoadingButton
@@ -359,7 +364,7 @@ export default function Page(props) {
                     &nbsp; &nbsp;
                   </>
                 ) : null}
-                {process.env.GROUPAROO_UI_EDITION !== "config" ? (
+                {grouparooUiEdition !== "config" ? (
                   <EnterpriseLink
                     href="/model/[modelId]/group/[groupId]/members"
                     as={`/model/${group.modelId}/group/${group.id}/members`}
@@ -374,7 +379,7 @@ export default function Page(props) {
           </ListGroup>
 
           <hr />
-          {process.env.GROUPAROO_UI_EDITION === "config" ? null : (
+          {grouparooUiEdition === "config" ? null : (
             <Form onSubmit={(event) => handleAdd(event)} autoComplete="off">
               <Row>
                 <Col md={9}>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -5,6 +5,7 @@ import PageHeader from "../../../../../components/pageHeader";
 import StateBadge from "../../../../../components/badges/stateBadge";
 import LockedBadge from "../../../../../components/badges/lockedBadge";
 import LoadingButton from "../../../../../components/loadingButton";
+import LinkButton from "../../../../../components/linkButton";
 import Link from "next/link";
 import SourceTabs from "../../../../../components/tabs/source";
 import Head from "next/head";
@@ -222,16 +223,13 @@ export default function Page(props) {
 
         <td>
           {existingProperty && existingProperty.sourceId === source.id ? (
-            <Link
-              href={`/model/[modelId]/property/[propertyId]/edit`}
-              as={`/model/${source.modelId}/property/${existingProperty.id}/edit`}
+            <LinkButton
+              variant="outline-info"
+              size="sm"
+              href={`/model/${source.modelId}/property/${existingProperty.id}/edit`}
             >
-              <a>
-                <Button variant="outline-info" size="sm">
-                  View
-                </Button>
-              </a>
-            </Link>
+              View
+            </LinkButton>
           ) : (
             <LoadingButton
               size="sm"

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -307,10 +307,7 @@ export default function Page(props) {
         From this page, you can quickly add simple Properties, using default
         options. If you need more control over your Properties, you can create a
         single Property from the{" "}
-        <Link
-          href={`/model/[modelId]/source/[sourceId]/overview`}
-          as={`/model/${source.modelId}/source/${source.id}/overview`}
-        >
+        <Link href={`/model/${source.modelId}/source/${source.id}/overview`}>
           <a>Source Overview page</a>
         </Link>
         .

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
@@ -16,6 +16,8 @@ import { formatTimestamp } from "../../../../../utils/formatTimestamp";
 import ModelBadge from "../../../../../components/badges/modelBadge";
 import { NextPageContext } from "next";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
+import LinkButton from "../../../../../components/linkButton";
+import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 
 export default function Page({
   errorHandler,
@@ -121,17 +123,17 @@ export default function Page({
             successHandler={successHandler}
             source={source}
           />
-          {process.env.GROUPAROO_UI_EDITION !== "community" &&
-          source.previewAvailable === true ? (
+          {source.previewAvailable === true ? (
             <>
               &nbsp;
-              <Button
+              <LinkButton
                 href={`/model/${source.modelId}/source/${source.id}/multipleProperties`}
                 size="sm"
                 variant="outline-primary"
+                hideOn={["community"]}
               >
                 Add Multiple Properties
-              </Button>
+              </LinkButton>
             </>
           ) : null}
           <hr />
@@ -167,7 +169,7 @@ export default function Page({
                     <StateBadge state={source.schedule.state} />
                   </p>
                 </Col>
-                {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                {grouparooUiEdition !== "config" && (
                   <Col>
                     <Alert variant="success">
                       <strong>Most Recent Run</strong>
@@ -205,7 +207,7 @@ export default function Page({
                     </Alert>
                   </Col>
                 )}
-                {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                {grouparooUiEdition !== "config" && (
                   <Col>
                     <Alert variant="info">
                       <p>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
@@ -58,7 +58,7 @@ export default function Page({
         <Col>
           <p>
             <strong>App</strong>:{" "}
-            <Link href="/app/[id]/edit" as={`/app/${source.app.id}/edit`}>
+            <Link href={`/app/${source.app.id}/edit`}>
               <a>{source.app.name}</a>
             </Link>
             <br />
@@ -92,8 +92,7 @@ export default function Page({
                 <tr key={`rule-${rule.id}`}>
                   <td>
                     <Link
-                      href="/model/[modelId]/property/[propertyId]/edit"
-                      as={`/model/${source.modelId}/property/${rule.id}/edit`}
+                      href={`/model/${source.modelId}/property/${rule.id}/edit`}
                     >
                       <a>
                         <strong>
@@ -145,8 +144,7 @@ export default function Page({
                 <Col>
                   <p>
                     <Link
-                      href="/model/[modelId]/source/[sourceId]/schedule"
-                      as={`/model/${source.modelId}/source/${source.id}/schedule`}
+                      href={`/model/${source.modelId}/source/${source.id}/schedule`}
                     >
                       <a>{source.schedule.name}</a>
                     </Link>
@@ -169,7 +167,7 @@ export default function Page({
                     <StateBadge state={source.schedule.state} />
                   </p>
                 </Col>
-                {grouparooUiEdition !== "config" && (
+                {grouparooUiEdition() !== "config" && (
                   <Col>
                     <Alert variant="success">
                       <strong>Most Recent Run</strong>
@@ -193,10 +191,7 @@ export default function Page({
                             <p>Completed {formatTimestamp(run.completedAt)}</p>
                           ) : null}
                           <p>
-                            <Link
-                              href="/run/[id]/edit"
-                              as={`/run/${run.id}/edit`}
-                            >
+                            <Link href={`/run/${run.id}/edit`}>
                               <a>See More</a>
                             </Link>
                           </p>
@@ -207,7 +202,7 @@ export default function Page({
                     </Alert>
                   </Col>
                 )}
-                {grouparooUiEdition !== "config" && (
+                {grouparooUiEdition() !== "config" && (
                   <Col>
                     <Alert variant="info">
                       <p>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -20,6 +20,7 @@ import { makeLocal } from "../../../../../utils/makeLocal";
 import ModelBadge from "../../../../../components/badges/modelBadge";
 import { NextPageContext } from "next";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
+import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 
 export default function Page(props) {
   const {
@@ -198,7 +199,7 @@ export default function Page(props) {
                       />
                     </Form.Group>
                   </Col>
-                  {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                  {grouparooUiEdition !== "config" && (
                     <Col>
                       <Alert variant="success">
                         <strong>Most Recent Run</strong>
@@ -240,7 +241,7 @@ export default function Page(props) {
                       </Alert>
                     </Col>
                   )}
-                  {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                  {grouparooUiEdition !== "config" && (
                     <Col>
                       <Alert variant="info">
                         <p>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -199,7 +199,7 @@ export default function Page(props) {
                       />
                     </Form.Group>
                   </Col>
-                  {grouparooUiEdition !== "config" && (
+                  {grouparooUiEdition() !== "config" && (
                     <Col>
                       <Alert variant="success">
                         <strong>Most Recent Run</strong>
@@ -227,10 +227,7 @@ export default function Page(props) {
                               </p>
                             ) : null}
                             <p>
-                              <Link
-                                href="/run/[id]/edit"
-                                as={`/run/${run.id}/edit`}
-                              >
+                              <Link href={`/run/${run.id}/edit`}>
                                 <a>See More</a>
                               </Link>
                             </p>
@@ -241,7 +238,7 @@ export default function Page(props) {
                       </Alert>
                     </Col>
                   )}
-                  {grouparooUiEdition !== "config" && (
+                  {grouparooUiEdition() !== "config" && (
                     <Col>
                       <Alert variant="info">
                         <p>

--- a/ui/ui-components/pages/model/[modelId]/source/new/index.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/new/index.tsx
@@ -1,11 +1,11 @@
 import Head from "next/head";
 import { useState } from "react";
-import { Form, Alert, Button } from "react-bootstrap";
+import { Form, Alert } from "react-bootstrap";
 import { useRouter } from "next/router";
-
 import { UseApi } from "../../../../../hooks/useApi";
 import AppSelectorList from "../../../../../components/appSelectorList";
 import { Actions } from "../../../../../utils/apiData";
+import LinkButton from "../../../../../components/linkButton";
 
 export default function Page(props) {
   const {
@@ -36,9 +36,9 @@ export default function Page(props) {
           There are no Apps in the ready state yet.
           <br />
           <br />
-          <Button size="sm" href="/apps">
+          <LinkButton size="sm" href="/apps">
             Add an App
-          </Button>
+          </LinkButton>
         </Alert>
       </>
     );

--- a/ui/ui-components/pages/model/[modelId]/sources.tsx
+++ b/ui/ui-components/pages/model/[modelId]/sources.tsx
@@ -1,7 +1,6 @@
 import { useState, Fragment } from "react";
 import { useRouter } from "next/router";
 import Head from "next/head";
-import { Button } from "react-bootstrap";
 import type { NextPageContext } from "next";
 import { UseApi } from "../../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../../hooks/URLParams";
@@ -16,6 +15,8 @@ import { formatTimestamp } from "../../../utils/formatTimestamp";
 import { SuccessHandler } from "../../../utils/successHandler";
 import { ErrorHandler } from "../../../utils/errorHandler";
 import LoadingButton from "../../../components/loadingButton";
+import LinkButton from "../../../components/linkButton";
+import { grouparooUiEdition } from "../../../utils/uiEdition";
 
 export default function Page(props) {
   const {
@@ -179,7 +180,7 @@ export default function Page(props) {
                         {schedule.recurring
                           ? `Every ${recurringFrequencyMinutes} minutes`
                           : "Not recurring"}
-                        {process.env.GROUPAROO_UI_EDITION !== "config" && (
+                        {grouparooUiEdition !== "config" && (
                           <>
                             <br />
                             Last Run:{" "}
@@ -213,28 +214,22 @@ export default function Page(props) {
         onPress={setOffset}
       />
       <br />
-      {process.env.GROUPAROO_UI_EDITION !== "community" ? (
-        <Button
-          variant="primary"
-          onClick={() => {
-            router.push(
-              "/model/[modelId]/source/new",
-              `/model/${router.query.modelId}/source/new`
-            );
-          }}
-        >
-          Add new Source
-        </Button>
-      ) : null}
+      <LinkButton
+        variant="primary"
+        href={`/model/${router.query.modelId}/source/new`}
+        hideOn={["community"]}
+      >
+        Add new Source
+      </LinkButton>
       &nbsp;
-      {process.env.GROUPAROO_UI_EDITION !== "config" ? (
-        <LoadingButton
-          variant="outline-primary"
-          onClick={() => enqueueAllSchedulesRun()}
-        >
-          Run all {modelName} Schedules
-        </LoadingButton>
-      ) : null}
+      <LoadingButton
+        variant="outline-primary"
+        disabled={loading}
+        onClick={() => enqueueAllSchedulesRun()}
+        hideOn={["config"]}
+      >
+        Run all {modelName} Schedules
+      </LoadingButton>
     </>
   );
 }

--- a/ui/ui-components/pages/model/[modelId]/sources.tsx
+++ b/ui/ui-components/pages/model/[modelId]/sources.tsx
@@ -5,7 +5,7 @@ import type { NextPageContext } from "next";
 import { UseApi } from "../../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../../hooks/URLParams";
 import { useSecondaryEffect } from "../../../hooks/useSecondaryEffect";
-import Link from "../../../components/enterpriseLink";
+import Link from "../../../components/grouparooLink";
 import Pagination from "../../../components/pagination";
 import LoadingTable from "../../../components/loadingTable";
 import AppIcon from "../../../components/appIcon";

--- a/ui/ui-components/pages/model/[modelId]/sources.tsx
+++ b/ui/ui-components/pages/model/[modelId]/sources.tsx
@@ -82,7 +82,6 @@ export default function Page(props) {
         successHandler.set({ message: `run ${response.run.id} enqueued` });
       }
     } finally {
-      console.log("FALSE");
       setLoading(false);
     }
   }

--- a/ui/ui-components/pages/model/[modelId]/sources.tsx
+++ b/ui/ui-components/pages/model/[modelId]/sources.tsx
@@ -143,8 +143,7 @@ export default function Page(props) {
                   </td>
                   <td>
                     <Link
-                      href="/model/[modelId]/source/[sourceId]/overview"
-                      as={`/model/${source.modelId}/source/${source.id}/overview`}
+                      href={`/model/${source.modelId}/source/${source.id}/overview`}
                     >
                       <a>
                         <strong>
@@ -160,10 +159,7 @@ export default function Page(props) {
                   </td>
                   <td>{source.connection.displayName}</td>
                   <td>
-                    <Link
-                      href="/app/[id]/edit"
-                      as={`/app/${source.app.id}/edit`}
-                    >
+                    <Link href={`/app/${source.app.id}/edit`}>
                       <a>
                         <strong>{source.app.name}</strong>
                       </a>
@@ -180,7 +176,7 @@ export default function Page(props) {
                         {schedule.recurring
                           ? `Every ${recurringFrequencyMinutes} minutes`
                           : "Not recurring"}
-                        {grouparooUiEdition !== "config" && (
+                        {grouparooUiEdition() !== "config" && (
                           <>
                             <br />
                             Last Run:{" "}

--- a/ui/ui-components/pages/model/[modelId]/sources.tsx
+++ b/ui/ui-components/pages/model/[modelId]/sources.tsx
@@ -3,7 +3,6 @@ import { useRouter } from "next/router";
 import Head from "next/head";
 import { Button } from "react-bootstrap";
 import type { NextPageContext } from "next";
-
 import { UseApi } from "../../../hooks/useApi";
 import { useOffset, updateURLParams } from "../../../hooks/URLParams";
 import { useSecondaryEffect } from "../../../hooks/useSecondaryEffect";
@@ -16,6 +15,7 @@ import { Models, Actions } from "../../../utils/apiData";
 import { formatTimestamp } from "../../../utils/formatTimestamp";
 import { SuccessHandler } from "../../../utils/successHandler";
 import { ErrorHandler } from "../../../utils/errorHandler";
+import LoadingButton from "../../../components/loadingButton";
 
 export default function Page(props) {
   const {
@@ -74,10 +74,15 @@ export default function Page(props) {
         "post",
         `/schedule/${source.schedule.id}/run`
       );
-      successHandler.set({ message: `run ${response.run.id} enqueued` });
+      if (response.run) {
+        const _runs = Object.assign({}, runs);
+        _runs[source.id] = await loadRun(source, execApi);
+        setRuns(_runs);
+        successHandler.set({ message: `run ${response.run.id} enqueued` });
+      }
     } finally {
+      console.log("FALSE");
       setLoading(false);
-      load();
     }
   }
 
@@ -180,14 +185,14 @@ export default function Page(props) {
                             Last Run:{" "}
                             {run ? formatTimestamp(run?.createdAt) : "Never"}
                             <br />
-                            <Button
+                            <LoadingButton
                               variant="outline-success"
                               size="sm"
-                              disabled={run?.state === "running"}
+                              disabled={loading}
                               onClick={() => enqueueScheduleRun(source)}
                             >
                               Run Now
-                            </Button>
+                            </LoadingButton>
                           </>
                         )}
                       </>
@@ -223,12 +228,12 @@ export default function Page(props) {
       ) : null}
       &nbsp;
       {process.env.GROUPAROO_UI_EDITION !== "config" ? (
-        <Button
+        <LoadingButton
           variant="outline-primary"
           onClick={() => enqueueAllSchedulesRun()}
         >
           Run all {modelName} Schedules
-        </Button>
+        </LoadingButton>
       ) : null}
     </>
   );

--- a/ui/ui-components/pages/models.tsx
+++ b/ui/ui-components/pages/models.tsx
@@ -81,10 +81,7 @@ export default function Page(props) {
                   <ModelIcon model={model} />
                 </td>
                 <td>
-                  <EnterpriseLink
-                    href="/model/[modelId]/edit"
-                    as={`/model/${model.id}/edit`}
-                  >
+                  <EnterpriseLink href={`/model/${model.id}/edit`}>
                     <a>
                       <strong>{model.name}</strong>
                     </a>

--- a/ui/ui-components/pages/models.tsx
+++ b/ui/ui-components/pages/models.tsx
@@ -7,12 +7,12 @@ import { useRouter } from "next/router";
 import Pagination from "../components/pagination";
 import LoadingTable from "../components/loadingTable";
 import ModelIcon from "../components/modelIcon";
-import { Button } from "react-bootstrap";
 import { Models, Actions } from "../utils/apiData";
 import { formatTimestamp } from "../utils/formatTimestamp";
 import { ErrorHandler } from "../utils/errorHandler";
 import EnterpriseLink from "../components/enterpriseLink";
 import StateBadge from "../components/badges/stateBadge";
+import LinkButton from "../components/linkButton";
 
 export default function Page(props) {
   const { errorHandler }: { errorHandler: ErrorHandler } = props;
@@ -111,16 +111,9 @@ export default function Page(props) {
 
       <br />
 
-      {process.env.GROUPAROO_UI_EDITION !== "community" ? (
-        <Button
-          variant="primary"
-          onClick={() => {
-            router.push("/model/new");
-          }}
-        >
-          Add Model
-        </Button>
-      ) : null}
+      <LinkButton variant="primary" hideOn={["community"]} href="/model/new">
+        Add Model
+      </LinkButton>
     </>
   );
 }

--- a/ui/ui-components/pages/models.tsx
+++ b/ui/ui-components/pages/models.tsx
@@ -10,7 +10,7 @@ import ModelIcon from "../components/modelIcon";
 import { Models, Actions } from "../utils/apiData";
 import { formatTimestamp } from "../utils/formatTimestamp";
 import { ErrorHandler } from "../utils/errorHandler";
-import EnterpriseLink from "../components/enterpriseLink";
+import GrouparooLink from "../components/grouparooLink";
 import StateBadge from "../components/badges/stateBadge";
 import LinkButton from "../components/linkButton";
 
@@ -81,11 +81,11 @@ export default function Page(props) {
                   <ModelIcon model={model} />
                 </td>
                 <td>
-                  <EnterpriseLink href={`/model/${model.id}/edit`}>
+                  <GrouparooLink href={`/model/${model.id}/edit`}>
                     <a>
                       <strong>{model.name}</strong>
                     </a>
-                  </EnterpriseLink>
+                  </GrouparooLink>
                 </td>
                 <td>{model.type}</td>
                 <td>

--- a/ui/ui-components/pages/notifications.tsx
+++ b/ui/ui-components/pages/notifications.tsx
@@ -83,10 +83,7 @@ export default function Page(props) {
                   )}
                 </td>
                 <td>
-                  <Link
-                    href="/notification/[id]/edit"
-                    as={`/notification/${notification.id}/edit`}
-                  >
+                  <Link href={`/notification/${notification.id}/edit`}>
                     <a>
                       {notification.readAt ? (
                         notification.subject

--- a/ui/ui-components/pages/object/[id].tsx
+++ b/ui/ui-components/pages/object/[id].tsx
@@ -43,7 +43,7 @@ export default function FindObject(props) {
       setError(`Cannot find object "${id}"`);
     } else if (
       response.records.length === 1 &&
-      grouparooUiEdition === "enterprise"
+      grouparooUiEdition() === "enterprise"
     ) {
       const table = response.records[0].tableName.toLowerCase();
       const detailPage = detailPages[table] || "edit";
@@ -54,7 +54,7 @@ export default function FindObject(props) {
       }
     } else if (
       response.records.length === 1 &&
-      grouparooUiEdition === "community"
+      grouparooUiEdition() === "community"
     ) {
       const listPage = getListPage(response.records[0].tableName.toLowerCase());
       router.push(listPage);
@@ -153,7 +153,7 @@ export default function FindObject(props) {
                   <td>
                     <Link
                       href={
-                        grouparooUiEdition === "enterprise" &&
+                        grouparooUiEdition() === "enterprise" &&
                         typeof detailPage === "string"
                           ? `/${singular(r)}/${id}/${detailPage}`
                           : getListPage(r)

--- a/ui/ui-components/pages/object/[id].tsx
+++ b/ui/ui-components/pages/object/[id].tsx
@@ -7,6 +7,7 @@ import { Actions } from "../../utils/apiData";
 import { Card } from "react-bootstrap";
 import { singular } from "pluralize";
 import { ErrorHandler } from "../../utils/errorHandler";
+import { grouparooUiEdition } from "../../utils/uiEdition";
 
 export default function FindObject(props) {
   const router = useRouter();
@@ -42,7 +43,7 @@ export default function FindObject(props) {
       setError(`Cannot find object "${id}"`);
     } else if (
       response.records.length === 1 &&
-      process.env.GROUPAROO_UI_EDITION === "enterprise"
+      grouparooUiEdition === "enterprise"
     ) {
       const table = response.records[0].tableName.toLowerCase();
       const detailPage = detailPages[table] || "edit";
@@ -53,7 +54,7 @@ export default function FindObject(props) {
       }
     } else if (
       response.records.length === 1 &&
-      process.env.GROUPAROO_UI_EDITION === "community"
+      grouparooUiEdition === "community"
     ) {
       const listPage = getListPage(response.records[0].tableName.toLowerCase());
       router.push(listPage);
@@ -152,7 +153,7 @@ export default function FindObject(props) {
                   <td>
                     <Link
                       href={
-                        process.env.GROUPAROO_UI_EDITION === "enterprise" &&
+                        grouparooUiEdition === "enterprise" &&
                         typeof detailPage === "string"
                           ? `/${singular(r)}/${id}/${detailPage}`
                           : getListPage(r)

--- a/ui/ui-components/pages/object/[id].tsx
+++ b/ui/ui-components/pages/object/[id].tsx
@@ -1,6 +1,6 @@
 import Loader from "../../components/loader";
 import { useEffect, useState } from "react";
-import Link from "../../components/enterpriseLink";
+import Link from "../../components/grouparooLink";
 import { useRouter } from "next/router";
 import { UseApi } from "../../hooks/useApi";
 import { Actions } from "../../utils/apiData";

--- a/ui/ui-components/pages/resque/queue/index.tsx
+++ b/ui/ui-components/pages/resque/queue/index.tsx
@@ -45,12 +45,7 @@ export default function ResqueQueue(props) {
             return (
               <tr key={queue}>
                 <td>
-                  <Link
-                    href="/resque/queue/[queue]"
-                    as={`/resque/queue/${queue}`}
-                  >
-                    {queue}
-                  </Link>
+                  <Link href={`/resque/queue/${queue}`}>{queue}</Link>
                 </td>
                 <td>{queues[queue].length} jobs</td>
               </tr>

--- a/ui/ui-components/pages/run/[id]/edit.tsx
+++ b/ui/ui-components/pages/run/[id]/edit.tsx
@@ -1,7 +1,7 @@
 import { UseApi } from "../../../hooks/useApi";
 import { useState, Fragment } from "react";
 import { Row, Col, Badge, Alert, Card } from "react-bootstrap";
-import Link from "../../../components/enterpriseLink";
+import Link from "../../../components/grouparooLink";
 import { GrouparooChart } from "../../../components/visualizations/grouparooChart";
 import RunTabs from "../../../components/tabs/run";
 import Head from "next/head";

--- a/ui/ui-components/pages/run/[id]/edit.tsx
+++ b/ui/ui-components/pages/run/[id]/edit.tsx
@@ -54,7 +54,7 @@ export default function Page(props) {
           <h2>Details</h2>
           <p>
             Creator:{" "}
-            <Link href="/object/[id]" as={`/object/${run.creatorId}`}>
+            <Link href={`/object/${run.creatorId}`}>
               <a>
                 {run.creatorType}: {run.creatorName}
               </a>
@@ -96,7 +96,7 @@ export default function Page(props) {
 
           <Row>
             <Col>
-              <Link href="/imports/[creatorId]" as={`/imports/${run.id}`}>
+              <Link href={`/imports/${run.id}`}>
                 <a>Imports Created: {run.importsCreated}</a>
               </Link>
               <br />

--- a/ui/ui-components/pages/team/[id]/members.tsx
+++ b/ui/ui-components/pages/team/[id]/members.tsx
@@ -76,10 +76,7 @@ export default function Page(props) {
                   />
                 </td>
                 <td>
-                  <Link
-                    href="/teamMember/[id]/edit"
-                    as={`/teamMember/${teamMember.id}/edit`}
-                  >
+                  <Link href={`/teamMember/${teamMember.id}/edit`}>
                     <a>{teamMember.email}</a>
                   </Link>
                 </td>

--- a/ui/ui-components/pages/teamMember/new.tsx
+++ b/ui/ui-components/pages/teamMember/new.tsx
@@ -43,7 +43,7 @@ export default function Page(props) {
     if (response?.teamMember) {
       teamMemberHandler.set([response.teamMember]);
       successHandler.set({ message: "Team Member Created" });
-      grouparooUiEdition === "enterprise"
+      grouparooUiEdition() === "enterprise"
         ? router.push(`/team/${response.teamMember.teamId}/members`)
         : router.push(`/teams`);
     } else {

--- a/ui/ui-components/pages/teamMember/new.tsx
+++ b/ui/ui-components/pages/teamMember/new.tsx
@@ -9,6 +9,7 @@ import { Actions, Models } from "../../utils/apiData";
 import { ErrorHandler } from "../../utils/errorHandler";
 import { TeamMemberHandler } from "../../utils/teamMembersHandler";
 import { SuccessHandler } from "../../utils/successHandler";
+import { grouparooUiEdition } from "../../utils/uiEdition";
 
 export default function Page(props) {
   const {
@@ -42,7 +43,7 @@ export default function Page(props) {
     if (response?.teamMember) {
       teamMemberHandler.set([response.teamMember]);
       successHandler.set({ message: "Team Member Created" });
-      process.env.GROUPAROO_UI_EDITION === "enterprise"
+      grouparooUiEdition === "enterprise"
         ? router.push(`/team/${response.teamMember.teamId}/members`)
         : router.push(`/teams`);
     } else {

--- a/ui/ui-components/pages/teams.tsx
+++ b/ui/ui-components/pages/teams.tsx
@@ -3,7 +3,7 @@ import { Alert } from "react-bootstrap";
 import { useRouter } from "next/router";
 import { UseApi } from "../hooks/useApi";
 import Link from "next/link";
-import EnterpriseLink from "../components/enterpriseLink";
+import EnterpriseLink from "../components/grouparooLink";
 import { Form } from "react-bootstrap";
 import LoadingTable from "../components/loadingTable";
 import RecordImageFromEmail from "../components/visualizations/recordImageFromEmail";

--- a/ui/ui-components/pages/teams.tsx
+++ b/ui/ui-components/pages/teams.tsx
@@ -67,7 +67,7 @@ export default function Page({
         Add Team
       </LinkButton>
 
-      {grouparooUiEdition !== "enterprise" ? (
+      {grouparooUiEdition() !== "enterprise" ? (
         <Alert variant="primary" style={{ textAlign: "center" }}>
           Does your organization need additional Teams with finer-grained
           permissions?{" "}

--- a/ui/ui-components/pages/teams.tsx
+++ b/ui/ui-components/pages/teams.tsx
@@ -42,10 +42,7 @@ export default function Page({
             return (
               <tr key={`team-${team.id}`}>
                 <td>
-                  <EnterpriseLink
-                    href="/team/[id]/edit"
-                    as={`/team/${team.id}/edit`}
-                  >
+                  <EnterpriseLink href={`/team/${team.id}/edit`}>
                     <a>
                       <strong>{team.name}</strong>
                       {/* <br /><span className='text-muted'>{team.id}</span> */}
@@ -109,10 +106,7 @@ export default function Page({
                   />
                 </td>
                 <td>
-                  <Link
-                    href="/teamMember/[id]/edit"
-                    as={`/teamMember/${teamMember.id}/edit`}
-                  >
+                  <Link href={`/teamMember/${teamMember.id}/edit`}>
                     <a>{teamMember.email}</a>
                   </Link>
                 </td>

--- a/ui/ui-components/pages/teams.tsx
+++ b/ui/ui-components/pages/teams.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { Button, Alert } from "react-bootstrap";
+import { Alert } from "react-bootstrap";
 import { useRouter } from "next/router";
 import { UseApi } from "../hooks/useApi";
 import Link from "next/link";
@@ -9,6 +9,8 @@ import LoadingTable from "../components/loadingTable";
 import RecordImageFromEmail from "../components/visualizations/recordImageFromEmail";
 import { Models } from "../utils/apiData";
 import { formatTimestamp } from "../utils/formatTimestamp";
+import LinkButton from "../components/linkButton";
+import { grouparooUiEdition } from "../utils/uiEdition";
 
 export default function Page({
   teams,
@@ -64,16 +66,11 @@ export default function Page({
         </tbody>
       </LoadingTable>
 
-      {process.env.GROUPAROO_UI_EDITION === "enterprise" ? (
-        <Button
-          variant="primary"
-          onClick={() => {
-            router.push("/team/new");
-          }}
-        >
-          Add Team
-        </Button>
-      ) : (
+      <LinkButton variant="primary" href="/team/new" displayOn={["enterprise"]}>
+        Add Team
+      </LinkButton>
+
+      {grouparooUiEdition !== "enterprise" ? (
         <Alert variant="primary" style={{ textAlign: "center" }}>
           Does your organization need additional Teams with finer-grained
           permissions?{" "}
@@ -82,7 +79,7 @@ export default function Page({
           </a>
           .
         </Alert>
-      )}
+      ) : null}
 
       <br />
       <br />
@@ -136,14 +133,9 @@ export default function Page({
         </tbody>
       </LoadingTable>
 
-      <Button
-        variant="primary"
-        onClick={() => {
-          router.push("/teamMember/new");
-        }}
-      >
+      <LinkButton variant="primary" href="/teamMember/new">
         Add Team Member
-      </Button>
+      </LinkButton>
     </>
   );
 }

--- a/ui/ui-components/pages/teams.tsx
+++ b/ui/ui-components/pages/teams.tsx
@@ -67,7 +67,7 @@ export default function Page({
         Add Team
       </LinkButton>
 
-      {grouparooUiEdition() !== "enterprise" ? (
+      {grouparooUiEdition() !== "enterprise" && (
         <Alert variant="primary" style={{ textAlign: "center" }}>
           Does your organization need additional Teams with finer-grained
           permissions?{" "}
@@ -76,7 +76,7 @@ export default function Page({
           </a>
           .
         </Alert>
-      ) : null}
+      )}
 
       <br />
       <br />

--- a/ui/ui-components/utils/uiEdition.ts
+++ b/ui/ui-components/utils/uiEdition.ts
@@ -1,3 +1,3 @@
 export type GrouparooUIEdition = "enterprise" | "community" | "config";
-export const grouparooUiEdition = process.env
-  .GROUPAROO_UI_EDITION as GrouparooUIEdition;
+export const grouparooUiEdition = () =>
+  process.env.GROUPAROO_UI_EDITION as GrouparooUIEdition;

--- a/ui/ui-components/utils/uiEdition.ts
+++ b/ui/ui-components/utils/uiEdition.ts
@@ -1,0 +1,3 @@
+export type GrouparooUIEdition = "enterprise" | "community" | "config";
+export const grouparooUiEdition = process.env
+  .GROUPAROO_UI_EDITION as GrouparooUIEdition;

--- a/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/runs.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/runs.tsx
@@ -7,11 +7,12 @@ import PageHeader from "@grouparoo/ui-components/components/pageHeader";
 import StateBadge from "@grouparoo/ui-components/components/badges/stateBadge";
 import LockedBadge from "@grouparoo/ui-components/components/badges/lockedBadge";
 import ModelBadge from "@grouparoo/ui-components/components/badges/modelBadge";
-import { Button, Row, Col } from "react-bootstrap";
+import { Row, Col } from "react-bootstrap";
 import { ErrorHandler } from "@grouparoo/ui-components/utils/errorHandler";
 import { SuccessHandler } from "@grouparoo/ui-components/utils/successHandler";
 import { RunsHandler } from "@grouparoo/ui-components/utils/runsHandler";
 import { Models, Actions } from "@grouparoo/ui-components/utils/apiData";
+import LoadingButton from "@grouparoo/ui-components/components/loadingButton";
 
 export default function Page(props) {
   const {
@@ -35,8 +36,10 @@ export default function Page(props) {
         "post",
         `/schedule/${source.schedule.id}/run`
       );
-      successHandler.set({ message: `run ${response.run.id} enqueued` });
-      runsHandler.set(null);
+      if (response.run) {
+        successHandler.set({ message: `run ${response.run.id} enqueued` });
+        runsHandler.set([response.run]);
+      }
     } finally {
       setLoading(false);
     }
@@ -69,7 +72,7 @@ export default function Page(props) {
 
             <Row>
               <Col>
-                <Button
+                <LoadingButton
                   size="sm"
                   variant="outline-primary"
                   disabled={loading}
@@ -78,7 +81,7 @@ export default function Page(props) {
                   }}
                 >
                   Run Now
-                </Button>
+                </LoadingButton>
                 <br />
                 <br />
               </Col>


### PR DESCRIPTION
This PR Updates a number of components in the UI

* Next `<Link />` tags no longer need an `as=` for dynamic links 🥳 
* Rather than checking the ENV directly, we now have a shared `grouparooUiEdition` method we check.
* New `<LinkButton />` component handles buttons that are links, and uses next's loader.  They can be customized to show/hide depending on `grouparooUiEdition`.  This simplifies the on-page rendering logic.
* New `<LoadingButton />`  can be customized to show/hide depending on `grouparooUiEdition`.  This simplifies the on-page rendering logic.
* Fixes the action & on-page logic when manually running a schedule to return and stop any already-running Runs.


From https://nextjs.org/docs/api-reference/next/link:
> as - Optional decorator for the path that will be shown in the browser URL bar. Before Next.js 9.5.3 this was used for dynamic routes, check our previous docs to see how it worked. Note: when this path differs from the one provided in href the previous href/as behavior is used as shown in the previous docs.


## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
