### PR TITLE
Fix redirects and multiplePropertyOptions

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
@@ -89,7 +89,10 @@ export default function Page(props) {
       propertiesHandler.set([response.property]);
       if (response.property.state === "ready" && property.state === "draft") {
         successHandler.set({ message: "Property Created" });
-        router.push(nextPage || `/model/${source.modelId}/properties`);
+        router.push(
+          nextPage ||
+            `/model/${source.modelId}/source/${property.sourceId}/overview`
+        );
       } else {
         setLoading(false);
         successHandler.set({ message: "Property Updated" });
@@ -113,7 +116,10 @@ export default function Page(props) {
       setLoading(false);
       if (success) {
         successHandler.set({ message: "Property Deleted" });
-        router.push(nextPage || `/model/${source.modelId}/properties`);
+        router.push(
+          nextPage ||
+            `/model/${source.modelId}/source/${property.sourceId}/overview`
+        );
       }
     }
   }

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState } from "react";
 import { UseApi } from "../../../../../hooks/useApi";
-import { Alert, Row, Col, Table, Form, Button } from "react-bootstrap";
+import { Alert, Row, Col, Table, Form } from "react-bootstrap";
 import PageHeader from "../../../../../components/PageHeader";
 import StateBadge from "../../../../../components/badges/StateBadge";
 import LockedBadge from "../../../../../components/badges/LockedBadge";
@@ -51,8 +51,6 @@ export default function Page(props) {
     return { key: dpo.key, defaultValue: defaultOpt.key };
   });
 
-  console.log(optionWithDefaultOptionDefaults);
-
   async function loadProperties() {
     const response: Actions.PropertiesList = await execApi(
       "get",
@@ -79,7 +77,7 @@ export default function Page(props) {
       if (property.filters?.length > 0) continue;
 
       let optMatch = true;
-      for (const key of Object.keys(property.options)) {
+      for (const [key, value] of Object.entries(property.options)) {
         if (key === primaryOptionKey) continue;
         if (!optionWithDefaults.map((dpo) => dpo.key).includes(key)) {
           optMatch = false;
@@ -87,10 +85,7 @@ export default function Page(props) {
         let defaultValue = optionWithDefaultOptionDefaults.find(
           (o) => o.key === key
         );
-        if (
-          defaultValue &&
-          defaultValue.defaultValue !== property.options[key]
-        ) {
+        if (defaultValue && defaultValue.defaultValue !== value) {
           optMatch = false;
         }
       }
@@ -148,9 +143,10 @@ export default function Page(props) {
       );
       if (response.property) {
         successHandler.set({ message: "Property Created!" });
-        await loadProperties();
+        loadProperties();
+      } else {
+        setLoading(false);
       }
-      setLoading(false);
     }
 
     return (


### PR DESCRIPTION
Fixes:
* A bug which would prevent the `multipleProperties` page from rendering existing properties properly
* Return the user so the `source/overview` page after editing or deleting a property, not `/properties/list`

Description here

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
