### PR TITLE
Groups config to match shape of other configs

### DIFF
--- a/core/public/templates/groups/calculated/{{{id}}}.js.template
+++ b/core/public/templates/groups/calculated/{{{id}}}.js.template
@@ -3,9 +3,9 @@ exports.default = async function buildConfig() {
     {
       class: "group",
       id: {{{id}}},
+      modelId: {{{modelId}}}, // The id of the Model that the Records in this Group belong to
       name: {{{id}}},
       type: "calculated",
-      modelId: {{{modelId}}}, // The id of the Model that the Records in this Group belong to
 
       /**
        The Rules for this group is an array. Here are some examples.

--- a/core/public/templates/groups/manual/{{{id}}}.js.template
+++ b/core/public/templates/groups/manual/{{{id}}}.js.template
@@ -3,9 +3,9 @@ exports.default = async function buildConfig() {
     {
       class: "group",
       id: {{{id}}},
+      modelId: {{{modelId}}}, // The id of the Model that the Records in this Group belong to
       name: {{{id}}},
       type: "manual",
-      modelId: {{{modelId}}}, // The id of the Model that the Records in this Group belong to
     },
   ];
 };

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -702,18 +702,18 @@ export class Group extends LoggedModel<Group> {
     }
 
     let configObject: {
-      id: string;
       class: string;
-      type: string;
-      name: string;
+      id: string;
       modelId: string;
+      name: string;
+      type: string;
       rules?: any[];
     } = {
-      id: this.getConfigId(),
       class: "Group",
-      type,
+      id: this.getConfigId(),
       modelId,
       name,
+      type,
     };
 
     if (type === "calculated") {

--- a/core/src/modules/configWriter.ts
+++ b/core/src/modules/configWriter.ts
@@ -212,6 +212,7 @@ export namespace ConfigWriter {
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
     const stringifyFilter = (k, v) => (v === null ? undefined : v);
     const content = JSON.stringify(object, stringifyFilter, 2);
+    console.log(content);
     await fs.writeFileSync(
       configFilePath,
       prettier.format(content, { parser: "json" })

--- a/core/src/modules/configWriter.ts
+++ b/core/src/modules/configWriter.ts
@@ -212,7 +212,6 @@ export namespace ConfigWriter {
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
     const stringifyFilter = (k, v) => (v === null ? undefined : v);
     const content = JSON.stringify(object, stringifyFilter, 2);
-    console.log(content);
     await fs.writeFileSync(
       configFilePath,
       prettier.format(content, { parser: "json" })


### PR DESCRIPTION
## Change description

Group config now in the same order as other config objects:

```json
{
  "class": "Group",
  "id": "my_group",
  "modelId": "model",
  "name": "my_group",
  "type": "calculated",
  "rules": [
    {
      "propertyId": "grouparooId",
      "operation": {
        "op": "exists"
      }
    },
    {
      "propertyId": "grouparooId",
      "operation": {
        "op": "exists"
      }
    }
  ]
}


```

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
