### PR TITLE
Use unescaped values for mustache strings

### DIFF
--- a/core/__tests__/classes/codeConfig.ts
+++ b/core/__tests__/classes/codeConfig.ts
@@ -68,7 +68,8 @@ describe("classes/codeConfig", () => {
         unique: false,
         isArray: false,
         options: {
-          query: "SELECT SUM(price) from purchases where user_id = {{userId}}",
+          query:
+            "SELECT SUM(price) from purchases where user_id = {{{userId}}}",
         },
       };
 

--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -1121,7 +1121,7 @@ describe("models/destination", () => {
         await destination.save();
 
         await destination.setOptions({
-          table: "thing-{{ now.sql }}",
+          table: "thing-{{{ now.sql }}}",
         });
 
         const parameterizedOptions = await destination.parameterizedOptions();

--- a/core/__tests__/models/property/dependsOn.ts
+++ b/core/__tests__/models/property/dependsOn.ts
@@ -1,6 +1,7 @@
 import { helper } from "@grouparoo/spec-helper";
 import { Property, Source } from "../../../src";
 import { PropertyOps } from "../../../src/modules/ops/property";
+import { Option } from "../../../src/models/option";
 
 describe("models/property", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -96,7 +97,7 @@ describe("models/property", () => {
       });
       await emailDomainProperty.setOptions({
         column:
-          "select split_part(email, '@', 2) AS domain from users where email = {{ email }}",
+          "select split_part(email, '@', 2) AS domain from users where email = {{{ email }}}",
       });
       await emailDomainProperty.update({ state: "ready" });
     });
@@ -125,7 +126,9 @@ describe("models/property", () => {
       expect(dependencies.map((rule) => rule.id)).toEqual([emailProperty.id]);
     });
 
-    test("mustache variables reference another rule", async () => {
+    test.only("mustache variables reference another rule", async () => {
+      // const _options = await emailDomainProperty.getOptions();
+      // console.info(_options);
       const dependencies = await PropertyOps.dependencies(emailDomainProperty);
       expect(dependencies.map((rule) => rule.id)).toEqual([
         userIdProperty.id, // from the mapping

--- a/core/__tests__/models/property/dependsOn.ts
+++ b/core/__tests__/models/property/dependsOn.ts
@@ -126,9 +126,7 @@ describe("models/property", () => {
       expect(dependencies.map((rule) => rule.id)).toEqual([emailProperty.id]);
     });
 
-    test.only("mustache variables reference another rule", async () => {
-      // const _options = await emailDomainProperty.getOptions();
-      // console.info(_options);
+    test("mustache variables reference another rule", async () => {
       const dependencies = await PropertyOps.dependencies(emailDomainProperty);
       expect(dependencies.map((rule) => rule.id)).toEqual([
         userIdProperty.id, // from the mapping

--- a/core/__tests__/models/property/dependsOn.ts
+++ b/core/__tests__/models/property/dependsOn.ts
@@ -1,7 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { Property, Source } from "../../../src";
 import { PropertyOps } from "../../../src/modules/ops/property";
-import { Option } from "../../../src/models/option";
 
 describe("models/property", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });

--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -395,7 +395,7 @@ describe("models/property", () => {
   test("options will have mustache keys converted to mustache ids", async () => {
     const property = await Property.findOne({ where: { key: "email" } });
     await property.setOptions({
-      column: "{{   email}}@example.com",
+      column: "{{{ email }}}@example.com",
     });
     let options = await property.getOptions();
     expect(options).toEqual({ column: "{{{ email }}}@example.com" }); //appears normal (but formatted) to the user
@@ -403,7 +403,7 @@ describe("models/property", () => {
     const rawOption = await Option.findOne({
       where: { ownerId: property.id },
     });
-    expect(rawOption.value).toBe(`{{ ${property.id} }}@example.com`);
+    expect(rawOption.value).toBe(`{{{ ${property.id} }}}@example.com`);
   });
 
   test("an array property cannot be used as an option", async () => {
@@ -424,7 +424,7 @@ describe("models/property", () => {
     const property = await Property.findOne({ where: { key: "email" } });
     await expect(
       property.setOptions({
-        column: "{{carts}}@example.com",
+        column: "{{{carts}}}@example.com",
       })
     ).rejects.toThrow('missing mustache key "carts"');
 
@@ -684,7 +684,7 @@ describe("models/property", () => {
                 ];
               },
               recordProperty: async ({ property, propertyOptions, record }) => {
-                const s = `the time is {{now.sql}} + ${JSON.stringify(
+                const s = `the time is {{{now.sql}}} + ${JSON.stringify(
                   propertyOptions
                 )}`;
                 const q = await property.parameterizedQueryFromRecord(

--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -398,7 +398,7 @@ describe("models/property", () => {
       column: "{{   email}}@example.com",
     });
     let options = await property.getOptions();
-    expect(options).toEqual({ column: "{{ email }}@example.com" }); //appears normal (but formatted) to the user
+    expect(options).toEqual({ column: "{{{ email }}}@example.com" }); //appears normal (but formatted) to the user
 
     const rawOption = await Option.findOne({
       where: { ownerId: property.id },

--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -1038,7 +1038,7 @@ describe("models/source", () => {
 
     it("replaces mustache template strings with variables", async () => {
       await source.setOptions({
-        table: "{{ previousRun.createdAt.sql }}",
+        table: "{{{ previousRun.createdAt.sql }}}",
       });
       await source.setMapping({ id: "userId" });
 

--- a/core/__tests__/modules/mustacheUtils.ts
+++ b/core/__tests__/modules/mustacheUtils.ts
@@ -12,7 +12,7 @@ describe("modules/mustacheUtils", () => {
 
   describe("#strictlyRender", () => {
     test("works with a valid string and data", () => {
-      const result = MustacheUtils.strictlyRender("hello {{value}}", {
+      const result = MustacheUtils.strictlyRender("hello {{{value}}}", {
         value: "world",
       });
       expect(result).toEqual("hello world");
@@ -20,7 +20,7 @@ describe("modules/mustacheUtils", () => {
 
     test("throws a good error message if data is missing", () => {
       expect(() =>
-        MustacheUtils.strictlyRender("hello {{value}}", {
+        MustacheUtils.strictlyRender("hello {{{value}}}", {
           foo: "world",
         })
       ).toThrow(/missing mustache key "value"/);
@@ -29,7 +29,7 @@ describe("modules/mustacheUtils", () => {
     test("null values can be OK", () => {
       expect(() =>
         MustacheUtils.strictlyRender(
-          "hello {{value}}",
+          "hello {{{value}}}",
           {
             value: null,
           },
@@ -39,7 +39,7 @@ describe("modules/mustacheUtils", () => {
       ).toThrow('null "value"');
 
       const result = MustacheUtils.strictlyRender(
-        "hello {{value}}",
+        "hello {{{value}}}",
         {
           value: null,
         },
@@ -53,7 +53,7 @@ describe("modules/mustacheUtils", () => {
   describe("#getMustacheVariables", () => {
     test("the names of the mustache variables can be extracted", () => {
       const keys = MustacheUtils.getMustacheVariables(
-        "I need a {{foo}}, a {{{ bar }}} and one more {{    thing}}"
+        "I need a {{{foo}}}, a {{{ bar }}} and one more {{{    thing}}}"
       );
       expect(keys).toEqual(["foo", "bar", "thing"]);
     });
@@ -62,7 +62,7 @@ describe("modules/mustacheUtils", () => {
   describe("#getMustacheVariablesAsPropertyIds", () => {
     test("it works with existing properties", async () => {
       const property = await Property.findOne({ where: { key: "userId" } });
-      const string = "SELECT email from users where id = {{ userId }}";
+      const string = "SELECT email from users where id = {{{ userId }}}";
       const ids = await MustacheUtils.getMustacheVariablesAsPropertyIds(string);
       expect(ids).toEqual([property.id]);
     });
@@ -70,7 +70,7 @@ describe("modules/mustacheUtils", () => {
     test("it works with additional codeConfig objects", async () => {
       const property = await Property.findOne({ where: { key: "userId" } });
       const string =
-        "SELECT email from users where id = {{ userId }} and {{ subscribed }} = true";
+        "SELECT email from users where id = {{{ userId }}} and {{{ subscribed }}} = true";
       const configObjects: AnyConfigurationObject[] = [
         { class: "property", id: "subscribed_id", name: "subscribed" },
       ];

--- a/core/__tests__/modules/plugin.ts
+++ b/core/__tests__/modules/plugin.ts
@@ -182,7 +182,7 @@ describe("modules/plugin", () => {
         });
 
         const initialString =
-          "select * from \"users\" where updatedAt >= '{{previousRun.createdAt.sql}}'; # The Previous Run Id is: {{previousRun.id}}";
+          "select * from \"users\" where updatedAt >= '{{{previousRun.createdAt.sql}}}'; # The Previous Run Id is: {{{previousRun.id}}}";
         const replacedString = await plugin.replaceTemplateRunVariables(
           initialString,
           run
@@ -199,7 +199,7 @@ describe("modules/plugin", () => {
         const schedule = await helper.factories.schedule();
 
         const initialString =
-          "select * from \"users\" where updatedAt >= '{{previousRun.createdAt.sql}}'; # The Previous Run Id is: {{previousRun.id}}";
+          "select * from \"users\" where updatedAt >= '{{{previousRun.createdAt.sql}}}'; # The Previous Run Id is: {{{previousRun.id}}}";
         const replacedString = await plugin.replaceTemplateRunVariables(
           initialString,
           run
@@ -214,7 +214,7 @@ describe("modules/plugin", () => {
       test("it throws an error if a template variable is missing", async () => {
         const run = await helper.factories.run();
         await expect(
-          plugin.replaceTemplateRunVariables(`hello {{world}}`, run)
+          plugin.replaceTemplateRunVariables(`hello {{{world}}}`, run)
         ).rejects.toThrow('missing mustache key "world"');
       });
     });
@@ -230,7 +230,7 @@ describe("modules/plugin", () => {
         });
 
         const initialString =
-          "select first_name from users where id = {{userId}} and email = '{{email}}' # GrouparooRecord Created at {{createdAt.sql}}";
+          "select first_name from users where id = {{{userId}}} and email = '{{{email}}}' # GrouparooRecord Created at {{{createdAt.sql}}}";
 
         const replacedString = await plugin.replaceTemplateRecordVariables(
           initialString,
@@ -249,7 +249,7 @@ describe("modules/plugin", () => {
         await record.addOrUpdateProperties({ userId: null });
         await expect(
           plugin.replaceTemplateRecordVariables(
-            `select email where id = {{userId}}`,
+            `select email where id = {{{userId}}}`,
             record
           )
         ).rejects.toThrow('missing mustache key "userId"');
@@ -269,7 +269,7 @@ describe("modules/plugin", () => {
             source.modelId
           );
         expect(replacedWithId).toEqual(
-          `select * from users where id = {{ ${property.id} }}`
+          `select * from users where id = {{{ ${property.id} }}}`
         );
 
         expect(
@@ -299,7 +299,7 @@ describe("modules/plugin", () => {
           where: { key: "userId" },
         });
         const source = await property.$get("source");
-        const initialString = `select * from users where id = {{ ${otherProperty.key} }}`;
+        const initialString = `select * from users where id = {{{ ${otherProperty.key} }}}`;
 
         await expect(
           plugin.replaceTemplateRecordPropertyKeysWithRecordPropertyId(

--- a/core/__tests__/modules/plugin.ts
+++ b/core/__tests__/modules/plugin.ts
@@ -262,7 +262,7 @@ describe("modules/plugin", () => {
           where: { key: "userId" },
         });
         const source = await property.$get("source");
-        const initialString = "select * from users where id = {{ userId }}";
+        const initialString = "select * from users where id = {{{ userId }}}";
         const replacedWithId =
           await plugin.replaceTemplateRecordPropertyKeysWithRecordPropertyId(
             initialString,

--- a/core/src/modules/ops/property.ts
+++ b/core/src/modules/ops/property.ts
@@ -134,7 +134,7 @@ export namespace PropertyOps {
     for (const key in ruleOptions) {
       const mustacheString = ruleOptions[key];
       const mustacheVariables: string[] = Mustache.parse(mustacheString)
-        .filter((chunk) => chunk[0] === "name")
+        .filter((chunk) => chunk[0] === "&")
         .map((chunk) => chunk[1]);
       properties
         .filter((p) => mustacheVariables.includes(p.key))

--- a/core/src/modules/plugin.ts
+++ b/core/src/modules/plugin.ts
@@ -377,7 +377,7 @@ export namespace plugin {
 
     const data = {};
     properties.forEach((rule) => {
-      data[rule.id] = `{{ ${rule.key} }}`;
+      data[rule.id] = `{{{ ${rule.key} }}}`;
     });
 
     return MustacheUtils.strictlyRender(string, data);

--- a/core/src/modules/plugin.ts
+++ b/core/src/modules/plugin.ts
@@ -343,12 +343,13 @@ export namespace plugin {
 
   /**
    * Takes a string with mustache variable (keys) and replaces them with the record property ids
-   * ie: `select * where id = {{ userId }}` => `select * where id = {{ ppr_abc123 }}`
+   * ie: `select * where id = {{{ userId }}}` => `select * where id = {{{ ppr_abc123 }}}`
    */
   export async function replaceTemplateRecordPropertyKeysWithRecordPropertyId(
     string: string,
     modelId: string
   ): Promise<string> {
+    //though we default to 3 brackets, if someone inputs the double bracket notation, we should accept it
     if (string.indexOf("{{") < 0) return string;
 
     const properties = (await Property.findAllWithCache(modelId)).filter(
@@ -357,7 +358,7 @@ export namespace plugin {
 
     const data = {};
     properties.forEach((rule) => {
-      data[rule.key] = `{{ ${rule.id} }}`;
+      data[rule.key] = `{{{ ${rule.id} }}}`;
     });
 
     return MustacheUtils.strictlyRender(string, data);
@@ -365,12 +366,13 @@ export namespace plugin {
 
   /**
    * Takes a string with mustache variable (ids) and replaces them with the record property keys
-   * ie: `select * where id = {{ ppr_abc123 }}` => `select * where id = {{ userId }}`
+   * ie: `select * where id = {{{ ppr_abc123 }}}` => `select * where id = {{{ userId }}}`
    */
   export async function replaceTemplateRecordPropertyIdsWithRecordPropertyKeys(
     string: string,
     modelId: string
   ): Promise<string> {
+    //though we default to 3 brackets, if someone inputs the double bracket notation, we should accept it
     if (string.indexOf("{{") < 0) return string;
 
     const properties = await Property.findAllWithCache(modelId);

--- a/plugins/@grouparoo/app-templates/public/templates/query-property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/app-templates/public/templates/query-property/{{{id}}}.js.template
@@ -9,7 +9,7 @@ exports.default = async function buildConfig() {
       unique: false, // Will Records have unique records for this Property?
       isArray: false, // Is this an Array Property?
       options: {
-        query: "SELECT SUM(price) from purchases where user_id = \{\{user_id\}\}", // The query to extract the property.  You can use mustache variables (https://github.com/janl/mustache.js#variables) to represent the keys of other properties in the system.
+        query: "SELECT SUM(price) from purchases where user_id = \{\{\{user_id\}\}\}", // The query to extract the property.  You can use mustache variables (https://github.com/janl/mustache.js#variables) to represent the keys of other properties in the system.  Our system defaults to the triple bracket (unescaped) version of mustache.
       },
     },
   ];

--- a/plugins/@grouparoo/bigquery/__tests__/integration/log-checking.ts
+++ b/plugins/@grouparoo/bigquery/__tests__/integration/log-checking.ts
@@ -57,7 +57,7 @@ describe("bigquery/integration/log-checking", () => {
   });
 
   it("should correctly do debug logging for bigquery queries", async () => {
-    const sql = "SELECT first_name FROM test.records WHERE id = {{ userId }}";
+    const sql = "SELECT first_name FROM test.records WHERE id = {{{ userId }}}";
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
 

--- a/plugins/@grouparoo/bigquery/__tests__/query-import/import-property.ts
+++ b/plugins/@grouparoo/bigquery/__tests__/query-import/import-property.ts
@@ -55,44 +55,45 @@ describe("bigquery/query/recordProperty", () => {
   });
 
   test("can run a integer query to get a string", async () => {
-    const sql = "SELECT first_name FROM test.records WHERE id = {{ userId }}";
+    const sql = "SELECT first_name FROM test.records WHERE id = {{{ userId }}}";
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a integer query to get a float", async () => {
-    const sql = "SELECT ltv FROM test.records WHERE id = {{ userId }}";
+    const sql = "SELECT ltv FROM test.records WHERE id = {{{ userId }}}";
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a integer query to get a boolean", async () => {
-    const sql = "SELECT ios_app FROM test.records WHERE id = {{ userId }}";
+    const sql = "SELECT ios_app FROM test.records WHERE id = {{{ userId }}}";
     const value = await getPropertyValue(sql);
     expect(value).toEqual([true]);
   });
 
   test("can run a string query to get a string", async () => {
     const sql =
-      "SELECT first_name FROM test.records WHERE email = '{{ email }}'";
+      "SELECT first_name FROM test.records WHERE email = '{{{ email }}}'";
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a string query to get a float", async () => {
-    const sql = "SELECT ltv FROM test.records WHERE email = '{{ email }}'";
+    const sql = "SELECT ltv FROM test.records WHERE email = '{{{ email }}}'";
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a string query to get a boolean", async () => {
-    const sql = "SELECT ios_app FROM test.records WHERE email = '{{ email }}'";
+    const sql =
+      "SELECT ios_app FROM test.records WHERE email = '{{{ email }}}'";
     const value = await getPropertyValue(sql);
     expect(value).toEqual([true]);
   });
 
   test("returns undefined when data is not available", async () => {
-    const sql = `SELECT ios_app FROM test.records WHERE email = '{{ badName }}'`;
+    const sql = `SELECT ios_app FROM test.records WHERE email = '{{{ badName }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(undefined);
   });

--- a/plugins/@grouparoo/calculated-property/__tests__/import/import-property.ts
+++ b/plugins/@grouparoo/calculated-property/__tests__/import/import-property.ts
@@ -44,7 +44,7 @@ describe("calculated-property/recordProperty", () => {
       userId: [1],
       email: ["ejervois0@example.com"],
       firstName: ["Mario"],
-      lastName: ["Jones"],
+      lastName: [`O'Donnell`],
       ltv: [390.42],
       lastLoginAt: ["2021-08-23 15:02:39.297-07"],
       isVIP: [true],
@@ -59,6 +59,13 @@ describe("calculated-property/recordProperty", () => {
     }`;
     const value = await getPropertyValue(fn);
     expect(value[0]).toEqual(`hi Mario`);
+  });
+  test("it evaluates string properties with escapable characters as expected", async () => {
+    const fn = `() => {
+        return "hi {{{firstName}}} {{{ lastName }}}"
+    }`;
+    const value = await getPropertyValue(fn);
+    expect(value[0]).toEqual(`hi Mario O'Donnell`);
   });
   test("it evaluates float properties as expected", async () => {
     const fn = `() => {

--- a/plugins/@grouparoo/calculated-property/__tests__/import/import-property.ts
+++ b/plugins/@grouparoo/calculated-property/__tests__/import/import-property.ts
@@ -62,7 +62,7 @@ describe("calculated-property/recordProperty", () => {
   });
   test("it evaluates float properties as expected", async () => {
     const fn = `() => {
-        return {{ltv}} * 2
+        return {{{ltv}}} * 2
     }`;
     const value = await getPropertyValue(fn);
     expect(value[0]).toEqual(780.84);
@@ -76,7 +76,7 @@ describe("calculated-property/recordProperty", () => {
   });
   test("it evaluates boolean properties as expected", async () => {
     const fn = `() => {
-        if({{isVIP}} === true) return true;
+        if({{{isVIP}}} === true) return true;
         return false;
     }`;
     const value = await getPropertyValue(fn);
@@ -85,7 +85,7 @@ describe("calculated-property/recordProperty", () => {
 
   test("it evaluates date strings as expected", async () => {
     const fn = `() => {
-          const date = new Date("{{lastLoginAt.iso}}");
+          const date = new Date("{{{lastLoginAt.iso}}}");
           return date.toISOString();
       }`;
     const value = await getPropertyValue(fn);
@@ -106,7 +106,7 @@ describe("calculated-property/recordProperty", () => {
   });
   test("it throws if mustached property does not exist", async () => {
     const fn = `() => {
-      return {{fakeProperty}}
+      return {{{fakeProperty}}}
     }`;
     await expect(getPropertyValue(fn)).rejects.toThrowError(
       "Could not calculate property: Error: Calculated property's /`customFunction/` undefined"

--- a/plugins/@grouparoo/calculated-property/__tests__/import/import-property.ts
+++ b/plugins/@grouparoo/calculated-property/__tests__/import/import-property.ts
@@ -55,7 +55,7 @@ describe("calculated-property/recordProperty", () => {
 
   test("it evaluates string properties as expected", async () => {
     const fn = `() => {
-        return "hi {{firstName}}"
+        return "hi {{{firstName}}}"
     }`;
     const value = await getPropertyValue(fn);
     expect(value[0]).toEqual(`hi Mario`);
@@ -69,7 +69,7 @@ describe("calculated-property/recordProperty", () => {
   });
   test("it evaluates null properties as an empty string", async () => {
     const fn = `() => {
-        if ("{{purchases}}" === "") return true;
+        if ("{{{purchases}}}" === "") return true;
         return false;}`;
     const value = await getPropertyValue(fn);
     expect(value[0]).toEqual(true);

--- a/plugins/@grouparoo/calculated-property/__tests__/integration/calculated-property-import.ts
+++ b/plugins/@grouparoo/calculated-property/__tests__/integration/calculated-property-import.ts
@@ -110,7 +110,7 @@ describe("integration/runs/calculated-property", () => {
       csrfToken,
       id: property.id,
       options: {
-        customFunction: `()=> { return "{{firstName}} {{lastName}}" }`,
+        customFunction: `()=> { return "{{{firstName}}} {{{lastName}}}" }`,
       },
       state: "ready",
     };

--- a/plugins/@grouparoo/calculated-property/public/templates/property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/calculated-property/public/templates/property/{{{id}}}.js.template
@@ -18,5 +18,5 @@ exports.default = async function buildConfig() {
 
 function customFunction () {
   // write your custom function here
-  // use mustache variables to reference the keys of any properties you would like to reference
+  // You can use mustache variables (https://github.com/janl/mustache.js#variables) to represent the keys of other properties in the system.  Our system defaults to the triple bracket (unescaped) version of mustache.
 }

--- a/plugins/@grouparoo/calculated-property/src/lib/propertyOptions.ts
+++ b/plugins/@grouparoo/calculated-property/src/lib/propertyOptions.ts
@@ -7,7 +7,7 @@ export const propertyOptions: PropertyOptionsMethod = async () => [
     description:
       "Javascript function to transform existing Property(ies) to create a new one",
     type: "textarea",
-    options: async () => {
+    options: () => {
       return null;
     },
   },

--- a/plugins/@grouparoo/clickhouse/__tests__/integration/clickhouse-query-import.ts
+++ b/plugins/@grouparoo/clickhouse/__tests__/integration/clickhouse-query-import.ts
@@ -126,7 +126,7 @@ describe("integration/runs/clickhouse", () => {
       csrfToken,
       id: property.id,
       options: {
-        query: `select email from ${usersTableName} where id = {{ userId }}`,
+        query: `select email from ${usersTableName} where id = {{{ userId }}}`,
       },
       state: "ready",
     };

--- a/plugins/@grouparoo/clickhouse/__tests__/query-import/import-property.ts
+++ b/plugins/@grouparoo/clickhouse/__tests__/query-import/import-property.ts
@@ -57,43 +57,43 @@ describe("clickhouse/query/recordProperty", () => {
   afterAll(async () => await afterData());
 
   test("can run a integer query to get a string", async () => {
-    const sql = `SELECT first_name FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT first_name FROM ${usersTableName} WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a integer query to get a float", async () => {
-    const sql = `SELECT ltv FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT ltv FROM ${usersTableName} WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a integer query to get a boolean", async () => {
-    const sql = `SELECT ios_app FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT ios_app FROM ${usersTableName} WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([1]);
   });
 
   test("can run a string query to get a string", async () => {
-    const sql = `SELECT first_name FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT first_name FROM ${usersTableName} WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a string query to get a float", async () => {
-    const sql = `SELECT ltv FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT ltv FROM ${usersTableName} WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a string query to get a boolean", async () => {
-    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([1]);
   });
 
   test("returns undefined when data is not available", async () => {
-    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{ badName }}'`;
+    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{{ badName }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(undefined);
   });

--- a/plugins/@grouparoo/demo/config/users/properties/full_name.json
+++ b/plugins/@grouparoo/demo/config/users/properties/full_name.json
@@ -7,7 +7,7 @@
   "unique": false,
   "isArray": false,
   "options": {
-    "customFunction": "() => \"{{ firstName }} {{ lastName }}\""
+    "customFunction": "() => \"{{{ firstName }}} {{{ lastName }}}\""
   },
   "filters": []
 }

--- a/plugins/@grouparoo/mongo/__tests__/integration/log-checking.ts
+++ b/plugins/@grouparoo/mongo/__tests__/integration/log-checking.ts
@@ -67,7 +67,7 @@ describe("mongo/integration/log-checking", () => {
     const query = [
       {
         $match: {
-          id: "{{userId}}",
+          id: "{{{userId}}}",
         },
       },
       {
@@ -78,8 +78,8 @@ describe("mongo/integration/log-checking", () => {
       },
     ];
     const queryString = JSON.stringify(query).replace(
-      /"{{userId}}"/,
-      "{{userId}}"
+      /"{{{userId}}}"/,
+      "{{{userId}}}"
     );
     const value = await getPropertyValue(queryString);
     expect(value).toEqual(["Erie"]);

--- a/plugins/@grouparoo/mongo/__tests__/query-import/import-property.ts
+++ b/plugins/@grouparoo/mongo/__tests__/query-import/import-property.ts
@@ -63,7 +63,7 @@ describe("mongo/query/recordProperty", () => {
     const query = [
       {
         $match: {
-          id: "{{userId}}",
+          id: "{{{userId}}}",
         },
       },
       {
@@ -74,8 +74,8 @@ describe("mongo/query/recordProperty", () => {
       },
     ];
     const queryString = JSON.stringify(query).replace(
-      /"{{userId}}"/,
-      "{{userId}}"
+      /"{{{userId}}}"/,
+      "{{{userId}}}"
     );
     const value = await getPropertyValue(queryString);
     expect(value).toEqual(["Erie"]);
@@ -85,7 +85,7 @@ describe("mongo/query/recordProperty", () => {
     const query = [
       {
         $match: {
-          id: "{{userId}}",
+          id: "{{{userId}}}",
         },
       },
       {
@@ -96,8 +96,8 @@ describe("mongo/query/recordProperty", () => {
       },
     ];
     const queryString = JSON.stringify(query).replace(
-      /"{{userId}}"/,
-      "{{userId}}"
+      /"{{{userId}}}"/,
+      "{{{userId}}}"
     );
     const value = await getPropertyValue(queryString);
     expect(value).toEqual([259.12]);
@@ -107,7 +107,7 @@ describe("mongo/query/recordProperty", () => {
     const query = [
       {
         $match: {
-          id: "{{userId}}",
+          id: "{{{userId}}}",
         },
       },
       {
@@ -118,8 +118,8 @@ describe("mongo/query/recordProperty", () => {
       },
     ];
     const queryString = JSON.stringify(query).replace(
-      /"{{userId}}"/,
-      "{{userId}}"
+      /"{{{userId}}}"/,
+      "{{{userId}}}"
     );
     const value = await getPropertyValue(queryString);
     expect(value).toEqual([true]);
@@ -129,7 +129,7 @@ describe("mongo/query/recordProperty", () => {
     const query = [
       {
         $match: {
-          email: "{{email}}",
+          email: "{{{email}}}",
         },
       },
       {
@@ -148,7 +148,7 @@ describe("mongo/query/recordProperty", () => {
     const query = [
       {
         $match: {
-          email: "{{email}}",
+          email: "{{{email}}}",
         },
       },
       {
@@ -167,7 +167,7 @@ describe("mongo/query/recordProperty", () => {
     const query = [
       {
         $match: {
-          email: "{{email}}",
+          email: "{{{email}}}",
         },
       },
       {
@@ -186,7 +186,7 @@ describe("mongo/query/recordProperty", () => {
     const query = [
       {
         $match: {
-          email: "{{email}}",
+          email: "{{{email}}}",
         },
       },
       {
@@ -204,7 +204,7 @@ describe("mongo/query/recordProperty", () => {
     const query = [
       {
         $match: {
-          email: "{{badName}}",
+          email: "{{{badName}}}",
         },
       },
       {

--- a/plugins/@grouparoo/mongo/public/templates/query-property/{{{id}}}.js.template
+++ b/plugins/@grouparoo/mongo/public/templates/query-property/{{{id}}}.js.template
@@ -28,7 +28,7 @@ exports.default = async function buildConfig() {
                  _id: 0,
                },
              },
-           ]), // The query to extract the property. You can use mustache variables (https://github.com/janl/mustache.js#variables) to represent the keys of other properties in the system.
+           ]), // The query to extract the property. You can use mustache variables (https://github.com/janl/mustache.js#variables) to represent the keys of other properties in the system.  Our system defaults to the triple bracket (unescaped) version of mustache.
       },
     },
   ];

--- a/plugins/@grouparoo/mysql/__tests__/integration/mysql-query-import.ts
+++ b/plugins/@grouparoo/mysql/__tests__/integration/mysql-query-import.ts
@@ -126,7 +126,7 @@ describe("integration/runs/mysql", () => {
       csrfToken,
       id: property.id,
       options: {
-        query: `select email from ${usersTableName} where id = {{ userId }}`,
+        query: `select email from ${usersTableName} where id = {{{ userId }}}`,
       },
       state: "ready",
     };

--- a/plugins/@grouparoo/mysql/__tests__/query-import/import-property.ts
+++ b/plugins/@grouparoo/mysql/__tests__/query-import/import-property.ts
@@ -56,43 +56,43 @@ describe("mysql/query/recordProperty", () => {
   afterAll(async () => await afterData());
 
   test("can run a integer query to get a string", async () => {
-    const sql = `SELECT first_name FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT first_name FROM ${usersTableName} WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a integer query to get a float", async () => {
-    const sql = `SELECT ltv FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT ltv FROM ${usersTableName} WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a integer query to get a boolean", async () => {
-    const sql = `SELECT ios_app FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT ios_app FROM ${usersTableName} WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["true"]);
   });
 
   test("can run a string query to get a string", async () => {
-    const sql = `SELECT first_name FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT first_name FROM ${usersTableName} WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a string query to get a float", async () => {
-    const sql = `SELECT ltv FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT ltv FROM ${usersTableName} WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a string query to get a boolean", async () => {
-    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["true"]);
   });
 
   test("returns undefined when data is not available", async () => {
-    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{ badName }}'`;
+    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{{ badName }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(undefined);
   });

--- a/plugins/@grouparoo/postgres/__tests__/integration/log-checking.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/log-checking.ts
@@ -57,10 +57,10 @@ describe("postgres/integration/log-checking", () => {
   afterAll(async () => await afterData());
 
   it("should correctly do debug logging for postgres queries", async () => {
-    const sql = `SELECT first_name FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT first_name FROM ${usersTableName} WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
-    const expectedString = `[ postgres ] ${sql.replace("{{ userId }}", "1")}`;
+    const expectedString = `[ postgres ] ${sql.replace("{{{ userId }}}", "1")}`;
     const postgresCall = logMock.mock.calls.find(([c]) => c === expectedString);
     expect(postgresCall).toEqual([expectedString, "debug", undefined]);
   });

--- a/plugins/@grouparoo/postgres/__tests__/integration/postgres-query-import.ts
+++ b/plugins/@grouparoo/postgres/__tests__/integration/postgres-query-import.ts
@@ -123,7 +123,7 @@ describe("integration/runs/postgres", () => {
       csrfToken,
       id: property.id,
       options: {
-        query: `select email from ${usersTableName} where id = {{ userId }}`,
+        query: `select email from ${usersTableName} where id = {{{ userId }}}`,
       },
       state: "ready",
     };

--- a/plugins/@grouparoo/postgres/__tests__/query-import/import-property.ts
+++ b/plugins/@grouparoo/postgres/__tests__/query-import/import-property.ts
@@ -58,43 +58,43 @@ describe("postgres/query/recordProperty", () => {
   afterAll(async () => await afterData());
 
   test("can run a integer query to get a string", async () => {
-    const sql = `SELECT first_name FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT first_name FROM ${usersTableName} WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a integer query to get a float", async () => {
-    const sql = `SELECT ltv FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT ltv FROM ${usersTableName} WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a integer query to get a boolean", async () => {
-    const sql = `SELECT ios_app FROM ${usersTableName} WHERE id = {{ userId }}`;
+    const sql = `SELECT ios_app FROM ${usersTableName} WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([true]);
   });
 
   test("can run a string query to get a string", async () => {
-    const sql = `SELECT first_name FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT first_name FROM ${usersTableName} WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a string query to get a float", async () => {
-    const sql = `SELECT ltv FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT ltv FROM ${usersTableName} WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a string query to get a boolean", async () => {
-    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{ email }}'`;
+    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([true]);
   });
 
   test("returns undefined when data is not available", async () => {
-    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{ badName }}'`;
+    const sql = `SELECT ios_app FROM ${usersTableName} WHERE email = '{{{ badName }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(undefined);
   });

--- a/plugins/@grouparoo/postgres/src/lib/validateQuery.ts
+++ b/plugins/@grouparoo/postgres/src/lib/validateQuery.ts
@@ -4,12 +4,7 @@ export function validateQuery(sql: string, allowLimitAndOffset = true) {
   if (!lowerCaseSQL.trim()) {
     throw new Error("please provide a query");
   }
-  if (
-    lowerCaseSQL.lastIndexOf("select") !== 0 &&
-    lowerCaseSQL.lastIndexOf("insert") !== 0 &&
-    lowerCaseSQL.lastIndexOf("update") !== 0 &&
-    lowerCaseSQL.lastIndexOf("delete") !== 0
-  ) {
+  if (lowerCaseSQL.indexOf(";") > 0) {
     throw new Error("only provide a single query");
   }
 

--- a/plugins/@grouparoo/postgres/src/lib/validateQuery.ts
+++ b/plugins/@grouparoo/postgres/src/lib/validateQuery.ts
@@ -4,7 +4,12 @@ export function validateQuery(sql: string, allowLimitAndOffset = true) {
   if (!lowerCaseSQL.trim()) {
     throw new Error("please provide a query");
   }
-  if (lowerCaseSQL.indexOf(";") >= 0) {
+  if (
+    lowerCaseSQL.lastIndexOf("select") !== 0 &&
+    lowerCaseSQL.lastIndexOf("insert") !== 0 &&
+    lowerCaseSQL.lastIndexOf("update") !== 0 &&
+    lowerCaseSQL.lastIndexOf("delete") !== 0
+  ) {
     throw new Error("only provide a single query");
   }
 

--- a/plugins/@grouparoo/redshift/__tests__/integration/redshift-query-import.ts
+++ b/plugins/@grouparoo/redshift/__tests__/integration/redshift-query-import.ts
@@ -120,7 +120,7 @@ describe("integration/runs/redshift-query", () => {
       csrfToken,
       id: property.id,
       options: {
-        query: `select email from ${usersTableName} where id = {{ userId }}`,
+        query: `select email from ${usersTableName} where id = {{{ userId }}}`,
       },
       state: "ready",
     };

--- a/plugins/@grouparoo/snowflake/__tests__/integration/log-checking.ts
+++ b/plugins/@grouparoo/snowflake/__tests__/integration/log-checking.ts
@@ -53,7 +53,7 @@ describe("snowflake/integration/log-checking", () => {
   });
 
   it("should correctly do debug logging for snowflake queries", async () => {
-    const sql = "SELECT first_name FROM profiles WHERE id = {{ userId }}";
+    const sql = "SELECT first_name FROM profiles WHERE id = {{{ userId }}}";
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
 

--- a/plugins/@grouparoo/snowflake/__tests__/query-import/import-property.ts
+++ b/plugins/@grouparoo/snowflake/__tests__/query-import/import-property.ts
@@ -50,43 +50,43 @@ describe("snowflake/query/recordProperty", () => {
   });
 
   test("can run a integer query to get a string", async () => {
-    const sql = "SELECT first_name FROM profiles WHERE id = {{ userId }}";
+    const sql = "SELECT first_name FROM profiles WHERE id = {{{ userId }}}";
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a integer query to get a float", async () => {
-    const sql = "SELECT ltv FROM profiles WHERE id = {{ userId }}";
+    const sql = "SELECT ltv FROM profiles WHERE id = {{{ userId }}}";
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a integer query to get a boolean", async () => {
-    const sql = "SELECT ios_app FROM profiles WHERE id = {{ userId }}";
+    const sql = "SELECT ios_app FROM profiles WHERE id = {{{ userId }}}";
     const value = await getPropertyValue(sql);
     expect(value).toEqual([true]);
   });
 
   test("can run a string query to get a string", async () => {
-    const sql = "SELECT first_name FROM profiles WHERE email = '{{ email }}'";
+    const sql = "SELECT first_name FROM profiles WHERE email = '{{{ email }}}'";
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a string query to get a float", async () => {
-    const sql = "SELECT ltv FROM profiles WHERE email = '{{ email }}'";
+    const sql = "SELECT ltv FROM profiles WHERE email = '{{{ email }}}'";
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a string query to get a boolean", async () => {
-    const sql = "SELECT ios_app FROM profiles WHERE email = '{{ email }}'";
+    const sql = "SELECT ios_app FROM profiles WHERE email = '{{{ email }}}'";
     const value = await getPropertyValue(sql);
     expect(value).toEqual([true]);
   });
 
   test("returns undefined when data is not available", async () => {
-    const sql = `SELECT ios_app FROM profiles WHERE email = '{{ badName }}'`;
+    const sql = `SELECT ios_app FROM profiles WHERE email = '{{{ badName }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(undefined);
   });

--- a/plugins/@grouparoo/sqlite/__tests__/integration/log-checking.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/integration/log-checking.ts
@@ -60,7 +60,7 @@ describe("sqlite/integration/log-checking", () => {
   afterAll(async () => await afterData());
 
   it("should correctly do debug logging for sqlite queries", async () => {
-    const sql = `SELECT first_name FROM "${usersTableName}" WHERE id = {{ userId }}`;
+    const sql = `SELECT first_name FROM "${usersTableName}" WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
 

--- a/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-query-import.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/integration/sqlite-query-import.ts
@@ -126,7 +126,7 @@ describe("integration/runs/sqlite", () => {
       csrfToken,
       id: property.id,
       options: {
-        query: `SELECT email FROM "${usersTableName}" WHERE id = {{ userId }}`,
+        query: `SELECT email FROM "${usersTableName}" WHERE id = {{{ userId }}}`,
       },
       state: "ready",
     };

--- a/plugins/@grouparoo/sqlite/__tests__/query-import/import-property.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/query-import/import-property.ts
@@ -58,55 +58,55 @@ describe("sqlite/query/recordProperty", () => {
   afterAll(async () => await afterData());
 
   test("can run a integer query to get a string", async () => {
-    const sql = `SELECT first_name FROM "${usersTableName}" WHERE id = {{ userId }}`;
+    const sql = `SELECT first_name FROM "${usersTableName}" WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a integer query to get a float", async () => {
-    const sql = `SELECT ltv FROM "${usersTableName}" WHERE id = {{ userId }}`;
+    const sql = `SELECT ltv FROM "${usersTableName}" WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a integer query to get a boolean", async () => {
-    const sql = `SELECT ios_app FROM "${usersTableName}" WHERE id = {{ userId }}`;
+    const sql = `SELECT ios_app FROM "${usersTableName}" WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["true"]);
   });
 
   test("can run a integer query to get a date", async () => {
-    const sql = `SELECT stamp FROM "${usersTableName}" WHERE id = {{ userId }}`;
+    const sql = `SELECT stamp FROM "${usersTableName}" WHERE id = {{{ userId }}}`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["2020/02/01 12:13:14"]);
   });
 
   test("can run a string query to get a string", async () => {
-    const sql = `SELECT first_name FROM "${usersTableName}" WHERE email = '{{ email }}'`;
+    const sql = `SELECT first_name FROM "${usersTableName}" WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["Erie"]);
   });
 
   test("can run a string query to get a float", async () => {
-    const sql = `SELECT ltv FROM "${usersTableName}" WHERE email = '{{ email }}'`;
+    const sql = `SELECT ltv FROM "${usersTableName}" WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual([259.12]);
   });
 
   test("can run a string query to get a boolean", async () => {
-    const sql = `SELECT ios_app FROM "${usersTableName}" WHERE email = '{{ email }}'`;
+    const sql = `SELECT ios_app FROM "${usersTableName}" WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["true"]);
   });
 
   test("can run a string query to get a date", async () => {
-    const sql = `SELECT stamp FROM "${usersTableName}" WHERE email = '{{ email }}'`;
+    const sql = `SELECT stamp FROM "${usersTableName}" WHERE email = '{{{ email }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(["2020/02/01 12:13:14"]);
   });
 
   test("returns undefined when data is not available", async () => {
-    const sql = `SELECT ios_app FROM "${usersTableName}" WHERE email = '{{ badName }}'`;
+    const sql = `SELECT ios_app FROM "${usersTableName}" WHERE email = '{{{ badName }}}'`;
     const value = await getPropertyValue(sql);
     expect(value).toEqual(undefined);
   });

--- a/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
@@ -467,10 +467,12 @@ export default function Page(props) {
                       </Form.Text>
                       <p>
                         Record Property Variables:{" "}
-                        <Badge variant="light">{`{{ now }}`}</Badge>
+                        <Badge variant="light">{`{{{ now }}}`}</Badge>
                         &nbsp;
-                        <Badge variant="light">{`{{ createdAt }}`}</Badge>&nbsp;
-                        <Badge variant="light">{`{{ updatedAt }}`}</Badge>&nbsp;
+                        <Badge variant="light">{`{{{ createdAt }}}`}</Badge>
+                        &nbsp;
+                        <Badge variant="light">{`{{{ updatedAt }}}`}</Badge>
+                        &nbsp;
                         {properties
                           .filter((rule) => rule.isArray === false)
                           .sort((a, b) => {
@@ -482,7 +484,7 @@ export default function Page(props) {
                           })
                           .map((ppr) => (
                             <Fragment key={`var-badge-${ppr.key}`}>
-                              <Badge variant="light">{`{{ ${ppr.key} }}`}</Badge>
+                              <Badge variant="light">{`{{{ ${ppr.key} }}}`}</Badge>
                               &nbsp;
                             </Fragment>
                           ))}


### PR DESCRIPTION
## Change description

Initially, we thought there was something wrong with SQLite's escaping.  It turns out, it was mustachejs returning escaped strings in Calculated Property functions.

Mustache variables automatically escape HTML. However, with calculated properties, we actually want to be using the unescaped HTML value of a string.  That way, if a property value has an HTML-escapable character like an apostrophe, it gets rendered correctly.

Because of how our system parses in the values for mustache strings, we'll start by defaulting to triple brackets (ie: `{{{ firstName }}}` everywhere.

I believe we will want to revisit this and simply keep whatever bracket notation a user inputs by making our parser more sophisticated.  For now, we'll start here.

O'Donoghue in `fullName` property used to be one of the culprits, now renders fine:

![Screen Shot 2021-12-10 at 4 55 39 PM](https://user-images.githubusercontent.com/63751206/145646477-2c4da81e-a313-4e19-abec-94e61faaa16a.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:
- Users who have properties that have an option with mustache variables will be replaced by the triple bracket version (both in the database when Grouparoo is running and within the actual config files if Config mode is run)
- All property options (calculated property or query source property) with mustache variables will now be saved as the triple bracket notation version of whatever is entered (double or triple)

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
