### PR TITLE
Only show properties for this Model in mustache builder

### DIFF
--- a/core/__tests__/modules/plugin.ts
+++ b/core/__tests__/modules/plugin.ts
@@ -307,6 +307,13 @@ describe("modules/plugin", () => {
             source.modelId
           )
         ).rejects.toThrow('missing mustache key "otherUserId"');
+
+        // cleanup
+        await otherSource.setMapping({});
+        await otherProperty.destroy();
+        await otherSource.destroy();
+        await otherApp.destroy();
+        await otherModel.destroy();
       });
     });
 

--- a/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
@@ -719,13 +719,11 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   const { propertyId, modelId } = ctx.query;
   const { execApi } = UseApi(ctx);
 
-  const { properties } = await execApi("get", `/properties`, {
-    state: "ready",
-  });
   const { sources } = await execApi("get", "/sources");
   const { types } = await execApi("get", `/propertyOptions`);
 
   let property: Models.PropertyType = {};
+  let properties = [];
   let pluginOptions = [];
   let filterOptions = {};
   let hydrationError: Error;
@@ -738,6 +736,12 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
       (s: Models.SourceType) => s.id === property.sourceId
     );
     ensureMatchingModel("Property", source.modelId, modelId.toString());
+
+    const propertiesResponse = await execApi("get", `/properties`, {
+      state: "ready",
+      modelId: source.modelId,
+    });
+    properties = propertiesResponse.properties;
 
     const pluginOptionsResponse = await execApi(
       "get",

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/exports.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/exports.tsx
@@ -66,7 +66,7 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   const { recordId, modelId } = ctx.query;
   const { record } = await execApi("get", `/record/${recordId}`);
   ensureMatchingModel("Record", record?.modelId, modelId.toString());
-  const { properties } = await execApi("get", `/properties`);
+  const { properties } = await execApi("get", `/properties`, { modelId });
   const exportListInitialProps = await ExportsList.hydrate(ctx);
   return { record, properties, ...exportListInitialProps };
 };

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/imports.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/imports.tsx
@@ -66,7 +66,7 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   const { recordId, modelId } = ctx.query;
   const { record } = await execApi("get", `/record/${recordId}`);
   ensureMatchingModel("Record", record?.modelId, modelId.toString());
-  const { properties } = await execApi("get", `/properties`);
+  const { properties } = await execApi("get", `/properties`, { modelId });
   const importListInitialProps = await ImportList.hydrate(ctx);
   return { record, properties, ...importListInitialProps };
 };

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/logs.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/logs.tsx
@@ -66,7 +66,7 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   const { execApi } = UseApi(ctx);
   const { record } = await execApi("get", `/record/${recordId}`);
   ensureMatchingModel("Record", record?.modelId, modelId.toString());
-  const { properties } = await execApi("get", `/properties`);
+  const { properties } = await execApi("get", `/properties`, { modelId });
   const logListInitialProps = await LogsList.hydrate(ctx);
   return { record, properties, ...logListInitialProps };
 };

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -71,6 +71,8 @@ export default function Page(props) {
     });
 
     let existingProperty: Models.PropertyType;
