### PR TITLE
show less on `/apps` in config mode

### DIFF
--- a/ui/ui-components/pages/apps.tsx
+++ b/ui/ui-components/pages/apps.tsx
@@ -140,11 +140,15 @@ export default function Page(props) {
                     <>
                       Query: {app.appRefreshQuery.refreshQuery}
                       <br />
-                      Value: {app.appRefreshQuery.value}
-                      <br />
-                      Last Checked:{" "}
-                      {formatTimestamp(app.appRefreshQuery.lastConfirmedAt)}
-                      <br />
+                      {grouparooUiEdition() !== "config" && (
+                        <>
+                          Value: {app.appRefreshQuery.value}
+                          <br />
+                          Last Checked:{" "}
+                          {formatTimestamp(app.appRefreshQuery.lastConfirmedAt)}
+                          <br />
+                        </>
+                      )}
                       Frequency: Every{" "}
                       {recurringFrequencyMinutes > 1 &&
                         recurringFrequencyMinutes}{" "}


### PR DESCRIPTION
## Change description

App Refresh Queries should behave like schedules in config mode.  We now show less in `config` mode (no button, no value, no timestamp) on `/apps`:
![Screen Shot 2021-12-07 at 11 45 03 AM](https://user-images.githubusercontent.com/63751206/145071832-eeeb8275-cb38-4d2c-9339-98f05206e8a4.png)

Community/enterprise remain untouched on `/apps`:
![Screen Shot 2021-12-07 at 11 50 05 AM](https://user-images.githubusercontent.com/63751206/145071584-2a60fa3d-19e5-46f0-9f9e-707cf63e1fe8.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
