### PR TITLE
App refresh timing

### DIFF
--- a/core/src/models/AppRefreshQuery.ts
+++ b/core/src/models/AppRefreshQuery.ts
@@ -144,6 +144,9 @@ export class AppRefreshQuery extends LoggedModel<AppRefreshQuery> {
     }
     //query and run if the query has changed
     if (instance.changed("refreshQuery")) {
+      instance.lastConfirmedAt = null;
+      instance.lastChangedAt = null;
+      instance.value = null;
       await CLS.enqueueTask("appRefreshQuery:run", {
         appRefreshQueryId: instance.id,
       });

--- a/core/src/models/AppRefreshQuery.ts
+++ b/core/src/models/AppRefreshQuery.ts
@@ -142,7 +142,7 @@ export class AppRefreshQuery extends LoggedModel<AppRefreshQuery> {
     if (instance.state === "ready") {
       await AppRefreshQueryOps.runAppQuery(instance);
     }
-    //query and run if the query has changed
+    //if the query has been changed, reset it and enqueue run.
     if (instance.changed("refreshQuery")) {
       instance.lastConfirmedAt = null;
       instance.lastChangedAt = null;

--- a/core/src/tasks/appRefreshQuery/run.ts
+++ b/core/src/tasks/appRefreshQuery/run.ts
@@ -25,17 +25,19 @@ export class AppRefreshQueryRun extends CLSTask {
 
     //check the query value, update 'confirmedAt'
     const sampleValue = await appRefreshQuery.query();
-    await appRefreshQuery.update({ lastConfirmedAt: new Date() });
 
     if (sampleValue !== appRefreshQuery.value) {
+      //trigger enqueues for all related schedules
+      await appRefreshQuery.triggerSchedules();
+
       // Update changedAt and set value
       await appRefreshQuery.update({
         value: sampleValue,
         lastChangedAt: new Date(),
+        lastConfirmedAt: new Date(),
       });
-
-      //trigger enqueues for all related schedules
-      await appRefreshQuery.triggerSchedules();
+    } else {
+      await appRefreshQuery.update({ lastConfirmedAt: new Date() });
     }
   }
 }

--- a/core/src/tasks/appRefreshQuery/run.ts
+++ b/core/src/tasks/appRefreshQuery/run.ts
@@ -23,14 +23,11 @@ export class AppRefreshQueryRun extends CLSTask {
 
     if (!appRefreshQuery) return;
 
-    //check the query value, update 'confirmedAt'
     const sampleValue = await appRefreshQuery.query();
 
     if (sampleValue !== appRefreshQuery.value) {
-      //trigger enqueues for all related schedules
       await appRefreshQuery.triggerSchedules();
 
-      // Update changedAt and set value
       await appRefreshQuery.update({
         value: sampleValue,
         lastChangedAt: new Date(),


### PR DESCRIPTION
## Change description

Previously, if an `app refresh query` was updated in config mode, it wouldn't run immediately when the server started.  This is because the `run` was triggered from the `@AfterSave` hook, but it couldn't actually run the task in config.  This means for a period when the server did start, the `value` was incorrect, and wouldn't be corrected until the `recurringFrequency` timer triggered a `run` task.

To prevent this, the `@BeforeSave` hook should set the timestamps and value on the `AppRefreshQuery` to `null`.  This both more accurately represents the data and ensures  a `run` task will be triggered on the server's start.  

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
