### PR TITLE
Ignore pnpm-lock from Prettier formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml


### PR DESCRIPTION
## Change description

I noticed that by enabling Prettier on vscode when saving it was rewriting the pnpm-lock file while I was resolving a conflict, so this change prevents auto-formatting from happening on the file, which causes the single quotes used in the file to switch to double quotes.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
