### PR TITLE
allow logging exports with GROUPAROO_EXPORT_LOG env var

### DIFF
--- a/core/__tests__/models/export.ts
+++ b/core/__tests__/models/export.ts
@@ -535,7 +535,7 @@ describe("models/export", () => {
     });
   });
 
-  describe.only("with GROUPAROO_EXPORT_LOG set", () => {
+  describe("with GROUPAROO_EXPORT_LOG set", () => {
     let oldLogPath = process.env.GROUPAROO_EXPORT_LOG;
     const workerId = process.env.JEST_WORKER_ID;
 

--- a/core/__tests__/models/export.ts
+++ b/core/__tests__/models/export.ts
@@ -1,11 +1,16 @@
+import os from "os";
+import fs from "fs";
+import path from "path";
+import { Op } from "sequelize";
+import { ensureDir } from "fs-extra";
 import { helper } from "@grouparoo/spec-helper";
 import {
   Destination,
   GrouparooRecord,
   Export,
   RecordProperty,
+  Errors,
 } from "../../src";
-import { Op } from "sequelize";
 
 describe("models/export", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -527,6 +532,96 @@ describe("models/export", () => {
       const remaining = await Export.findAll();
       expect(remaining.length).toBe(1);
       expect(remaining[0].id).toBe(exports[0].id);
+    });
+  });
+
+  describe.only("with GROUPAROO_EXPORT_LOG set", () => {
+    let oldLogPath = process.env.GROUPAROO_EXPORT_LOG;
+    const workerId = process.env.JEST_WORKER_ID;
+
+    const logPath = `${os.tmpdir()}/test/${workerId}/exports.log`;
+
+    let _export: Export;
+
+    beforeAll(async () => {
+      await ensureDir(path.dirname(logPath));
+      if (fs.existsSync(logPath)) fs.rmSync(logPath);
+      process.env.GROUPAROO_EXPORT_LOG = logPath;
+    });
+
+    afterAll(() => {
+      process.env.GROUPAROO_EXPORT_LOG = oldLogPath;
+    });
+
+    test("Exports will not be logged to file on creation or common updates", async () => {
+      _export = await helper.factories.export();
+      await _export.update({ startedAt: new Date(), sendAt: new Date() });
+
+      _export.force = true;
+      await _export.save();
+
+      expect(fs.existsSync(logPath)).toBe(false);
+    });
+
+    test("Exports will be logged to file when successfully completed", async () => {
+      await _export.complete();
+
+      expect(fs.existsSync(logPath)).toBe(true);
+
+      const logs = fs.readFileSync(logPath, "utf-8");
+      const lines = logs.split("\n");
+      expect(lines.length).toBe(2);
+
+      const loggedObj = JSON.parse(lines[0]);
+      expect(loggedObj.id).toBe(_export.id);
+      expect(loggedObj.state).toBe("complete");
+      expect(loggedObj.recordId).toBe(_export.recordId);
+      expect(loggedObj.timestamp).toBeDefined();
+    });
+
+    test("Exports will be logged to file when failed", async () => {
+      _export = await helper.factories.export();
+      await _export.setError(
+        new Errors.InfoError("Something terribly wrong happened")
+      );
+
+      const logs = fs.readFileSync(logPath, "utf-8");
+      const lines = logs.split("\n");
+      expect(lines.length).toBe(3);
+
+      const loggedObj = JSON.parse(lines[1]);
+      expect(loggedObj.id).toBe(_export.id);
+      expect(loggedObj.state).toBe("failed");
+      expect(loggedObj.errorMessage).toBe("Something terribly wrong happened");
+      expect(loggedObj.errorLevel).toBe("info");
+      expect(loggedObj.recordId).toBe(_export.recordId);
+      expect(loggedObj.timestamp).toBeDefined();
+    });
+
+    test("Exports will be logged to file when canceled", async () => {
+      _export = await helper.factories.export();
+      await _export.update({ state: "canceled" });
+
+      const logs = fs.readFileSync(logPath, "utf-8");
+      const lines = logs.split("\n");
+      expect(lines.length).toBe(4);
+
+      const loggedObj = JSON.parse(lines[2]);
+      expect(loggedObj.id).toBe(_export.id);
+      expect(loggedObj.state).toBe("canceled");
+      expect(loggedObj.recordId).toBe(_export.recordId);
+      expect(loggedObj.timestamp).toBeDefined();
+    });
+
+    test("Exports will not be logged if GROUPAROO_EXPORT_LOG is not set", async () => {
+      delete process.env.GROUPAROO_EXPORT_LOG;
+
+      fs.rmSync(logPath);
+
+      _export = await helper.factories.export();
+      await _export.complete();
+
+      expect(fs.existsSync(logPath)).toBe(false);
     });
   });
 

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -10,7 +10,8 @@ import {
   Default,
   AfterUpdate,
 } from "sequelize-typescript";
-import { appendFile } from "fs/promises";
+import path from "path";
+import { appendFile } from "fs-extra";
 import { api, config, log } from "actionhero";
 import { Destination } from "./Destination";
 import { GrouparooRecord } from "./GrouparooRecord";
@@ -24,6 +25,7 @@ import { ExportProcessor } from "./ExportProcessor";
 import { Errors } from "../modules/errors";
 import { PropertyTypes } from "./Property";
 import { CommonModel } from "../classes/commonModel";
+import { getParentPath } from "../modules/pluginDetails";
 
 /**
  * The GrouparooRecord Properties in their normal data types (string, boolean, date, etc)
@@ -320,7 +322,11 @@ export class Export extends CommonModel<Export> {
       if (process.env.GROUPAROO_EXPORT_LOG === "stdout") {
         log(`[ export ] ${message}`);
       } else {
-        await appendFile(process.env.GROUPAROO_EXPORT_LOG, `${message}\n`);
+        const logPath = path.isAbsolute(process.env.GROUPAROO_EXPORT_LOG)
+          ? process.env.GROUPAROO_EXPORT_LOG
+          : path.join(getParentPath(), process.env.GROUPAROO_EXPORT_LOG);
+
+        await appendFile(logPath, `${message}\n`);
       }
     }
   }

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -305,7 +305,7 @@ export class Export extends CommonModel<Export> {
     ) {
       const exportData = {
         ...(await instance.apiData(false)),
-        timestamp: new Date().toISOString(),
+        timestamp: APIData.formatDate(new Date()),
       };
 
       const message = JSON.stringify(exportData);

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -304,16 +304,7 @@ export class Export extends CommonModel<Export> {
       ["canceled", "failed", "complete"].includes(instance.state)
     ) {
       const exportData = {
-        id: instance.id,
-        state: instance.state,
-        recordId: instance.recordId,
-        modelId: (await instance.$get("record")).modelId,
-        destinationId: instance.destinationId,
-        newRecordProperties: instance.newRecordProperties,
-        newGroups: instance.newGroups,
-        toDelete: instance.toDelete,
-        errorMessage: instance.errorMessage,
-        errorLevel: instance.errorLevel,
+        ...(await instance.apiData(false)),
         timestamp: new Date().toISOString(),
       };
 


### PR DESCRIPTION
## Change description

New environment variable `GROUPAROO_EXPORT_LOG` can be used to enable logging of `complete`, `failed` or `canceled` Exports. Set it to a filepath (e.g. `/path/to/exports.log`) to append to a file or `stdout` to log as info messages. The file will be created automatically if it does not yet exist.

Each line in the log file is a JSON object, such as:
```
{"id":"exp_59b8dc72-48b5-4f8e-8dca-8d8ebdd6b289","destinationName":"PG Destination","recordId":"rec_88450e86-8cfc-4df2-8781-d7ea49802fe7","exportProcessorId":null,"state":"complete","force":false,"createdAt":1640032838583,"sendAt":1640032838583,"startedAt":1640032849107,"completedAt":1640032850676,"retryCount":0,"oldRecordProperties":{"firstName":"Ave","id":89},"newRecordProperties":{"firstName":"Ave","id":89},"oldGroups":[],"newGroups":[],"toDelete":true,"hasChanges":true,"errorMessage":null,"errorLevel":null,"timestamp":1640032850678}
```

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
