### PR TITLE
`private_key_passphrase` for Snowflake keypair apps

### DIFF
--- a/plugins/@grouparoo/snowflake/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/snowflake/src/initializers/plugin.ts
@@ -123,6 +123,14 @@ export class Plugins extends Initializer {
                 "The Private Key used to connect to your warehouse.  Likely generated as rsa_key.p8, e.g. -----BEGIN PRIVATE KEY-----\nMII ...",
             },
             {
+              key: "private_key_passphrase",
+              displayName: "Private Key Passphrase",
+              type: "password",
+              required: false,
+              description:
+                "Does your private key requires a passphrase to use?",
+            },
+            {
               key: "warehouse",
               displayName: "Warehouse",
               required: true,

--- a/plugins/@grouparoo/snowflake/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/snowflake/src/initializers/plugin.ts
@@ -127,8 +127,7 @@ export class Plugins extends Initializer {
               displayName: "Private Key Passphrase",
               type: "password",
               required: false,
-              description:
-                "Does your private key requires a passphrase to use?",
+              description: "Does your private key require a passphrase to use?",
             },
             {
               key: "warehouse",

--- a/plugins/@grouparoo/snowflake/src/lib/connect.ts
+++ b/plugins/@grouparoo/snowflake/src/lib/connect.ts
@@ -10,6 +10,7 @@ export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
   const username = appOptions.username?.toString();
   const password = appOptions.password?.toString();
   const private_key = appOptions.private_key?.toString();
+  const private_key_passphrase = appOptions.private_key_passphrase?.toString();
   const warehouse = appOptions.warehouse?.toString();
   const database = appOptions.database?.toString();
   const schema = appOptions.schema?.toString() || "PUBLIC";
@@ -30,6 +31,7 @@ export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
       .createPrivateKey({
         key: private_key.replace(/\\n/g, "\n"),
         format: "pem",
+        passphrase: private_key_passphrase,
       })
       .export({
         format: "pem",


### PR DESCRIPTION
This PR allows the use of keypair connections to snowflakes which use an encrypted keypair.  Learn more @ https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
