### PR TITLE
First-time User Improvements

### DIFF
--- a/core/__tests__/actions/sessions.ts
+++ b/core/__tests__/actions/sessions.ts
@@ -7,6 +7,7 @@ import {
   SessionDestroy,
   SessionView,
 } from "../../src/actions/session";
+import { PrivateStatus } from "../../src/actions/status";
 
 // enable the web server
 process.env.WEB_SERVER = "true";
@@ -14,582 +15,616 @@ process.env.WEB_SERVER = "true";
 describe("session", () => {
   helper.grouparooTestServer({ truncate: true });
 
-  beforeAll(async () => {
-    await specHelper.runAction("team:initialize", {
-      firstName: "Peach",
-      lastName: "Toadstool",
-      password: "P@ssw0rd!",
-      email: "peach@example.com",
-    });
-  });
-
-  describe("session:create", () => {
-    test("can log in", async () => {
-      const { success, teamMember, error } =
-        await specHelper.runAction<SessionCreate>("session:create", {
-          email: "peach@example.com",
-          password: "P@ssw0rd!",
-        });
-
-      expect(error).toBeUndefined();
-      expect(success).toEqual(true);
-      expect(teamMember.id).toBeTruthy();
-    });
-
-    test("can log in with email not in lowercase", async () => {
-      const { success, teamMember, error } =
-        await specHelper.runAction<SessionCreate>("session:create", {
-          email: "PEACH@example.COM",
-          password: "P@ssw0rd!",
-        });
-
-      expect(error).toBeUndefined();
-      expect(success).toEqual(true);
-      expect(teamMember.id).toBeTruthy();
-    });
-
-    test("cannot log in with unknown user", async () => {
-      const { success, teamMember, error } =
-        await specHelper.runAction<SessionCreate>("session:create", {
-          email: "fff@example.com",
-          password: "x",
-        });
-
-      expect(error.message).toMatch(/team member not found/);
-      expect(error.code).toMatch("AUTHENTICATION_ERROR");
-      expect(success).toBeUndefined();
-      expect(teamMember).toBeUndefined();
-    });
-
-    test("cannot log in with bad password", async () => {
-      const { success, teamMember, error } =
-        await specHelper.runAction<SessionCreate>("session:create", {
-          email: "peach@example.com",
-          password: "x",
-        });
-
-      expect(error.message).toMatch(/password does not match/);
-      expect(error.code).toMatch("AUTHENTICATION_ERROR");
-      expect(success).toBeUndefined();
-      expect(teamMember).toBeUndefined();
-    });
-  });
-
-  describe("session:view", () => {
-    test("can view session details", async () => {
-      const connection = await specHelper.buildConnection();
-      connection.params = { email: "peach@example.com", password: "P@ssw0rd!" };
-      const signInResponse = await specHelper.runAction<SessionCreate>(
-        "session:create",
-        connection
+  describe("without team", () => {
+    test("authenticated methods called without valid session before a team exists throw a specific error", async () => {
+      const { error } = await specHelper.runAction<PrivateStatus>(
+        "status:private"
       );
-      expect(signInResponse.error).toBeUndefined();
-      expect(signInResponse.success).toBe(true);
-      const csrfToken = signInResponse.csrfToken;
-
-      connection.params = { csrfToken };
-      const {
-        csrfToken: newCsrfToken,
-        teamMember,
-        error,
-      } = await specHelper.runAction<SessionView>("session:view", connection);
-
-      expect(error).toBeUndefined();
-      expect(newCsrfToken).toBe(csrfToken);
-      expect(teamMember.id).toBeTruthy();
+      expect(error.code).toBe("NO_TEAMS_ERROR");
     });
   });
 
-  describe("session:destroy", () => {
-    test("can log out", async () => {
-      const { success, error, csrfToken } =
-        await specHelper.runAction<SessionCreate>("session:create", {
-          email: "peach@example.com",
-          password: "P@ssw0rd!",
-        });
+  describe("with team", () => {
+    beforeAll(async () => {
+      await specHelper.runAction("team:initialize", {
+        firstName: "Peach",
+        lastName: "Toadstool",
+        password: "P@ssw0rd!",
+        email: "peach@example.com",
+      });
+    });
 
-      expect(error).toBeUndefined();
-      expect(success).toEqual(true);
-
-      const destroyResponse = await specHelper.runAction<SessionDestroy>(
-        "session:destroy",
-        {
-          csrfToken,
-        }
+    test("authenticated methods called without valid session after a team exists throw a specific error", async () => {
+      const { error } = await specHelper.runAction<PrivateStatus>(
+        "status:private"
       );
-
-      expect(destroyResponse.error).toBeUndefined();
-      expect(destroyResponse.success).toEqual(true);
-    });
-  });
-
-  describe("permissions", () => {
-    beforeAll(() => {
-      api.actions.versions.appReadAction = [1];
-      api.actions.versions.appWriteAction = [1];
-      api.actions.versions.systemReadAction = [1];
-      api.actions.versions.optionallyAuthenticatedAction = [1];
-
-      api.actions.actions.appReadAction = {
-        1: {
-          name: "appReadAction",
-          description: "I am a test",
-          version: 1,
-          outputExample: {},
-          middleware: ["authenticated-action"],
-          //@ts-ignore
-          permission: { topic: "app", mode: "read" },
-          run: async (data) => {
-            data.response.success = true;
-          },
-        },
-      };
-
-      api.actions.actions.appWriteAction = {
-        1: {
-          name: "appWriteAction",
-          description: "I am a test",
-          version: 1,
-          outputExample: {},
-          middleware: ["authenticated-action"],
-          //@ts-ignore
-          permission: { topic: "app", mode: "write" },
-          run: async (data) => {
-            data.response.success = true;
-          },
-        },
-      };
-
-      api.actions.actions.systemReadAction = {
-        1: {
-          name: "systemReadAction",
-          description: "I am a test",
-          version: 1,
-          outputExample: {},
-          middleware: ["authenticated-action"],
-          //@ts-ignore
-          permission: { topic: "system", mode: "read" },
-          run: async (data) => {
-            data.response.success = true;
-          },
-        },
-      };
-
-      api.actions.actions.optionallyAuthenticatedAction = {
-        1: {
-          name: "systemReadAction",
-          description: "I am a test",
-          version: 1,
-          outputExample: {},
-          middleware: ["optionally-authenticated-action"],
-          //@ts-ignore
-          permission: { topic: "*", mode: "read" },
-          run: async (data) => {
-            data.response.success = true;
-          },
-        },
-      };
-
-      api.routes.loadRoutes();
+      expect(error.code).toBe("AUTHENTICATION_ERROR");
     });
 
-    afterAll(() => {
-      delete api.actions.actions.appReadAction;
-      delete api.actions.versions.appReadAction;
-      delete api.actions.actions.appWriteAction;
-      delete api.actions.versions.appWriteAction;
-      delete api.actions.actions.systemReadAction;
-      delete api.actions.versions.systemReadAction;
-      delete api.actions.actions.optionallyAuthenticatedAction;
-      delete api.actions.versions.optionallyAuthenticatedAction;
+    describe("session:create", () => {
+      test("can log in", async () => {
+        const { success, teamMember, error } =
+          await specHelper.runAction<SessionCreate>("session:create", {
+            email: "peach@example.com",
+            password: "P@ssw0rd!",
+          });
+
+        expect(error).toBeUndefined();
+        expect(success).toEqual(true);
+        expect(teamMember.id).toBeTruthy();
+      });
+
+      test("can log in with email not in lowercase", async () => {
+        const { success, teamMember, error } =
+          await specHelper.runAction<SessionCreate>("session:create", {
+            email: "PEACH@example.COM",
+            password: "P@ssw0rd!",
+          });
+
+        expect(error).toBeUndefined();
+        expect(success).toEqual(true);
+        expect(teamMember.id).toBeTruthy();
+      });
+
+      test("cannot log in with unknown user", async () => {
+        const { success, teamMember, error } =
+          await specHelper.runAction<SessionCreate>("session:create", {
+            email: "fff@example.com",
+            password: "x",
+          });
+
+        expect(error.message).toMatch(/team member not found/);
+        expect(error.code).toMatch("AUTHENTICATION_ERROR");
+        expect(success).toBeUndefined();
+        expect(teamMember).toBeUndefined();
+      });
+
+      test("cannot log in with bad password", async () => {
+        const { success, teamMember, error } =
+          await specHelper.runAction<SessionCreate>("session:create", {
+            email: "peach@example.com",
+            password: "x",
+          });
+
+        expect(error.message).toMatch(/password does not match/);
+        expect(error.code).toMatch("AUTHENTICATION_ERROR");
+        expect(success).toBeUndefined();
+        expect(teamMember).toBeUndefined();
+      });
     });
 
-    describe("session", () => {
-      let toad: TeamMember;
-      let team: Team;
-      let connection;
-      let csrfToken: string;
-
-      async function signIn() {
+    describe("session:view", () => {
+      test("can view session details", async () => {
+        const connection = await specHelper.buildConnection();
         connection.params = {
-          email: "toad@example.com",
-          password: "mushrooms",
+          email: "peach@example.com",
+          password: "P@ssw0rd!",
         };
-        const sessionResponse = await specHelper.runAction<SessionCreate>(
+        const signInResponse = await specHelper.runAction<SessionCreate>(
           "session:create",
           connection
         );
-        csrfToken = sessionResponse.csrfToken;
-      }
+        expect(signInResponse.error).toBeUndefined();
+        expect(signInResponse.success).toBe(true);
+        const csrfToken = signInResponse.csrfToken;
 
-      beforeAll(async () => {
-        team = await helper.factories.team();
-
-        // start with no read or write permissions
-        const permissions = await team.$get("permissions");
-        for (const i in permissions) {
-          //@ts-ignore
-          await permissions[i].update(
-            { read: false, write: false },
-            { hooks: false }
-          );
-        }
-
-        toad = new TeamMember({
-          teamId: team.id,
-          firstName: "Toad",
-          lastName: "Toadstool",
-          email: "toad@example.com",
-        });
-
-        await toad.save();
-        await toad.updatePassword("mushrooms");
-
-        connection = await specHelper.buildConnection();
-
-        await signIn();
-      });
-
-      test("without a csrfToken or grouparoo header, actions are not authenticated", async () => {
-        let response = await specHelper.runAction("appReadAction", connection);
-        expect(response.error.message).toBe("CSRF error");
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
-        expect(response["success"]).toBeFalsy();
-      });
-
-      test("once a CSRF token error occurs, the session is destroyed", async () => {
-        await signIn();
-        let firstResponse = await specHelper.runAction(
-          "appReadAction",
-          Object.assign({}, connection, {
-            params: { csrfToken: "not-the-token" },
-          })
-        );
-        expect(firstResponse.error.code).toBe("AUTHENTICATION_ERROR");
-        expect(firstResponse.error.message).toBe("CSRF error");
-        expect(firstResponse["success"]).toBeFalsy();
-
-        let secondResponse = await specHelper.runAction(
-          "appReadAction",
-          Object.assign({}, connection, { params: { csrfToken } })
-        );
-        expect(secondResponse.error.code).toBe("AUTHENTICATION_ERROR");
-        expect(secondResponse.error.message).toBe("Please log in to continue");
-        expect(secondResponse["success"]).toBeFalsy();
-      });
-
-      test("a member of an authenticated team cannot view any action", async () => {
-        await signIn();
-        let response = await specHelper.runAction(
-          "appReadAction",
-          Object.assign({}, connection, { params: { csrfToken } })
-        );
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
-
-        await signIn();
-        response = await specHelper.runAction(
-          "appWriteAction",
-          Object.assign({}, connection, { params: { csrfToken } })
-        );
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
-
-        await signIn();
-        response = await specHelper.runAction(
-          "systemReadAction",
-          Object.assign({}, connection, { params: { csrfToken } })
-        );
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
-      });
-
-      test("changing the permission topic to read authorizes only the actions of that topic - read", async () => {
-        const permission = await Permission.findOne({
-          where: { ownerId: team.id, topic: "app" },
-        });
-        //@ts-ignore
-        await permission.update({ read: true, write: false }, { hooks: false });
-
-        await signIn();
-        let response = await specHelper.runAction(
-          "appReadAction",
-          Object.assign({}, connection, { params: { csrfToken } })
-        );
-        expect(response.error).toBeFalsy();
-        expect(response["success"]).toBe(true);
-
-        await signIn();
-        response = await specHelper.runAction(
-          "appWriteAction",
-          Object.assign({}, connection, { params: { csrfToken } })
-        );
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
-
-        await signIn();
-        response = await specHelper.runAction(
-          "systemReadAction",
-          Object.assign({}, connection, { params: { csrfToken } })
-        );
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
-      });
-
-      test("changing the permission topic to read authorizes only the actions of that topic - write", async () => {
-        const permission = await Permission.findOne({
-          where: { ownerId: team.id, topic: "app" },
-        });
-        //@ts-ignore
-        await permission.update({ read: false, write: true }, { hooks: false });
-
-        await signIn();
         connection.params = { csrfToken };
-        let response = await specHelper.runAction(
-          "appReadAction",
-          Object.assign({}, connection, { params: { csrfToken } })
-        );
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
+        const {
+          csrfToken: newCsrfToken,
+          teamMember,
+          error,
+        } = await specHelper.runAction<SessionView>("session:view", connection);
 
-        await signIn();
-        response = await specHelper.runAction(
-          "appWriteAction",
-          Object.assign({}, connection, { params: { csrfToken } })
-        );
-        expect(response.error).toBeFalsy();
-        expect(response["success"]).toBe(true);
-
-        await signIn();
-        response = await specHelper.runAction(
-          "systemReadAction",
-          Object.assign({}, connection, { params: { csrfToken } })
-        );
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
-      });
-
-      test("optionally authenticated actions can be read by logged out users", async () => {
-        let response = await specHelper.runAction(
-          "optionallyAuthenticatedAction"
-          // no connection
-        );
-        expect(response.error).toBeFalsy();
-        expect(response["success"]).toBe(true);
-      });
-
-      test("optionally authenticated actions can be read by logged out users, but require proper credentials", async () => {
-        let response = await specHelper.runAction(
-          "optionallyAuthenticatedAction",
-          Object.assign({}, connection, { params: { csrfToken } })
-        );
-        expect(response.error).toBeFalsy();
-        expect(response["success"]).toBe(true);
-
-        response = await specHelper.runAction(
-          "optionallyAuthenticatedAction",
-          Object.assign({}, connection, { params: { csrfToken: "BAD TOKEN" } })
-        );
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
-        expect(response["success"]).toBeFalsy();
+        expect(error).toBeUndefined();
+        expect(newCsrfToken).toBe(csrfToken);
+        expect(teamMember.id).toBeTruthy();
       });
     });
 
-    describe("header, cookie, and csrf authentication", () => {
-      let url: string;
-      let csrfToken: string;
-      let cookie: string;
+    describe("session:destroy", () => {
+      test("can log out", async () => {
+        const { success, error, csrfToken } =
+          await specHelper.runAction<SessionCreate>("session:create", {
+            email: "peach@example.com",
+            password: "P@ssw0rd!",
+          });
 
+        expect(error).toBeUndefined();
+        expect(success).toEqual(true);
+
+        const destroyResponse = await specHelper.runAction<SessionDestroy>(
+          "session:destroy",
+          {
+            csrfToken,
+          }
+        );
+
+        expect(destroyResponse.error).toBeUndefined();
+        expect(destroyResponse.success).toEqual(true);
+      });
+    });
+
+    describe("permissions", () => {
       beforeAll(() => {
-        url = `http://localhost:${config.servers.web.port}`;
+        api.actions.versions.appReadAction = [1];
+        api.actions.versions.appWriteAction = [1];
+        api.actions.versions.systemReadAction = [1];
+        api.actions.versions.optionallyAuthenticatedAction = [1];
+
+        api.actions.actions.appReadAction = {
+          1: {
+            name: "appReadAction",
+            description: "I am a test",
+            version: 1,
+            outputExample: {},
+            middleware: ["authenticated-action"],
+            //@ts-ignore
+            permission: { topic: "app", mode: "read" },
+            run: async (data) => {
+              data.response.success = true;
+            },
+          },
+        };
+
+        api.actions.actions.appWriteAction = {
+          1: {
+            name: "appWriteAction",
+            description: "I am a test",
+            version: 1,
+            outputExample: {},
+            middleware: ["authenticated-action"],
+            //@ts-ignore
+            permission: { topic: "app", mode: "write" },
+            run: async (data) => {
+              data.response.success = true;
+            },
+          },
+        };
+
+        api.actions.actions.systemReadAction = {
+          1: {
+            name: "systemReadAction",
+            description: "I am a test",
+            version: 1,
+            outputExample: {},
+            middleware: ["authenticated-action"],
+            //@ts-ignore
+            permission: { topic: "system", mode: "read" },
+            run: async (data) => {
+              data.response.success = true;
+            },
+          },
+        };
+
+        api.actions.actions.optionallyAuthenticatedAction = {
+          1: {
+            name: "systemReadAction",
+            description: "I am a test",
+            version: 1,
+            outputExample: {},
+            middleware: ["optionally-authenticated-action"],
+            //@ts-ignore
+            permission: { topic: "*", mode: "read" },
+            run: async (data) => {
+              data.response.success = true;
+            },
+          },
+        };
+
+        api.routes.loadRoutes();
       });
 
-      async function buildSessionAndCookie() {
-        let response = await fetch(`${url}/api/v1/session`, {
-          method: "POST",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
+      afterAll(() => {
+        delete api.actions.actions.appReadAction;
+        delete api.actions.versions.appReadAction;
+        delete api.actions.actions.appWriteAction;
+        delete api.actions.versions.appWriteAction;
+        delete api.actions.actions.systemReadAction;
+        delete api.actions.versions.systemReadAction;
+        delete api.actions.actions.optionallyAuthenticatedAction;
+        delete api.actions.versions.optionallyAuthenticatedAction;
+      });
+
+      describe("session", () => {
+        let toad: TeamMember;
+        let team: Team;
+        let connection;
+        let csrfToken: string;
+
+        async function signIn() {
+          connection.params = {
             email: "toad@example.com",
             password: "mushrooms",
-          }),
-        }).then((r) => {
-          const setCookie = r.headers.get("set-cookie");
-          cookie = setCookie.substr(0, setCookie.indexOf(";"));
-          return r.json();
-        });
-        csrfToken = response.csrfToken;
-      }
+          };
+          const sessionResponse = await specHelper.runAction<SessionCreate>(
+            "session:create",
+            connection
+          );
+          csrfToken = sessionResponse.csrfToken;
+        }
 
-      test("a user can log in with email and password to obtain a csrf token and a session cookie", async () => {
-        await buildSessionAndCookie();
-        expect(cookie).toMatch(/grouparooSessionId=/);
-        expect(csrfToken).toBeTruthy();
+        beforeAll(async () => {
+          team = await helper.factories.team();
+
+          // start with no read or write permissions
+          const permissions = await team.$get("permissions");
+          for (const i in permissions) {
+            //@ts-ignore
+            await permissions[i].update(
+              { read: false, write: false },
+              { hooks: false }
+            );
+          }
+
+          toad = new TeamMember({
+            teamId: team.id,
+            firstName: "Toad",
+            lastName: "Toadstool",
+            email: "toad@example.com",
+          });
+
+          await toad.save();
+          await toad.updatePassword("mushrooms");
+
+          connection = await specHelper.buildConnection();
+
+          await signIn();
+        });
+
+        test("without a csrfToken or grouparoo header, actions are not authenticated", async () => {
+          let response = await specHelper.runAction(
+            "appReadAction",
+            connection
+          );
+          expect(response.error.message).toBe("CSRF error");
+          expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+          expect(response["success"]).toBeFalsy();
+        });
+
+        test("once a CSRF token error occurs, the session is destroyed", async () => {
+          await signIn();
+          let firstResponse = await specHelper.runAction(
+            "appReadAction",
+            Object.assign({}, connection, {
+              params: { csrfToken: "not-the-token" },
+            })
+          );
+          expect(firstResponse.error.code).toBe("AUTHENTICATION_ERROR");
+          expect(firstResponse.error.message).toBe("CSRF error");
+          expect(firstResponse["success"]).toBeFalsy();
+
+          let secondResponse = await specHelper.runAction(
+            "appReadAction",
+            Object.assign({}, connection, { params: { csrfToken } })
+          );
+          expect(secondResponse.error.code).toBe("AUTHENTICATION_ERROR");
+          expect(secondResponse.error.message).toBe(
+            "Please log in to continue"
+          );
+          expect(secondResponse["success"]).toBeFalsy();
+        });
+
+        test("a member of an authenticated team cannot view any action", async () => {
+          await signIn();
+          let response = await specHelper.runAction(
+            "appReadAction",
+            Object.assign({}, connection, { params: { csrfToken } })
+          );
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
+
+          await signIn();
+          response = await specHelper.runAction(
+            "appWriteAction",
+            Object.assign({}, connection, { params: { csrfToken } })
+          );
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
+
+          await signIn();
+          response = await specHelper.runAction(
+            "systemReadAction",
+            Object.assign({}, connection, { params: { csrfToken } })
+          );
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
+        });
+
+        test("changing the permission topic to read authorizes only the actions of that topic - read", async () => {
+          const permission = await Permission.findOne({
+            where: { ownerId: team.id, topic: "app" },
+          });
+          //@ts-ignore
+          await permission.update(
+            { read: true, write: false },
+            { hooks: false }
+          );
+
+          await signIn();
+          let response = await specHelper.runAction(
+            "appReadAction",
+            Object.assign({}, connection, { params: { csrfToken } })
+          );
+          expect(response.error).toBeFalsy();
+          expect(response["success"]).toBe(true);
+
+          await signIn();
+          response = await specHelper.runAction(
+            "appWriteAction",
+            Object.assign({}, connection, { params: { csrfToken } })
+          );
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
+
+          await signIn();
+          response = await specHelper.runAction(
+            "systemReadAction",
+            Object.assign({}, connection, { params: { csrfToken } })
+          );
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
+        });
+
+        test("changing the permission topic to read authorizes only the actions of that topic - write", async () => {
+          const permission = await Permission.findOne({
+            where: { ownerId: team.id, topic: "app" },
+          });
+          //@ts-ignore
+          await permission.update(
+            { read: false, write: true },
+            { hooks: false }
+          );
+
+          await signIn();
+          connection.params = { csrfToken };
+          let response = await specHelper.runAction(
+            "appReadAction",
+            Object.assign({}, connection, { params: { csrfToken } })
+          );
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
+
+          await signIn();
+          response = await specHelper.runAction(
+            "appWriteAction",
+            Object.assign({}, connection, { params: { csrfToken } })
+          );
+          expect(response.error).toBeFalsy();
+          expect(response["success"]).toBe(true);
+
+          await signIn();
+          response = await specHelper.runAction(
+            "systemReadAction",
+            Object.assign({}, connection, { params: { csrfToken } })
+          );
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
+        });
+
+        test("optionally authenticated actions can be read by logged out users", async () => {
+          let response = await specHelper.runAction(
+            "optionallyAuthenticatedAction"
+            // no connection
+          );
+          expect(response.error).toBeFalsy();
+          expect(response["success"]).toBe(true);
+        });
+
+        test("optionally authenticated actions can be read by logged out users, but require proper credentials", async () => {
+          let response = await specHelper.runAction(
+            "optionallyAuthenticatedAction",
+            Object.assign({}, connection, { params: { csrfToken } })
+          );
+          expect(response.error).toBeFalsy();
+          expect(response["success"]).toBe(true);
+
+          response = await specHelper.runAction(
+            "optionallyAuthenticatedAction",
+            Object.assign({}, connection, {
+              params: { csrfToken: "BAD TOKEN" },
+            })
+          );
+          expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+          expect(response["success"]).toBeFalsy();
+        });
       });
 
-      test("actions can be authenticated with the CSRF token + cookie", async () => {
-        await buildSessionAndCookie();
-        const response = await fetch(
-          `${url}/api/v1/account?csrfToken=${csrfToken}`,
-          {
+      describe("header, cookie, and csrf authentication", () => {
+        let url: string;
+        let csrfToken: string;
+        let cookie: string;
+
+        beforeAll(() => {
+          url = `http://localhost:${config.servers.web.port}`;
+        });
+
+        async function buildSessionAndCookie() {
+          let response = await fetch(`${url}/api/v1/session`, {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email: "toad@example.com",
+              password: "mushrooms",
+            }),
+          }).then((r) => {
+            const setCookie = r.headers.get("set-cookie");
+            cookie = setCookie.substr(0, setCookie.indexOf(";"));
+            return r.json();
+          });
+          csrfToken = response.csrfToken;
+        }
+
+        test("a user can log in with email and password to obtain a csrf token and a session cookie", async () => {
+          await buildSessionAndCookie();
+          expect(cookie).toMatch(/grouparooSessionId=/);
+          expect(csrfToken).toBeTruthy();
+        });
+
+        test("actions can be authenticated with the CSRF token + cookie", async () => {
+          await buildSessionAndCookie();
+          const response = await fetch(
+            `${url}/api/v1/account?csrfToken=${csrfToken}`,
+            {
+              method: "GET",
+              credentials: "include",
+              headers: { "Content-Type": "application/json", Cookie: cookie },
+            }
+          ).then((r) => r.json());
+          expect(response.teamMember.id).toBeTruthy();
+        });
+
+        test("actions cannot be authenticated with the cookie without the CSRF token", async () => {
+          await buildSessionAndCookie();
+          const response = await fetch(`${url}/api/v1/account`, {
             method: "GET",
             credentials: "include",
             headers: { "Content-Type": "application/json", Cookie: cookie },
-          }
-        ).then((r) => r.json());
-        expect(response.teamMember.id).toBeTruthy();
-      });
+          }).then((r) => r.json());
+          expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+          expect(response.teamMember).toBeFalsy();
+        });
 
-      test("actions cannot be authenticated with the cookie without the CSRF token", async () => {
-        await buildSessionAndCookie();
-        const response = await fetch(`${url}/api/v1/account`, {
-          method: "GET",
-          credentials: "include",
-          headers: { "Content-Type": "application/json", Cookie: cookie },
-        }).then((r) => r.json());
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
-        expect(response.teamMember).toBeFalsy();
-      });
+        test("actions cannot be authenticated without the cookie and with the CSRF token", async () => {
+          await buildSessionAndCookie();
+          const response = await fetch(
+            `${url}/api/v1/account?csrfToken=${csrfToken}`,
+            {
+              method: "GET",
+              credentials: "include",
+              headers: { "Content-Type": "application/json" },
+            }
+          ).then((r) => r.json());
+          expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+          expect(response.teamMember).toBeFalsy();
+        });
 
-      test("actions cannot be authenticated without the cookie and with the CSRF token", async () => {
-        await buildSessionAndCookie();
-        const response = await fetch(
-          `${url}/api/v1/account?csrfToken=${csrfToken}`,
-          {
+        test("actions cannot be authenticated with the x-grouparoo-server-token header and without the cookie", async () => {
+          await buildSessionAndCookie();
+          const response = await fetch(`${url}/api/v1/account`, {
             method: "GET",
             credentials: "include",
-            headers: { "Content-Type": "application/json" },
+            headers: {
+              "Content-Type": "application/json",
+              "X-GROUPAROO-SERVER-TOKEN": config.general.serverToken,
+            },
+          }).then((r) => r.json());
+          expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+          expect(response.teamMember).toBeFalsy();
+        });
+
+        test("actions can be authenticated with the x-grouparoo-server-token header and the cookie", async () => {
+          const response = await fetch(`${url}/api/v1/account`, {
+            method: "GET",
+            credentials: "include",
+            headers: {
+              "Content-Type": "application/json",
+              Cookie: cookie,
+              "X-GROUPAROO-SERVER-TOKEN": config.general.serverToken,
+            },
+          }).then((r) => r.json());
+          expect(response.teamMember.id).toBeTruthy();
+        });
+      });
+
+      describe("apiKey", () => {
+        let apiKey: ApiKey;
+
+        beforeAll(async () => {
+          apiKey = await helper.factories.apiKey();
+
+          // start with no read or write permissions
+          const permissions = await apiKey.$get("permissions");
+          for (const i in permissions) {
+            await permissions[i].update({ read: false, write: false });
           }
-        ).then((r) => r.json());
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
-        expect(response.teamMember).toBeFalsy();
-      });
-
-      test("actions cannot be authenticated with the x-grouparoo-server-token header and without the cookie", async () => {
-        await buildSessionAndCookie();
-        const response = await fetch(`${url}/api/v1/account`, {
-          method: "GET",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-            "X-GROUPAROO-SERVER-TOKEN": config.general.serverToken,
-          },
-        }).then((r) => r.json());
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
-        expect(response.teamMember).toBeFalsy();
-      });
-
-      test("actions can be authenticated with the x-grouparoo-server-token header and the cookie", async () => {
-        const response = await fetch(`${url}/api/v1/account`, {
-          method: "GET",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-            Cookie: cookie,
-            "X-GROUPAROO-SERVER-TOKEN": config.general.serverToken,
-          },
-        }).then((r) => r.json());
-        expect(response.teamMember.id).toBeTruthy();
-      });
-    });
-
-    describe("apiKey", () => {
-      let apiKey: ApiKey;
-
-      beforeAll(async () => {
-        apiKey = await helper.factories.apiKey();
-
-        // start with no read or write permissions
-        const permissions = await apiKey.$get("permissions");
-        for (const i in permissions) {
-          await permissions[i].update({ read: false, write: false });
-        }
-      });
-
-      test("without an apiKey, actions are not authenticated", async () => {
-        let response = await specHelper.runAction("appReadAction", {});
-        expect(response.error.message).toBe("Please log in to continue");
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
-        expect(response["success"]).toBeFalsy();
-      });
-
-      test("with an invalid apiKey, actions are not authorized", async () => {
-        let response = await specHelper.runAction("appReadAction", {
-          apiKey: "abc123",
         });
-        expect(response.error.message).toBe("apiKey not found");
-        expect(response.error.code).toBe("AUTHENTICATION_ERROR");
-        expect(response["success"]).toBeFalsy();
-      });
 
-      test("an apiKey with no permissions can not run any actions", async () => {
-        let response = await specHelper.runAction("appReadAction", {
-          apiKey: apiKey.apiKey,
+        test("without an apiKey, actions are not authenticated", async () => {
+          let response = await specHelper.runAction("appReadAction", {});
+          expect(response.error.message).toBe("Please log in to continue");
+          expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+          expect(response["success"]).toBeFalsy();
         });
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
 
-        response = await specHelper.runAction("appWriteAction", {
-          apiKey: apiKey.apiKey,
+        test("with an invalid apiKey, actions are not authorized", async () => {
+          let response = await specHelper.runAction("appReadAction", {
+            apiKey: "abc123",
+          });
+          expect(response.error.message).toBe("apiKey not found");
+          expect(response.error.code).toBe("AUTHENTICATION_ERROR");
+          expect(response["success"]).toBeFalsy();
         });
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
 
-        response = await specHelper.runAction("systemReadAction", {
-          apiKey: apiKey.apiKey,
-        });
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
-      });
+        test("an apiKey with no permissions can not run any actions", async () => {
+          let response = await specHelper.runAction("appReadAction", {
+            apiKey: apiKey.apiKey,
+          });
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
 
-      test("changing the permission topic to read authorizes only the actions of that topic - read", async () => {
-        const permission = await Permission.findOne({
-          where: { ownerId: apiKey.id, topic: "app" },
-        });
-        await permission.update({ read: true, write: false });
+          response = await specHelper.runAction("appWriteAction", {
+            apiKey: apiKey.apiKey,
+          });
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
 
-        let response = await specHelper.runAction("appReadAction", {
-          apiKey: apiKey.apiKey,
+          response = await specHelper.runAction("systemReadAction", {
+            apiKey: apiKey.apiKey,
+          });
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
         });
-        expect(response.error).toBeFalsy();
-        expect(response["success"]).toBe(true);
 
-        response = await specHelper.runAction("appWriteAction", {
-          apiKey: apiKey.apiKey,
-        });
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
+        test("changing the permission topic to read authorizes only the actions of that topic - read", async () => {
+          const permission = await Permission.findOne({
+            where: { ownerId: apiKey.id, topic: "app" },
+          });
+          await permission.update({ read: true, write: false });
 
-        response = await specHelper.runAction("systemReadAction", {
-          apiKey: apiKey.apiKey,
-        });
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
-      });
+          let response = await specHelper.runAction("appReadAction", {
+            apiKey: apiKey.apiKey,
+          });
+          expect(response.error).toBeFalsy();
+          expect(response["success"]).toBe(true);
 
-      test("changing the permission topic to read authorizes only the actions of that topic - write", async () => {
-        const permission = await Permission.findOne({
-          where: { ownerId: apiKey.id, topic: "app" },
-        });
-        await permission.update({ read: false, write: true });
+          response = await specHelper.runAction("appWriteAction", {
+            apiKey: apiKey.apiKey,
+          });
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
 
-        let response = await specHelper.runAction("appReadAction", {
-          apiKey: apiKey.apiKey,
+          response = await specHelper.runAction("systemReadAction", {
+            apiKey: apiKey.apiKey,
+          });
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
         });
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
 
-        response = await specHelper.runAction("appWriteAction", {
-          apiKey: apiKey.apiKey,
-        });
-        expect(response.error).toBeFalsy();
-        expect(response["success"]).toBe(true);
+        test("changing the permission topic to read authorizes only the actions of that topic - write", async () => {
+          const permission = await Permission.findOne({
+            where: { ownerId: apiKey.id, topic: "app" },
+          });
+          await permission.update({ read: false, write: true });
 
-        response = await specHelper.runAction("systemReadAction", {
-          apiKey: apiKey.apiKey,
+          let response = await specHelper.runAction("appReadAction", {
+            apiKey: apiKey.apiKey,
+          });
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
+
+          response = await specHelper.runAction("appWriteAction", {
+            apiKey: apiKey.apiKey,
+          });
+          expect(response.error).toBeFalsy();
+          expect(response["success"]).toBe(true);
+
+          response = await specHelper.runAction("systemReadAction", {
+            apiKey: apiKey.apiKey,
+          });
+          expect(response.error.code).toBe("AUTHORIZATION_ERROR");
+          expect(response["success"]).toBeFalsy();
         });
-        expect(response.error.code).toBe("AUTHORIZATION_ERROR");
-        expect(response["success"]).toBeFalsy();
       });
     });
   });

--- a/core/__tests__/actions/status.ts
+++ b/core/__tests__/actions/status.ts
@@ -6,6 +6,7 @@ import { ConfigUser } from "../../src/modules/configUser";
 import { Status } from "../../src/modules/status";
 import { PrivateStatus, PublicStatus } from "../../src/actions/status";
 import { SessionCreate } from "../../src/actions/session";
+import { Team } from "../../src";
 
 const workerId = process.env.JEST_WORKER_ID;
 const configDir = `${os.tmpdir()}/test/${workerId}/configUser/config`;
@@ -14,6 +15,15 @@ process.env.GROUPAROO_CONFIG_DIR = configDir;
 
 describe("actions/status", () => {
   helper.grouparooTestServer({ truncate: true, resetSettings: true });
+
+  beforeAll(async () => {
+    await specHelper.runAction("team:initialize", {
+      firstName: "Mario",
+      lastName: "Mario",
+      password: "P@ssw0rd!",
+      email: "mario@example.com",
+    });
+  });
 
   describe("signed out", () => {
     describe("status:public", () => {

--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -164,7 +164,7 @@ describe("models/property", () => {
     });
 
     test("keys cannot be from the reserved list of keys", async () => {
-      const reservedKeys = ["grouparooId", "grouparooCreatedAt"];
+      const reservedKeys = ["grouparooId", "grouparooCreatedAt", "_meta"];
       for (const i in reservedKeys) {
         const key = reservedKeys[i];
         await expect(
@@ -175,6 +175,15 @@ describe("models/property", () => {
           })
         ).rejects.toThrow(/is a reserved key and cannot be used/);
       }
+    });
+
+    test("`id` is a valid property key", async () => {
+      const property = await Property.create({
+        sourceId: source.id,
+        type: "string",
+        key: "id",
+      }); // does not throw
+      await property.destroy();
     });
 
     test("a property can be isArray", async () => {

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -1050,6 +1050,14 @@ describe("modules/configWriter", () => {
       });
     });
 
+    test("record without a directlyMapped property value will not be persisted", async () => {
+      const record: GrouparooRecord = await helper.factories.record();
+      const properties = { [bootstrapPropertyId]: [null] };
+      await record.addOrUpdateProperties(properties);
+      const config = await record.getConfigObject();
+      expect(config).toBeUndefined();
+    });
+
     // --- Setting ---
 
     test("settings should only humanize their ID if it matches default pattern", async () => {

--- a/core/src/models/GrouparooRecord.ts
+++ b/core/src/models/GrouparooRecord.ts
@@ -242,7 +242,13 @@ export class GrouparooRecord extends LoggedModel<GrouparooRecord> {
       }
     }
 
-    if (!modelId) {
+    if (!modelId) return;
+    if (
+      Object.keys(directlyMappedProps).length === 0 ||
+      Object.values(directlyMappedProps)
+        .flat()
+        .filter((v) => v !== undefined && v !== null).length === 0
+    ) {
       return;
     }
 

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -336,7 +336,7 @@ export class Property extends LoggedModel<Property> {
     }
 
     CachedProperties.properties = await Property.findAll({
-      include: [{ model: Source, required: false }],
+      include: [{ model: Source.unscoped(), required: false }],
     });
     CachedProperties.expires = now + CACHE_TTL;
     return modelId
@@ -353,7 +353,7 @@ export class Property extends LoggedModel<Property> {
     if (!property) {
       property = await Property.findOne({
         where: { [key]: value },
-        include: [{ model: Source, required: false }],
+        include: [{ model: Source.unscoped(), required: false }],
       });
       if (!property) await Property.invalidateCache();
     }

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -493,7 +493,9 @@ export class Property extends LoggedModel<Property> {
 
   @BeforeSave
   static async validateReservedKeys(instance: Property) {
-    const reservedKeys = TopLevelGroupRules.map((tlgr) => tlgr.key);
+    const reservedKeys = ["_meta"].concat(
+      TopLevelGroupRules.map((tlgr) => tlgr.key)
+    );
     if (reservedKeys.includes(instance.key)) {
       throw new Error(
         `${instance.key} is a reserved key and cannot be used as a property`

--- a/core/src/modules/mappingHelper.ts
+++ b/core/src/modules/mappingHelper.ts
@@ -15,7 +15,7 @@ export namespace MappingHelper {
     instance: Source | Destination,
     propertyColumn?: "key" | "id"
   ) {
-    const MappingObject: Mappings = {};
+    const mappingObject: Mappings = {};
     const mappings =
       instance.mappings ??
       (await Mapping.findAll({
@@ -36,14 +36,14 @@ export namespace MappingHelper {
           `cannot find property or this source/destination not ready (remoteKey: ${mapping.remoteKey}, propertyId: ${mapping.propertyId})`
         );
       }
-      MappingObject[mapping.remoteKey] = property[propertyColumn || "key"];
+      mappingObject[mapping.remoteKey] = property[propertyColumn || "key"];
     }
 
-    return MappingObject;
+    return mappingObject;
   }
 
   export async function getConfigMapping(instance: Source | Destination) {
-    const MappingObject: Mappings = {};
+    const mappingObject: Mappings = {};
 
     const mappings = await Mapping.findAll({
       where: { ownerId: instance.id },
@@ -57,10 +57,10 @@ export namespace MappingHelper {
           `cannot find property or this source/destination not ready (remoteKey: ${mapping.remoteKey})`
         );
       }
-      MappingObject[mapping.remoteKey] = property.getConfigId();
+      mappingObject[mapping.remoteKey] = property.getConfigId();
     }
 
-    return MappingObject;
+    return mappingObject;
   }
 
   export async function setMapping(

--- a/core/src/modules/middleware/authentication.ts
+++ b/core/src/modules/middleware/authentication.ts
@@ -52,7 +52,15 @@ async function authenticateTeamMemberFromSession(
       const session = await api.session.load(data.connection);
       if (!session && optional) return;
       if (!session || !session.id) {
-        throw new Errors.AuthenticationError("Please log in to continue");
+        const teamsCount = await Team.count();
+        if (teamsCount === 0) {
+          throw new Errors.AuthenticationError(
+            "Please create the first team",
+            "NO_TEAMS_ERROR"
+          );
+        } else {
+          throw new Errors.AuthenticationError("Please log in to continue");
+        }
       } else if (
         (data.params.csrfToken && data.params.csrfToken !== session.id) ||
         (!data.params.csrfToken &&

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -303,7 +303,7 @@ export namespace RecordOps {
 
         const keys = Object.keys(recordProperties[recordOffset]);
         checkKeys: for (const key of keys) {
-          if (key === "id") continue checkKeys;
+          // this special, internal-ony key is used to send extra information though an Import.  `_meta` is prevented from being a valid Property key
           if (key === "_meta") continue checkKeys;
 
           const h: { [key: string]: Array<string | number | boolean | Date> } =

--- a/plugins/@grouparoo/sentry/src/initializers/sentry.ts
+++ b/plugins/@grouparoo/sentry/src/initializers/sentry.ts
@@ -26,6 +26,7 @@ export class SentryInitializer extends Initializer {
       // skip reporting some types of errors
       if (error?.code === "AUTHENTICATION_ERROR") return null;
       if (error?.code === "AUTHORIZATION_ERROR") return null;
+      if (error?.code === "NO_TEAMS_ERROR") return null;
 
       return event;
     }

--- a/ui/ui-components/client/client.ts
+++ b/ui/ui-components/client/client.ts
@@ -88,6 +88,15 @@ export class Client {
           res.end();
         }
       }
+    } else if (code === "NO_TEAMS_ERROR") {
+      if (isBrowser()) {
+        window.location.href = `/`;
+      } else {
+        if (req && res) {
+          res.writeHead(302, { Location: `/` });
+          res.end();
+        }
+      }
     } else if (code === "AUTHORIZATION_ERROR") {
       // ok, it will be rendered on the page
     }


### PR DESCRIPTION
* Allows Properties to have the key `id`
  * There was an explicit check that Grouparoo would not set Record Properties with a key of `id` that should have been removed as part of https://github.com/grouparoo/grouparoo/pull/1996
  * Added a test that locks in `id` is a valid Property Key
* Fixes a bug when determining a Property's scope if the Model is not ready yet
  * This manifested itself in strange ways, like when bootstrapping the first property for a source/model Grouparoo was unable to determine if the Source was ready to have a schedule or not
* Prevents the saving of Sample Records when there are no non-null directlyMapped Property Values
  * The fixes above should prevent users from getting into this state, but we'll be extra safe about this in the future
* If there are no Teams yet on the Grouparoo instance, and an authorization/authentication error occurs, redirect the user to `/` to start the team creation process
  * This happens commonly when someone transitions from `grouparoo config` to `grouparoo start` for the first time and they use the same browser tab

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
