### PR TITLE
Fix `APIData.ensureObject` optional recusion flag

### DIFF
--- a/core/__tests__/modules/apiData.ts
+++ b/core/__tests__/modules/apiData.ts
@@ -89,6 +89,11 @@ describe("apiDAta", () => {
       expect(APIData.ensureObject(JSON.stringify(obj))).toEqual(obj);
     });
 
+    test("it works for stringified arrays", () => {
+      const obj = "[a,b,1,2]";
+      expect(APIData.ensureObject(JSON.stringify(obj))).toEqual(obj);
+    });
+
     test("it works for partially stringified arrays", () => {
       const obj = [
         JSON.stringify({ a: 1, b: 2, c: "three" }),

--- a/core/src/modules/apiData.ts
+++ b/core/src/modules/apiData.ts
@@ -1,13 +1,16 @@
+import { Api } from "actionhero";
+
 export namespace APIData {
   export function ensureObject(
     param: { [key: string]: any } | string,
+    api: Api,
     recursing = false
   ) {
     if (!param) {
       return null;
     } else if (Array.isArray(param)) {
       try {
-        return param.map((row) => APIData.ensureObject(row, true));
+        return param.map((row) => APIData.ensureObject(row, api, true));
       } catch (error) {
         throw new Error(
           `${param} cannot be converted to JSON object (${error})`

--- a/core/src/modules/apiData.ts
+++ b/core/src/modules/apiData.ts
@@ -3,7 +3,7 @@ import { Api } from "actionhero";
 export namespace APIData {
   export function ensureObject(
     param: { [key: string]: any } | string,
-    api: Api,
+    api?: Api,
     recursing = false
   ) {
     if (!param) {


### PR DESCRIPTION
Fixes a bug in our API's input formatter - the second option was always `api` when called from an action.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
