### PR TITLE
Add `location` as App option for BigQuery

### DIFF
--- a/plugins/@grouparoo/bigquery/public/templates/app/{{{id}}}.js.template
+++ b/plugins/@grouparoo/bigquery/public/templates/app/{{{id}}}.js.template
@@ -14,6 +14,7 @@ exports.default = async function buildConfig() {
         dataset: "...", // Default dataset ID to use for sources - e.g. `dataset: "dataset"`
         client_email: "xxx@xxx.iam.gserviceaccount.com", // Client Email Address
         private_key: "-----BEGIN PRIVATE KEY-----\n...", // Private key of service account
+        //location: "..." // Optional: If your dataset is located outside of the US, you'll need to provide the region or multi-region location: https://cloud.google.com/bigquery/docs/locations 
       }
     },
   ];

--- a/plugins/@grouparoo/bigquery/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/bigquery/src/initializers/plugin.ts
@@ -85,7 +85,7 @@ export class Plugins extends Initializer {
               displayName: "Location",
               required: false,
               description:
-                "Region or multi-region code of your dataset.  Required for datasets outside the US.",
+                'Region or multi-region code of your dataset. ("US", "EU", "asia-east1", etc.) Required for datasets outside the US.',
               placeholder: "e.g. EU",
             },
           ],

--- a/plugins/@grouparoo/bigquery/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/bigquery/src/initializers/plugin.ts
@@ -80,6 +80,14 @@ export class Plugins extends Initializer {
               description: "Private key of service account.",
               placeholder: "e.g. -----BEGIN PRIVATE KEY-----\nMII ...",
             },
+            {
+              key: "location",
+              displayName: "Location",
+              required: false,
+              description:
+                "Region or multi-region code of your dataset.  Required for datasets outside the US.",
+              placeholder: "e.g. EU",
+            },
           ],
           methods: { test, connect, disconnect, appQuery },
         },

--- a/plugins/@grouparoo/bigquery/src/lib/connect.ts
+++ b/plugins/@grouparoo/bigquery/src/lib/connect.ts
@@ -6,6 +6,9 @@ export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
   const projectId = appOptions.project_id?.toString() || "";
   const dataset = appOptions.dataset?.toString() || "";
   const client_email = appOptions.client_email?.toString() || "";
+  const datasetOptions = appOptions.location
+    ? { location: appOptions.location?.toString() }
+    : {};
   const private_key = (appOptions.private_key || "")
     .toString()
     .replace(/\\n/g, "\n");
@@ -14,7 +17,7 @@ export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
     credentials: { client_email, private_key },
   });
 
-  const bqClient = client.dataset(dataset);
+  const bqClient = client.dataset(dataset, datasetOptions);
   const queryShim: typeof bqClient.query = bqClient.query.bind(bqClient);
   (bqClient as any).query = (
     options: Parameters<typeof bqClient.query>[0],


### PR DESCRIPTION
## Change description

Previously, because BigQuery defaults to US, we could only support US datasets.  This PR adds an optional `appOption` to BigQuery plugin for the region or multi-region code of a BigQuery dataset, passes that as part of the connection.  This is only required for users with a dataset outside the United States.

![Screen Shot 2021-12-01 at 10 42 35 AM](https://user-images.githubusercontent.com/63751206/144265562-19ef5215-5d92-4f3f-ae0f-c0ee587be7cf.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