+    let otherProperties: Models.PropertyType[] = [];
+
     for (const property of properties) {
       if (property.sourceId !== source.id) continue;
       if (property.options[primaryOptionKey] !== column) continue;
@@ -93,6 +95,8 @@ export default function Page(props) {
       if (optMatch) {
         existingProperty = property;
         break;
+      } else {
+        otherProperties.push(property);
       }
     }
 
@@ -150,24 +154,25 @@ export default function Page(props) {
     }
 
     return (
-      <tr>
-        <td>
-          <Fragment>
-            {Object.keys(options)
-              .filter((opt) => !hiddenOptions.includes(opt))
-              .sort()
-              .map((opt) => (
-                <Form.Group as={Col} key={`opt-${column}-${opt}`}>
-                  <Form.Row>
-                    <Col md={3}>
-                      <code>
-                        <Form.Label>{opt}: </Form.Label>
-                      </code>
-                    </Col>
-                    <Col>
-                      <strong>{options[opt].toString()}</strong>
-                      {/* We actually don't want to allow changes to the provided source options? */}
-                      {/* <Form.Control
+      <>
+        <tr>
+          <td>
+            <Fragment>
+              {Object.keys(options)
+                .filter((opt) => !hiddenOptions.includes(opt))
+                .sort()
+                .map((opt) => (
+                  <Form.Group as={Col} key={`opt-${column}-${opt}`}>
+                    <Form.Row>
+                      <Col md={3}>
+                        <code>
+                          <Form.Label>{opt}: </Form.Label>
+                        </code>
+                      </Col>
+                      <Col>
+                        <strong>{options[opt].toString()}</strong>
+                        {/* We actually don't want to allow changes to the provided source options? */}
+                        {/* <Form.Control
                         size="sm"
                         type="text"
                         value={options[opt].toString()}
@@ -178,65 +183,85 @@ export default function Page(props) {
                           setOptions(_options);
                         }}
                       /> */}
-                    </Col>
-                  </Form.Row>
-                </Form.Group>
+                      </Col>
+                    </Form.Row>
+                  </Form.Group>
+                ))}
+            </Fragment>
+          </td>
+          <td>➡</td>
+          <td>
+            <Form.Control
+              size="sm"
+              type="text"
+              value={key}
+              onChange={(e) => setKey(e.target.value)}
+              disabled={disabled}
+            />
+          </td>
+          <td>
+            <Form.Control
+              size="sm"
+              as="select"
+              value={type}
+              onChange={(e) =>
+                setType(e.target.value as typeof existingProperty["type"])
+              }
+              disabled={disabled}
+            >
+              {types.map((v) => (
+                <option key={`types-opt-${v}`}>{v}</option>
               ))}
-          </Fragment>
-        </td>
-        <td>➡</td>
-        <td>
-          <Form.Control
-            size="sm"
-            type="text"
-            value={key}
-            onChange={(e) => setKey(e.target.value)}
-            disabled={disabled}
-          />
-        </td>
-        <td>
-          <Form.Control
-            size="sm"
-            as="select"
-            value={type}
-            onChange={(e) =>
-              setType(e.target.value as typeof existingProperty["type"])
-            }
-            disabled={disabled}
-          >
-            {types.map((v) => (
-              <option key={`types-opt-${v}`}>{v}</option>
-            ))}
-          </Form.Control>
-        </td>
-        <td>
-          <Form.Check
-            checked={unique}
-            onChange={(e) => setUnique(e.target.checked)}
-            disabled={disabled}
-          />
-        </td>
-
-        <td>
-          {existingProperty && existingProperty.sourceId === source.id ? (
-            <LinkButton
-              variant="outline-info"
-              size="sm"
-              href={`/model/${source.modelId}/property/${existingProperty.id}/edit`}
-            >
-              View
-            </LinkButton>
-          ) : (
-            <LoadingButton
-              size="sm"
-              disabled={loading}
-              onClick={() => createProperty()}
-            >
-              Create
-            </LoadingButton>
-          )}
-        </td>
-      </tr>
+            </Form.Control>
+          </td>
+          <td>
+            <Form.Check
+              checked={unique}
+              onChange={(e) => setUnique(e.target.checked)}
+              disabled={disabled}
+            />
+          </td>
+          <td>
+            {existingProperty && existingProperty.sourceId === source.id ? (
+              <LinkButton
+                variant="outline-info"
+                size="sm"
+                href={`/model/${source.modelId}/property/${existingProperty.id}/edit`}
+              >
+                View
+              </LinkButton>
+            ) : (
+              <LoadingButton
+                size="sm"
+                disabled={loading}
+                onClick={() => createProperty()}
+              >
+                Create
+              </LoadingButton>
+            )}
+          </td>
+        </tr>
+        {otherProperties.map((otherProperty) => (
+          <tr key={`otherProperty-${otherProperty.id}`}>
+            <td style={{ border: 0 }} />
+            <td style={{ border: 0 }}>➡</td>
+            <td style={{ border: 0 }}>
+              <strong>{otherProperty.key}</strong>
+            </td>
+            <td style={{ border: 0 }} />
+            <td style={{ border: 0 }} />
+            <td style={{ border: 0 }}>
+              <LinkButton
+                variant="outline-info"
+                size="sm"
+                href={`/model/${source.modelId}/property/${otherProperty.id}/edit`}
+              >
+                View
+              </LinkButton>
+            </td>
+          </tr>
+        ))}
+      </>
     );
   }
 
@@ -349,7 +374,7 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
     "get",
     `/source/${sourceId}/defaultPropertyOptions`
   );
