### PR TITLE
Synced Records per Month

### DIFF
--- a/core/__tests__/models/export.ts
+++ b/core/__tests__/models/export.ts
@@ -358,7 +358,7 @@ describe("models/export", () => {
   });
 
   test("exports can be marked as having changes or not", async () => {
-    await Export.destroy({ where: { destinationId: destination.id } });
+    await Export.truncate();
     const group = await helper.factories.group();
     await group.addRecord(record);
     await destination.updateTracking("group", group.id);
@@ -391,52 +391,115 @@ describe("models/export", () => {
     await newExport.destroy();
   });
 
-  test("old entries can be swept away, not the newest one for each record + destination", async () => {
-    const oldExport = await Export.create({
-      destinationId: destination.id,
-      recordId: record.id,
-      startedAt: new Date(),
-      oldRecordProperties: {},
-      newRecordProperties: {},
-      oldGroups: [],
-      newGroups: [],
-      state: "pending",
+  describe("sweep", () => {
+    async function makeOldExport(state = "complete", createdAt = new Date(0)) {
+      const _export = await Export.create({
+        destinationId: destination.id,
+        recordId: record.id,
+        startedAt: new Date(),
+        oldRecordProperties: {},
+        newRecordProperties: {},
+        oldGroups: [],
+        newGroups: [],
+        state,
+      });
+
+      _export.set({ createdAt }, { raw: true });
+      _export.changed("createdAt", true);
+      await _export.save({
+        silent: true,
+        fields: ["createdAt"],
+      });
+
+      return _export;
+    }
+
+    test("old complete entries can be swept away, not the newest one for each record + destination", async () => {
+      await Export.truncate();
+      const oldExport = await makeOldExport("complete", new Date(0));
+      const oldExportMostRecent = await makeOldExport(
+        "complete",
+        new Date(1000 * 61)
+      );
+
+      let count = await Export.count();
+      expect(count).toBe(2);
+
+      await Export.sweep(1000);
+      const remaining = await Export.findAll();
+      expect(remaining.length).toBe(1);
+      expect(remaining[0].id).toBe(oldExportMostRecent.id);
     });
 
-    const oldExportMostRecent = await Export.create({
-      destinationId: destination.id,
-      recordId: record.id,
-      startedAt: new Date(),
-      oldRecordProperties: {},
-      newRecordProperties: {},
-      oldGroups: [],
-      newGroups: [],
-      completedAt: new Date(),
-      state: "complete",
+    test("old pending entries will not be swept await that exist alongside a complete export", async () => {
+      await Export.truncate();
+      const oldExport = await makeOldExport("pending", new Date(0));
+      const oldExportMostRecent = await makeOldExport(
+        "complete",
+        new Date(1000 * 61)
+      );
+
+      let count = await Export.count();
+      expect(count).toBe(2);
+
+      await Export.sweep(1000);
+      const remaining = await Export.findAll();
+      expect(remaining.length).toBe(2);
     });
 
-    oldExport.set({ createdAt: new Date(0) }, { raw: true });
-    oldExport.changed("createdAt", true);
-    await oldExport.save({
-      silent: true,
-      fields: ["createdAt"],
+    test("if there are no complete exports for the record+destination, old exports will not be swept", async () => {
+      await Export.truncate();
+      const oldExport = await makeOldExport("pending", new Date(0));
+      const oldExportMostRecent = await makeOldExport(
+        "pending",
+        new Date(1000 * 61)
+      );
+
+      let count = await Export.count();
+      expect(count).toBe(2);
+
+      await Export.sweep(1000);
+      const remaining = await Export.findAll();
+      expect(remaining.length).toBe(2);
     });
 
-    oldExportMostRecent.set({ createdAt: new Date(1000 * 61) }, { raw: true });
-    oldExportMostRecent.changed("createdAt", true);
-    await oldExportMostRecent.save({
-      silent: true,
-      fields: ["createdAt"],
+    test("all exports older than 90 days which do not have a record will be swept", async () => {
+      await Export.truncate();
+      const exports = [
+        await makeOldExport("pending", new Date()), // not old enough
+        await makeOldExport("failed", new Date(0)),
+        await makeOldExport("complete", new Date(0)),
+        await makeOldExport("pending", new Date(0)),
+      ];
+      await Promise.all(exports.map((e) => e.update({ recordId: "foo" })));
+
+      let count = await Export.count();
+      expect(count).toBe(4);
+
+      await Export.sweep(1000);
+      const remaining = await Export.findAll();
+      expect(remaining.length).toBe(1);
+      expect(remaining[0].id).toBe(exports[0].id);
     });
 
-    let count = await Export.count();
-    expect(count).toBe(2);
+    test("all exports older than 90 days which do not have a destination will be swept", async () => {
+      await Export.truncate();
+      const exports = [
+        await makeOldExport("pending", new Date()), // not old enough
+        await makeOldExport("failed", new Date(0)),
+        await makeOldExport("complete", new Date(0)),
+        await makeOldExport("pending", new Date(0)),
+      ];
+      await Promise.all(exports.map((e) => e.update({ destinationId: "foo" })));
 
-    await Export.sweep(999);
+      let count = await Export.count();
+      expect(count).toBe(4);
 
-    const remaining = await Export.findAll();
-    expect(remaining.length).toBe(1);
-    expect(remaining[0].id).toBe(oldExportMostRecent.id);
+      await Export.sweep(1000);
+      const remaining = await Export.findAll();
+      expect(remaining.length).toBe(1);
+      expect(remaining[0].id).toBe(exports[0].id);
+    });
   });
 
   describe("errors", () => {

--- a/core/__tests__/models/setting.ts
+++ b/core/__tests__/models/setting.ts
@@ -155,7 +155,7 @@ describe("models/setting", () => {
       await SettingOps.prepare();
       const settings = await Setting.findAll();
       expect(settings.filter((s) => s.pluginName === "core").length).toEqual(
-        15
+        14
       );
       expect(
         settings.filter((s) => s.pluginName === "interface").length

--- a/core/__tests__/modules/status.ts
+++ b/core/__tests__/modules/status.ts
@@ -5,7 +5,15 @@ import {
   FinalSummaryReporters,
 } from "../../src/modules/statusReporters";
 import { Status } from "../../src/modules/status";
-import { Destination, GrouparooRecord, Source, Schedule } from "../../src";
+import {
+  Destination,
+  GrouparooRecord,
+  Source,
+  Schedule,
+  Export,
+} from "../../src";
+import Moment from "moment";
+import { StatusReporters } from "../../dist/modules/statusReporters";
 
 describe("modules/status", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -590,6 +598,93 @@ describe("modules/status", () => {
           expect(destinations[0].exportsComplete).toEqual(1);
         }
       );
+    });
+  });
+
+  describe("exports", () => {
+    async function makeOldExport(
+      destination: Destination,
+      record: GrouparooRecord,
+      createdAt = new Date(0)
+    ) {
+      const _export = await Export.create({
+        destinationId: destination.id,
+        recordId: record.id,
+        startedAt: new Date(),
+        oldRecordProperties: {},
+        newRecordProperties: {},
+        oldGroups: [],
+        newGroups: [],
+        state: "complete",
+      });
+
+      _export.set({ createdAt }, { raw: true });
+      _export.changed("createdAt", true);
+      await _export.save({
+        silent: true,
+        fields: ["createdAt"],
+      });
+
+      return _export;
+    }
+
+    it("counts up unique records exported", async () => {
+      await Destination.truncate();
+      await Export.truncate();
+
+      const recordA = await helper.factories.record();
+      const recordB = await helper.factories.record();
+      const recordC = await helper.factories.record(); // never exported
+      const destinationA = await helper.factories.destination();
+      const destinationB = await helper.factories.destination();
+
+      const oldExportA = await makeOldExport(
+        destinationA,
+        recordA,
+        new Date(0)
+      );
+      const thisMonthExportA = await makeOldExport(
+        destinationA,
+        recordA,
+        Moment().subtract(10, "days").toDate()
+      );
+      const todayExportA = await makeOldExport(
+        destinationB,
+        recordA,
+        Moment().subtract(10, "minutes").toDate()
+      );
+      const thisMonthExportB = await makeOldExport(
+        destinationA,
+        recordB,
+        Moment().subtract(10, "days").toDate()
+      );
+      const thisWeekExportB = await makeOldExport(
+        destinationA,
+        recordB,
+        Moment().subtract(5, "days").toDate()
+      );
+
+      const metrics = await StatusReporters.Totals.UniqueRecordsExported();
+      expect(metrics).toEqual([
+        {
+          collection: "1DayDistinct",
+          topic: "Export",
+          aggregation: "count",
+          count: 1,
+        },
+        {
+          collection: "7DayDistinct",
+          topic: "Export",
+          aggregation: "count",
+          count: 2,
+        },
+        {
+          collection: "30DayDistinct",
+          topic: "Export",
+          aggregation: "count",
+          count: 2,
+        },
+      ]);
     });
   });
 

--- a/core/__tests__/modules/status.ts
+++ b/core/__tests__/modules/status.ts
@@ -152,6 +152,39 @@ describe("modules/status", () => {
               timestamp: expect.any(Number),
             },
           ],
+          "1DayDistinct": [
+            {
+              metric: {
+                aggregation: "count",
+                collection: "1DayDistinct",
+                count: 0,
+                topic: "Export",
+              },
+              timestamp: expect.any(Number),
+            },
+          ],
+          "30DayDistinct": [
+            {
+              metric: {
+                aggregation: "count",
+                collection: "30DayDistinct",
+                count: 0,
+                topic: "Export",
+              },
+              timestamp: expect.any(Number),
+            },
+          ],
+          "7DayDistinct": [
+            {
+              metric: {
+                aggregation: "count",
+                collection: "7DayDistinct",
+                count: 0,
+                topic: "Export",
+              },
+              timestamp: expect.any(Number),
+            },
+          ],
         },
         Group: {
           deleted: [

--- a/core/__tests__/tasks/export/enqueue.ts
+++ b/core/__tests__/tasks/export/enqueue.ts
@@ -193,6 +193,7 @@ describe("tasks/export:enqueue", () => {
 
     afterAll(async () => {
       await record.destroy();
+      await Export.truncate();
       await destination.destroy();
       await deletedDestination.destroy();
     });

--- a/core/__tests__/tasks/record/destroy.ts
+++ b/core/__tests__/tasks/record/destroy.ts
@@ -221,7 +221,7 @@ describe("tasks/record:destroy", () => {
     await expect(record.reload()).rejects.toThrow(/does not exist anymore/);
   });
 
-  test("all related models are cleaned up", async () => {
+  test("all related models are cleaned up (except for records)", async () => {
     const record = await helper.factories.record();
     const _import = await helper.factories.import(
       undefined,
@@ -253,6 +253,6 @@ describe("tasks/record:destroy", () => {
 
     await expect(record.reload()).rejects.toThrow(/does not exist anymore/);
     await expect(_import.reload()).rejects.toThrow(/does not exist anymore/);
-    await expect(_export.reload()).rejects.toThrow(/does not exist anymore/);
+    await _export.reload(); // does not throw
   });
 });

--- a/core/__tests__/tasks/system/sweeper.ts
+++ b/core/__tests__/tasks/system/sweeper.ts
@@ -77,54 +77,56 @@ describe("tasks/sweeper", () => {
 
     test("it will delete old exports but not the newest one for each record or all exports if none is complete", async () => {
       await Export.truncate();
-      const recordA = await helper.factories.record();
-      const oldExportA = await helper.factories.export(recordA);
-      const newerExportA = await helper.factories.export(recordA);
-      const recordB = await helper.factories.record();
-      const newerExportB = await helper.factories.export(recordB);
-      const recordC = await helper.factories.record();
-      const oldExportC = await helper.factories.export(recordC);
-      const oldExportD = await helper.factories.export(recordC);
+      const destination = await helper.factories.destination();
 
+      const recordA = await helper.factories.record();
+      const oldExportA = await helper.factories.export(recordA, destination);
+      const newerExportA = await helper.factories.export(recordA, destination);
+      const recordB = await helper.factories.record();
+      const newerExportB = await helper.factories.export(recordB, destination);
+      const recordC = await helper.factories.record();
+      const oldExportC = await helper.factories.export(recordC, destination);
+      const oldExportD = await helper.factories.export(recordC, destination);
+
+      await oldExportA.update({ state: "complete" });
       oldExportA.set({ createdAt: new Date(0) }, { raw: true });
       oldExportA.changed("createdAt", true);
       await oldExportA.save({
         silent: true,
         fields: ["createdAt"],
       });
-      await oldExportA.update({ state: "complete" });
 
+      await newerExportA.update({ state: "complete" });
       newerExportA.set({ createdAt: new Date(1000 * 60 * 60) }, { raw: true });
       newerExportA.changed("createdAt", true);
       await newerExportA.save({
         silent: true,
         fields: ["createdAt"],
       });
-      await newerExportA.update({ state: "complete" });
 
+      await newerExportB.update({ state: "canceled" });
       newerExportB.set({ createdAt: new Date() }, { raw: true });
       newerExportB.changed("createdAt", true);
       await newerExportB.save({
         silent: true,
         fields: ["createdAt"],
       });
-      await newerExportB.update({ state: "canceled" });
 
+      await oldExportC.update({ state: "failed" });
       oldExportC.set({ createdAt: new Date(1000 * 60 * 60) }, { raw: true });
       oldExportC.changed("createdAt", true);
       await oldExportC.save({
         silent: true,
         fields: ["createdAt"],
       });
-      await oldExportC.update({ state: "failed" });
 
+      await oldExportD.update({ state: "canceled" });
       oldExportD.set({ createdAt: new Date(1000 * 60 * 60) }, { raw: true });
       oldExportD.changed("createdAt", true);
       await oldExportD.save({
         silent: true,
         fields: ["createdAt"],
       });
-      await oldExportD.update({ state: "canceled" });
 
       let count = await Export.count();
       expect(count).toBe(5);

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -744,11 +744,4 @@ export class Destination extends LoggedModel<Destination> {
       where: { destinationId: instance.id },
     });
   }
-
-  @AfterDestroy
-  static async destroyExports(instance: Destination) {
-    await Export.destroy({
-      where: { destinationId: instance.id },
-    });
-  }
 }

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -298,7 +298,7 @@ export class Export extends CommonModel<Export> {
     let responseCountWithNoRecord: number;
     let responseCountWithNoDestination: number;
 
-    // 1. Delete Complete Exports for the GrouparooRecord older than the oldest complete Export
+    // 1. Delete Complete Exports for the GrouparooRecord older than the oldest complete Export for this Record+Destination
     const rowsWithCompleteExport: { id: string }[] = await api.sequelize.query(
       `
       DELETE FROM exports
@@ -310,8 +310,9 @@ export class Export extends CommonModel<Export> {
           SELECT MAX("createdAt")
           FROM exports e2
           WHERE
-            e2."recordId" = exports."recordId"
-            AND state = 'complete'
+            state = 'complete'
+            AND e2."recordId" = exports."recordId"
+            AND e2."destinationId" = exports."destinationId"
         )
         LIMIT ${limit}
       )

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -288,26 +288,24 @@ export class Export extends CommonModel<Export> {
   }
 
   static async sweep(limit: number) {
-    const days = parseInt(
-      (await plugin.readSetting("core", "sweeper-delete-old-exports-days"))
-        .value
-    );
-
+    const days = 90; // keep all exports for at least 90 days
     const whereDate = Moment()
       .subtract(days, "days")
       .format("YYYY-MM-DD HH:mm:ss");
 
     // for SQLite secondary changes queries
     let responseCountWithCompleteExport: number;
-    let responseCountWithNoCompleteExports: number;
+    let responseCountWithNoRecord: number;
+    let responseCountWithNoDestination: number;
 
-    // 1. Delete Exports for the GrouparooRecord older than the oldest complete Export
+    // 1. Delete Complete Exports for the GrouparooRecord older than the oldest complete Export
     const rowsWithCompleteExport: { id: string }[] = await api.sequelize.query(
       `
       DELETE FROM exports
       WHERE id IN (
         SELECT id FROM exports
-        WHERE "createdAt" < '${whereDate}'
+        WHERE "state" IN ('complete', 'failed', 'canceled')
+        AND "createdAt" < '${whereDate}'
         AND "createdAt" < (
           SELECT MAX("createdAt")
           FROM exports e2
@@ -330,42 +328,67 @@ export class Export extends CommonModel<Export> {
       responseCountWithCompleteExport = changesRows[0]["count"];
     }
 
-    // 2. If there are no complete Exports for the GrouparooRecord, any old Exports can be deleted
-    const rowsWithNoCompleteExport: { id: string }[] =
-      await api.sequelize.query(
-        `
+    // 2. Delete exports older than the limit which no longer have a Record
+    const rowsWithNoRecord: { id: string }[] = await api.sequelize.query(
+      `
       DELETE FROM exports
       WHERE id IN (
         SELECT id FROM exports
         WHERE "createdAt" < '${whereDate}'
-        AND 0 = (
-          SELECT COUNT(id)
-          FROM exports e2
-          WHERE
-            e2."recordId" = exports."recordId"
-            AND state = 'complete'
-        )
+        AND (
+          SELECT id
+          FROM records
+          WHERE "records"."id" = "exports"."recordId"
+        ) IS NULL
         LIMIT ${limit}
       )
      ${config.sequelize.dialect === "postgres" ? "RETURNING id" : ""}
       ;`,
-        { type: QueryTypes.SELECT }
-      );
-
+      { type: QueryTypes.SELECT }
+    );
     if (config.sequelize.dialect === "sqlite") {
       const changesRows = await api.sequelize.query(
         "SELECT changes() as count;",
         { type: QueryTypes.SELECT }
       );
-      responseCountWithNoCompleteExports = changesRows[0]["count"];
+      responseCountWithNoRecord = changesRows[0]["count"];
+    }
+
+    // 3. Delete exports older than the limit which no longer have a Destination
+    const rowsWithNoDestination: { id: string }[] = await api.sequelize.query(
+      `
+          DELETE FROM exports
+          WHERE id IN (
+            SELECT id FROM exports
+            WHERE "createdAt" < '${whereDate}'
+            AND (
+              SELECT id
+              FROM destinations
+              WHERE "destinations"."id" = "exports"."destinationId"
+            ) IS NULL
+            LIMIT ${limit}
+          )
+         ${config.sequelize.dialect === "postgres" ? "RETURNING id" : ""}
+          ;`,
+      { type: QueryTypes.SELECT }
+    );
+    if (config.sequelize.dialect === "sqlite") {
+      const changesRows = await api.sequelize.query(
+        "SELECT changes() as count;",
+        { type: QueryTypes.SELECT }
+      );
+      responseCountWithNoDestination = changesRows[0]["count"];
     }
 
     return {
       count:
         config.sequelize.dialect === "postgres"
-          ? rowsWithCompleteExport.length + rowsWithNoCompleteExport.length
+          ? rowsWithCompleteExport.length +
+            rowsWithNoRecord.length +
+            rowsWithNoDestination.length
           : responseCountWithCompleteExport +
-            responseCountWithNoCompleteExports,
+            responseCountWithNoRecord +
+            responseCountWithNoDestination,
       days,
     };
   }

--- a/core/src/models/GrouparooRecord.ts
+++ b/core/src/models/GrouparooRecord.ts
@@ -307,11 +307,4 @@ export class GrouparooRecord extends LoggedModel<GrouparooRecord> {
       where: { recordId: instance.id },
     });
   }
-
-  @AfterDestroy
-  static async destroyExports(instance: GrouparooRecord) {
-    await Export.destroy({
-      where: { recordId: instance.id },
-    });
-  }
 }

--- a/core/src/modules/ops/setting.ts
+++ b/core/src/modules/ops/setting.ts
@@ -161,14 +161,6 @@ export namespace SettingOps {
       type: "number",
     },
     {
-      key: "sweeper-delete-old-exports-days",
-      title: "Sweeper: Delete Old Exports Days",
-      defaultValue: 31,
-      description:
-        "How many days should we keep Export records for on the server?  We will keep the most recent export for each Record & Destination.",
-      type: "number",
-    },
-    {
       key: "sweeper-delete-old-logs-days",
       title: "Sweeper: Delete Old Logs Days",
       defaultValue: 7,

--- a/core/src/modules/status.ts
+++ b/core/src/modules/status.ts
@@ -35,6 +35,7 @@ export namespace Status {
 
     // usage counts (we only care about some of the models)
     async () => StatusReporters.Totals.Models([GrouparooRecord, Group]),
+    async () => StatusReporters.Totals.UniqueRecordsExported(),
 
     // thing in progress
     async () => StatusReporters.Pending.pendingImports(),

--- a/core/src/modules/telemetry.ts
+++ b/core/src/modules/telemetry.ts
@@ -80,6 +80,9 @@ export namespace Telemetry {
     // usage by destination
     metrics.push(...(await StatusReporters.Totals.DestinationTotals()));
 
+    // records exported
+    metrics.push(...(await StatusReporters.Totals.UniqueRecordsExported()));
+
     errors.forEach((e, idx) => {
       if (e) {
         metrics.push({

--- a/ui/ui-components/components/visualizations/homepageWidgets.tsx
+++ b/ui/ui-components/components/visualizations/homepageWidgets.tsx
@@ -95,11 +95,13 @@ export function RecordsExported({
     <Card>
       <Card.Body>
         <Card.Title>Records Exported</Card.Title>
-        Today: {days1 >= 0 ? days1 : <Loading size="sm" />}
+        Today: {days1 >= 0 ? <strong>{days1}</strong> : <Loading size="sm" />}
         <br />
-        This Week: {days7 >= 0 ? days7 : <Loading size="sm" />}
+        Last 7 Days:{" "}
+        {days7 >= 0 ? <strong>{days7}</strong> : <Loading size="sm" />}
         <br />
-        This Month: {days30 >= 0 ? days30 : <Loading size="sm" />}
+        Last 30 Days:{" "}
+        {days30 >= 0 ? <strong>{days30}</strong> : <Loading size="sm" />}
       </Card.Body>
     </Card>
   );

--- a/ui/ui-components/components/visualizations/homepageWidgets.tsx
+++ b/ui/ui-components/components/visualizations/homepageWidgets.tsx
@@ -12,13 +12,15 @@ const maxSampleLength = 30;
 
 export function BigTotalNumber({
   statusHandler,
-  model,
+  topic,
   title,
+  collection = "totals",
   href = null,
 }: {
   statusHandler: StatusHandler;
-  model: string;
   title: string;
+  topic: string;
+  collection?: string;
   href?: string;
 }) {
   const [total, setTotal] = useState<number>(-1);
@@ -30,7 +32,7 @@ export function BigTotalNumber({
       ({ metric }: { metric: Misc.StatusMetricType }) => {
         setTotal(metric.count);
       },
-      { topic: model, collection: "totals" }
+      { topic, collection }
     );
 
     return () => {
@@ -51,7 +53,53 @@ export function BigTotalNumber({
           )}
         </Card.Title>
 
-        <span style={{ fontSize: 25 }}>{total >= 0 ? total : <Loading />}</span>
+        <h3 style={{ fontWeight: "normal" }}>
+          {total >= 0 ? total : <Loading />}
+        </h3>
+        <br />
+      </Card.Body>
+    </Card>
+  );
+}
+
+export function RecordsExported({
+  statusHandler,
+}: {
+  statusHandler: StatusHandler;
+}) {
+  const [days1, setDays1] = useState<number>(-1);
+  const [days7, setDays7] = useState<number>(-1);
+  const [days30, setDays30] = useState<number>(-1);
+
+  [1, 7, 30].forEach((n, idx) => {
+    useEffect(() => {
+      const subscriptionName = `records-exported-day-${n}`;
+
+      statusHandler.subscribe(
+        subscriptionName,
+        ({ metric }: { metric: Misc.StatusMetricType }) => {
+          if (idx === 0) return setDays1(metric.count);
+          if (idx === 1) return setDays7(metric.count);
+          if (idx === 2) return setDays30(metric.count);
+        },
+        { topic: "Export", collection: `${n}DayDistinct` }
+      );
+
+      return () => {
+        statusHandler.unsubscribe(subscriptionName);
+      };
+    }, []);
+  });
+
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Title>Records Exported</Card.Title>
+        Today: {days1 >= 0 ? days1 : <Loading size="sm" />}
+        <br />
+        This Week: {days7 >= 0 ? days7 : <Loading size="sm" />}
+        <br />
+        This Month: {days30 >= 0 ? days30 : <Loading size="sm" />}
       </Card.Body>
     </Card>
   );

--- a/ui/ui-components/components/visualizations/homepageWidgets.tsx
+++ b/ui/ui-components/components/visualizations/homepageWidgets.tsx
@@ -23,7 +23,7 @@ export function BigTotalNumber({
   collection?: string;
   href?: string;
 }) {
-  const [total, setTotal] = useState<number>(-1);
+  const [total, setTotal] = useState<number>();
   const subscriptionName = `big-total-number-${title}`;
 
   useEffect(() => {
@@ -53,9 +53,7 @@ export function BigTotalNumber({
           )}
         </Card.Title>
 
-        <h3 style={{ fontWeight: "normal" }}>
-          {total >= 0 ? total : <Loading />}
-        </h3>
+        <h3 style={{ fontWeight: "normal" }}>{total ?? <Loading />}</h3>
         <br />
       </Card.Body>
     </Card>
@@ -67,9 +65,9 @@ export function RecordsExported({
 }: {
   statusHandler: StatusHandler;
 }) {
-  const [days1, setDays1] = useState<number>(-1);
-  const [days7, setDays7] = useState<number>(-1);
-  const [days30, setDays30] = useState<number>(-1);
+  const [days1, setDays1] = useState<number>(null);
+  const [days7, setDays7] = useState<number>(null);
+  const [days30, setDays30] = useState<number>(null);
 
   [1, 7, 30].forEach((n, idx) => {
     useEffect(() => {
@@ -95,13 +93,14 @@ export function RecordsExported({
     <Card>
       <Card.Body>
         <Card.Title>Records Exported</Card.Title>
-        Today: {days1 >= 0 ? <strong>{days1}</strong> : <Loading size="sm" />}
+        Today:{" "}
+        {days1 !== null ? <strong>{days1}</strong> : <Loading size="sm" />}
         <br />
         Last 7 Days:{" "}
-        {days7 >= 0 ? <strong>{days7}</strong> : <Loading size="sm" />}
+        {days7 !== null ? <strong>{days7}</strong> : <Loading size="sm" />}
         <br />
         Last 30 Days:{" "}
-        {days30 >= 0 ? <strong>{days30}</strong> : <Loading size="sm" />}
+        {days30 !== null ? <strong>{days30}</strong> : <Loading size="sm" />}
       </Card.Body>
     </Card>
   );
@@ -399,7 +398,7 @@ export function PendingImports({
   };
 
   const [sources, setSources] = useState<ImportsBySource[]>([]);
-  const [pendingRecordsCount, setPendingRecordsCount] = useState(-1);
+  const [pendingRecordsCount, setPendingRecordsCount] = useState<number>(null);
   const [chartData, setChartData] = useState<ChartLinData>([]);
   const [pendingImportKeys, setPendingImportKeys] = useState<string[]>([]);
 
@@ -475,7 +474,9 @@ export function PendingImports({
   return (
     <Card>
       <Card.Body>
-        <Card.Title>Pending Records ({pendingRecordsCount})</Card.Title>
+        <Card.Title>
+          Pending Records ({pendingRecordsCount ?? <Loading size="sm" />})
+        </Card.Title>
         <div style={{ height: 300 }}>
           <GrouparooChart
             data={chartData}
@@ -500,7 +501,7 @@ export function PendingExports({
   };
 
   const [destinations, setDestinations] = useState<ExportsByDestination[]>([]);
-  const [pendingExportsCount, setPendingExportsCount] = useState(0);
+  const [pendingExportsCount, setPendingExportsCount] = useState(null);
   const [chartData, setChartData] = useState<ChartLinData>([]);
   const [pendingExportKeys, setPendingExportKeys] = useState<string[]>([]);
 
@@ -579,7 +580,9 @@ export function PendingExports({
   return (
     <Card>
       <Card.Body>
-        <Card.Title>Pending Exports ({pendingExportsCount})</Card.Title>
+        <Card.Title>
+          Pending Exports ({pendingExportsCount ?? <Loading size="sm" />})
+        </Card.Title>
         <div style={{ height: 300 }}>
           <GrouparooChart
             data={chartData}

--- a/ui/ui-components/pages/dashboard.tsx
+++ b/ui/ui-components/pages/dashboard.tsx
@@ -43,12 +43,6 @@ export default function Page(props) {
         </Col>
 
         <Col>
-          {/* <BigTotalNumber
-            statusHandler={statusHandler}
-            topic="Export"
-            collection="30DayDistinct"
-            title="Records Exported (Past 30 days)"
-          /> */}
           <RecordsExported statusHandler={statusHandler} />
         </Col>
       </Row>

--- a/ui/ui-components/pages/dashboard.tsx
+++ b/ui/ui-components/pages/dashboard.tsx
@@ -2,6 +2,7 @@ import Head from "next/head";
 import { Row, Col } from "react-bootstrap";
 import {
   BigTotalNumber,
+  RecordsExported,
   GroupsByNewestMember,
   RunningRuns,
   ScheduleRuns,
@@ -28,7 +29,7 @@ export default function Page(props) {
         <Col>
           <BigTotalNumber
             statusHandler={statusHandler}
-            model="GrouparooRecord"
+            topic="GrouparooRecord"
             title="Records"
           />
         </Col>
@@ -36,9 +37,19 @@ export default function Page(props) {
         <Col>
           <BigTotalNumber
             statusHandler={statusHandler}
-            model="Group"
+            topic="Group"
             title="Groups"
           />
+        </Col>
+
+        <Col>
+          {/* <BigTotalNumber
+            statusHandler={statusHandler}
+            topic="Export"
+            collection="30DayDistinct"
+            title="Records Exported (Past 30 days)"
+          /> */}
+          <RecordsExported statusHandler={statusHandler} />
         </Col>
       </Row>
 


### PR DESCRIPTION
To simplify Grouparoo Cloud's billing, we will be tracking the metric "Synced Records per Month".

1. Keep at least one Export per Destination + Record for 90 days
2. When a Record or Destination is deleted, we will still keep the most recent related Exports, to satisfy the above
3. Display Synced Exports for the last 30 days on the dashboard
4. Send Synced Exports for the last 30 days to Telemetry
 
<img width="1599" alt="Screen Shot 2021-11-02 at 12 40 39 PM" src="https://user-images.githubusercontent.com/303226/139941072-2a570972-f061-44bb-9999-62b48c96f988.png">

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
