### PR TITLE
Disable Telemetry in Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,8 @@ jobs:
             - ui/ui-config/.next
             - ui/ui-enterprise/.next
   license-checker:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -202,6 +204,8 @@ jobs:
           name: license-checker
           command: ./tools/license-checker/check
   spell-checker:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -236,6 +240,8 @@ jobs:
           name: spell-checker
           command: ./tools/spell-checker/check
   linter:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -270,6 +276,8 @@ jobs:
           name: linter
           command: pnpm run lint
   test-core-actions:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -323,6 +331,8 @@ jobs:
           name: test
           command: cd core && ./node_modules/.bin/jest __tests__/actions --ci --maxWorkers 2
   test-core-bin:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -376,6 +386,8 @@ jobs:
           name: test
           command: cd core && ./node_modules/.bin/jest __tests__/bin --ci --maxWorkers 2
   test-core-classes:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -429,6 +441,8 @@ jobs:
           name: test
           command: cd core && ./node_modules/.bin/jest __tests__/classes --ci --maxWorkers 2
   test-core-initializers:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -482,6 +496,8 @@ jobs:
           name: test
           command: cd core && ./node_modules/.bin/jest __tests__/initializers --ci --maxWorkers 2
   test-core-integration:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -535,6 +551,8 @@ jobs:
           name: test
           command: cd core && ./node_modules/.bin/jest __tests__/integration --ci --maxWorkers 2
   test-core-models:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -588,6 +606,8 @@ jobs:
           name: test
           command: cd core && ./node_modules/.bin/jest __tests__/models --ci --maxWorkers 2
   test-core-modules:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -641,6 +661,8 @@ jobs:
           name: test
           command: cd core && ./node_modules/.bin/jest __tests__/modules --ci --maxWorkers 2
   test-core-notifiers:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -694,6 +716,8 @@ jobs:
           name: test
           command: cd core && ./node_modules/.bin/jest __tests__/notifiers --ci --maxWorkers 2
   test-core-snapshots:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -747,6 +771,8 @@ jobs:
           name: test
           command: cd core && ./node_modules/.bin/jest __tests__/snapshots --ci --maxWorkers 2
   test-core-tasks:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -800,6 +826,8 @@ jobs:
           name: test
           command: cd core && ./node_modules/.bin/jest __tests__/tasks --ci --maxWorkers 2
   test-core-local-models:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -837,6 +865,8 @@ jobs:
           environment:
             DB_DIALECT: sqlite
   test-core-local-actions:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -874,6 +904,8 @@ jobs:
           environment:
             DB_DIALECT: sqlite
   test-core-local-tasks:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -911,6 +943,8 @@ jobs:
           environment:
             DB_DIALECT: sqlite
   test-ui-components:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -970,6 +1004,8 @@ jobs:
           environment:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-ui-community:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1029,6 +1065,8 @@ jobs:
           environment:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-ui-enterprise:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1088,6 +1126,8 @@ jobs:
           environment:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-ui-config:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1147,6 +1187,8 @@ jobs:
           environment:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-staging-community:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1207,6 +1249,8 @@ jobs:
             WEB_SERVER: "true"
             WORKERS: 1
   test-staging-enterprise:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1267,6 +1311,8 @@ jobs:
             WEB_SERVER: "true"
             WORKERS: 1
   test-plugin-app-templates:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1320,6 +1366,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/app-templates && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-bigquery:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1373,6 +1421,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/bigquery && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-braze:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1426,6 +1476,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/braze && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-calculated-property:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1479,6 +1531,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/calculated-property && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-cloudwatch:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1532,6 +1586,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/cloudwatch && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-csv:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1585,6 +1641,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/csv && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-customerio:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1638,6 +1696,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/customerio && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-dbt:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1691,6 +1751,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/dbt && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-demo:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1744,6 +1806,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/demo && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-eloqua:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1797,6 +1861,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/eloqua && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-facebook:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1850,6 +1916,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/facebook && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-google-sheets:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1903,6 +1971,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/google-sheets && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-hubspot:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1956,6 +2026,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/hubspot && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-intercom:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2009,6 +2081,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/intercom && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-iterable:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2062,6 +2136,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/iterable && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-logger:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2115,6 +2191,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/logger && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mailchimp:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2168,6 +2246,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/mailchimp && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mailjet:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2221,6 +2301,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/mailjet && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-marketo:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2274,6 +2356,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/marketo && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mixpanel:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2327,6 +2411,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/mixpanel && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mongo:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2384,6 +2470,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/mongo && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mysql:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2449,6 +2537,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/mysql && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-newrelic:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2502,6 +2592,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/newrelic && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-onesignal:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2555,6 +2647,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/onesignal && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-pardot:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2608,6 +2702,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/pardot && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-pipedrive:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2661,6 +2757,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/pipedrive && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-postgres:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2714,6 +2812,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/postgres && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-prometheus:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2767,6 +2867,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/prometheus && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-redshift:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2820,6 +2922,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/redshift && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sailthru:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2873,6 +2977,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/sailthru && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-salesforce:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2926,6 +3032,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/salesforce && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sendgrid:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2979,6 +3087,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/sendgrid && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sentry:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -3032,6 +3142,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/sentry && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-snowflake:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -3085,6 +3197,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/snowflake && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-spec-helper:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -3138,6 +3252,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/spec-helper && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sqlite:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -3191,6 +3307,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/sqlite && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-zendesk:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -3244,6 +3362,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/zendesk && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-cli:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: circleci/node:16.8.0
         auth:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ jobs:
             - ui/ui-enterprise/.next
   license-checker:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -205,7 +205,7 @@ jobs:
           command: ./tools/license-checker/check
   spell-checker:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -241,7 +241,7 @@ jobs:
           command: ./tools/spell-checker/check
   linter:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -277,7 +277,7 @@ jobs:
           command: pnpm run lint
   test-core-actions:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -332,7 +332,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/actions --ci --maxWorkers 2
   test-core-bin:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -387,7 +387,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/bin --ci --maxWorkers 2
   test-core-classes:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -442,7 +442,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/classes --ci --maxWorkers 2
   test-core-initializers:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -497,7 +497,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/initializers --ci --maxWorkers 2
   test-core-integration:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -552,7 +552,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/integration --ci --maxWorkers 2
   test-core-models:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -607,7 +607,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/models --ci --maxWorkers 2
   test-core-modules:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -662,7 +662,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/modules --ci --maxWorkers 2
   test-core-notifiers:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -717,7 +717,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/notifiers --ci --maxWorkers 2
   test-core-snapshots:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -772,7 +772,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/snapshots --ci --maxWorkers 2
   test-core-tasks:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -827,7 +827,7 @@ jobs:
           command: cd core && ./node_modules/.bin/jest __tests__/tasks --ci --maxWorkers 2
   test-core-local-models:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -866,7 +866,7 @@ jobs:
             DB_DIALECT: sqlite
   test-core-local-actions:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -905,7 +905,7 @@ jobs:
             DB_DIALECT: sqlite
   test-core-local-tasks:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -944,7 +944,7 @@ jobs:
             DB_DIALECT: sqlite
   test-ui-components:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1005,7 +1005,7 @@ jobs:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-ui-community:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1066,7 +1066,7 @@ jobs:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-ui-enterprise:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1127,7 +1127,7 @@ jobs:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-ui-config:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1188,7 +1188,7 @@ jobs:
             SELENIUM_REMOTE_URL: http://localhost:4444/wd/hub
   test-staging-community:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1250,7 +1250,7 @@ jobs:
             WORKERS: 1
   test-staging-enterprise:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1312,7 +1312,7 @@ jobs:
             WORKERS: 1
   test-plugin-app-templates:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1367,7 +1367,7 @@ jobs:
           command: cd plugins/@grouparoo/app-templates && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-bigquery:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1422,7 +1422,7 @@ jobs:
           command: cd plugins/@grouparoo/bigquery && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-braze:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1477,7 +1477,7 @@ jobs:
           command: cd plugins/@grouparoo/braze && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-calculated-property:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1532,7 +1532,7 @@ jobs:
           command: cd plugins/@grouparoo/calculated-property && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-cloudwatch:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1587,7 +1587,7 @@ jobs:
           command: cd plugins/@grouparoo/cloudwatch && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-csv:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1642,7 +1642,7 @@ jobs:
           command: cd plugins/@grouparoo/csv && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-customerio:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1697,7 +1697,7 @@ jobs:
           command: cd plugins/@grouparoo/customerio && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-dbt:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1752,7 +1752,7 @@ jobs:
           command: cd plugins/@grouparoo/dbt && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-demo:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1807,7 +1807,7 @@ jobs:
           command: cd plugins/@grouparoo/demo && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-eloqua:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1862,7 +1862,7 @@ jobs:
           command: cd plugins/@grouparoo/eloqua && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-facebook:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1917,7 +1917,7 @@ jobs:
           command: cd plugins/@grouparoo/facebook && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-google-sheets:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1972,7 +1972,7 @@ jobs:
           command: cd plugins/@grouparoo/google-sheets && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-hubspot:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2027,7 +2027,7 @@ jobs:
           command: cd plugins/@grouparoo/hubspot && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-intercom:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2082,7 +2082,7 @@ jobs:
           command: cd plugins/@grouparoo/intercom && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-iterable:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2137,7 +2137,7 @@ jobs:
           command: cd plugins/@grouparoo/iterable && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-logger:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2192,7 +2192,7 @@ jobs:
           command: cd plugins/@grouparoo/logger && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mailchimp:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2247,7 +2247,7 @@ jobs:
           command: cd plugins/@grouparoo/mailchimp && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mailjet:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2302,7 +2302,7 @@ jobs:
           command: cd plugins/@grouparoo/mailjet && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-marketo:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2357,7 +2357,7 @@ jobs:
           command: cd plugins/@grouparoo/marketo && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mixpanel:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2412,7 +2412,7 @@ jobs:
           command: cd plugins/@grouparoo/mixpanel && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mongo:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2471,7 +2471,7 @@ jobs:
           command: cd plugins/@grouparoo/mongo && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-mysql:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2538,7 +2538,7 @@ jobs:
           command: cd plugins/@grouparoo/mysql && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-newrelic:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2593,7 +2593,7 @@ jobs:
           command: cd plugins/@grouparoo/newrelic && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-onesignal:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2648,7 +2648,7 @@ jobs:
           command: cd plugins/@grouparoo/onesignal && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-pardot:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2703,7 +2703,7 @@ jobs:
           command: cd plugins/@grouparoo/pardot && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-pipedrive:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2758,7 +2758,7 @@ jobs:
           command: cd plugins/@grouparoo/pipedrive && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-postgres:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2813,7 +2813,7 @@ jobs:
           command: cd plugins/@grouparoo/postgres && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-prometheus:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2868,7 +2868,7 @@ jobs:
           command: cd plugins/@grouparoo/prometheus && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-redshift:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2923,7 +2923,7 @@ jobs:
           command: cd plugins/@grouparoo/redshift && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sailthru:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -2978,7 +2978,7 @@ jobs:
           command: cd plugins/@grouparoo/sailthru && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-salesforce:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -3033,7 +3033,7 @@ jobs:
           command: cd plugins/@grouparoo/salesforce && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sendgrid:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -3088,7 +3088,7 @@ jobs:
           command: cd plugins/@grouparoo/sendgrid && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sentry:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -3143,7 +3143,7 @@ jobs:
           command: cd plugins/@grouparoo/sentry && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-snowflake:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -3198,7 +3198,7 @@ jobs:
           command: cd plugins/@grouparoo/snowflake && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-spec-helper:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -3253,7 +3253,7 @@ jobs:
           command: cd plugins/@grouparoo/spec-helper && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-sqlite:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -3308,7 +3308,7 @@ jobs:
           command: cd plugins/@grouparoo/sqlite && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-zendesk:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -3363,7 +3363,7 @@ jobs:
           command: cd plugins/@grouparoo/zendesk && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-cli:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1204,7 +1204,6 @@ jobs:
           command: cd apps/staging-community && ./__tests__/integration
           environment:
             PORT: 3000
