### PR TITLE
Update `LoadingButton` with separate `loading`, `disabled` states and keep size on loading

### DIFF
--- a/ui/ui-components/components/Loader.tsx
+++ b/ui/ui-components/components/Loader.tsx
@@ -4,8 +4,8 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
   size?: SpinnerProps["size"];
 }
 
-const Loader: React.FC<Props> = ({ size, ...props }) => (
-  <Spinner {...props} animation="border" role="status" size={size} />
+const Loader: React.FC<Props> = (props) => (
+  <Spinner {...props} animation="border" role="status" />
 );
 
 export default Loader;

--- a/ui/ui-components/components/Loader.tsx
+++ b/ui/ui-components/components/Loader.tsx
@@ -1,6 +1,11 @@
-import * as React from "react";
-import { Spinner } from "react-bootstrap";
+import { Spinner, SpinnerProps } from "react-bootstrap";
 
-export default function Loader({ size }: { size?: "sm" }) {
-  return <Spinner animation="grow" role="status" size={size} />;
+interface Props extends React.HTMLAttributes<HTMLElement> {
+  size?: SpinnerProps["size"];
 }
+
+const Loader: React.FC<Props> = ({ size, ...props }) => (
+  <Spinner {...props} animation="border" role="status" size={size} />
+);
+
+export default Loader;

--- a/ui/ui-components/components/LoadingButton.tsx
+++ b/ui/ui-components/components/LoadingButton.tsx
@@ -2,22 +2,53 @@ import { Button, ButtonProps } from "react-bootstrap";
 import { GrouparooUIEdition, grouparooUiEdition } from "../utils/uiEdition";
 import Loader from "./Loader";
 
-export default function LoadingButton(
-  props: ButtonProps & {
-    displayOn?: GrouparooUIEdition[];
-    hideOn?: GrouparooUIEdition[];
-  }
-) {
-  const { children, displayOn, hideOn, ...buttonProps } = props;
+const uiEdition = grouparooUiEdition();
 
-  if (displayOn && !displayOn.includes(grouparooUiEdition())) {
-    return null;
-  }
-
-  if (hideOn && hideOn.includes(grouparooUiEdition())) {
-    return null;
-  }
-
-  const message = props.disabled ? <Loader size="sm" /> : children || "Submit";
-  return <Button {...buttonProps}>{message}</Button>;
+interface Props extends ButtonProps {
+  loading?: boolean;
+  displayOn?: GrouparooUIEdition[];
+  hideOn?: GrouparooUIEdition[];
 }
+
+const LoadingButton: React.FC<Props> = ({
+  children = "Submit",
+  disabled,
+  displayOn,
+  hideOn,
+  loading,
+  ...buttonProps
+}) => {
+  if (
+    (displayOn && !displayOn.includes(uiEdition)) ||
+    (hideOn && hideOn.includes(uiEdition))
+  ) {
+    return null;
+  }
+
+  return (
+    <Button
+      {...buttonProps}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        ...buttonProps.style,
+      }}
+      disabled={disabled || loading}
+    >
+      {loading && (
+        <Loader
+          size="sm"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            position: "absolute",
+          }}
+        />
+      )}
+      <span style={loading ? { opacity: 0 } : undefined}>{children}</span>
+    </Button>
+  );
+};
+
+export default LoadingButton;

--- a/ui/ui-components/components/LoadingButton.tsx
+++ b/ui/ui-components/components/LoadingButton.tsx
@@ -46,7 +46,7 @@ const LoadingButton: React.FC<Props> = ({
           }}
         />
       )}
-      <span style={loading ? { opacity: 0 } : undefined}>{children}</span>
+      <span style={{ opacity: loading ? 0 : 1 }}>{children}</span>
     </Button>
   );
 };

