### PR TITLE
Move Toasts to bottom right and show close button

### DIFF
--- a/ui/ui-components/components/alerts/Toast.tsx
+++ b/ui/ui-components/components/alerts/Toast.tsx
@@ -43,8 +43,8 @@ export default function GrouparooToast({
       autohide
       style={{ width: 300 }}
     >
-      <Toast.Header className={`bg-${variant}`} closeButton={false}>
-        <strong className="text-white">
+      <Toast.Header className={`bg-${variant}`}>
+        <strong className="text-white mr-auto">
           {variant === "success" ? "Success" : "Error"}
         </strong>
       </Toast.Header>

--- a/ui/ui-components/components/layouts/Main.tsx
+++ b/ui/ui-components/components/layouts/Main.tsx
@@ -171,7 +171,7 @@ export default function Main(props) {
           <div
             style={{
               position: "fixed",
-              top: 0,
+              bottom: 0,
               right: 0,
               padding: 20,
               zIndex: 99,


### PR DESCRIPTION
Following after https://github.com/grouparoo/grouparoo/pull/2675, this PR moves the Toasts to the bottom right of the viewport and shows a close button

![Screen Shot 2021-12-13 at 10 16 26 AM](https://user-images.githubusercontent.com/303226/145866552-dd8bf33f-cc1a-4ca1-8e42-afebdd04aef3.png)


## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
