### PR TITLE
use saved refresh query instead of props

### DIFF
--- a/ui/ui-components/pages/app/[id]/refresh.tsx
+++ b/ui/ui-components/pages/app/[id]/refresh.tsx
@@ -131,7 +131,7 @@ export default function Page(props) {
             }`,
           });
         }
-        setAppRefreshQuery(response.appRefreshQuery);
+        setAppRefreshQuery(response?.appRefreshQuery);
       } finally {
         setLoading(false);
       }
@@ -142,7 +142,12 @@ export default function Page(props) {
   }
 
   async function cancelEdit() {
-    setAppRefreshQuery(props.appRefreshQuery);
+    const response: Actions.AppRefreshQueryView = await execApi(
+      "get",
+      `/appRefreshQuery/${appRefreshQuery.id}/`,
+      { id: appRefreshQuery.id }
+    );
+    if (response?.appRefreshQuery) setAppRefreshQuery(response.appRefreshQuery);
     setEditing(false);
   }
 


### PR DESCRIPTION
## Change description

fixes an issue where if a user changes the app refresh query, then goes to edit a second time and hits "cancel", the UI reverts to the value from when the page first loaded instead of the current value.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
