### PR TITLE
Model overview page fixes

### DIFF
--- a/ui/ui-components/components/badges/StateBadge.tsx
+++ b/ui/ui-components/components/badges/StateBadge.tsx
@@ -1,21 +1,13 @@
-import { Badge } from "react-bootstrap";
+import { Badge, BadgeProps } from "react-bootstrap";
 
-export default function StateBadge({
-  state,
-  marginBottom,
-}: {
+interface Props {
   state: string;
   marginBottom?: number;
-}) {
-  let variant:
-    | "primary"
-    | "secondary"
-    | "success"
-    | "danger"
-    | "warning"
-    | "info"
-    | "light"
-    | "dark";
+  style?: React.CSSProperties;
+}
+
+const StateBadge: React.FC<Props> = ({ state, marginBottom, style }) => {
+  let variant: BadgeProps["variant"];
 
   switch (state) {
     case "ready":
@@ -56,10 +48,13 @@ export default function StateBadge({
         marginLeft: 3,
         marginRight: 3,
         marginBottom: marginBottom ?? 20,
+        ...style,
       }}
       variant={variant}
     >
       {state}
     </Badge>
   );
-}
+};
+
+export default StateBadge;

--- a/ui/ui-components/components/lib/entity/EntityInfoHeader.tsx
+++ b/ui/ui-components/components/lib/entity/EntityInfoHeader.tsx
@@ -26,7 +26,15 @@ const EntityInfoHeader: React.FC<Props> = ({
 
   return (
     <div>
-      {nameLink} <StateBadge state={entity.state} marginBottom={0} />
+      {nameLink}{" "}
+      <StateBadge
+        state={entity.state}
+        marginBottom={0}
+        style={{
+          verticalAlign: "middle",
+          marginTop: "-0.25em",
+        }}
+      />
     </div>
   );
 };

--- a/ui/ui-components/components/lib/entity/EntityList.tsx
+++ b/ui/ui-components/components/lib/entity/EntityList.tsx
@@ -13,6 +13,7 @@ import {
 import { useGrouparooModelContext } from "../../../contexts/grouparooModel";
 import { Models } from "../../../utils/apiData";
 import { formatName } from "../../../utils/formatName";
+import StateBadge from "../../badges/StateBadge";
 import SeparatedItems from "../SeparatedItems";
 
 const renderNameList = function <T extends Models.EntityTypes>(
@@ -27,6 +28,12 @@ const renderNameList = function <T extends Models.EntityTypes>(
       ? "overview"
       : "edit";
   const itemPath = itemType === "schedule" ? "source" : itemType;
+  const style: React.CSSProperties = {
+    verticalAlign: "middle",
+    marginTop: "-0.25em",
+    marginRight: 0,
+    marginBottom: 0,
+  };
 
   const links = items.map((item, index) => {
     const itemId =
@@ -34,9 +41,14 @@ const renderNameList = function <T extends Models.EntityTypes>(
         ? (item as Models.ScheduleType).sourceId
         : item.id;
     return (
-      <Link href={`/model/${model.id}/${itemPath}/${itemId}/${page}`}>
-        <a>{formatName(item)}</a>
-      </Link>
+      <>
+        <Link href={`/model/${model.id}/${itemPath}/${itemId}/${page}`}>
+          <a>{formatName(item)}</a>
+        </Link>
+        {item.state !== "ready" && (
+          <StateBadge state={item.state} style={style} />
+        )}
+      </>
     );
   });
 

--- a/ui/ui-components/components/model/overview/ModelOverviewDestinations.tsx
+++ b/ui/ui-components/components/model/overview/ModelOverviewDestinations.tsx
@@ -1,4 +1,4 @@
-import { Col, ListGroup, ListGroupItem, Row } from "react-bootstrap";
+import { ListGroup, ListGroupItem } from "react-bootstrap";
 import { Models } from "../../../utils/apiData";
 import { grouparooUiEdition } from "../../../utils/uiEdition";
 import DestinationCollectionLink from "../../destination/DestinationCollectionLink";
@@ -30,7 +30,6 @@ const DestinationInfo: React.FC<{
         linkComponent={LinkComponent}
       />
       <div>{connection?.displayName}</div>
-      <div>Pending Exports: {exportTotals.pending}</div>
       <div>
         Collection Tracked:{" "}
         <DestinationCollectionLink destination={destination} />

--- a/ui/ui-components/pages/model/[modelId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/overview.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps, NextPage } from "next";
 import Head from "next/head";
 import Link from "next/link";
 import { useMemo } from "react";
-import { Col, Container, ListGroup, ListGroupItem, Row } from "react-bootstrap";
+import { Col, ListGroup, ListGroupItem, Row } from "react-bootstrap";
 import ManagedCard from "../../../components/lib/ManagedCard";
 import ModelOverviewDestinations from "../../../components/model/overview/ModelOverviewDestinations";
 import ModelOverviewGroups from "../../../components/model/overview/ModelOverviewGroups";
@@ -51,70 +51,68 @@ const Page: NextPage<Props & { ctx: any; errorHandler: any }> = ({
         <title>Grouparoo: {model.name}</title>
       </Head>
 
-      <Container>
-        <PageHeader
-          iconType="grouparooModel"
-          icon={model.icon}
-          title={model.name}
-          actions={[<Link href={`/model/${model.id}/edit`}>Edit</Link>]}
-        />
-        <p>
-          Define your {model.name} Model here with Sources, Groups, and
-          Destinations.
-        </p>
+      <PageHeader
+        iconType="grouparooModel"
+        icon={model.icon}
+        title={model.name}
+        actions={[<Link href={`/model/${model.id}/edit`}>Edit</Link>]}
+      />
+      <p>
+        Define your {model.name} Model here with Sources, Groups, and
+        Destinations.
+      </p>
 
-        <Row className="mb-4">
-          <Col>
-            <ManagedCard title="Model Data">
-              <ListGroup className="list-group-flush">
-                <ListGroupItem>
-                  <ModelOverviewPrimarySource source={primarySource} />
-                </ListGroupItem>
+      <Row className="mb-4">
+        <Col>
+          <ManagedCard title="Model Data">
+            <ListGroup className="list-group-flush">
+              <ListGroupItem>
+                <ModelOverviewPrimarySource source={primarySource} />
+              </ListGroupItem>
 
-                <ListGroupItem>
-                  <ModelOverviewSecondarySources
-                    sources={secondarySources}
-                    disabled={!primarySource}
-                  />
-                </ListGroupItem>
+              <ListGroupItem>
+                <ModelOverviewSecondarySources
+                  sources={secondarySources}
+                  disabled={!primarySource}
+                />
+              </ListGroupItem>
 
-                <ListGroupItem>
-                  <ModelOverviewGroups
-                    groups={groups}
-                    disabled={!sources.length}
-                  />
-                </ListGroupItem>
+              <ListGroupItem>
+                <ModelOverviewGroups
+                  groups={groups}
+                  disabled={!sources.length}
+                />
+              </ListGroupItem>
 
-                <ListGroupItem>
-                  <ModelOverviewSchedules
-                    schedules={schedules}
-                    sources={sources}
-                    execApi={execApi}
-                  />
-                </ListGroupItem>
-              </ListGroup>
-            </ManagedCard>
-          </Col>
-        </Row>
-        <Row className="mb-4">
-          <Col>
-            <ModelOverviewSampleRecord
-              modelId={model.id}
-              properties={properties}
-              execApi={execApi}
-              disabled={!sources.length}
-            />
-          </Col>
-        </Row>
-        <Row>
-          <Col>
-            <ModelOverviewDestinations
-              destinations={destinations}
-              disabled={!destinations.length && !groups.length}
-            />
-          </Col>
-        </Row>
-      </Container>
+              <ListGroupItem>
+                <ModelOverviewSchedules
+                  schedules={schedules}
+                  sources={sources}
+                  execApi={execApi}
+                />
+              </ListGroupItem>
+            </ListGroup>
+          </ManagedCard>
+        </Col>
+      </Row>
+      <Row className="mb-4">
+        <Col>
+          <ModelOverviewSampleRecord
+            modelId={model.id}
+            properties={properties}
+            execApi={execApi}
+            disabled={!sources.length}
+          />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <ModelOverviewDestinations
+            destinations={destinations}
+            disabled={!destinations.length && !groups.length}
+          />
+        </Col>
+      </Row>
     </GrouparooModelContextProvider>
   );
 };

--- a/ui/ui-components/pages/model/[modelId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/overview.tsx
@@ -45,6 +45,11 @@ const Page: NextPage<Props & { ctx: any; errorHandler: any }> = ({
     return result;
   }, [primarySource, secondarySources]);
 
+  const hasReadyProperties = useMemo<boolean>(
+    () => !!properties.find((property) => property.state === "ready"),
+    [properties]
+  );
+
   return (
     <GrouparooModelContextProvider model={model}>
       <Head>
@@ -80,7 +85,7 @@ const Page: NextPage<Props & { ctx: any; errorHandler: any }> = ({
               <ListGroupItem>
                 <ModelOverviewGroups
                   groups={groups}
-                  disabled={!sources.length}
+                  disabled={!sources.length || !hasReadyProperties}
                 />
               </ListGroupItem>
 
@@ -146,9 +151,12 @@ export const getServerSideProps: GetServerSideProps<Props> = async (
   ]);
 
   const primaryKeyProperty = properties.find((p) => p.isPrimaryKey);
-  const primarySource = primaryKeyProperty
-    ? sources.find(({ id }) => id === primaryKeyProperty.sourceId)
-    : null;
+  const primarySource =
+    sources.length === 1
+      ? sources[0] // If there is only one source this will be the primary source
+      : primaryKeyProperty
+      ? sources.find(({ id }) => id === primaryKeyProperty.sourceId)
+      : null;
   const secondarySources = primarySource
     ? sources.filter(({ id }) => id !== primarySource.id)
     : sources;


### PR DESCRIPTION
## Change description

This fixes a number of trivial issues with the model overview page:
- Removes the container component, now the page renders full width
- Disables groups when there are no properties with a `ready` state
- Shows the state on the collapsed list of entities when the state is not `ready`
- Removes the "pending exports" from the destination cards
- Fixes layout issues with the state badge
- If there is only one source, even in a draft state, let's assume it's the primary source (for now until further changes to the flow are made)

![image](https://user-images.githubusercontent.com/168664/146089322-74977b3c-6f45-4308-8b4e-4bc37767f024.png)
![image](https://user-images.githubusercontent.com/168664/146089497-b9c23bb1-d5fa-4131-89d5-485fa1543826.png)



## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
