### PR TITLE
Clarify UI disabled logic when object is locked

### DIFF
--- a/core/__tests__/integration/errors.ts
+++ b/core/__tests__/integration/errors.ts
@@ -48,7 +48,7 @@ describe("errors", () => {
       message: "name must be unique",
       code: "unique violation",
       fields: ["name"],
-      sql: 'INSERT INTO "teams" ("id","name","locked","permissionAllRead","permissionAllWrite","createdAt","updatedAt") VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING "id","name","locked","permissionAllRead","permissionAllWrite","createdAt","updatedAt";',
+      sql: 'INSERT INTO "teams" ("id","name","permissionAllRead","permissionAllWrite","createdAt","updatedAt") VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id","name","locked","permissionAllRead","permissionAllWrite","createdAt","updatedAt";',
     });
   });
 });

--- a/core/__tests__/integration/errors.ts
+++ b/core/__tests__/integration/errors.ts
@@ -48,7 +48,7 @@ describe("errors", () => {
       message: "name must be unique",
       code: "unique violation",
       fields: ["name"],
-      sql: 'INSERT INTO "teams" ("id","name","permissionAllRead","permissionAllWrite","createdAt","updatedAt") VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id","name","locked","permissionAllRead","permissionAllWrite","createdAt","updatedAt";',
+      sql: 'INSERT INTO "teams" ("id","name","locked","permissionAllRead","permissionAllWrite","createdAt","updatedAt") VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING "id","name","locked","permissionAllRead","permissionAllWrite","createdAt","updatedAt";',
     });
   });
 });

