### PR TITLE
add deprecation warning

### DIFF
--- a/core/src/bin/generate.ts
+++ b/core/src/bin/generate.ts
@@ -10,6 +10,7 @@ import path from "path";
 import fs from "fs-extra";
 import prettier from "prettier";
 import { getConfigDir } from "../modules/pluginDetails";
+import { Deprecation } from "../modules/deprecation";
 
 export class Generate extends CLI {
   constructor() {
@@ -113,6 +114,8 @@ Commands:
   };
 
   async run({ params }) {
+    Deprecation.warnReplaced("CLI", "grouparoo generate", "UI config");
+
     const [template, id] = params._arguments || [];
     if (template) params.template = template;
     if (id) params.id = id;

--- a/core/src/modules/deprecation.ts
+++ b/core/src/modules/deprecation.ts
@@ -8,6 +8,17 @@ export namespace Deprecation {
     );
   }
 
+  export function warnReplaced(
+    topic: string,
+    oldName: string,
+    newName: string
+  ) {
+    log(
+      `[${topic}] - deprecation warning: \`${oldName}\` command has been replaced by ${newName} and will be removed in a future release.  `,
+      "warning"
+    );
+  }
+
   export function warnRemoved(
     topic: string,
     container: string,


### PR DESCRIPTION
## Change description

- Adds a "replaced by" class of deprecation warnings
- Adds the following deprecation warning when a user uses `grouparoo generate`:

```
warning: [CLI] - deprecation warning: `grouparoo generate` command has been replaced by UI Config and will be removed in a future release. 
```

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
