### PR TITLE
App Refresh Query UI: hitting cancel on an empty query

### DIFF
--- a/ui/ui-components/pages/app/[id]/refresh.tsx
+++ b/ui/ui-components/pages/app/[id]/refresh.tsx
@@ -289,7 +289,7 @@ export default function Page(props) {
                   as="textarea"
                   disabled={disabled || !editing}
                   rows={6}
-                  value={appRefreshQuery.refreshQuery}
+                  value={appRefreshQuery.refreshQuery || ""}
                   onChange={(e) => update(e)}
                   placeholder="select statement to check app for new data"
                   style={{


### PR DESCRIPTION
## Change description

On `/app/[id]/refresh`: When an edit is cancelled, the textarea will now revert back to the previous value (either from the object or an empty string)


![Screen Shot 2021-12-03 at 4 02 59 PM](https://user-images.githubusercontent.com/63751206/144672472-303ef6d9-6870-484a-8c97-09ca6f37b963.png)


There's still a bit of wonkiness in UI config due to the null/undefined bug that @evantahler is going to help look into.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
