### PR TITLE
UI bug fixes -- query schedules textarea, `/sources`

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -371,7 +371,7 @@ export default function Page(props) {
                           onChange={(e) =>
                             updateOption(opt.key, e.target["value"])
                           }
-                          placeholder="select statement with mustache template"
+                          placeholder="select statement to look for new data"
                           style={{
                             fontFamily:
                               'SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',

--- a/ui/ui-components/pages/model/[modelId]/sources.tsx
+++ b/ui/ui-components/pages/model/[modelId]/sources.tsx
@@ -19,6 +19,7 @@ import { grouparooUiEdition } from "../../../utils/uiEdition";
 import { formatSchedule } from "../../../utils/formatSchedule";
 import { formatName } from "../../../utils/formatName";
 import RunAllSchedulesButton from "../../../components/schedule/RunAllSchedulesButton";
+import { Table } from "react-bootstrap";
 
 export default function Page(props) {
   const {
@@ -101,7 +102,7 @@ export default function Page(props) {
         offset={offset}
         onPress={setOffset}
       />
-      <table>
+      <Table>
         <thead>
           <tr>
             <th></th>
@@ -175,7 +176,7 @@ export default function Page(props) {
             );
           })}
         </tbody>
-      </table>
+      </Table>
       <Pagination
         total={total}
         limit={limit}


### PR DESCRIPTION
## Change description

- `/sources` was using a plain HTML table instead of the React Bootstrap `Table`.  Now its styling is consistent with other tables in our UI.
![Screen Shot 2021-12-01 at 8 42 13 AM](https://user-images.githubusercontent.com/63751206/144244983-19230a1c-cf2a-4320-a41a-0f443284dd2e.png)

- Query source schedules default text used to mention mustache variables, but those aren't supported here.  New placeholder text:
![Screen Shot 2021-12-01 at 8 42 05 AM](https://user-images.githubusercontent.com/63751206/144245126-c028cd48-6097-4150-aac8-abd3738b281b.png)

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
