### PR TITLE
Ignore null/undefined config objects and return a useful error about the file with the problem

### DIFF
--- a/core/__tests__/classes/codeConfig.ts
+++ b/core/__tests__/classes/codeConfig.ts
@@ -17,7 +17,7 @@ describe("classes/codeConfig", () => {
 
   beforeAll(async () => {
     const dir = path.join(__dirname, "..", "fixtures", "codeConfig", "initial");
-    configObjects = await loadConfigObjects(dir);
+    ({ configObjects } = await loadConfigObjects(dir));
   });
 
   describe("#getParentIds", () => {
@@ -222,7 +222,7 @@ describe("classes/codeConfig", () => {
         "codeConfig",
         "multiple-sources"
       );
-      const _configObjects = await loadConfigObjects(dir);
+      const { configObjects: _configObjects } = await loadConfigObjects(dir);
       const source = _configObjects.find(
         (o) => o.id === "purchases_table"
       ) as SourceConfigurationObject;
@@ -242,7 +242,7 @@ describe("classes/codeConfig", () => {
         "codeConfig",
         "error-bootstrap-not-unique"
       );
-      const _configObjects = await loadConfigObjects(dir);
+      const { configObjects: _configObjects } = await loadConfigObjects(dir);
       const source = _configObjects.find(
         (o) => o.id === "users_table"
       ) as SourceConfigurationObject;
@@ -260,7 +260,7 @@ describe("classes/codeConfig", () => {
         "codeConfig",
         "error-bootstrap-is-array"
       );
-      const _configObjects = await loadConfigObjects(dir);
+      const { configObjects: _configObjects } = await loadConfigObjects(dir);
       const source = _configObjects.find(
         (o) => o.id === "users_table"
       ) as SourceConfigurationObject;

--- a/core/__tests__/fixtures/codeConfig/error-null-objects/config.js
+++ b/core/__tests__/fixtures/codeConfig/error-null-objects/config.js
@@ -1,0 +1,91 @@
+module.exports = async function getConfig() {
+  return [
+    {
+      id: "data_warehouse", // id -> `data_warehouse`
+      name: "Data Warehouse",
+      class: "App",
+      type: "test-plugin-app",
+      options: {
+        fileId: "test-file-path.db",
+      },
+    },
+
+    {
+      id: "mod_profiles",
+      class: "Model",
+      name: "Profiles",
+      type: "profile",
+    },
+
+    {
+      id: "users_table", // id -> `data_warehouse`
+      name: "Users Table",
+      class: "Source",
+      type: "test-plugin-import",
+      modelId: "mod_profiles",
+      appId: "data_warehouse", // appId -> `data_warehouse`
+      options: {
+        table: "users",
+      },
+      mapping: {
+        id: "user_id",
+      },
+    },
+
+    {
+      id: "user_id", // id -> `user_id`
+      name: "userId",
+      class: "Property",
+      type: "integer",
+      unique: true,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "id",
+      },
+      filters: [],
+    },
+
+    {
+      id: "email", // id -> `email`
+      name: "email",
+      class: "Property",
+      type: "email",
+      unique: true,
+      isArray: false,
+      sourceId: "users_table", // sourceId -> `users_table`
+      options: {
+        column: "email",
+      },
+      filters: [],
+    },
+
+    // We have 3 good records, and 2 bad ones
+    {
+      id: "rec_e1e3be15-8cc6-4f46-a786-dceb080f0394",
+      class: "Record",
+      modelId: "customer",
+      properties: {
+        id: [1],
+      },
+    },
+    {
+      id: "rec_c040168b-16f5-488e-adca-63b298b64a65",
+      class: "Record",
+      modelId: "customer",
+      properties: {
+        id: [5],
+      },
+    },
+    {
+      id: "rec_af4967c8-4024-48b5-8462-bb408416abd0",
+      class: "Record",
+      modelId: "customer",
+      properties: {
+        id: [10],
+      },
+    },
+    null,
+    undefined,
+  ];
+};

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -1104,6 +1104,26 @@ describe("modules/codeConfig", () => {
         });
       });
 
+      test("null record objects should provides a useful error", async () => {
+        await helper.truncate();
+
+        const { errors } = await loadConfigDirectory(
+          path.join(
+            __dirname,
+            "..",
+            "..",
+            "fixtures",
+            "codeConfig",
+            "error-null-objects"
+          )
+        );
+        expect(errors.length).toEqual(1);
+        expect(errors[0]).toMatch(
+          /has 2 null or undefined top-level config objects/
+        );
+        expect(errors[0]).toMatch("error-null-objects/config.js");
+      });
+
       test("records are loaded in cli:config mode", async () => {
         await helper.truncate();
 

--- a/core/__tests__/modules/codeConfig/validate.ts
+++ b/core/__tests__/modules/codeConfig/validate.ts
@@ -63,7 +63,7 @@ describe("modules/codeConfig", () => {
         "initial"
       );
 
-      const configObjects = await loadConfigObjects(dir);
+      const { configObjects } = await loadConfigObjects(dir);
 
       await expect(
         api.sequelize.transaction(async () => {
@@ -111,7 +111,7 @@ describe("modules/codeConfig", () => {
         "error-group"
       );
 
-      const configObjects = await loadConfigObjects(dir);
+      const { configObjects } = await loadConfigObjects(dir);
 
       await expect(
         api.sequelize.transaction(async () => {
@@ -144,7 +144,7 @@ describe("modules/codeConfig", () => {
         "error-group"
       );
 
-      const configObjects = await loadConfigObjects(dir);
+      const { configObjects } = await loadConfigObjects(dir);
 
       await expect(
         api.sequelize.transaction(async () => {
@@ -177,7 +177,7 @@ describe("modules/codeConfig", () => {
         "error-app-remote"
       );
 
-      const configObjects = await loadConfigObjects(dir);
+      const { configObjects } = await loadConfigObjects(dir);
 
       await expect(
         api.sequelize.transaction(async () => {
@@ -213,7 +213,7 @@ describe("modules/codeConfig", () => {
         "error-app-remote"
       );
 
-      const configObjects = await loadConfigObjects(dir);
+      const { configObjects } = await loadConfigObjects(dir);
 
       await expect(
         api.sequelize.transaction(async () => {
@@ -243,7 +243,7 @@ describe("modules/codeConfig", () => {
         "error-app-remote"
       );
 
-      const configObjects = await loadConfigObjects(dir);
+      const { configObjects } = await loadConfigObjects(dir);
 
       await expect(
         api.sequelize.transaction(async () => {
@@ -276,7 +276,7 @@ describe("modules/codeConfig", () => {
         "error-app-destination-remote"
       );
 
-      const configObjects = await loadConfigObjects(dir);
+      const { configObjects } = await loadConfigObjects(dir);
 
       await expect(
         api.sequelize.transaction(async () => {

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -434,15 +434,15 @@ describe("modules/configWriter", () => {
           object: await property.getConfigObject(),
         },
         {
-          filePath: `settings/${setting.getConfigId()}.json`,
-          object: await setting.getConfigObject(),
-        },
-        {
-          filePath: `development/records.json`,
+          filePath: `development/${model.getConfigId()}/records.json`,
           object: [
             await record.getConfigObject(),
             await record2.getConfigObject(),
           ],
+        },
+        {
+          filePath: `settings/${setting.getConfigId()}.json`,
+          object: await setting.getConfigObject(),
         },
       ]);
     });

--- a/core/src/bin/apply.ts
+++ b/core/src/bin/apply.ts
@@ -38,7 +38,8 @@ export class Apply extends CLI {
     GrouparooCLI.logCLI(this.name);
 
     const configDir = await getConfigDir(true);
-    const configObjects = await loadConfigObjects(configDir);
+    const { configObjects, errors } = await loadConfigObjects(configDir);
+    if (errors.length > 0) throw new Error(errors.join("; "));
 
     const response = await CLS.wrap(
       async () => {

--- a/core/src/bin/validate.ts
+++ b/core/src/bin/validate.ts
@@ -42,7 +42,11 @@ export class Validate extends CLI {
 
     // Can we read the config directory?  Is the JSON/JS valid?
     try {
-      configObjects = await loadConfigObjects(configDir);
+      const loadResponse = await loadConfigObjects(configDir);
+      if (loadResponse.errors.length > 0) {
+        throw new Error(loadResponse.errors.join("; "));
+      }
+      configObjects = loadResponse.configObjects;
     } catch (error) {
       return GrouparooCLI.logger.fatal(
         `Error loading config from ${configDir}: \r\n\r\n${error.stack}`

--- a/core/src/initializers/codeConfig.ts
+++ b/core/src/initializers/codeConfig.ts
@@ -32,7 +32,10 @@ export class CodeConfig extends CLSInitializer {
 
     const { errors } = await loadConfigDirectory(configDir);
 
-    if (errors.length > 0) throw new Error("code config error");
+    if (errors.length > 0) {
+      throw new Error("code config error: " + errors.join("; "));
+    }
+
     api.codeConfig.allowLockedModelChanges = false; // after this point in the Actionhero boot lifecycle, locked models cannot be changed
   }
 

--- a/core/src/migrations/000083-models.ts
+++ b/core/src/migrations/000083-models.ts
@@ -43,7 +43,8 @@ export default {
       // OK, we don't have any records we need to worry about updating
     } else if (codeConfigInUse === true) {
       const configDir = await getConfigDir();
-      const configObjects = await loadConfigObjects(configDir);
+      const { configObjects, errors } = await loadConfigObjects(configDir);
+      if (errors.length > 0) throw new Error(errors.join("; "));
       const modelConfigObjects = configObjects.filter(
         (o) => o.class === "Model"
       ) as Required<ModelConfigurationObject>[];

--- a/tools/merger/package-lock.json
+++ b/tools/merger/package-lock.json
@@ -1,8 +1,383 @@
 {
   "name": "@grouparoo/merger",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@grouparoo/merger",
+      "version": "0.1.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "glob": "7.1.7",
+        "mustache": "4.0.1",
+        "prettier": "2.0.2",
+        "yargs": "15.3.1"
+      },
+      "devDependencies": {},
+      "engines": {
+        "node": ">=12.0.0 <17.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA==",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
+      "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "node_modules/string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/y18n": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
+    },
+    "node_modules/yargs": {
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+      "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
   "dependencies": {
     "ansi-regex": {
       "version": "5.0.1",


### PR DESCRIPTION
1. If there are null or undefined config objects, we now return an error with the filename that has the problem (rather than mysteriously crashing)
2. If there's a problem saving the Sample Record, don't write `null` to the config file

This PR also changes config object writing (specifically for records, but it may apply in the future to other config types). This allows for merging config objects that share a destination filepath.

What this allows us to do is break out `Record` config files on a per-model basis

Before:
```
config/development/records.json
```

After:
```
config/development/customers/records.json
config/development/accounts/records.json
```

Thanks to @rwfeather!

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
