### PR TITLE
Throw error when mapping to source's own property while primary key belongs to another source

### DIFF
--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -634,7 +634,6 @@ describe("models/property", () => {
   });
 
   describe("with plugin", () => {
-    // let model: GrouparooModel;
     let app: App;
     let source: Source;
     let queryCounter = 0;

--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -634,9 +634,18 @@ describe("models/property", () => {
   });
 
   describe("with plugin", () => {
+    // let model: GrouparooModel;
     let app: App;
     let source: Source;
     let queryCounter = 0;
+
+    const propertiesToMoveKeys = Object.freeze([
+      "userId",
+      "firstName",
+      "lastName",
+    ]);
+    const prevSourceIds: string[] = [];
+
     beforeAll(async () => {
       plugin.registerPlugin({
         name: "test-plugin",
@@ -732,29 +741,43 @@ describe("models/property", () => {
         appId: app.id,
         modelId: model.id,
       });
-      await source.setMapping({ id: "userId" });
+
       await source.update({ state: "ready" });
 
-      const firstNameProperty = await Property.findOne({
-        where: { key: "firstName" },
-      });
-
-      firstNameProperty.sourceId = source.id;
-      await firstNameProperty.save();
-
-      const lastNameProperty = await Property.findOne({
-        where: { key: "lastName" },
-      });
-      lastNameProperty.sourceId = source.id;
-      await lastNameProperty.save();
+      for (const key of propertiesToMoveKeys) {
+        const propertyToMove = await Property.findOne({
+          where: { key },
+        });
+        prevSourceIds.push(propertyToMove.sourceId);
+        propertyToMove.sourceId = source.id;
+        await propertyToMove.save();
+      }
     });
 
     beforeEach(() => {
       queryCounter = 0;
     });
 
+    afterAll(async () => {
+      for (const key of propertiesToMoveKeys) {
+        const prevSourceId = prevSourceIds.shift();
+        const propertyToMove = await Property.findOne({
+          where: { key },
+        });
+        propertyToMove.sourceId = prevSourceId;
+        await propertyToMove.save();
+      }
+    });
+
     describe("mapped though a non-unique property", () => {
       let property: Property;
+
+      const updateUserIdPropertyUnique = async (unique: boolean) => {
+        const userIdProperty = await Property.scope(null).findOne({
+          where: { key: "userId" },
+        });
+        await userIdProperty.update({ unique });
+      };
 
       beforeAll(async () => {
         property = await helper.factories.property(
@@ -768,9 +791,13 @@ describe("models/property", () => {
         await property.update({ unique: false, isArray: false });
       });
 
+      afterEach(async () => {
+        await source.setMapping({});
+        await updateUserIdPropertyUnique(true);
+      });
+
       afterAll(async () => {
         await property.destroy();
-        await source.setMapping({ id: "userId" });
       });
 
       test("properties mapped through unique properties can be unique", async () => {
@@ -786,16 +813,18 @@ describe("models/property", () => {
       });
 
       test("properties mapped through non-unique properties cannot be unique", async () => {
-        await source.setMapping({ id: "lastName" });
+        await updateUserIdPropertyUnique(false);
+        await source.setMapping({ last_name: "lastName" });
         await expect(property.update({ unique: true })).rejects.toThrow(
-          /A unique Property cannot be mapped through a non-unique Property/
+          /Unique Property .+ cannot be mapped through a non-unique Property/
         );
       });
 
       test("properties mapped through non-unique properties cannot be arrays", async () => {
-        await source.setMapping({ id: "lastName" });
+        await updateUserIdPropertyUnique(false);
+        await source.setMapping({ last_name: "lastName" });
         await expect(property.update({ isArray: true })).rejects.toThrow(
-          /An array Property cannot be mapped through a non-unique Property/
+          /Array Property .+ cannot be mapped through a non-unique Property/
         );
       });
     });

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -732,9 +732,15 @@ describe("modules/configWriter", () => {
     });
 
     test("sources with a nameless schedule provide a single object", async () => {
-      const source = await helper.factories.source();
+      const model: GrouparooModel = await GrouparooModel.create({
+        type: "profile",
+        name: "People",
+        id: "mod_" + uuid.v4(),
+      });
+      const app = await helper.factories.app();
+      const source = await helper.factories.source(app, { modelId: model.id });
       await source.setOptions({ table: "test-table-05" });
-      await source.bootstrapUniqueProperty("uId05", "integer", "id", "uid05");
+      await source.bootstrapUniqueProperty("uId05", "integer", "id");
       await source.setMapping({ id: "uId05" });
       await source.update({ state: "ready" });
       property = await helper.factories.property(
@@ -748,14 +754,13 @@ describe("modules/configWriter", () => {
       const config = await source.getConfigObject();
 
       const { name, type } = source;
-      const app = await source.$get("app");
       const options = await source.getOptions();
       const mapping = await MappingHelper.getConfigMapping(source);
 
       expect(config).toEqual({
         class: "Source",
         id: source.getConfigId(),
-        modelId: "profiles",
+        modelId: "people",
         name,
         type,
         appId: app.getConfigId(),

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -509,12 +509,12 @@ export class Property extends LoggedModel<Property> {
 
     if (instance.unique)
       throw new Error(
-        `A unique Property cannot be mapped through a non-unique Property - ${mappedProperty.key} (${mappedProperty.id})`
+        `Unique Property ${instance.key} (${instance.id}) cannot be mapped through a non-unique Property - ${mappedProperty.key} (${mappedProperty.id})`
       );
 
     if (instance.isArray)
       throw new Error(
-        `An array Property cannot be mapped through a non-unique Property - ${mappedProperty.key} (${mappedProperty.id})`
+        `Array Property ${instance.key} (${instance.id}) cannot be mapped through a non-unique Property - ${mappedProperty.key} (${mappedProperty.id})`
       );
   }
 

--- a/core/src/modules/mappingHelper.ts
+++ b/core/src/modules/mappingHelper.ts
@@ -117,7 +117,9 @@ export namespace MappingHelper {
 
       if (otherSourcePrimaryKey && property.sourceId === instance.id) {
         throw new Error(
-          `'${instance.name}' cannot map '${remoteKey}' to own Property '${key}'. '${source.name}' must map to a Property from primary Source '${otherSourcePrimaryKey.source.name}'.`
+          `'${instance.name}' cannot map '${remoteKey}' to own Property '${key}'.
+          '${otherSourcePrimaryKey.source.name}' is the primary Source for Model
+          ${instance.modelId} and '${instance.name}' requires a mapping back to '${otherSourcePrimaryKey.source.name}.'`
         );
       }
 


### PR DESCRIPTION
This change ensures that it's not possible to set a mapping to a property in the source when another source owns the primary key by throwing an error.

When running `grouparoo config` where two different sources (`PG users` and `PG purchases`) in the same model point to their own properties in the mapping, we see an error such as:

```
warning: [ config ] error with Source `PG users` (pg_users): 'PG users' cannot map 'id' to own
Property 'userId'. 'PG users' must map to a Property from primary Source 'Pg purchases'. 
```

Related: #2572 

## Change description

Description here

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

In the case that a customer had already setup a configuration where two sources were mapping to their own keys, they would need to update the mapping in the config files.


### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
