### PR TITLE
Display Resque task args in progress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1533,6 +1533,8 @@ jobs:
           name: test
           command: cd plugins/@grouparoo/calculated-property && ./node_modules/.bin/jest  --ci --passWithNoTests --runInBand
   test-plugin-clickhouse:
+    environment:
+      GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
       - image: circleci/node:16.8.0
         auth:

--- a/ui/ui-components/pages/resque/overview.tsx
+++ b/ui/ui-components/pages/resque/overview.tsx
@@ -214,11 +214,25 @@ export default function ResqueOverview(props) {
                     return (
                       <tr key={name}>
                         <td>
-                          <span
-                            className={worker.delta > 0 ? "text-success" : ""}
+                          <Link
+                            href={
+                              "/resque/workers#" +
+                              `${worker.host}:${worker.id}`.replace(
+                                /[\W_-]/g,
+                                "-"
+                              )
+                            }
                           >
-                            {name}
-                          </span>
+                            <a>
+                              <span
+                                className={
+                                  worker.delta > 0 ? "text-success" : ""
+                                }
+                              >
+                                {name}
+                              </span>
+                            </a>
+                          </Link>
                         </td>
                         <td>
                           <span
@@ -253,35 +267,36 @@ function formatWorkersForDisplay(
 ) {
   const response: {
     [workerName: string]: {
+      host: string;
+      id: string;
       status: string;
       delta: number;
     };
   } = {};
 
-  Object.keys(_workers).forEach((workerName) => {
-    const worker = _workers[workerName];
-    if (typeof worker === "string") {
-      response[workerName] = {
-        status: worker,
-        delta: 0,
-      };
-    } else {
-      const delta = Math.ceil(
-        (new Date().getTime() - new Date(worker.run_at).getTime()) / 1000
-      );
-      response[workerName] = {
-        delta,
-        status:
-          "working on " +
+  for (const [name, worker] of Object.entries(_workers)) {
+    const delta = Math.ceil(
+      (new Date().getTime() - new Date(worker.run_at).getTime()) / 1000
+    );
+    const nameParts = name.split(":");
+    const id = nameParts.pop();
+    const host = nameParts.join(":");
+
+    response[name] = {
+      host,
+      id,
+      delta,
+      status: worker.payload
+        ? "working on " +
           worker.queue +
           "#" +
           worker.payload.class +
           " for " +
           delta +
-          "s",
-      };
-    }
-  });
+          "s"
+        : "pending",
+    };
+  }
 
   return response;
 }


### PR DESCRIPTION
Updates the resque workers page to:
* have linkable anchors for navigation
* hide the long list of queues until expanded
* show the arguments of the task in progress

![Screen Shot 2021-11-16 at 4 40 01 PM](https://user-images.githubusercontent.com/303226/142088580-4561e64b-30d8-4de8-a3ad-957d6b14f83f.png)


## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