-            GROUPAROO_TELEMETRY_ENABLED: "false"
             WEB_SERVER: "true"
             WORKERS: 1
   test-staging-enterprise:
@@ -1265,7 +1264,6 @@ jobs:
           command: cd apps/staging-enterprise && ./__tests__/integration
           environment:
             PORT: 3000
-            GROUPAROO_TELEMETRY_ENABLED: "false"
             WEB_SERVER: "true"
             WORKERS: 1
   test-plugin-app-templates:

--- a/apps/staging-enterprise/__tests__/cli
+++ b/apps/staging-enterprise/__tests__/cli
@@ -9,7 +9,6 @@ source ./../../tools/shared/max_bg_procs
 CLI="$PROJECT_PATH/../../cli/dist/grouparoo.js"
 
 # Set needed ENV
-export GROUPAROO_TELEMETRY_ENABLED=false
 export REDIS_URL="redis://mock"
 export DATABASE_URL="sqlite://grouparoo_test.sqlite"
 export SERVER_TOKEN="ABC123"

--- a/apps/staging-enterprise/__tests__/integration
+++ b/apps/staging-enterprise/__tests__/integration
@@ -5,7 +5,6 @@ set -e
 cd "`dirname "$0"`/.."
 
 # Set needed ENV
-export GROUPAROO_TELEMETRY_ENABLED=false
 export REDIS_URL="redis://mock"
 export DATABASE_URL="sqlite://grouparoo_test.sqlite"
 export SERVER_TOKEN="ABC123"