--- a/ui/ui-components/components/log/List.tsx
+++ b/ui/ui-components/components/log/List.tsx
@@ -159,7 +159,7 @@ export default function LogsList(props) {
       {newLogs > 0 ? (
         <Alert variant="secondary">
           {newLogs} new logs.{" "}
-          <LoadingButton size="sm" onClick={load} disabled={loading}>
+          <LoadingButton size="sm" onClick={load} loading={loading}>
             Load
           </LoadingButton>
         </Alert>

--- a/ui/ui-components/components/property/Add.tsx
+++ b/ui/ui-components/components/property/Add.tsx
@@ -51,7 +51,7 @@ export default function PropertyAddButton(props) {
     <LoadingButton
       size="sm"
       variant="outline-primary"
-      disabled={loading}
+      loading={loading}
       onClick={create}
     >
       Add Property

--- a/ui/ui-components/components/record/Add.tsx
+++ b/ui/ui-components/components/record/Add.tsx
@@ -21,7 +21,7 @@ export default function AddRecord(props) {
 
   return (
     <>
-      <LoadingButton variant="warning" disabled={loading} onClick={create}>
+      <LoadingButton variant="warning" loading={loading} onClick={create}>
         Add new Record
       </LoadingButton>
     </>

--- a/ui/ui-components/components/record/List.tsx
+++ b/ui/ui-components/components/record/List.tsx
@@ -217,7 +217,7 @@ export default function RecordsList(props) {
             ) : null}
 
             <Col md={2} style={{ marginTop: 33 }}>
-              <LoadingButton size="sm" type="submit" disabled={loading}>
+              <LoadingButton size="sm" type="submit" loading={loading}>
                 Search
               </LoadingButton>
             </Col>

--- a/ui/ui-components/components/schedule/Add.tsx
+++ b/ui/ui-components/components/schedule/Add.tsx
@@ -30,7 +30,7 @@ export default function AddScheduleForm(props) {
     <LoadingButton
       size="sm"
       variant="outline-primary"
-      disabled={loading}
+      loading={loading}
       onClick={create}
     >
       Add Schedule

--- a/ui/ui-components/components/schedule/RunAllSchedulesButton.tsx
+++ b/ui/ui-components/components/schedule/RunAllSchedulesButton.tsx
@@ -25,14 +25,14 @@ const RunAllSchedulesButton: React.FC<Props> = ({
   onSuccess,
   onComplete,
 }) => {
-  const [isLoading, setIsLoading] = useState(false);
+  const [loading, setLoading] = useState(false);
   const hide = grouparooUiEdition() === "config";
 
   if (hide) {
     return null;
   }
 
-  if (disabled && !isLoading) {
+  if (disabled && !loading) {
     return (
       <Button variant="outline-primary" disabled={disabled} size={size}>
         Run all Schedules
@@ -42,7 +42,7 @@ const RunAllSchedulesButton: React.FC<Props> = ({
 
   async function enqueueAllSchedulesRun() {
     onStart?.();
-    setIsLoading(true);
+    setLoading(true);
     try {
       const { runs } = await execApi<Actions.SchedulesRun>(
         "post",
@@ -52,7 +52,7 @@ const RunAllSchedulesButton: React.FC<Props> = ({
       successHandler.set({ message: `${runs.length} runs enqueued` });
       onSuccess?.();
     } finally {
-      setIsLoading(false);
+      setLoading(false);
       onComplete?.();
     }
   }
@@ -61,7 +61,7 @@ const RunAllSchedulesButton: React.FC<Props> = ({
     <LoadingButton
       variant="outline-primary"
       size={size}
-      disabled={isLoading}
+      loading={loading}
       onClick={() => enqueueAllSchedulesRun()}
       hideOn={["config"]}
     >

--- a/ui/ui-components/components/session/SignIn.tsx
+++ b/ui/ui-components/components/session/SignIn.tsx
@@ -93,7 +93,7 @@ export default function SignInForm(props) {
         </Form.Control.Feedback>
       </Form.Group>
 
-      <LoadingButton disabled={loading} variant="primary" type="submit">
+      <LoadingButton loading={loading} variant="primary" type="submit">
         Sign In
       </LoadingButton>
     </Form>

--- a/ui/ui-components/components/settings/ImportAndUpdate.tsx
+++ b/ui/ui-components/components/settings/ImportAndUpdate.tsx
@@ -42,7 +42,7 @@ export default function ImportAndUpdateRecord(props) {
         <Card.Text>
           <LoadingButton
             onClick={importAndUpdate}
-            disabled={loading}
+            loading={loading}
             size="sm"
             variant="outline-warning"
           >

--- a/ui/ui-components/components/settings/ResetCache.tsx
+++ b/ui/ui-components/components/settings/ResetCache.tsx
@@ -50,7 +50,7 @@ export default function ResetCache(props) {
             onClick={reset}
             size="sm"
             variant="outline-warning"
-            disabled={loading}
+            loading={loading}
           >
             Reset Cache
           </LoadingButton>

--- a/ui/ui-components/components/settings/ResetCluster.tsx
+++ b/ui/ui-components/components/settings/ResetCluster.tsx
@@ -52,7 +52,7 @@ export default function ResetCluster(props) {
         <Card.Text>
           <LoadingButton
             onClick={reset}
-            disabled={loading}
+            loading={loading}
             size="sm"
             variant="outline-danger"
           >

--- a/ui/ui-components/components/settings/ResetData.tsx
+++ b/ui/ui-components/components/settings/ResetData.tsx
@@ -49,7 +49,7 @@ export default function ResetData(props) {
             onClick={reset}
             size="sm"
             variant="outline-danger"
-            disabled={loading}
+            loading={loading}
           >
             Reset Data
           </LoadingButton>

--- a/ui/ui-components/components/settings/SettingCard.tsx
+++ b/ui/ui-components/components/settings/SettingCard.tsx
@@ -73,7 +73,7 @@ export default function SettingCard({
 
               <LoadingButton
                 style={{ marginTop: 5 }}
-                disabled={loading}
+                loading={loading}
                 size="sm"
                 type="submit"
                 variant="outline-secondary"

--- a/ui/ui-components/components/setupSteps/SetupStepCard.tsx
+++ b/ui/ui-components/components/setupSteps/SetupStepCard.tsx
@@ -104,7 +104,7 @@ export default function SetupStepCard({
                       {step.skipped ? (
                         <LoadingButton
                           size="sm"
-                          loading={loading}
+                          disabled={loading}
                           className="m-1"
                           variant="outline-dark"
                           onClick={() => skip()}
@@ -114,7 +114,7 @@ export default function SetupStepCard({
                       ) : (
                         <LoadingButton
                           size="sm"
-                          loading={loading}
+                          disabled={loading}
                           className="m-1"
                           variant="outline-dark"
                           onClick={() => skip()}

--- a/ui/ui-components/components/setupSteps/SetupStepCard.tsx
+++ b/ui/ui-components/components/setupSteps/SetupStepCard.tsx
@@ -104,7 +104,7 @@ export default function SetupStepCard({
                       {step.skipped ? (
                         <LoadingButton
                           size="sm"
-                          disabled={loading}
+                          loading={loading}
                           className="m-1"
                           variant="outline-dark"
                           onClick={() => skip()}
@@ -114,12 +114,12 @@ export default function SetupStepCard({
                       ) : (
                         <LoadingButton
                           size="sm"
-                          disabled={loading}
+                          loading={loading}
                           className="m-1"
                           variant="outline-dark"
                           onClick={() => skip()}
                         >
-                          skip
+                          Skip
                         </LoadingButton>
                       )}
                     </Col>

--- a/ui/ui-components/pages/account.tsx
+++ b/ui/ui-components/pages/account.tsx
@@ -111,7 +111,7 @@ export default function Page(props) {
                 />
               </Form.Group>
 
-              <LoadingButton variant="primary" type="submit" disabled={loading}>
+              <LoadingButton variant="primary" type="submit" loading={loading}>
                 Update
               </LoadingButton>
             </fieldset>

--- a/ui/ui-components/pages/app/[id]/edit.tsx
+++ b/ui/ui-components/pages/app/[id]/edit.tsx
@@ -347,7 +347,7 @@ export default function Page(props) {
                   variant="outline-secondary"
                   size="sm"
                   onClick={test}
-                  disabled={testLoading}
+                  loading={testLoading}
                 >
                   Test Connection
                 </LoadingButton>
@@ -373,7 +373,7 @@ export default function Page(props) {
             </Row>
 
             <fieldset disabled={app.locked !== null}>
-              <LoadingButton variant="primary" type="submit" disabled={loading}>
+              <LoadingButton variant="primary" type="submit" loading={loading}>
                 Update
               </LoadingButton>
 
@@ -384,7 +384,7 @@ export default function Page(props) {
                 variant="danger"
                 size="sm"
                 onClick={handleDelete}
-                disabled={loading}
+                loading={loading}
               >
                 Delete
               </LoadingButton>

--- a/ui/ui-components/pages/app/[id]/refresh.tsx
+++ b/ui/ui-components/pages/app/[id]/refresh.tsx
@@ -381,7 +381,7 @@ export default function Page(props) {
                       className="m-3 mx-auto"
                       variant="success"
                       onClick={runQuery}
-                      disabled={loading}
+                      loading={loading}
                       hidden={editing}
                     >
                       Run Refresh Query

--- a/ui/ui-components/pages/app/new/[...plugin].tsx
+++ b/ui/ui-components/pages/app/new/[...plugin].tsx
@@ -94,7 +94,7 @@ export default function Page(props) {
                   ))}
               </Card.Text>
               <LoadingButton
-                disabled={loading}
+                loading={loading}
                 variant="primary"
                 onClick={() => create(app)}
               >

--- a/ui/ui-components/pages/apps.tsx
+++ b/ui/ui-components/pages/apps.tsx
@@ -154,7 +154,7 @@ export default function Page(props) {
                         <LoadingButton
                           variant="outline-success"
                           size="sm"
-                          disabled={loading}
+                          loading={loading}
                           onClick={() => runRefreshQuery(app)}
                         >
                           Run Now

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -811,7 +811,7 @@ export default function Page(props) {
                   <LoadingButton
                     type="submit"
                     variant="primary"
-                    disabled={loading}
+                    loading={loading}
                   >
                     Save Destination Data
                   </LoadingButton>

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
@@ -407,7 +407,7 @@ export default function Page(props) {
 
               <br />
 
-              <LoadingButton variant="primary" type="submit" disabled={loading}>
+              <LoadingButton variant="primary" type="submit" loading={loading}>
                 Update
               </LoadingButton>
 
@@ -417,7 +417,7 @@ export default function Page(props) {
               <LoadingButton
                 variant="danger"
                 size="sm"
-                disabled={loading}
+                loading={loading}
                 onClick={() => {
                   handleDelete(grouparooUiEdition() === "config");
                 }}

--- a/ui/ui-components/pages/model/[modelId]/destination/new/[appId].tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/new/[appId].tsx
@@ -85,7 +85,7 @@ export default function Page(props) {
               <Card.Title>{humanizePluginName(connection.name)}</Card.Title>
               <Card.Text>{connection.description}</Card.Text>
               <LoadingButton
-                disabled={loading}
+                loading={loading}
                 variant="primary"
                 onClick={() => create(connection)}
               >

--- a/ui/ui-components/pages/model/[modelId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/edit.tsx
@@ -121,7 +121,7 @@ export default function Page(props) {
             </fieldset>
 
             <fieldset disabled={model.locked !== null}>
-              <LoadingButton variant="primary" type="submit" disabled={loading}>
+              <LoadingButton variant="primary" type="submit" loading={loading}>
                 Update
               </LoadingButton>
 
@@ -132,7 +132,7 @@ export default function Page(props) {
                 variant="danger"
                 size="sm"
                 onClick={handleDelete}
-                disabled={loading}
+                loading={loading}
               >
                 Delete
               </LoadingButton>

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
@@ -173,7 +173,7 @@ export default function Page(props) {
                 </Form.Control>
               </Form.Group>
 
-              <LoadingButton variant="primary" type="submit" disabled={loading}>
+              <LoadingButton variant="primary" type="submit" loading={loading}>
                 Update
               </LoadingButton>
 
@@ -184,7 +184,7 @@ export default function Page(props) {
                 <>
                   <LoadingButton
                     variant="danger"
-                    disabled={loading}
+                    loading={loading}
                     size="sm"
                     onClick={() => {
                       handleDelete(true);
@@ -204,7 +204,7 @@ export default function Page(props) {
               ) : (
                 <LoadingButton
                   variant="danger"
-                  disabled={loading}
+                  loading={loading}
                   size="sm"
                   onClick={() => {
                     handleDelete(grouparooUiEdition() === "config");

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -487,7 +487,7 @@ export default function Page(props) {
           </Button>
           &nbsp;
           <LoadingButton
-            disabled={loading}
+            loading={loading}
             variant="outline-dark"
             size="sm"
             hideOn={["config"]}
@@ -501,7 +501,7 @@ export default function Page(props) {
             <Button disabled>Save Rules</Button>
           ) : (
             <LoadingButton
-              disabled={loading}
+              loading={loading}
               variant="primary"
               onClick={async () => {
                 await updateRules();

--- a/ui/ui-components/pages/model/[modelId]/group/new.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/new.tsx
@@ -81,7 +81,7 @@ export default function NewGroup(props) {
           </Form.Control>
         </Form.Group>
 
-        <LoadingButton variant="primary" type="submit" disabled={loading}>
+        <LoadingButton variant="primary" type="submit" loading={loading}>
           Submit
         </LoadingButton>
       </Form>

--- a/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
@@ -687,7 +687,7 @@ export default function Page(props) {
                 </>
               ) : null}
               <hr />
-              <LoadingButton variant="primary" type="submit" disabled={loading}>
+              <LoadingButton variant="primary" type="submit" loading={loading}>
                 Update
               </LoadingButton>
               <br />
@@ -695,7 +695,7 @@ export default function Page(props) {
               <LoadingButton
                 variant="danger"
                 size="sm"
-                disabled={loading}
+                loading={loading}
                 onClick={() => handleDelete()}
               >
                 Delete

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
@@ -242,7 +242,7 @@ export default function Page(props) {
             <Col>
               <LoadingButton
                 variant="outline-primary"
-                disabled={loading}
+                loading={loading}
                 onClick={() => {
                   importRecord();
                 }}
@@ -251,7 +251,7 @@ export default function Page(props) {
               </LoadingButton>{" "}
               <LoadingButton
                 variant="outline-primary"
-                disabled={loading}
+                loading={loading}
                 onClick={exportRecord}
               >
                 Export
@@ -260,7 +260,7 @@ export default function Page(props) {
                 <>
                   {" "}
                   <LoadingButton
-                    disabled={loading}
+                    loading={loading}
                     variant="outline-danger"
                     onClick={() => {
                       handleDelete();
@@ -361,7 +361,7 @@ export default function Page(props) {
                 {group.type === "manual" ? (
                   <>
                     <LoadingButton
-                      disabled={loading}
+                      loading={loading}
                       size="sm"
                       variant="danger"
                       onClick={() => {
@@ -417,7 +417,7 @@ export default function Page(props) {
                     variant="outline-primary"
                     size="sm"
                     type="submit"
-                    disabled={loading}
+                    loading={loading}
                   >
                     Add
                   </LoadingButton>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -431,13 +431,13 @@ export default function Page(props) {
 
               <br />
 
-              <LoadingButton variant="primary" type="submit" disabled={loading}>
+              <LoadingButton variant="primary" type="submit" loading={loading}>
                 Update
               </LoadingButton>
               <br />
               <br />
               <LoadingButton
-                disabled={loading}
+                loading={loading}
                 variant="danger"
                 size="sm"
                 onClick={() => {

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/mapping.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/mapping.tsx
@@ -274,7 +274,7 @@ export default function Page(props: Props & NextPageContext) {
               ) : (
                 <LoadingButton
                   type="submit"
-                  disabled={loading}
+                  loading={loading}
                   onClick={(e) => updateMapping(e)}
                 >
                   Save Mapping
@@ -416,7 +416,7 @@ export default function Page(props: Props & NextPageContext) {
                   <LoadingButton
                     size="sm"
                     variant="outline-primary"
-                    disabled={loading}
+                    loading={loading}
                     onClick={bootstrapUniqueProperty}
                   >
                     Create Property

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -231,7 +231,7 @@ export default function Page(props) {
             ) : (
               <LoadingButton
                 size="sm"
-                disabled={loading}
+                loading={loading}
                 onClick={() => createProperty()}
               >
                 Create

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -576,14 +576,14 @@ export default function Page(props) {
                 </Alert>
               ) : null}
 
-              <LoadingButton variant="primary" type="submit" disabled={loading}>
+              <LoadingButton variant="primary" type="submit" loading={loading}>
                 Update
               </LoadingButton>
               <br />
               <br />
               <LoadingButton
                 variant="danger"
-                disabled={loading}
+                loading={loading}
                 size="sm"
                 onClick={handleDelete}
               >

--- a/ui/ui-components/pages/model/[modelId]/source/new/[appId].tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/new/[appId].tsx
@@ -81,7 +81,7 @@ export default function Page(props) {
               <Card.Title>{humanizePluginName(connection.name)}</Card.Title>
               <Card.Text>{connection.description}</Card.Text>
               <LoadingButton
-                disabled={loading}
+                loading={loading}
                 variant="primary"
                 onClick={() => create(connection)}
               >

--- a/ui/ui-components/pages/model/[modelId]/sources.tsx
+++ b/ui/ui-components/pages/model/[modelId]/sources.tsx
@@ -159,7 +159,7 @@ export default function Page(props) {
                             <LoadingButton
                               variant="outline-success"
                               size="sm"
-                              disabled={loading}
+                              loading={loading}
                               onClick={() => enqueueScheduleRun(source)}
                             >
                               Run Now

--- a/ui/ui-components/pages/model/new.tsx
+++ b/ui/ui-components/pages/model/new.tsx
@@ -75,7 +75,7 @@ export default function Page(props) {
           </Form.Control>
         </Form.Group>
 
-        <LoadingButton variant="primary" type="submit" disabled={loading}>
+        <LoadingButton variant="primary" type="submit" loading={loading}>
           Submit
         </LoadingButton>
       </Form>

--- a/ui/ui-components/pages/resque/delayed.tsx
+++ b/ui/ui-components/pages/resque/delayed.tsx
@@ -152,7 +152,7 @@ export default function ResqueDelayedList(props) {
                                 </td>
                                 <td>
                                   <LoadingButton
-                                    disabled={loading}
+                                    loading={loading}
                                     onClick={() => runDelayed(t.key, jidx)}
                                     variant="warning"
                                     size="sm"
@@ -162,7 +162,7 @@ export default function ResqueDelayedList(props) {
                                 </td>
                                 <td>
                                   <LoadingButton
-                                    disabled={loading}
+                                    loading={loading}
                                     onClick={() => delDelayed(t.key, jidx)}
                                     variant="danger"
                                     size="sm"

--- a/ui/ui-components/pages/resque/failed.tsx
+++ b/ui/ui-components/pages/resque/failed.tsx
@@ -116,7 +116,7 @@ export default function ResqueFailedList(props) {
         <Col md={12}>
           <ButtonToolbar>
             <LoadingButton
-              disabled={loading}
+              loading={loading}
               onClick={() => {
                 retryAllFailedJobs();
               }}
@@ -127,7 +127,7 @@ export default function ResqueFailedList(props) {
             </LoadingButton>
             &nbsp;
             <LoadingButton
-              disabled={loading}
+              loading={loading}
               onClick={() => {
                 removeAllFailedJobs();
               }}
@@ -196,7 +196,7 @@ export default function ResqueFailedList(props) {
                     </td>
                     <td>
                       <LoadingButton
-                        disabled={loading}
+                        loading={loading}
                         onClick={() => retryFailedJob(offset + idx)}
                         variant="warning"
                         size="sm"
@@ -206,7 +206,7 @@ export default function ResqueFailedList(props) {
                     </td>
                     <td>
                       <LoadingButton
-                        disabled={loading}
+                        loading={loading}
                         onClick={() => removeFailedJob(offset + idx)}
                         variant="danger"
                         size="sm"

--- a/ui/ui-components/pages/resque/locks.tsx
+++ b/ui/ui-components/pages/resque/locks.tsx
@@ -91,7 +91,7 @@ export default function ResqueLocksList(props) {
                     <td>{l.at.toString()}</td>
                     <td>
                       <LoadingButton
-                        disabled={loading}
+                        loading={loading}
                         onClick={() => {
                           delLock(l.lock);
                         }}

--- a/ui/ui-components/pages/resque/queue/[queue].tsx
+++ b/ui/ui-components/pages/resque/queue/[queue].tsx
@@ -61,7 +61,7 @@ export default function ResqueQueue(props) {
 
       <p>
         <LoadingButton
-          disabled={loading}
+          loading={loading}
           onClick={() => {
             delQueue();
           }}

--- a/ui/ui-components/pages/resque/workers.tsx
+++ b/ui/ui-components/pages/resque/workers.tsx
@@ -169,7 +169,7 @@ export default function ResqueWorkersList(props) {
                     </td>
                     <td>
                       <LoadingButton
-                        disabled={loading}
+                        loading={loading}
                         onClick={() => {
                           forceCleanWorker(worker.name);
                         }}

--- a/ui/ui-components/pages/run/[id]/edit.tsx
+++ b/ui/ui-components/pages/run/[id]/edit.tsx
@@ -72,7 +72,7 @@ export default function Page(props) {
                 <LoadingButton
                   variant="warning"
                   size="sm"
-                  disabled={loading}
+                  loading={loading}
                   onClick={stopRun}
                 >
                   Stop run

--- a/ui/ui-components/pages/setup.tsx
+++ b/ui/ui-components/pages/setup.tsx
@@ -60,7 +60,6 @@ export default function Page(props) {
       <Head>
         <title>Grouparoo: Setup</title>
       </Head>
-
       <h1 id="setup">Setup Grouparoo</h1>
       {currentStep ? (
         <p>
@@ -81,7 +80,6 @@ export default function Page(props) {
           <br />
         </Alert>
       )}
-
       <div>
         Progress: {completeStepsCount} / {totalStepsCount} steps completed
         <br />
@@ -91,9 +89,7 @@ export default function Page(props) {
           now={percentComplete}
         />
       </div>
-
       <br />
-
       <Row>
         <Col>
           {setupSteps.map((setupStep) => (
@@ -106,7 +102,6 @@ export default function Page(props) {
           ))}
         </Col>
       </Row>
-
       <br />
     </>
   );

--- a/ui/ui-components/pages/team/[id]/edit.tsx
+++ b/ui/ui-components/pages/team/[id]/edit.tsx
@@ -132,7 +132,7 @@ export default function Page(props) {
 
           {team.locked ? null : (
             <>
-              <LoadingButton disabled={loading} variant="primary" type="submit">
+              <LoadingButton loading={loading} variant="primary" type="submit">
                 Update
               </LoadingButton>
 
@@ -140,7 +140,7 @@ export default function Page(props) {
               <br />
 
               <LoadingButton
-                disabled={loading}
+                loading={loading}
                 variant="danger"
                 size="sm"
                 onClick={() => {

--- a/ui/ui-components/pages/team/[id]/members.tsx
+++ b/ui/ui-components/pages/team/[id]/members.tsx
@@ -91,7 +91,7 @@ export default function Page(props) {
                 <td>
                   <LoadingButton
                     size="sm"
-                    disabled={loading}
+                    loading={loading}
                     variant="danger"
                     onClick={() => {
                       handleDelete(teamMember);
@@ -108,7 +108,7 @@ export default function Page(props) {
 
       <LoadingButton
         variant="primary"
-        disabled={loading}
+        loading={loading}
         onClick={() => {
           router.push(`/team/${team.id}/teamMember/new`);
         }}

--- a/ui/ui-components/pages/team/initialize.tsx
+++ b/ui/ui-components/pages/team/initialize.tsx
@@ -176,7 +176,7 @@ export default function TeamInitializePage(props) {
 
         <br />
 
-        <LoadingButton variant="primary" type="submit" disabled={loading}>
+        <LoadingButton variant="primary" type="submit" loading={loading}>
           Submit
         </LoadingButton>
       </Form>

--- a/ui/ui-components/pages/team/new.tsx
+++ b/ui/ui-components/pages/team/new.tsx
@@ -50,7 +50,7 @@ export default function NewTeamPage(props) {
           </Form.Control.Feedback>
         </Form.Group>
 
-        <LoadingButton variant="primary" type="submit" disabled={loading}>
+        <LoadingButton variant="primary" type="submit" loading={loading}>
           Submit
         </LoadingButton>
       </Form>

--- a/ui/ui-components/pages/teamMember/[id]/edit.tsx
+++ b/ui/ui-components/pages/teamMember/[id]/edit.tsx
@@ -164,13 +164,13 @@ export default function Page(props) {
                 />
               </Form.Group>
 
-              <LoadingButton variant="primary" disabled={loading} type="submit">
+              <LoadingButton variant="primary" loading={loading} type="submit">
                 Update
               </LoadingButton>
               <br />
               <br />
               <LoadingButton
-                disabled={loading}
+                loading={loading}
                 variant="danger"
                 size="sm"
                 onClick={() => {

--- a/ui/ui-components/pages/teamMember/new.tsx
+++ b/ui/ui-components/pages/teamMember/new.tsx
@@ -156,7 +156,7 @@ export default function Page(props) {
           </a>
         </p>
 
-        <LoadingButton variant="primary" type="submit" disabled={loading}>
+        <LoadingButton variant="primary" type="submit" loading={loading}>
           Submit
         </LoadingButton>
       </Form>


### PR DESCRIPTION
## Change description

This change splits the difference between disabled and loading states for the `LoadingButton`. How you can set the button to either disabled or loading (loading implies disabled).

The loading state now keeps the same size of the button and it uses the more commonly used _border_ animation.

All usages of buttons have been updated to use the `loading` prop since this is was the intent. However, in future changes you can now define whether the button needs to show as disabled or it's directly impacting something that is loading.


https://user-images.githubusercontent.com/168664/145064038-75b1dd90-e906-490f-974d-1585b394506d.mov


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
