### PR TITLE
Retry cli uploads on timeout

### DIFF
--- a/core/__tests__/bin/push.ts
+++ b/core/__tests__/bin/push.ts
@@ -182,6 +182,94 @@ describe("bin/push", () => {
     );
   });
 
+  test("can retry if there is a timeout reached", async () => {
+    const timeoutNock = nock("https://cloud.grouparoo.com")
+      .post("/api/v1/configuration")
+      .query(true)
+      .times(4)
+      .replyWithError({ message: "timeout!", code: "ETIMEDOUT" });
+
+    const happyNock = nock("https://cloud.grouparoo.com")
+      .post("/api/v1/configuration")
+      .query(true)
+      .reply(200, {
+        configuration: { id: "config-id" },
+      });
+
+    nock("https://cloud.grouparoo.com")
+      .get("/api/v1/configuration/config-id")
+      .query(true)
+      .reply(200, {
+        configuration: {
+          validateJobId: "validate-id",
+          state: "validated",
+        },
+      });
+
+    nock("https://cloud.grouparoo.com")
+      .get("/api/v1/configuration/config-id")
+      .query(true)
+      .reply(200, {
+        configuration: {
+          state: "finished",
+        },
+      });
+
+    nock("https://cloud.grouparoo.com")
+      .get("/api/v1/job/validate-id")
+      .query(true)
+      .reply(200, {
+        job: {
+          type: "validate",
+          logs: "validate job logs go here",
+        },
+      });
+
+    const command = new Push();
+    const toStop = await command.run({
+      params: {
+        archivePath,
+        projectId: "my-project",
+        token: "some-token",
+        apply: false,
+      },
+    });
+    expect(toStop).toBe(true);
+
+    expect(timeoutNock.isDone()).toBe(true);
+    expect(happyNock.isDone()).toBe(true);
+
+    const output = messages.join(" ");
+    console.log(output);
+    expect(output).toContain(
+      "The configuration has been successfully validated"
+    );
+  });
+
+  test("it will only retry 5 times", async () => {
+    nock("https://cloud.grouparoo.com")
+      .post("/api/v1/configuration")
+      .query(true)
+      .times(5)
+      .replyWithError({ message: "timeout!", code: "ETIMEDOUT" });
+
+    const command = new Push();
+    const toStop = await command.run({
+      params: {
+        archivePath,
+        projectId: "my-project",
+        token: "some-token",
+        apply: false,
+      },
+    });
+    expect(toStop).toBe(true);
+
+    const output = messages.join(" ");
+    console.log(output);
+    expect(output).toContain("❌");
+    expect(output).toContain("timeout!");
+  });
+
   test("logs error if an error was attached to the configuration", async () => {
     nock("https://cloud.grouparoo.com")
       .post("/api/v1/configuration")

--- a/core/__tests__/bin/push.ts
+++ b/core/__tests__/bin/push.ts
@@ -240,7 +240,6 @@ describe("bin/push", () => {
     expect(happyNock.isDone()).toBe(true);
 
     const output = messages.join(" ");
-    console.log(output);
     expect(output).toContain(
       "The configuration has been successfully validated"
     );
@@ -265,7 +264,6 @@ describe("bin/push", () => {
     expect(toStop).toBe(true);
 
     const output = messages.join(" ");
-    console.log(output);
     expect(output).toContain("❌");
     expect(output).toContain("timeout!");
   });

--- a/core/src/modules/cloud.ts
+++ b/core/src/modules/cloud.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import FormData from "form-data";
 import fetch from "isomorphic-fetch";
 import { mkdtemp, copy, remove } from "fs-extra";
+import { utils } from "actionhero";
 
 export class CloudError extends Error {
   code: string;
@@ -89,12 +90,25 @@ export class CloudClient {
       process.env.GROUPAROO_CLOUD_API_URL ?? "https://cloud.grouparoo.com";
   }
 
-  async request(url: string, options?: RequestInit, attempts = 0) {
+  async request(
+    url: string,
+    options?: RequestInit & { _buildFormData?: () => FormData },
+    attempts = 0
+  ) {
     const fetchUrl = new URL(url, this.baseUrl);
     fetchUrl.searchParams.append("apiToken", this.token);
 
+    // when retrying a form based on a readStream, we need to restart the stream on every attempt
+    if (typeof options?._buildFormData === "function") {
+      const formData = options._buildFormData.bind(this)();
+      //@ts-ignore typings are incorrectly not allowing FormData to be set as body
+      options.body = formData;
+      options.headers = formData.getHeaders();
+    }
+
     try {
-      const res = await fetch(fetchUrl.toString(), options);
+      const optionsToSend = { ...options, _buildFormData: undefined };
+      const res = await fetch(fetchUrl.toString(), optionsToSend);
       const data = await res.json();
 
       if (res.status !== 200) {
@@ -104,7 +118,11 @@ export class CloudClient {
 
       return data;
     } catch (error) {
-      if (error.toString().match("ETIMEDOUT") && attempts < maxAttempts) {
+      if (
+        (error?.code === "ETIMEDOUT" || error.toString().match("ETIMEDOUT")) &&
+        attempts < maxAttempts - 1
+      ) {
+        await utils.sleep(100);
         return this.request(url, options, attempts + 1);
       } else throw error;
     }
@@ -116,21 +134,21 @@ export class CloudClient {
     message?: string,
     externalUrl?: string
   ) {
-    const formData = new FormData();
-    formData.append("_file", fs.createReadStream(tarballPath));
-    formData.append("projectId", this.projectId);
-    formData.append("toApply", toApply.toString());
-
-    if (message) formData.append("message", message);
-    if (externalUrl) formData.append("externalUrl", externalUrl);
+    function _buildFormData() {
+      const formData = new FormData();
+      formData.append("_file", fs.createReadStream(tarballPath));
+      formData.append("projectId", this.projectId);
+      formData.append("toApply", toApply.toString());
+      if (message) formData.append("message", message);
+      if (externalUrl) formData.append("externalUrl", externalUrl);
+      return formData;
+    }
 
     const data: { configuration: ConfigurationApiData } = await this.request(
       "/api/v1/configuration",
       {
         method: "POST",
-        //@ts-ignore typings are incorrectly not allowing FormData to be set as body
-        body: formData,
-        headers: formData.getHeaders(),
+        _buildFormData,
       }
     );
     return data.configuration;

--- a/core/src/modules/cloudCli.ts
+++ b/core/src/modules/cloudCli.ts
@@ -119,11 +119,11 @@ export namespace CloudCLI {
     const tempPath = await mkdtemp(path.join(os.tmpdir(), "grouparoo-cli-"));
     const archivePath = path.join(tempPath, "grouparoo.tar.gz");
 
-    GrouparooCLI.logger.log("Building config archive...\n");
+    GrouparooCLI.logger.log("\n🛠 Building config archive...\n");
 
     await CloudCLI.pack(archivePath);
 
-    GrouparooCLI.logger.log("\nUploading config...\n");
+    GrouparooCLI.logger.log("\n☁️ Uploading config...\n");
 
     await CloudCLI.push({
       archivePath,


### PR DESCRIPTION
When `grouparoo ci` or `grouparoo deploy` has a networking timeout, retry (up to 5 times).

It turns out that `fetch` itself doesn't have a timeout.  These errors might be coming from an upstrem proxy used by Github actions.  Rather than increase the timeout in the request, we can look for errors matching `ETIMEDOUT ` and retry N times

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
