### PR TITLE
Empty query crashes "run query"

### DIFF
--- a/ui/ui-components/components/alerts/Success.tsx
+++ b/ui/ui-components/components/alerts/Success.tsx
@@ -42,6 +42,7 @@ export default function SuccessAlert({
       show={show}
       onClose={() => setShow(false)}
       variant="success"
+      className="text-break"
     >
       {message}
     </Alert>

--- a/ui/ui-components/pages/app/[id]/refresh.tsx
+++ b/ui/ui-components/pages/app/[id]/refresh.tsx
@@ -304,7 +304,7 @@ export default function Page(props) {
                   testResult.success !== false &&
                   testResult.success !== undefined &&
                   !testResult.error ? (
-                    <Alert variant="success">
+                    <Alert variant="success" className="text-break">
                       <strong>Test Passed. </strong>Sample Value ={" "}
                       {testResult.message}
                     </Alert>
@@ -313,6 +313,7 @@ export default function Page(props) {
                       <strong>Test Failed</strong> {testResult.error}
                     </Alert>
                   ) : null}
+
                   {loading ? <Loader /> : null}
                 </Col>
               </Form.Group>{" "}

--- a/ui/ui-components/pages/app/[id]/refresh.tsx
+++ b/ui/ui-components/pages/app/[id]/refresh.tsx
@@ -88,8 +88,26 @@ export default function Page(props) {
     );
     if (response?.appRefreshQuery) {
       setLoading(false);
-      successHandler.set({ message: "App Refresh Query Updated" });
       setAppRefreshQuery(response.appRefreshQuery);
+
+      try {
+        const response: Actions.AppRefreshQueryQuery = await execApi(
+          "post",
+          `/appRefreshQuery/${appRefreshQuery.id}/query`
+        );
+        if (response?.valueUpdated == true) {
+          successHandler.set({
+            message: `App Refresh Query updated. Returned ${response.appRefreshQuery.value}. Enqueueing Schedules.`,
+          });
+        } else {
+          successHandler.set({
+            message: `App Refresh Query updated. Query returned ${response.appRefreshQuery.value}. No schedules enqueued.`,
+          });
+        }
+        setAppRefreshQuery(response.appRefreshQuery);
+      } finally {
+        setLoading(false);
+      }
     } else {
       setLoading(false);
     }
@@ -273,7 +291,6 @@ export default function Page(props) {
                         variant="outline-danger"
                         size="sm"
                         className="my-2 ml-2"
-                        // disabled={disabled}
                         hidden={!editing}
                         onClick={cancelEdit}
                       >
@@ -282,7 +299,6 @@ export default function Page(props) {
                     </Row>
                   </Col>
                 </Row>{" "}
-                {/* </fieldset> */}
                 <Col>
                   {testResult.success !== null &&
                   testResult.success !== false &&
@@ -301,26 +317,28 @@ export default function Page(props) {
                 </Col>
               </Form.Group>{" "}
             </Col>
-
-            <Col className="col-md-4 ">
-              <Row className="mx-auto">
-                <AppRefreshQueryStats
-                  app={app}
-                  appRefreshQuery={appRefreshQuery}
-                />
-              </Row>
-              <Row>
-                <LoadingButton
-                  className="m-3 mx-auto"
-                  variant="success"
-                  onClick={runQuery}
-                  disabled={loading}
-                  hidden={editing}
-                >
-                  Run Refresh Query
-                </LoadingButton>
-              </Row>
-            </Col>
+            {appRefreshQuery?.refreshQuery?.length > 1 &&
+              appRefreshQuery?.state === "ready" && (
+                <Col className="col-md-4 ">
+                  <Row className="mx-auto">
+                    <AppRefreshQueryStats
+                      app={app}
+                      appRefreshQuery={appRefreshQuery}
+                    />
+                  </Row>
+                  <Row>
+                    <LoadingButton
+                      className="m-3 mx-auto"
+                      variant="success"
+                      onClick={runQuery}
+                      disabled={loading}
+                      hidden={editing}
+                    >
+                      Run Refresh Query
+                    </LoadingButton>
+                  </Row>
+                </Col>
+              )}
           </Row>
           <hr />
           <strong>Schedules:</strong>


### PR DESCRIPTION
## Change description

Check that a query is at least 1 character long and is in the "ready state" to display the "run refresh query" button.  Also triggers a run when the query is created.

before adding query: 
<img width="1191" alt="Screen Shot 2021-11-18 at 1 10 46 PM" src="https://user-images.githubusercontent.com/63751206/142472522-37f11231-12cb-4f94-86ec-64f689d635ca.png">

after adding query:
<img width="1182" alt="Screen Shot 2021-11-18 at 1 15 19 PM" src="https://user-images.githubusercontent.com/63751206/142473141-89b79621-6dc2-4b3d-adf4-2b9deedea518.png">


Also, add bootstrap class `text-break` to result so results don't overflow the box

<img width="609" alt="Screen Shot 2021-11-18 at 1 10 13 PM" src="https://user-images.githubusercontent.com/63751206/142472455-40e3b679-85e0-4886-b73e-f89c0a465372.png">


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