-  const { properties } = await execApi("get", `/properties`);
+  const { properties } = await execApi("get", `/properties`, { modelId });
   const { types } = await execApi("get", `/propertyOptions`);
 
   return {

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -94,7 +94,6 @@ export default function Page(props) {
 
       if (optMatch) {
         existingProperty = property;
-        break;
       } else {
         otherProperties.push(property);
       }

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -70,15 +70,16 @@ export default function Page(props) {
       defaultOptions[propertyOption.key] = defaultOption.key;
     });
 
-    let existingProperty: Models.PropertyType;
+    let exactProperty: Models.PropertyType;
     let otherProperties: Models.PropertyType[] = [];
 
     for (const property of properties) {
       if (property.sourceId !== source.id) continue;
       if (property.options[primaryOptionKey] !== column) continue;
-      if (property.filters?.length > 0) continue;
 
       let optMatch = true;
+      if (property.filters?.length > 0) optMatch = false;
+
       for (const [key, value] of Object.entries(property.options)) {
         if (key === primaryOptionKey) continue;
         if (!optionWithDefaults.map((dpo) => dpo.key).includes(key)) {
@@ -93,38 +94,36 @@ export default function Page(props) {
       }
 
       if (optMatch) {
-        existingProperty = property;
+        exactProperty = property;
       } else {
         otherProperties.push(property);
       }
     }
 
-    const disabled = existingProperty
-      ? existingProperty.sourceId === source.id
+    const disabled = exactProperty
+      ? exactProperty.sourceId === source.id
       : false;
 
     const [key, setKey] = useState(
-      existingProperty && existingProperty.sourceId === source.id
-        ? existingProperty.key
-        : existingProperty && existingProperty.sourceId !== source.id
+      exactProperty && exactProperty.sourceId === source.id
+        ? exactProperty.key
+        : exactProperty && exactProperty.sourceId !== source.id
         ? generateId(`${source.name}-${column}`)
         : generateId(column)
     );
-    const [type, setType] = useState<typeof existingProperty["type"]>(
-      existingProperty && existingProperty.sourceId === source.id
-        ? existingProperty.type
+    const [type, setType] = useState<typeof exactProperty["type"]>(
+      exactProperty && exactProperty.sourceId === source.id
+        ? exactProperty.type
         : columnSpeculation[column].type
     );
     const [unique, setUnique] = useState(
-      existingProperty
-        ? existingProperty.unique
-        : columnSpeculation[column].isUnique
+      exactProperty ? exactProperty.unique : columnSpeculation[column].isUnique
     );
 
     const hiddenOptions = optionWithDefaults.map((o) => o.key);
     const [options, setOptions] = useState(
-      existingProperty && existingProperty.sourceId === source.id
-        ? existingProperty.options
+      exactProperty && exactProperty.sourceId === source.id
+        ? exactProperty.options
         : defaultOptions
     );
 
@@ -204,7 +203,7 @@ export default function Page(props) {
               as="select"
               value={type}
               onChange={(e) =>
-                setType(e.target.value as typeof existingProperty["type"])
+                setType(e.target.value as typeof exactProperty["type"])
               }
               disabled={disabled}
             >
@@ -221,11 +220,11 @@ export default function Page(props) {
             />
           </td>
           <td>
-            {existingProperty && existingProperty.sourceId === source.id ? (
+            {exactProperty && exactProperty.sourceId === source.id ? (
               <LinkButton
                 variant="outline-info"
                 size="sm"
-                href={`/model/${source.modelId}/property/${existingProperty.id}/edit`}
+                href={`/model/${source.modelId}/property/${exactProperty.id}/edit`}
               >
                 View
               </LinkButton>


### PR DESCRIPTION
Fixes a bug in which Grouparoo was displaying properties from other models as options for the Mustache property builder

![Screen Shot 2021-11-01 at 2 00 45 PM](https://user-images.githubusercontent.com/303226/142676395-b5196e94-9c1a-4676-b444-80dd25aa8f08.png)

This PR also now shows Properties that are mapped to a Source's column that are not directly mapped

<img width="1498" alt="Screen Shot 2021-11-19 at 10 54 01 AM" src="https://user-images.githubusercontent.com/303226/142676456-f9f45fd6-87e6-4224-948e-454f6b2d678f.png">



## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
