### PR TITLE
Plugin Connections can use multiple Apps

### DIFF
--- a/core/__tests__/actions/properties.ts
+++ b/core/__tests__/actions/properties.ts
@@ -487,7 +487,7 @@ describe("actions/properties", () => {
               name: "dynamic-property-options-source",
               displayName: "dynamic-property-options-source",
               description: "a test app connection",
-              app: "test-dynamic-app",
+              apps: ["test-dynamic-app"],
               direction: "import",
               options: [],
               methods: {

--- a/core/__tests__/actions/sources.ts
+++ b/core/__tests__/actions/sources.ts
@@ -124,7 +124,7 @@ describe("actions/sources", () => {
         );
       expect(error).toBeUndefined();
       expect(connectionApps[0].app.id).toBe(app.id);
-      expect(connectionApps[0].connection.app).toBe("test-plugin-app");
+      expect(connectionApps[0].connection.apps).toEqual(["test-plugin-app"]);
     });
 
     describe("options from environment variables", () => {

--- a/core/__tests__/models/app/app.ts
+++ b/core/__tests__/models/app/app.ts
@@ -414,7 +414,7 @@ describe("models/app", () => {
             name: "import-from-test-template-app",
             displayName: "import-from-test-template-app",
             description: "a test app connection",
-            app: "test-template-app",
+            apps: ["test-template-app"],
             direction: "import" as "import",
             options: [],
             methods: {

--- a/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
+++ b/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
@@ -380,7 +380,7 @@ describe("models/destination", () => {
             name: "destinationMapping-test-connection",
             displayName: "destinationMapping-test-connection",
             description: "a test app connection",
-            app: "test-destinationMapping-app",
+            apps: ["test-destinationMapping-app"],
             direction: "export",
             syncModes: ["sync", "additive", "enrich"],
             options: [],

--- a/core/__tests__/models/destination/plugins/exportRecord.ts
+++ b/core/__tests__/models/destination/plugins/exportRecord.ts
@@ -78,7 +78,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
           name: "export-from-test-app",
           displayName: "export-from-test-app",
           description: "a test app connection",
-          app: "test-template-app",
+          apps: ["test-template-app"],
           direction: "export",
           options: [],
           syncModes: ["sync", "enrich", "additive"],

--- a/core/__tests__/models/destination/plugins/exportRecords.ts
+++ b/core/__tests__/models/destination/plugins/exportRecords.ts
@@ -63,7 +63,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
           name: "export-from-test-template-app",
           displayName: "export-from-test-template-app",
           description: "a test app connection",
-          app: "test-template-app",
+          apps: ["test-template-app"],
           direction: "export",
           syncModes: ["sync", "enrich", "additive"],
           options: [],

--- a/core/__tests__/models/destination/plugins/noExportMethods.ts
+++ b/core/__tests__/models/destination/plugins/noExportMethods.ts
@@ -33,7 +33,7 @@ describe("models/destination", () => {
               name: "import-from-test-template-app",
               displayName: "import-from-test-template-app",
               description: "a test app connection",
-              app: "test-template-app",
+              apps: ["test-template-app"],
               direction: "export",
               syncModes: ["sync", "additive", "enrich"],
               options: [],

--- a/core/__tests__/models/destination/plugins/processExportedProfiles.ts
+++ b/core/__tests__/models/destination/plugins/processExportedProfiles.ts
@@ -93,7 +93,7 @@ describe("models/destination - with custom processExportedRecords", () => {
           name: "export-from-test-template-app",
           displayName: "export-from-test-template-app",
           description: "a test app connection",
-          app: "test-template-app",
+          apps: ["test-template-app"],
           direction: "export",
           syncModes: ["sync", "enrich", "additive"],
           options: [],

--- a/core/__tests__/models/option.ts
+++ b/core/__tests__/models/option.ts
@@ -229,7 +229,7 @@ describe("models/option", () => {
               name: "export-from-test-template-app",
               displayName: "export-from-test-template-app",
               description: "a test app connection",
-              app: "test-template-app",
+              apps: ["test-template-app"],
               direction: "export",
               syncModes: ["sync", "additive", "enrich"],
               options: [

--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -303,7 +303,7 @@ describe("models/property", () => {
           name: "source-no-options",
           displayName: "source-no-options",
           description: "a test source",
-          app: "app-no-options",
+          apps: ["app-no-options"],
           direction: "import",
           options: [],
           methods: {
@@ -674,7 +674,7 @@ describe("models/property", () => {
             name: "import-from-test-app",
             displayName: "import-from-test-app",
             description: "a test app",
-            app: "test-template-app",
+            apps: ["test-template-app"],
             direction: "import",
             options: [],
             methods: {

--- a/core/__tests__/models/record/record.ts
+++ b/core/__tests__/models/record/record.ts
@@ -937,7 +937,7 @@ describe("models/record", () => {
             name: "import-from-test-template-app",
             displayName: "import-from-test-template-app",
             description: "a test app connection",
-            app: "test-template-app",
+            apps: ["test-template-app"],
             direction: "import" as "import",
             options: [{ key: "table", required: true }],
             methods: {

--- a/core/__tests__/models/run/run.ts
+++ b/core/__tests__/models/run/run.ts
@@ -626,7 +626,7 @@ describe("models/run", () => {
             name: "test-error-connection",
             displayName: "test-error-connection",
             description: "a test app",
-            app: "test-error-app",
+            apps: ["test-error-app"],
             direction: "import",
             options: [{ key: "query", required: true }],
             methods: {

--- a/core/__tests__/models/schedule.ts
+++ b/core/__tests__/models/schedule.ts
@@ -312,7 +312,7 @@ describe("models/schedule", () => {
               name: "test-plugin-source-no-schedule",
               displayName: "test-plugin-source-no-schedule",
               description: "a test connection",
-              app: "test-plugin-app-no-schedule",
+              apps: ["test-plugin-app-no-schedule"],
               direction: "import",
               options: [],
               methods: {
@@ -675,7 +675,7 @@ describe("models/schedule", () => {
             name: "import-from-test-template-app",
             displayName: "import-from-test-template-app",
             description: "a test app connection",
-            app: "test-template-app",
+            apps: ["test-template-app"],
             direction: "import" as "import",
             options: [],
             methods: {

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -1613,7 +1613,7 @@ describe("modules/codeConfig", () => {
             name: "source-no-options",
             displayName: "source-no-options",
             description: "a test source",
-            app: "app-no-options",
+            apps: ["app-no-options"],
             direction: "import",
             options: [],
             methods: {

--- a/core/__tests__/modules/plugin.ts
+++ b/core/__tests__/modules/plugin.ts
@@ -34,7 +34,7 @@ describe("modules/plugin", () => {
             displayName: "sample-plugin-import",
             direction: "import",
             description: "import or update records from an uploaded file",
-            app: "sample-plugin-app",
+            apps: ["sample-plugin-app"],
             options: [],
             methods: {
               sourceOptions: async ({ sourceOptions }) => {
@@ -92,7 +92,7 @@ describe("modules/plugin", () => {
               displayName: "sample-plugin-export",
               direction: "export",
               description: "export stuff",
-              app: "sample-plugin-app",
+              apps: ["sample-plugin-app"],
               options: [],
               methods: {},
             },

--- a/core/__tests__/tasks/appRefreshQuery/query.ts
+++ b/core/__tests__/tasks/appRefreshQuery/query.ts
@@ -5,18 +5,13 @@ import {
   Schedule,
   App,
   Run,
-  plugin,
   GrouparooModel,
   AppRefreshQuery,
 } from "../../../src";
-import { RunOps } from "../../../src/modules/ops/runs";
 
 describe("tasks/appRefreshQuery:query", () => {
-  let model: GrouparooModel;
-  let source: Source;
-  let schedule: Schedule;
-
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
   beforeEach(async () => {
     await api.resque.queue.connection.redis.flushdb();
     await Run.truncate();

--- a/core/__tests__/tasks/export/send.ts
+++ b/core/__tests__/tasks/export/send.ts
@@ -153,7 +153,7 @@ describe("tasks/export:send", () => {
               name: "export-from-test-app",
               displayName: "export-from-test-app",
               description: "a test app connection",
-              app: "test-template-app",
+              apps: ["test-template-app"],
               direction: "export",
               options: [],
               methods: {

--- a/core/__tests__/tasks/export/sendBatch.ts
+++ b/core/__tests__/tasks/export/sendBatch.ts
@@ -164,7 +164,7 @@ describe("tasks/export:sendBatch", () => {
               name: "export-from-test-app",
               displayName: "export-from-test-app",
               description: "a test app connection",
-              app: "test-template-app",
+              apps: ["test-template-app"],
               direction: "export",
               options: [],
               methods: {

--- a/core/__tests__/tasks/record/export.ts
+++ b/core/__tests__/tasks/record/export.ts
@@ -87,7 +87,7 @@ describe("tasks/record:export", () => {
               name: "export-from-test-template-app",
               displayName: "export-from-test-template-app",
               description: "a test app connection",
-              app: "test-template-app",
+              apps: ["test-template-app"],
               direction: "export",
               syncModes: ["sync", "additive", "enrich"],
               options: [],

--- a/core/__tests__/tasks/recordProperty/importRecordProperties.ts
+++ b/core/__tests__/tasks/recordProperty/importRecordProperties.ts
@@ -452,7 +452,7 @@ describe("tasks/recordProperty:importRecordProperties", () => {
               name: "test-non-unique-connection",
               displayName: "test-non-unique-connection",
               description: "a test app",
-              app: "test-non-unique-app",
+              apps: ["test-non-unique-app"],
               direction: "import",
               options: [],
               groupAggregations: [AggregationMethod.Exact],

--- a/core/__tests__/tasks/schedule/run.ts
+++ b/core/__tests__/tasks/schedule/run.ts
@@ -90,7 +90,7 @@ describe("tasks/schedule:run", () => {
             name: "import-from-test-template-app",
             displayName: "import-from-test-template-app",
             description: "a test app connection",
-            app: "test-template-app",
+            apps: ["test-template-app"],
             direction: "import" as "import",
             options: [],
             methods: {

--- a/core/src/actions/apps.ts
+++ b/core/src/actions/apps.ts
@@ -77,7 +77,7 @@ export class AppOptions extends AuthenticatedAction {
           const app = plugin.apps[j];
           const source = api.plugins.plugins.find((p) =>
             p?.connections?.find(
-              (c) => c.app === app.name && c.direction === "import"
+              (c) => c.apps.includes(app.name) && c.direction === "import"
             )
           )
             ? true
@@ -85,7 +85,7 @@ export class AppOptions extends AuthenticatedAction {
 
           const destination = api.plugins.plugins.find((p) =>
             p?.connections?.find(
-              (c) => c.app === app.name && c.direction === "export"
+              (c) => c.apps.includes(app.name) && c.direction === "export"
             )
           )
             ? true

--- a/core/src/actions/destinations.ts
+++ b/core/src/actions/destinations.ts
@@ -79,22 +79,28 @@ export class DestinationConnectionApps extends AuthenticatedAction {
     const apps = await App.findAll();
     const existingAppTypes = apps.map((a) => a.type);
 
-    let importConnections = [];
+    let importConnections: PluginConnection[] = [];
     api.plugins.plugins.forEach((plugin: GrouparooPlugin) => {
       if (plugin.connections) {
         plugin.connections
           .filter((c) => c.direction === "export")
-          .filter((c) => existingAppTypes.includes(c.app))
+          .filter((c) => {
+            let match = false;
+            for (const app of c.apps) {
+              if (existingAppTypes.includes(app)) match = true;
+            }
+            return match;
+          })
           .map((c) => importConnections.push(c));
       }
     });
 
-    for (const i in apps) {
-      for (const j in importConnections) {
-        if (apps[i].type === importConnections[j].app) {
+    for (const app of apps) {
+      for (const connection of importConnections) {
+        if (connection.apps.includes(app.type)) {
           connectionApps.push({
-            app: await apps[i].apiData(),
-            connection: importConnections[j],
+            app: await app.apiData(),
+            connection,
           });
         }
       }

--- a/core/src/actions/sources.ts
+++ b/core/src/actions/sources.ts
@@ -74,22 +74,28 @@ export class SourceConnectionApps extends AuthenticatedAction {
       connection: PluginConnection;
     }> = [];
 
-    let importConnections = [];
+    let importConnections: PluginConnection[] = [];
     api.plugins.plugins.forEach((plugin: GrouparooPlugin) => {
       if (plugin.connections) {
         plugin.connections
           .filter((c) => c.direction === "import")
-          .filter((c) => existingAppTypes.includes(c.app))
+          .filter((c) => {
+            let match = false;
+            for (const app of c.apps) {
+              if (existingAppTypes.includes(app)) match = true;
+            }
+            return match;
+          })
           .map((c) => importConnections.push(c));
       }
     });
 
-    for (const i in apps) {
-      for (const j in importConnections) {
-        if (apps[i].type === importConnections[j].app) {
+    for (const app of apps) {
+      for (const connection of importConnections) {
+        if (connection.apps.includes(app.type)) {
           connectionApps.push({
-            app: await apps[i].apiData(),
-            connection: importConnections[j],
+            app: await app.apiData(),
+            connection,
           });
         }
       }

--- a/core/src/classes/plugin.ts
+++ b/core/src/classes/plugin.ts
@@ -74,7 +74,7 @@ export interface PluginConnection {
   description: string;
   direction: "import" | "export";
   skipSourceMapping?: boolean;
-  app: string;
+  apps: string[];
   options: ConnectionOptionsOption[];
   syncModes?: DestinationSyncMode[];
   defaultSyncMode?: DestinationSyncMode;

--- a/core/src/initializers/plugins.ts
+++ b/core/src/initializers/plugins.ts
@@ -164,7 +164,7 @@ export class Plugins extends Initializer {
             .includes(connection.name)
         ) {
           errors.push(
-            `a plugin connection named ${connection.name} is already registered (${connection.name})`
+            `a plugin connection named ${connection.name} is already registered`
           );
         }
         if (!connection.apps || connection.apps.length < 1) {

--- a/core/src/initializers/plugins.ts
+++ b/core/src/initializers/plugins.ts
@@ -164,32 +164,32 @@ export class Plugins extends Initializer {
             .includes(connection.name)
         ) {
           errors.push(
-            `a plugin connection named ${connection.name} is already registered`
+            `a plugin connection named ${connection.name} is already registered (${connection.name})`
           );
         }
-        if (!connection.app) {
+        if (!connection.apps || connection.apps.length < 1) {
           errors.push(
-            `connection.app is required for a Grouparoo Plugin Connection`
+            `connection.apps is required for a Grouparoo Plugin Connection (${connection.name})`
           );
         }
         if (!connection.description) {
           errors.push(
-            `connection.description is required for a Grouparoo Plugin Connection`
+            `connection.description is required for a Grouparoo Plugin Connection (${connection.name})`
           );
         }
         if (!connection.direction) {
           errors.push(
-            `connection.direction is required for a Grouparoo Plugin Connection`
+            `connection.direction is required for a Grouparoo Plugin Connection (${connection.name})`
           );
         }
         if (!connection.options) {
           errors.push(
-            `connection.options is required for a Grouparoo Plugin Connection`
+            `connection.options is required for a Grouparoo Plugin Connection (${connection.name})`
           );
         }
         if (!["import", "export"].includes(connection.direction)) {
           errors.push(
-            `connection.direction must be either import or export for a Grouparoo Plugin Connection`
+            `connection.direction must be either import or export for a Grouparoo Plugin Connection (${connection.name})`
           );
         }
         if (
@@ -199,7 +199,7 @@ export class Plugins extends Initializer {
           !connection.methods.recordProperties
         ) {
           errors.push(
-            `import connections must provide a way to import records`
+            `import connections must provide a way to import records (${connection.name})`
           );
         }
         if (
@@ -208,7 +208,7 @@ export class Plugins extends Initializer {
           !connection.methods.exportRecords
         ) {
           errors.push(
-            `export connections must provide either connection.methods.exportRecord or connection.methods.exportRecords`
+            `export connections must provide either connection.methods.exportRecord or connection.methods.exportRecords (${connection.name})`
           );
         }
       });

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -219,7 +219,7 @@ export class App extends LoggedModel<App> {
   provides() {
     const source = api.plugins.plugins.find((p) =>
       p?.connections?.find(
-        (c) => c.app === this.type && c.direction === "import"
+        (c) => c.apps.includes(this.type) && c.direction === "import"
       )
     )
       ? true
@@ -227,7 +227,7 @@ export class App extends LoggedModel<App> {
 
     const destination = api.plugins.plugins.find((p) =>
       p?.connections?.find(
-        (c) => c.app === this.type && c.direction === "export"
+        (c) => c.apps.includes(this.type) && c.direction === "export"
       )
     )
       ? true

--- a/plugins/@grouparoo/app-templates/src/source/query/meta.ts
+++ b/plugins/@grouparoo/app-templates/src/source/query/meta.ts
@@ -64,7 +64,7 @@ export const buildConnection: BuildConnectionMethod = ({
     displayName,
     direction: "import",
     description,
-    app,
+    apps: [app],
     options,
     skipSourceMapping: true,
     groupAggregations: [],

--- a/plugins/@grouparoo/app-templates/src/source/query/meta.ts
+++ b/plugins/@grouparoo/app-templates/src/source/query/meta.ts
@@ -22,7 +22,7 @@ export interface BuildConnectionMethod {
     name: string;
     displayName: string;
     description: string;
-    app: string;
+    apps: string[];
     tableOptionDescription?: string;
     tableOptionDisplayName?: string;
     options?: ConnectionOptionsOption[];
@@ -37,7 +37,7 @@ export const buildConnection: BuildConnectionMethod = ({
   name,
   displayName,
   description,
-  app,
+  apps,
   tableOptionDescription = null,
   options = [],
   executeQuery,
@@ -64,7 +64,7 @@ export const buildConnection: BuildConnectionMethod = ({
     displayName,
     direction: "import",
     description,
-    apps: [app],
+    apps,
     options,
     skipSourceMapping: true,
     groupAggregations: [],

--- a/plugins/@grouparoo/app-templates/src/source/table/meta.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/meta.ts
@@ -120,7 +120,7 @@ export const buildConnection: BuildConnectionMethod = ({
     displayName,
     direction: "import",
     description,
-    app,
+    apps: [app],
     options,
     groupAggregations: [AggregationMethod.Exact],
     methods: {

--- a/plugins/@grouparoo/app-templates/src/source/table/meta.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/meta.ts
@@ -37,7 +37,7 @@ export interface BuildConnectionMethod {
     name: string;
     displayName: string;
     description: string;
-    app: string;
+    apps: string[];
     tableOptionDescription?: string;
     tableOptionDisplayName?: string;
     sourceOptions?: SourceOptionsExtra;
@@ -55,7 +55,7 @@ export const buildConnection: BuildConnectionMethod = ({
   name,
   displayName,
   description,
-  app,
+  apps,
   tableOptionDescription = null,
   tableOptionDisplayName = null,
   sourceOptions: additionalOptions,
@@ -120,7 +120,7 @@ export const buildConnection: BuildConnectionMethod = ({
     displayName,
     direction: "import",
     description,
-    apps: [app],
+    apps,
     options,
     groupAggregations: [AggregationMethod.Exact],
     methods: {

--- a/plugins/@grouparoo/bigquery/src/lib/query-import/connection.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/query-import/connection.ts
@@ -4,7 +4,7 @@ import { getChangedRows } from "./getChangedRows";
 
 export function getConnection() {
   return buildConnection({
-    app: "bigquery",
+    apps: ["bigquery"],
     name: "bigquery-import-query",
     displayName: "BigQuery Query Import",
     description: "Import or update records via a custom Bigquery query.",

--- a/plugins/@grouparoo/bigquery/src/lib/table-import/connection.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/table-import/connection.ts
@@ -9,7 +9,7 @@ import { getChangedRowCount } from "./getChangedRowCount";
 
 export function getConnection() {
   return buildConnection({
-    app: "bigquery",
+    apps: ["bigquery"],
     name: "bigquery-import-table",
     displayName: "BigQuery Table Import",
     description: "Import or update Records from a Bigquery database table.",

--- a/plugins/@grouparoo/braze/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/braze/src/initializers/plugin.ts
@@ -70,7 +70,7 @@ export class Plugins extends Initializer {
           direction: "export",
           description:
             "Export Users to Braze and add them to Subscription Groups.",
-          app: "braze",
+          apps: ["braze"],
           syncModes,
           defaultSyncMode,
           options: [],

--- a/plugins/@grouparoo/calculated-property/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/calculated-property/src/initializers/plugin.ts
@@ -43,7 +43,7 @@ export class Plugins extends Initializer {
           direction: "import",
           description:
             "Import and calculate Calculated Properties from other sources",
-          app: "calculated-property",
+          apps: ["calculated-property"],
           groupAggregations: [],
           options: [],
           methods: {

--- a/plugins/@grouparoo/csv/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/csv/src/initializers/plugin.ts
@@ -45,7 +45,7 @@ export class Plugins extends Initializer {
           displayName: "CSV Table Import",
           direction: "import",
           description: "Import or update Records from a remote CSV.",
-          app: "csv",
+          apps: ["csv"],
           groupAggregations: [AggregationMethod.Exact],
           options: [
             {

--- a/plugins/@grouparoo/customerio/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/customerio/src/initializers/plugin.ts
@@ -73,7 +73,7 @@ export class Plugins extends Initializer {
           displayName: "Customer.io Export Customers",
           direction: "export",
           description: "Export records to customer.io as Customers",
-          app: "customerio",
+          apps: ["customerio"],
           syncModes,
           defaultSyncMode,
           options: [],

--- a/plugins/@grouparoo/eloqua/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/eloqua/src/initializers/plugin.ts
@@ -74,7 +74,7 @@ export class Plugins extends Initializer {
           displayName: "Eloqua Export Contacts",
           direction: "export",
           description: "Export records to Eloqua as Contacts",
-          app: "eloqua",
+          apps: ["eloqua"],
           syncModes,
           defaultSyncMode,
           options: [],

--- a/plugins/@grouparoo/facebook/src/lib/export-custom/connection.ts
+++ b/plugins/@grouparoo/facebook/src/lib/export-custom/connection.ts
@@ -12,7 +12,7 @@ export function buildConnection(): PluginConnection {
     displayName: "Facebook Export Custom Audiences",
     direction: "export",
     description: "Export to Facebook Custom Audiences",
-    app: "facebook",
+    apps: ["facebook"],
     syncModes: supportedSyncModes,
     options: [
       {

--- a/plugins/@grouparoo/facebook/src/lib/export-lookalike/connection.ts
+++ b/plugins/@grouparoo/facebook/src/lib/export-lookalike/connection.ts
@@ -11,7 +11,7 @@ export function buildConnection(): PluginConnection {
     displayName: "Facebook Export Audiences Lookalike",
     direction: "export",
     description: "Adds users to Facebook Lookalike Audiences.",
-    app: "facebook",
+    apps: ["facebook"],
     options: [
       {
         key: "primaryKey",

--- a/plugins/@grouparoo/google-sheets/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/google-sheets/src/initializers/plugin.ts
@@ -63,7 +63,7 @@ export class Plugins extends Initializer {
           displayName: "Google Sheets Import",
           direction: "import",
           description: "Import or update Records from a Google Sheet.",
-          app: "google-sheets",
+          apps: ["google-sheets"],
           options: [
             {
               key: "sheet_url",

--- a/plugins/@grouparoo/hubspot/src/lib/export-contacts/connection.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/export-contacts/connection.ts
@@ -17,7 +17,7 @@ export const contactsDestinationConnection: PluginConnection = {
   direction: "export",
   description:
     "Export Records as Hubspot Contacts and add them to Contact Lists.",
-  app: "hubspot",
+  apps: ["hubspot"],
   syncModes: contactsSupportedSyncModes,
   defaultSyncMode: "sync",
   options: [],

--- a/plugins/@grouparoo/hubspot/src/lib/export-objects/connection.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/export-objects/connection.ts
@@ -17,7 +17,7 @@ export const objectsDestinationConnection: PluginConnection = {
   direction: "export",
   description:
     "Export Records as Hubspot Custom Objects or Hubspot standard objects.",
-  app: "hubspot",
+  apps: ["hubspot"],
   syncModes: objectsSupportedSyncModes,
   defaultSyncMode: "sync",
   options: [

--- a/plugins/@grouparoo/intercom/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/intercom/src/initializers/plugin.ts
@@ -60,7 +60,7 @@ export class Plugins extends Initializer {
           displayName: "Intercom Export Contacts",
           direction: "export",
           description: "Export Records to contacts in an Intercom account.",
-          app: "intercom",
+          apps: ["intercom"],
           syncModes,
           options: [
             {

--- a/plugins/@grouparoo/iterable/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/iterable/src/initializers/plugin.ts
@@ -62,7 +62,7 @@ export class Plugins extends Initializer {
           direction: "export",
           description:
             "Export records to Iterable as Users and put them in static Lists.",
-          app: "iterable",
+          apps: ["iterable"],
           syncModes,
           defaultSyncMode,
           options: [],

--- a/plugins/@grouparoo/logger/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/logger/src/initializers/plugin.ts
@@ -63,7 +63,7 @@ export class Plugins extends Initializer {
           displayName: "Logger Export Records",
           direction: "export",
           description: "Export Records to a log file as JSON.",
-          app: "logger",
+          apps: ["logger"],
           options: [],
           methods: {
             exportRecords,

--- a/plugins/@grouparoo/mailchimp/src/lib/export-id/connection.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/export-id/connection.ts
@@ -13,7 +13,7 @@ export const idDestinationConnection: PluginConnection = {
   direction: "export",
   description:
     "Updates existing contacts in a Mailchimp list based on a known Mailchimp ID.",
-  app: "mailchimp",
+  apps: ["mailchimp"],
   syncModes: idSupportedSyncModes,
   defaultSyncMode: "enrich",
   options: [

--- a/plugins/@grouparoo/mailchimp/src/lib/export/connection.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/export/connection.ts
@@ -16,7 +16,7 @@ export const emailDestinationConnection: PluginConnection = {
   displayName: "Mailchimp Export Contacts",
   direction: "export",
   description: "Export Records to a Mailchimp list with MergeVars and Tags.",
-  app: "mailchimp",
+  apps: ["mailchimp"],
   syncModes: emailSupportedSyncModes,
   defaultSyncMode: "sync",
   options: [

--- a/plugins/@grouparoo/mailchimp/src/lib/import/connection.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/import/connection.ts
@@ -10,7 +10,7 @@ const connection: PluginConnection = {
   displayName: "Mailchimp Import Contacts",
   direction: "import",
   description: "Import or update records with data from Mailchimp contacts.",
-  app: "mailchimp",
+  apps: ["mailchimp"],
   options: [
     {
       key: "listId",

--- a/plugins/@grouparoo/mailjet/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mailjet/src/initializers/plugin.ts
@@ -69,7 +69,7 @@ export class Plugins extends Initializer {
           direction: "export",
           description:
             "Export Records to Mailjet and add them to Contact Lists.",
-          app: "mailjet",
+          apps: ["mailjet"],
           syncModes,
           defaultSyncMode,
           options: [],

--- a/plugins/@grouparoo/marketo/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/marketo/src/initializers/plugin.ts
@@ -82,7 +82,7 @@ export class Plugins extends Initializer {
           displayName: "Marketo Export Leads",
           direction: "export",
           description: "Export Records to a Marketo account.",
-          app: "marketo",
+          apps: ["marketo"],
           syncModes,
           defaultSyncMode,
           options: [],

--- a/plugins/@grouparoo/mixpanel/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mixpanel/src/initializers/plugin.ts
@@ -80,7 +80,7 @@ export class Plugins extends Initializer {
           displayName: "Mixpanel Export Profiles",
           direction: "export",
           description: "Export Records to Mixpanel as User Profiles",
-          app: "mixpanel",
+          apps: ["mixpanel"],
           syncModes,
           defaultSyncMode,
           options: [],

--- a/plugins/@grouparoo/mongo/src/lib/query-import/connection.ts
+++ b/plugins/@grouparoo/mongo/src/lib/query-import/connection.ts
@@ -6,7 +6,7 @@ import { validateQuery } from "./validateQuery";
 
 export function getConnection() {
   return buildConnection({
-    app: "mongo",
+    apps: ["mongo"],
     name: "mongo-import-query",
     displayName: "MongoDB Query Import",
     description:

--- a/plugins/@grouparoo/mongo/src/lib/table-import/connection.ts
+++ b/plugins/@grouparoo/mongo/src/lib/table-import/connection.ts
@@ -9,7 +9,7 @@ import { getChangedRowCount } from "./getChangedRowCount";
 
 export function getConnection() {
   return buildConnection({
-    app: "mongo",
+    apps: ["mongo"],
     name: "mongo-import-table",
     displayName: "MongoDB Table Import",
     description:

--- a/plugins/@grouparoo/mysql/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mysql/src/initializers/plugin.ts
@@ -110,7 +110,7 @@ export class Plugins extends Initializer {
           direction: "export",
           description:
             "Export Records to a MySQL table.  Groups will be exported to a secondary table linked by a foreign key.",
-          app: "mysql",
+          apps: ["mysql"],
           options: [
             {
               key: "table",

--- a/plugins/@grouparoo/mysql/src/lib/query-import/connection.ts
+++ b/plugins/@grouparoo/mysql/src/lib/query-import/connection.ts
@@ -4,7 +4,7 @@ import { getChangedRows } from "./getChangedRows";
 
 export function getConnection() {
   return buildConnection({
-    app: "mysql",
+    apps: ["mysql"],
     name: "mysql-import-query",
     displayName: "MySQL Query Import",
     description: "Import or update Records via a custom MySQL query.",

--- a/plugins/@grouparoo/mysql/src/lib/table-import/connection.ts
+++ b/plugins/@grouparoo/mysql/src/lib/table-import/connection.ts
@@ -9,7 +9,7 @@ import { getChangedRowCount } from "./getChangedRowCount";
 
 export function getConnection() {
   return buildConnection({
-    app: "mysql",
+    apps: ["mysql"],
     name: "mysql-import-table",
     displayName: "MySQL Table Import",
     description: "Import or update Records from a MySQL database table.",

--- a/plugins/@grouparoo/onesignal/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/onesignal/src/initializers/plugin.ts
@@ -69,7 +69,7 @@ export class Plugins extends Initializer {
           direction: "export",
           description:
             "Enrich OneSignal devices with record and group information as tags",
-          app: "onesignal",
+          apps: ["onesignal"],
           syncModes,
           defaultSyncMode,
           options: [],

--- a/plugins/@grouparoo/pardot/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/pardot/src/initializers/plugin.ts
@@ -97,7 +97,7 @@ export class Plugins extends Initializer {
           direction: "export",
           description:
             "Export Records and Groups to Pardot as Prospects and Lists",
-          app: "pardot",
+          apps: ["pardot"],
           syncModes,
           defaultSyncMode,
           options: [],

--- a/plugins/@grouparoo/pipedrive/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/pipedrive/src/initializers/plugin.ts
@@ -61,7 +61,7 @@ export class Plugins extends Initializer {
           displayName: "Pipedrive Export Persons",
           direction: "export",
           description: "Export records to Pipedrive as Person contacts",
-          app: "pipedrive",
+          apps: ["pipedrive"],
           syncModes,
           defaultSyncMode,
           options: [],

--- a/plugins/@grouparoo/postgres/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/postgres/src/initializers/plugin.ts
@@ -143,7 +143,7 @@ export class Plugins extends Initializer {
           direction: "export",
           description:
             "Export Records to a Postgres table.  Groups will be exported to a secondary table linked by a foreign key.",
-          app: "postgres",
+          apps: ["postgres"],
           syncModes,
           defaultSyncMode,
           options: [

--- a/plugins/@grouparoo/postgres/src/lib/query-import/connection.ts
+++ b/plugins/@grouparoo/postgres/src/lib/query-import/connection.ts
@@ -4,7 +4,7 @@ import { getChangedRows } from "./getChangedRows";
 
 export function getConnection() {
   return buildConnection({
-    app: "postgres",
+    apps: ["postgres"],
     name: "postgres-import-query",
     displayName: "Postgres Query Import",
     description: "Import or update Records via a custom Postgres query.",

--- a/plugins/@grouparoo/postgres/src/lib/table-import/connection.ts
+++ b/plugins/@grouparoo/postgres/src/lib/table-import/connection.ts
@@ -9,7 +9,7 @@ import { getChangedRowCount } from "./getChangedRowCount";
 
 export function getConnection() {
   return buildConnection({
-    app: "postgres",
+    apps: ["postgres"],
     name: "postgres-import-table",
     displayName: "Postgres Table Import",
     description: "Import or update Records from a Postgres database table.",

--- a/plugins/@grouparoo/redshift/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/redshift/src/initializers/plugin.ts
@@ -142,7 +142,7 @@ export class Plugins extends Initializer {
           direction: "export",
           description:
             "Export Records to a Redshift table.  Groups will be exported to a secondary table linked by a foreign key.",
-          app: "redshift",
+          apps: ["redshift"],
           syncModes,
           defaultSyncMode,
           options: [

--- a/plugins/@grouparoo/redshift/src/lib/query-import/connection.ts
+++ b/plugins/@grouparoo/redshift/src/lib/query-import/connection.ts
@@ -3,7 +3,7 @@ import { executeQuery } from "@grouparoo/postgres/dist/lib/query-import/executeQ
 
 export function getConnection() {
   return buildConnection({
-    app: "redshift",
+    apps: ["redshift"],
     name: "redshift-import-query",
     displayName: "Redshift Query Import",
     description: "Import or update Records via a custom Redshift query.",

--- a/plugins/@grouparoo/redshift/src/lib/table-import/connection.ts
+++ b/plugins/@grouparoo/redshift/src/lib/table-import/connection.ts
@@ -9,7 +9,7 @@ import { getChangedRowCount } from "@grouparoo/postgres/dist/lib/table-import/ge
 
 export function getConnection() {
   return buildConnection({
-    app: "redshift",
+    apps: ["redshift"],
     name: "redshift-import-table",
     displayName: "Redshift Table Import",
     description: "Import or update Records from a Redshift database table.",

--- a/plugins/@grouparoo/sailthru/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/sailthru/src/initializers/plugin.ts
@@ -66,7 +66,7 @@ export class Plugins extends Initializer {
           displayName: "SailThru Export Users",
           direction: "export",
           description: "Export Records to Sailthru.",
-          app: "sailthru",
+          apps: ["sailthru"],
           syncModes,
           defaultSyncMode,
           options: [],

--- a/plugins/@grouparoo/salesforce/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/salesforce/src/initializers/plugin.ts
@@ -80,7 +80,7 @@ export class Plugins extends Initializer {
           direction: "export",
           description:
             "Export Records and Groups to Salesforce sales cloud objects.",
-          app: "salesforce",
+          apps: ["salesforce"],
           syncModes,
           options: [
             {

--- a/plugins/@grouparoo/sendgrid/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/sendgrid/src/initializers/plugin.ts
@@ -62,7 +62,7 @@ export class Plugins extends Initializer {
           direction: "export",
           description:
             "Export records to Sendgrid marketing as Contacts and put them in static Lists.",
-          app: "sendgrid",
+          apps: ["sendgrid"],
           syncModes,
           defaultSyncMode,
           options: [],

--- a/plugins/@grouparoo/snowflake/src/lib/query-import/connection.ts
+++ b/plugins/@grouparoo/snowflake/src/lib/query-import/connection.ts
@@ -4,7 +4,7 @@ import { getChangedRows } from "./getChangedRows";
 
 export function getConnection() {
   return buildConnection({
-    app: "snowflake",
+    apps: ["snowflake"],
     name: "snowflake-import-query",
     displayName: "Snowflake Query Import",
     description: "Import or update records via a custom Snowflake query.",

--- a/plugins/@grouparoo/snowflake/src/lib/table-import/connection.ts
+++ b/plugins/@grouparoo/snowflake/src/lib/table-import/connection.ts
@@ -9,7 +9,7 @@ import { getChangedRowCount } from "./getChangedRowCount";
 
 export function getConnection() {
   return buildConnection({
-    app: "snowflake",
+    apps: ["snowflake"],
     name: "snowflake-import-table",
     displayName: "Snowflake Table Import",
     description: "Import or update Records from a Snowflake database table.",

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -299,7 +299,7 @@ export namespace helper {
           displayName: "test-plugin-import",
           direction: "import",
           description: "import or update records from a table",
-          app: "test-plugin-app",
+          apps: ["test-plugin-app"],
           options: [
             { key: "table", required: true },
             { key: "where", required: false },
@@ -410,7 +410,7 @@ export namespace helper {
           displayName: "test-plugin-export",
           direction: "export",
           description: "export records to nowhere",
-          app: "test-plugin-app",
+          apps: ["test-plugin-app"],
           syncModes: ["sync", "enrich", "additive"],
           options: [
             { key: "table", required: true },
@@ -466,7 +466,7 @@ export namespace helper {
           displayName: "test-plugin-export-batch",
           direction: "export",
           description: "export records to nowhere",
-          app: "test-plugin-app",
+          apps: ["test-plugin-app"],
           syncModes: ["sync", "enrich", "additive"],
           defaultSyncMode: "additive",
           options: [

--- a/plugins/@grouparoo/sqlite/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/sqlite/src/initializers/plugin.ts
@@ -84,7 +84,7 @@ export class Plugins extends Initializer {
           direction: "export",
           description:
             "Export Records to a SQLite table. Groups will be exported to a secondary table linked by a foreign key.",
-          app: "sqlite",
+          apps: ["sqlite"],
           syncModes,
           defaultSyncMode,
           options: [

--- a/plugins/@grouparoo/sqlite/src/lib/query-import/connection.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/query-import/connection.ts
@@ -4,7 +4,7 @@ import { getChangedRows } from "./getChangedRows";
 
 export function getConnection() {
   return buildConnection({
-    app: "sqlite",
+    apps: ["sqlite"],
     name: "sqlite-import-query",
     displayName: "SQLite Query Import",
     description: "Import or update Records via a custom SQLite query.",

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/connection.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/connection.ts
@@ -9,7 +9,7 @@ import { getChangedRowCount } from "./getChangedRowCount";
 
 export function getConnection() {
   return buildConnection({
-    app: "sqlite",
+    apps: ["sqlite"],
     name: "sqlite-import-table",
     displayName: "SQLite Table Import",
     description: "Import or update Records from a SQLite database table.",

--- a/plugins/@grouparoo/zendesk/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/zendesk/src/initializers/plugin.ts
@@ -73,7 +73,7 @@ export class Plugins extends Initializer {
           displayName: "Zendesk Export Users",
           direction: "export",
           description: "Export Records to a Zendesk account.",
-          app: "zendesk",
+          apps: ["zendesk"],
           syncModes,
           defaultSyncMode,
           options: [],


### PR DESCRIPTION
Now, Plugin Connections (import and export) can use more than one app type.  This opens the door for multiple ways of connecting to apps - perhaps there's an oAuth app and a user/password app, or a PEM vs user/password way to connect.  More to come!

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
