### PR TITLE
set serverName on sentry events, allow env overriding

### DIFF
--- a/plugins/@grouparoo/sentry/src/initializers/sentry.ts
+++ b/plugins/@grouparoo/sentry/src/initializers/sentry.ts
@@ -32,9 +32,10 @@ export class SentryInitializer extends Initializer {
 
     Sentry.init({
       dsn: process.env.SENTRY_DSN,
-      environment: env,
+      environment: process.env.SENTRY_ENVIRONMENT ?? env,
       tracesSampleRate: parseFloat(process.env.SENTRY_TRACE_SAMPLE_RATE),
       release: packageJSON.version,
+      serverName: process.env.WEB_URL ?? new URL(process.env.WEB_URL).hostname,
       integrations: [
         new Sentry.Integrations.Http({ tracing: true }),
         new Tracing.Integrations.Postgres(),

--- a/plugins/@grouparoo/sentry/src/initializers/sentry.ts
+++ b/plugins/@grouparoo/sentry/src/initializers/sentry.ts
@@ -35,7 +35,9 @@ export class SentryInitializer extends Initializer {
       environment: process.env.SENTRY_ENVIRONMENT ?? env,
       tracesSampleRate: parseFloat(process.env.SENTRY_TRACE_SAMPLE_RATE),
       release: packageJSON.version,
-      serverName: process.env.WEB_URL ?? new URL(process.env.WEB_URL).hostname,
+      serverName: process.env.WEB_URL
+        ? new URL(process.env.WEB_URL).hostname
+        : undefined,
       integrations: [
         new Sentry.Integrations.Http({ tracing: true }),
         new Tracing.Integrations.Postgres(),


### PR DESCRIPTION
## Change description

- Allow the sentry env to be set via a `SENTRY_ENVIRONMENT` env var. If this isn't set, `NODE_ENV` will continue to be used. This is because we want to keep `NODE_ENV=production` on staging apps, but want sentry to report `staging` as the environment.
- Set `serverName` based on the configured `WEB_URL` environment variable. This is searchable and shows up on sentry traces and errors:

![image](https://user-images.githubusercontent.com/4368928/140185209-1fe7109f-4b6a-4ab8-888e-20e9db0dcebd.png)
![image](https://user-images.githubusercontent.com/4368928/140185351-53b33fa5-8fc7-414e-a9f8-b8a274aa36db.png)

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
