### PR TITLE
add space after app environment var options

### DIFF
--- a/ui/ui-components/pages/app/[id]/edit.tsx
+++ b/ui/ui-components/pages/app/[id]/edit.tsx
@@ -176,9 +176,11 @@ export default function Page(props) {
                       <p className="mb-0">
                         Available environment variables for apps:{" "}
                         {environmentVariableOptions.sort().map((envOpt) => (
-                          <Badge key={`envOpt-${envOpt}`} variant="info">
-                            {envOpt}
-                          </Badge>
+                          <>
+                            <Badge key={`envOpt-${envOpt}`} variant="info">
+                              {envOpt}
+                            </Badge>{" "}
+                          </>
                         ))}
                       </p>
                     )}


### PR DESCRIPTION
## Change description

Ran into a mild annoyance trying to copy/paste the avilable env options into the text boxes. Double clicking to select an option would select all options. Adding a space after each one fixes it and lets you select a single one for easy copy/pasting 😄 

**Before**

![copy-env-opts-before](https://user-images.githubusercontent.com/4368928/145470072-cd0073c8-4615-485d-8683-0ef64495a3c6.gif)

**After**

![copy-env-opts-after](https://user-images.githubusercontent.com/4368928/145470067-3fe9f785-1908-4ea3-bbfc-885aebf3b7f6.gif)


## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