--- a/core/src/migrations/000054-lockedString.ts
+++ b/core/src/migrations/000054-lockedString.ts
@@ -23,6 +23,7 @@ export default {
       const table = tables[i];
       await queryInterface.changeColumn(table, "locked", {
         type: DataTypes.STRING(191),
+        defaultValue: null, // normally the default value of a string column is null, but since we are migrating from a boolean, we need to re-set the default
         allowNull: true,
       });
       if (table !== "teams") {

--- a/core/src/migrations/000054-lockedString.ts
+++ b/core/src/migrations/000054-lockedString.ts
@@ -24,7 +24,6 @@ export default {
       await queryInterface.changeColumn(table, "locked", {
         type: DataTypes.STRING(191),
         allowNull: true,
-        defaultValue: null,
       });
       if (table !== "teams") {
         await queryInterface.sequelize.query(

--- a/core/src/migrations/000055-errorLevelForExports.ts
+++ b/core/src/migrations/000055-errorLevelForExports.ts
@@ -8,7 +8,6 @@ export default {
     await queryInterface.addColumn("exports", "errorLevel", {
       type: DataTypes.STRING(191),
       allowNull: true,
-      defaultValue: null,
     });
 
     await queryInterface.sequelize.query(

--- a/core/src/migrations/000058-runDestinationId.ts
+++ b/core/src/migrations/000058-runDestinationId.ts
@@ -8,7 +8,6 @@ export default {
     await queryInterface.addColumn("runs", "destinationId", {
       type: DataTypes.STRING(40),
       allowNull: true,
-      defaultValue: null,
     });
   },
 

--- a/core/src/migrations/000089-createAppDataRefreshes.ts
+++ b/core/src/migrations/000089-createAppDataRefreshes.ts
@@ -36,6 +36,7 @@ export default {
 
       locked: {
         type: DataTypes.STRING(191),
+        allowNull: true,
       },
 
       state: {

--- a/core/src/models/ApiKey.ts
+++ b/core/src/models/ApiKey.ts
@@ -6,6 +6,7 @@ import {
   HasMany,
   AfterSave,
   AfterDestroy,
+  Default,
   BeforeValidate,
   BeforeSave,
   BeforeDestroy,
@@ -37,6 +38,7 @@ export class ApiKey extends LoggedModel<ApiKey> {
   apiKey: string;
 
   @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/ApiKey.ts
+++ b/core/src/models/ApiKey.ts
@@ -37,16 +37,12 @@ export class ApiKey extends LoggedModel<ApiKey> {
   @Column
   apiKey: string;
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 
-  @AllowNull(true)
   @Column
   permissionAllRead: boolean;
 
-  @AllowNull(true)
   @Column
   permissionAllWrite: boolean;
 

--- a/core/src/models/ApiKey.ts
+++ b/core/src/models/ApiKey.ts
@@ -6,7 +6,6 @@ import {
   HasMany,
   AfterSave,
   AfterDestroy,
-  Default,
   BeforeValidate,
   BeforeSave,
   BeforeDestroy,

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -55,7 +55,6 @@ export class App extends LoggedModel<App> {
     return "app";
   }
 
-  @AllowNull(true)
   @Length({ min: 0, max: 191 })
   @Default("")
   @Column
@@ -65,8 +64,6 @@ export class App extends LoggedModel<App> {
   @Column
   type: string;
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -66,6 +66,7 @@ export class App extends LoggedModel<App> {
   type: string;
 
   @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/AppRefreshQuery.ts
+++ b/core/src/models/AppRefreshQuery.ts
@@ -50,6 +50,8 @@ export class AppRefreshQuery extends LoggedModel<AppRefreshQuery> {
   @Column
   value: string;
 
+  @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/AppRefreshQuery.ts
+++ b/core/src/models/AppRefreshQuery.ts
@@ -50,8 +50,6 @@ export class AppRefreshQuery extends LoggedModel<AppRefreshQuery> {
   @Column
   value: string;
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -151,6 +151,7 @@ export class Destination extends LoggedModel<Destination> {
   type: string;
 
   @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -140,7 +140,6 @@ export class Destination extends LoggedModel<Destination> {
   @ForeignKey(() => App)
   appId: string;
 
-  @AllowNull(true)
   @Length({ min: 0, max: 191 })
   @Default("")
   @Column
@@ -150,8 +149,6 @@ export class Destination extends LoggedModel<Destination> {
   @Column
   type: string;
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 
@@ -160,12 +157,10 @@ export class Destination extends LoggedModel<Destination> {
   @Column(DataType.ENUM(...STATES))
   state: typeof STATES[number];
 
-  @AllowNull(true)
   @Column
   @ForeignKey(() => Group)
   groupId: string;
 
-  @AllowNull(true)
   @Column(DataType.ENUM(...SYNC_MODES))
   syncMode: DestinationSyncMode;
 

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -78,7 +78,6 @@ export class Export extends CommonModel<Export> {
   @Column
   recordId: string;
 
-  @AllowNull(true)
   @ForeignKey(() => ExportProcessor)
   @Column
   exportProcessorId: string;

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -134,6 +134,7 @@ export class Group extends LoggedModel<Group> {
   state: typeof STATES[number];
 
   @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -103,7 +103,6 @@ export class Group extends LoggedModel<Group> {
     return "grp";
   }
 
-  @AllowNull(true)
   @Length({ min: 0, max: 191 })
   @Default("")
   @Column
@@ -133,8 +132,6 @@ export class Group extends LoggedModel<Group> {
   @Column(DataType.ENUM(...STATES))
   state: typeof STATES[number];
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/GroupRule.ts
+++ b/core/src/models/GroupRule.ts
@@ -22,12 +22,10 @@ export class GroupRule extends CommonModel<GroupRule> {
   @Column
   groupId: string;
 
-  @AllowNull(true)
   @ForeignKey(() => Property)
   @Column
   propertyId: string;
 
-  @AllowNull(true)
   @Column
   recordColumn: string;
 

--- a/core/src/models/GrouparooModel.ts
+++ b/core/src/models/GrouparooModel.ts
@@ -64,6 +64,7 @@ export class GrouparooModel extends LoggedModel<GrouparooModel> {
   type: ModelType;
 
   @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/GrouparooModel.ts
+++ b/core/src/models/GrouparooModel.ts
@@ -63,8 +63,6 @@ export class GrouparooModel extends LoggedModel<GrouparooModel> {
   @Column(DataType.ENUM(...ModelTypes))
   type: ModelType;
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Notification.ts
+++ b/core/src/models/Notification.ts
@@ -20,15 +20,12 @@ export class Notification extends LoggedModel<Notification> {
   @Column
   body: string;
 
-  @AllowNull(true)
   @Column
   cta: string;
 
-  @AllowNull(true)
   @Column
   ctaLink: string;
 
-  @AllowNull(true)
   @Column
   readAt: Date;
 

--- a/core/src/models/Permission.ts
+++ b/core/src/models/Permission.ts
@@ -69,8 +69,6 @@ export class Permission extends LoggedModel<Permission> {
   @Column
   write: boolean;
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Permission.ts
+++ b/core/src/models/Permission.ts
@@ -70,6 +70,7 @@ export class Permission extends LoggedModel<Permission> {
   write: boolean;
 
   @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -134,6 +134,7 @@ export class Property extends LoggedModel<Property> {
   state: typeof STATES[number];
 
   @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -103,7 +103,6 @@ export class Property extends LoggedModel<Property> {
     return "prp";
   }
 
-  @AllowNull(true)
   @Length({ min: 0, max: 191 })
   @Default("")
   @Column
@@ -133,8 +132,6 @@ export class Property extends LoggedModel<Property> {
   @Column(DataType.ENUM(...STATES))
   state: typeof STATES[number];
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/RecordProperty.ts
+++ b/core/src/models/RecordProperty.ts
@@ -68,7 +68,6 @@ export class RecordProperty extends CommonModel<RecordProperty> {
   @Column
   unique: boolean;
 
-  @AllowNull(true)
   @Column
   valueChangedAt: Date;
 
@@ -77,11 +76,9 @@ export class RecordProperty extends CommonModel<RecordProperty> {
   @Column
   stateChangedAt: Date;
 
-  @AllowNull(true)
   @Column
   confirmedAt: Date;
 
-  @AllowNull(true)
   @Column
   startedAt: Date;
 

--- a/core/src/models/Run.ts
+++ b/core/src/models/Run.ts
@@ -119,7 +119,6 @@ export class Run extends CommonModel<Run> {
   @Column
   percentComplete: number;
 
-  @AllowNull(true)
   @Column
   destinationId: string;
 

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -103,6 +103,7 @@ export class Schedule extends LoggedModel<Schedule> {
   state: typeof STATES[number];
 
   @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -91,7 +91,6 @@ export class Schedule extends LoggedModel<Schedule> {
   @ForeignKey(() => Source)
   sourceId: string;
 
-  @AllowNull(true)
   @Length({ min: 0, max: 191 })
   @Default("")
   @Column
@@ -102,8 +101,6 @@ export class Schedule extends LoggedModel<Schedule> {
   @Column(DataType.ENUM(...STATES))
   state: typeof STATES[number];
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Setting.ts
+++ b/core/src/models/Setting.ts
@@ -54,8 +54,6 @@ export class Setting extends LoggedModel<Setting> {
   @Column(DataType.ENUM(...settingTypes))
   type: typeof settingTypes[number];
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Setting.ts
+++ b/core/src/models/Setting.ts
@@ -1,6 +1,7 @@
 import {
   Table,
   Column,
+  Default,
   AllowNull,
   BeforeSave,
   DataType,
@@ -54,6 +55,7 @@ export class Setting extends LoggedModel<Setting> {
   type: typeof settingTypes[number];
 
   @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Setting.ts
+++ b/core/src/models/Setting.ts
@@ -1,7 +1,6 @@
 import {
   Table,
   Column,
-  Default,
   AllowNull,
   BeforeSave,
   DataType,

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -100,6 +100,7 @@ export class Source extends LoggedModel<Source> {
   state: typeof STATES[number];
 
   @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -84,7 +84,6 @@ export class Source extends LoggedModel<Source> {
   @Column
   appId: string;
 
-  @AllowNull(true)
   @Length({ min: 0, max: 191 })
   @Default("")
   @Column
@@ -99,8 +98,6 @@ export class Source extends LoggedModel<Source> {
   @Column(DataType.ENUM(...STATES))
   state: typeof STATES[number];
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/Team.ts
+++ b/core/src/models/Team.ts
@@ -33,16 +33,12 @@ export class Team extends LoggedModel<Team> {
   @Column
   name: string;
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 
-  @AllowNull(true)
   @Column
   permissionAllRead: boolean;
 
-  @AllowNull(true)
   @Column
   permissionAllWrite: boolean;
 

--- a/core/src/models/Team.ts
+++ b/core/src/models/Team.ts
@@ -3,7 +3,6 @@ import {
   Column,
   AllowNull,
   Length,
-  Default,
   AfterSave,
   BeforeDestroy,
   HasMany,

--- a/core/src/models/Team.ts
+++ b/core/src/models/Team.ts
@@ -3,6 +3,7 @@ import {
   Column,
   AllowNull,
   Length,
+  Default,
   AfterSave,
   BeforeDestroy,
   HasMany,
@@ -33,6 +34,7 @@ export class Team extends LoggedModel<Team> {
   name: string;
 
   @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/TeamMember.ts
+++ b/core/src/models/TeamMember.ts
@@ -3,6 +3,7 @@ import {
   Column,
   AllowNull,
   IsEmail,
+  Default,
   BelongsTo,
   BeforeSave,
   ForeignKey,
@@ -30,6 +31,7 @@ export class TeamMember extends LoggedModel<TeamMember> {
   teamId: string;
 
   @AllowNull(true)
+  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/TeamMember.ts
+++ b/core/src/models/TeamMember.ts
@@ -30,8 +30,6 @@ export class TeamMember extends LoggedModel<TeamMember> {
   @ForeignKey(() => Team)
   teamId: string;
 
-  @AllowNull(true)
-  @Default(null)
   @Column
   locked: string;
 

--- a/core/src/models/TeamMember.ts
+++ b/core/src/models/TeamMember.ts
@@ -3,7 +3,6 @@ import {
   Column,
   AllowNull,
   IsEmail,
-  Default,
   BelongsTo,
   BeforeSave,
   ForeignKey,

--- a/core/src/modules/lockableHelper.ts
+++ b/core/src/modules/lockableHelper.ts
@@ -6,7 +6,10 @@ export namespace LockableHelper {
     instance,
     allowedColumnsThatCanChangeWhenLocked: string[] = []
   ) {
-    if (instance.locked === null || instance.locked === undefined) return;
+    // because of the strange way that SQLite handles undefined values, we need to convert any `undefined` to `null`
+    if (instance.locked === undefined) instance.locked = null;
+
+    if (!Boolean(instance.locked)) return;
     if (api?.codeConfig?.allowLockedModelChanges !== false) return;
     if (instance.isNewRecord) return;
 

--- a/core/src/modules/lockableHelper.ts
+++ b/core/src/modules/lockableHelper.ts
@@ -26,31 +26,35 @@ export namespace LockableHelper {
         throw new Error(
           `you cannot update this locked ${modelName(instance)} (${
             instance.id
-          }) [${changedCols.map((k) => `\`${k}\``).join(", ")} has changes]`
+          } - ${instance.locked}) [${changedCols
+            .map((k) => `\`${k}\``)
+            .join(", ")} has changes]`
         );
       }
     }
   }
 
   export async function beforeUpdateOptions(instance, hasChanges = true) {
-    if (instance.locked === null || instance.locked === undefined) return;
+    if (!Boolean(instance.locked)) return;
     if (api?.codeConfig?.allowLockedModelChanges !== false) return;
 
     if (hasChanges) {
       throw new Error(
         `you cannot update the options for a locked ${modelName(instance)} (${
           instance.id
-        })`
+        }) - ${instance.locked}`
       );
     }
   }
 
   export async function beforeDestroy(instance) {
-    if (instance.locked === null || instance.locked === undefined) return;
+    if (!Boolean(instance.locked)) return;
     if (api?.codeConfig?.allowLockedModelChanges !== false) return;
 
     throw new Error(
-      `you cannot destroy a locked ${modelName(instance)} (${instance.id})`
+      `you cannot destroy a locked ${modelName(instance)} (${instance.id} - ${
+        instance.locked
+      })`
     );
   }
 }

--- a/ui/ui-components/components/Permissions.tsx
+++ b/ui/ui-components/components/Permissions.tsx
@@ -119,7 +119,7 @@ export default function PermissionsList({
                   <Form.Group controlId={`${permission.id}~read`}>
                     <Form.Check
                       checked={permission.read}
-                      disabled={permission.locked !== null}
+                      disabled={Boolean(permission.locked)}
                       type="checkbox"
                       label="Read Access"
                       onChange={() => {
@@ -136,7 +136,7 @@ export default function PermissionsList({
                   <Form.Group controlId={`${permission.id}~write`}>
                     <Form.Check
                       checked={permission.write}
-                      disabled={permission.locked !== null}
+                      disabled={Boolean(permission.locked)}
                       type="checkbox"
                       label="Write Access"
                       onChange={() => {

--- a/ui/ui-components/components/settings/SettingCard.tsx
+++ b/ui/ui-components/components/settings/SettingCard.tsx
@@ -34,7 +34,7 @@ export default function SettingCard({
           <LockedBadge object={setting} />
 
           <Form onSubmit={handleSubmit(onSubmit)} autoComplete="off">
-            <fieldset disabled={setting.locked !== null}>
+            <fieldset disabled={Boolean(setting.locked)}>
               <Form.Group>
                 {setting.type === "string" ? (
                   <Form.Control

--- a/ui/ui-components/pages/account.tsx
+++ b/ui/ui-components/pages/account.tsx
@@ -66,7 +66,7 @@ export default function Page(props) {
         </Col>
         <Col md={10}>
           <Form id="form" onSubmit={submit}>
-            <fieldset disabled={teamMember.locked !== null}>
+            <fieldset disabled={Boolean(teamMember.locked)}>
               <Form.Group controlId="firstName">
                 <Form.Label>First Name</Form.Label>
                 <Form.Control

--- a/ui/ui-components/pages/app/[id]/edit.tsx
+++ b/ui/ui-components/pages/app/[id]/edit.tsx
@@ -133,7 +133,7 @@ export default function Page(props) {
       <Row>
         <Col>
           <Form id="form" onSubmit={edit} autoComplete="off">
-            <fieldset disabled={app.locked !== null}>
+            <fieldset disabled={Boolean(app.locked)}>
               <Form.Group controlId="name">
                 <Form.Label>Name</Form.Label>
                 <Form.Control
@@ -371,8 +371,7 @@ export default function Page(props) {
                 {loading ? <Loader /> : null}
               </Col>
             </Row>
-
-            <fieldset disabled={app.locked !== null}>
+            <fieldset disabled={Boolean(app.locked)}>
               <LoadingButton variant="primary" type="submit" loading={loading}>
                 Update
               </LoadingButton>

--- a/ui/ui-components/pages/app/[id]/refresh.tsx
+++ b/ui/ui-components/pages/app/[id]/refresh.tsx
@@ -47,7 +47,7 @@ export default function Page(props) {
   const { id } = router.query;
   const { schedules, runs, sources } = props;
   const disabled = useMemo(
-    () => app?.locked !== null || appRefreshQuery?.locked !== null,
+    () => Boolean(app?.locked || appRefreshQuery?.locked),
     [app, appRefreshQuery]
   );
 
@@ -224,7 +224,7 @@ export default function Page(props) {
             <p>{app.name} has no App Refresh Query.</p>
             <Button
               onClick={create}
-              disabled={app.locked !== null}
+              disabled={Boolean(app.locked)}
               className="mx-auto"
             >
               Add an App Refresh Query
@@ -401,7 +401,7 @@ export default function Page(props) {
             runs={runs}
             sources={sources}
           />
-          <fieldset disabled={appRefreshQuery.locked !== null}>
+          <fieldset disabled={Boolean(appRefreshQuery.locked)}>
             <Row className="ml-2 my-3"></Row>
             <Row className="ml-2 my-3">
               <Button

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -289,7 +289,7 @@ export default function Page(props) {
       <Row>
         <Col>
           <Form id="form" onSubmit={update}>
-            <fieldset disabled={destination.locked !== null}>
+            <fieldset disabled={Boolean(destination.locked)}>
               <Row>
                 <Col>
                   <h5>

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
@@ -163,7 +163,7 @@ export default function Page(props) {
       <Row>
         <Col>
           <Form id="form" onSubmit={onSubmit} autoComplete="off">
-            <fieldset disabled={destination.locked !== null}>
+            <fieldset disabled={Boolean(destination.locked)}>
               <Form.Group controlId="name">
                 <Form.Label>Name</Form.Label>
                 <Form.Control

--- a/ui/ui-components/pages/model/[modelId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/edit.tsx
@@ -89,7 +89,7 @@ export default function Page(props) {
       <Row>
         <Col>
           <Form id="form" onSubmit={edit} autoComplete="off">
-            <fieldset disabled={model.locked !== null}>
+            <fieldset disabled={Boolean(model.locked)}>
               <Form.Group controlId="name">
                 <Form.Label>Name</Form.Label>
                 <Form.Control
@@ -119,8 +119,7 @@ export default function Page(props) {
                 </Form.Control>
               </Form.Group>
             </fieldset>
-
-            <fieldset disabled={model.locked !== null}>
+            <fieldset disabled={Boolean(model.locked)}>
               <LoadingButton variant="primary" type="submit" loading={loading}>
                 Update
               </LoadingButton>

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
@@ -130,7 +130,7 @@ export default function Page(props) {
       <Row>
         <Col>
           <Form id="form" onSubmit={submit} autoComplete="off">
-            <fieldset disabled={group.locked !== null}>
+            <fieldset disabled={Boolean(group.locked)}>
               <Form.Group controlId="name">
                 <Form.Label>Name</Form.Label>
                 <Form.Control

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -187,7 +187,7 @@ export default function Page(props) {
         of these rules.
       </p>
       <Form inline autoComplete="off">
-        <fieldset disabled={group.locked !== null}>
+        <fieldset disabled={Boolean(group.locked)}>
           <Table bordered size="sm">
             <thead>
               <tr>

--- a/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
@@ -229,7 +229,7 @@ export default function Page(props) {
       />
 
       <Form id="form" onSubmit={onSubmit} autoComplete="off">
-        <fieldset disabled={property.locked !== null}>
+        <fieldset disabled={Boolean(property.locked)}>
           <Row>
             <Col>
               <Form.Group controlId="key">

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -189,7 +189,7 @@ export default function Page(props) {
       <Row>
         <Col>
           <Form id="form" onSubmit={onSubmit} autoComplete="off">
-            <fieldset disabled={source.locked !== null}>
+            <fieldset disabled={Boolean(source.locked)}>
               <Form.Group controlId="name">
                 <Form.Label>Name</Form.Label>
                 <Form.Control

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/mapping.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/mapping.tsx
@@ -215,7 +215,7 @@ export default function Page(props: Props & NextPageContext) {
         possible, choose to map though a unique Property.
       </p>
       <Form>
-        <fieldset disabled={source.locked !== null}>
+        <fieldset disabled={Boolean(source.locked)}>
           <Row>
             <Col>
               <p>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -159,7 +159,7 @@ export default function Page(props) {
       />
 
       <Form id="form" onSubmit={edit} autoComplete="off">
-        <fieldset disabled={schedule.locked !== null}>
+        <fieldset disabled={Boolean(schedule.locked)}>
           <Row>
             <Col>
               <Form.Group controlId="confirmRecords">

--- a/ui/ui-components/pages/team/[id]/edit.tsx
+++ b/ui/ui-components/pages/team/[id]/edit.tsx
@@ -99,7 +99,7 @@ export default function Page(props) {
       <LockedBadge object={team} />
 
       <Form id="form" onSubmit={updateTeam} autoComplete="off">
-        <fieldset disabled={team.locked !== null}>
+        <fieldset disabled={Boolean(team.locked)}>
           <Form.Group>
             <Form.Label>Name</Form.Label>
             <Form.Control

--- a/ui/ui-components/pages/teamMember/[id]/edit.tsx
+++ b/ui/ui-components/pages/teamMember/[id]/edit.tsx
@@ -92,7 +92,7 @@ export default function Page(props) {
         </Col>
         <Col md={10}>
           <Form id="form" onSubmit={submit} autoComplete="off">
-            <fieldset disabled={teamMember.locked !== null}>
+            <fieldset disabled={Boolean(teamMember.locked)}>
               <Form.Group controlId="email">
                 <Form.Label>Email</Form.Label>
                 <Form.Control

--- a/ui/ui-components/pages/teams.tsx
+++ b/ui/ui-components/pages/teams.tsx
@@ -54,7 +54,7 @@ export default function Page({
                   <Form.Check
                     type="checkbox"
                     disabled
-                    checked={team.locked !== null}
+                    checked={Boolean(team.locked)}
                   />
                 </td>
               </tr>

--- a/ui/ui-enterprise/pages/apiKey/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/apiKey/[id]/edit.tsx
@@ -97,7 +97,7 @@ export default function Page(props) {
       <h1>{apiKey.name}</h1>
       <LockedBadge object={apiKey} />
       <Form id="form" onSubmit={updateApiKey} autoComplete="off">
-        <fieldset disabled={apiKey.locked !== null}>
+        <fieldset disabled={Boolean(apiKey.locked)}>
           <Form.Group>
             <Form.Label>Name</Form.Label>
             <Form.Control


### PR DESCRIPTION
Clarifies the UI logic when an object is disabled.  We cast the string to a Boolean which handles `null` and `undefined` as we expect

```
Welcome to Node.js v16.13.1.
Type ".help" for more information.
> Boolean('')
false
> Boolean(null)
false
> Boolean(undefined)
false
> Boolean('foo')
true
```

---

When using in-memory SQLite, the creation of new objects may have `undefined` default values when the object is initially created.  Subsequent reading of that object will return `null` values.  Rather than re-read each object when fetching `apiData()`, we'll be safer in the UI. 

This PR also clarifies some older migration behavior:
* No default values (a default value of `NULL` is the default behavior anyway - this is a safe change).  Default values belong in the model, [per our convention](https://www.grouparoo.com/docs/development/databases)
* Clarify `allowNull=true` (this is the default behavior anyway - this is a safe change)

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
