### PR TITLE
Set CloudWatch log retention to 90 days by default, allow customization

### DIFF
--- a/plugins/@grouparoo/cloudwatch/README.md
+++ b/plugins/@grouparoo/cloudwatch/README.md
@@ -14,4 +14,6 @@ The following environment variables are required:
 - `AWS_SECRET_ACCESS_KEY`
 - `AWS_REGION`
 
+By default, logs have a 90 day retention period. You can customize this setting by using the `AWS_CLOUDWATCH_LOG_RETENTION_DAYS` environment variable.
+
 Note that, `GROUPAROO_LOG_LEVEL` also effects this logger. By default, the log-level of this logger is is "notice" NOT "info".

--- a/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/cloudwatch/src/initializers/plugin.ts
@@ -34,7 +34,9 @@ export default class CloudwatchInitializer extends Initializer {
         return `${name}-${id}-${date}`;
       },
       jsonMessage: true,
-      retentionInDays: 7, // store the logs for 7 days
+      retentionInDays: process.env.AWS_CLOUDWATCH_LOG_RETENTION_DAYS
+        ? parseInt(process.env.AWS_CLOUDWATCH_LOG_RETENTION_DAYS)
+        : 90, // store the logs for 90 days by default
       awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID,
       awsSecretKey: process.env.AWS_SECRET_ACCESS_KEY,
       awsRegion: process.env.AWS_REGION,


### PR DESCRIPTION
## Change description

To be in line with our desired behavior, the cloudwatch log group now has a 90-day retention period. In case others need to customize this in the future, a new `AWS_CLOUDWATCH_LOG_RETENTION_DAYS` environment variable can be set.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