--- a/cli/__tests__/test
+++ b/cli/__tests__/test
@@ -9,7 +9,6 @@ CORE_VERSION=`cat lerna.json | jq --raw-output '.version'`
 cd "./cli/__tests__"
 WORKDIR="/tmp/grouparoo-$TIME"
 export INIT_CWD=$WORKDIR
-export GROUPAROO_TELEMETRY_ENABLED=false
 
 echo " >>> testing with WORKDIR=$WORKDIR against CORE_VERSION=$CORE_VERSION <<< "
 

--- a/core/__tests__/modules/status.ts
+++ b/core/__tests__/modules/status.ts
@@ -20,7 +20,6 @@ describe("modules/status", () => {
 
   beforeAll(async () => {
     process.env.GROUPAROO_RUN_MODE = "x";
-    process.env.GROUPAROO_TELEMETRY_ENABLED = "false";
     await helper.factories.properties();
   });
 

--- a/core/__tests__/modules/telemetry.ts
+++ b/core/__tests__/modules/telemetry.ts
@@ -19,7 +19,6 @@ describe("modules/status", () => {
     await api.resque.queue.connection.redis.flushdb();
     config.telemetry.enabled = true;
     process.env.GROUPAROO_RUN_MODE = "x";
-    process.env.GROUPAROO_TELEMETRY_ENABLED = "false";
   });
 
   afterEach(() => {

--- a/plugins/@grouparoo/spec-helper/src/lib/cliSpecHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/cliSpecHelper.ts
@@ -42,7 +42,11 @@ export namespace CLISpecHelper {
 
       const spawnProcess = spawn(command, args, {
         cwd,
-        env,
+        env: {
+          ...env,
+          GROUPAROO_TELEMETRY_DISABLED:
+            process.env.GROUPAROO_TELEMETRY_DISABLED,
+        },
       });
 
       spawnProcess.stdout.on("data", (data) => {
@@ -68,7 +72,10 @@ export namespace CLISpecHelper {
   ): { exitCode: number; stderr: string; stdout: string } {
     const syncResponse = spawnSync(command, args, {
       cwd,
-      env,
+      env: {
+        ...env,
+        GROUPAROO_TELEMETRY_DISABLED: process.env.GROUPAROO_TELEMETRY_DISABLED,
+      },
     });
     const stdout = syncResponse.stdout.toString();
     const stderr = syncResponse.stderr.toString();

--- a/plugins/@grouparoo/spec-helper/src/lib/cliSpecHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/cliSpecHelper.ts
@@ -44,7 +44,7 @@ export namespace CLISpecHelper {
         cwd,
         env: {
           ...env,
-          GROUPAROO_TELEMETRY_ENABLED: process.env.GROUPAROO_TELEMETRY_ENABLED,
+          GROUPAROO_TELEMETRY_ENABLED: "false",
         },
       });
 
@@ -73,7 +73,7 @@ export namespace CLISpecHelper {
       cwd,
       env: {
         ...env,
-        GROUPAROO_TELEMETRY_ENABLED: process.env.GROUPAROO_TELEMETRY_ENABLED,
+        GROUPAROO_TELEMETRY_ENABLED: "false",
       },
     });
     const stdout = syncResponse.stdout.toString();

--- a/plugins/@grouparoo/spec-helper/src/lib/cliSpecHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/cliSpecHelper.ts
@@ -44,8 +44,7 @@ export namespace CLISpecHelper {
         cwd,
         env: {
           ...env,
-          GROUPAROO_TELEMETRY_DISABLED:
-            process.env.GROUPAROO_TELEMETRY_DISABLED,
+          GROUPAROO_TELEMETRY_ENABLED: process.env.GROUPAROO_TELEMETRY_ENABLED,
         },
       });
 
@@ -74,7 +73,7 @@ export namespace CLISpecHelper {
       cwd,
       env: {
         ...env,
-        GROUPAROO_TELEMETRY_DISABLED: process.env.GROUPAROO_TELEMETRY_DISABLED,
+        GROUPAROO_TELEMETRY_ENABLED: process.env.GROUPAROO_TELEMETRY_ENABLED,
       },
     });
     const stdout = syncResponse.stdout.toString();

--- a/tools/merger/data/ci/apps/job.yml.template
+++ b/tools/merger/data/ci/apps/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/apps/job.yml.template
+++ b/tools/merger/data/ci/apps/job.yml.template
@@ -1,4 +1,6 @@
   {{{job_name}}}:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/apps/job.yml.template
+++ b/tools/merger/data/ci/apps/job.yml.template
@@ -39,7 +39,6 @@
           command: cd {{{relative_path}}}/{{section}} && ./__tests__/integration
           environment:
             PORT: 3000
-            GROUPAROO_TELEMETRY_ENABLED: "false"
             WEB_SERVER: "true"
             WORKERS: 1
 {{{custom_test}}}

--- a/tools/merger/data/ci/cli/job.yml.template
+++ b/tools/merger/data/ci/cli/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/cli/job.yml.template
+++ b/tools/merger/data/ci/cli/job.yml.template
@@ -1,4 +1,6 @@
   {{{job_name}}}:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/client/job.yml.template
+++ b/tools/merger/data/ci/client/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/client/job.yml.template
+++ b/tools/merger/data/ci/client/job.yml.template
@@ -1,4 +1,6 @@
   {{{job_name}}}:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/command/job.yml.template
+++ b/tools/merger/data/ci/command/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/command/job.yml.template
+++ b/tools/merger/data/ci/command/job.yml.template
@@ -1,4 +1,6 @@
   {{{job_name}}}:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/core-local/job.yml.template
+++ b/tools/merger/data/ci/core-local/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/core-local/job.yml.template
+++ b/tools/merger/data/ci/core-local/job.yml.template
@@ -1,4 +1,6 @@
   {{{job_name}}}:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/core/job.yml.template
+++ b/tools/merger/data/ci/core/job.yml.template
@@ -1,6 +1,6 @@
   test-{{{type}}}-{{{test_section}}}:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/core/job.yml.template
+++ b/tools/merger/data/ci/core/job.yml.template
@@ -1,4 +1,6 @@
   test-{{{type}}}-{{{test_section}}}:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/plugin/job.yml.template
+++ b/tools/merger/data/ci/plugin/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/plugin/job.yml.template
+++ b/tools/merger/data/ci/plugin/job.yml.template
@@ -1,4 +1,6 @@
   {{{job_name}}}:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/ui/job.yml.template
+++ b/tools/merger/data/ci/ui/job.yml.template
@@ -1,6 +1,6 @@
   {{{job_name}}}:
     environment:
-      GROUPAROO_TELEMETRY_DISABLED: "true"
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: {{{docker_image}}}
         auth:

--- a/tools/merger/data/ci/ui/job.yml.template
+++ b/tools/merger/data/ci/ui/job.yml.template
@@ -1,4 +1,6 @@
   {{{job_name}}}:
+    environment:
+      GROUPAROO_TELEMETRY_DISABLED: "true"
     docker:
       - image: {{{docker_image}}}
         auth:


### PR DESCRIPTION
More throughly disabled sending telemetry in tests.  We'll do this by setting the ENV variable `GROUPAROO_TELEMETRY_DISABLED` at the system level

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [ ] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
