### PR TITLE
Fix property selection in source mapping page to be based on which source has the primary key property

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/mapping.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/mapping.tsx
@@ -40,6 +40,11 @@ export default function Page(props: Props & NextPageContext) {
   const [newMappingValue, setNewMappingValue] = useState(
     () => (Object.values(props.source.mapping)[0] as string) || ""
   );
+  const hasPrimaryKeyProperty = useMemo(
+    () =>
+      props.properties.filter(({ isPrimaryKey }) => isPrimaryKey).length > 0,
+    [props.properties]
+  );
   const [properties, setProperties] = useState(() => {
     const isPrimaryKeyInSource =
       props.source &&
@@ -352,7 +357,7 @@ export default function Page(props: Props & NextPageContext) {
                 </>
               ) : null}
 
-              {newMappingValue === "" ? (
+              {!hasPrimaryKeyProperty && newMappingValue === "" ? (
                 <>
                   <hr />
                   <p>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/mapping.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/mapping.tsx
@@ -48,16 +48,19 @@ export default function Page(props: Props & NextPageContext) {
   const [properties, setProperties] = useState(() => {
     const isPrimaryKeyInSource =
       props.source &&
-      props.properties.find(
+      props.properties.filter(
         (property) =>
           property.isPrimaryKey && property.sourceId === props.source.id
-      );
+      ).length > 0;
 
-    return isPrimaryKeyInSource
-      ? props.properties.filter(
-          (property) => property.sourceId === props.source.id
-        )
-      : props.properties;
+    // Properties rules:
+    // Include properties in own source if it has the primary key or the primary key has not been defined
+    // Otherwise, show properties from other sources
+    return props.properties.filter((property) =>
+      isPrimaryKeyInSource || !hasPrimaryKeyProperty
+        ? property.sourceId === props.source.id
+        : property.sourceId !== props.source.id
+    );
   });
   const [preview, setPreview] = useState(props.preview || []);
   const [propertyExamples, setPropertyExamples] = useState(
@@ -335,13 +338,7 @@ export default function Page(props: Props & NextPageContext) {
                                   )}
                                 </strong>
                               </td>
-                              <td>
-                                <input
-                                  type="checkbox"
-                                  disabled={true}
-                                  checked={property.unique}
-                                />
-                              </td>
+                              <td>{property.unique ? "✅" : null}</td>
                               <td>
                                 {propertyExamples[property.id]
                                   ? propertyExamples[property.id]


### PR DESCRIPTION
## Change description
This change fixes the property selection in the source mapping page so that:

- When there is no primary key property defined in the model, the user can add a unique property on the mapping page
- When the source owns the primary key property, the user can update the mapping to properties only available in that source
- When the source does not own the primary key property, mapping only shows the properties from other sources

Bonus: It updates the "Unique" checkmark in the mapping table with ✅  match the rest of the app
![image](https://user-images.githubusercontent.com/168664/143090354-d3be4c62-b1c1-401f-b53b-780062dce04f.png)

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
