### PR TITLE
Scope Group Rules with topLevelRules to just this model

### DIFF
--- a/core/__tests__/models/group/calculatedGroup.ts
+++ b/core/__tests__/models/group/calculatedGroup.ts
@@ -33,11 +33,12 @@ describe("models/group", () => {
     beforeEach(async () => {
       const response = await SharedGroupTests.beforeEach();
       group = response.group;
-      run = response.run;
+      run = await helper.factories.run();
     });
 
     afterEach(async () => {
       await SharedGroupTests.afterEach();
+      await run.destroy();
       process.env.GROUPAROO_RUN_MODE = undefined;
     });
 

--- a/core/__tests__/models/group/rules/topLevelGroupRules.ts
+++ b/core/__tests__/models/group/rules/topLevelGroupRules.ts
@@ -19,6 +19,11 @@ describe("model/group", () => {
     toad = response.toad;
   }, helper.setupTime);
 
+  beforeAll(async () => {
+    const otherModel = await helper.factories.model({ name: "other model" });
+    await GrouparooRecord.create({ modelId: otherModel.id });
+  });
+
   beforeEach(async () => {
     const response = await SharedGroupTests.beforeEach();
     group = response.group;

--- a/core/__tests__/utils/prepareSharedGroupTest.ts
+++ b/core/__tests__/utils/prepareSharedGroupTest.ts
@@ -86,8 +86,6 @@ export namespace SharedGroupTests {
 
     await group.update({ matchType: "all" });
 
-    run = await helper.factories.run();
-
     await RecordProperty.update(
       { state: "ready" },
       { where: { recordId: [mario.id, luigi.id, peach.id, toad.id] } }
@@ -97,6 +95,11 @@ export namespace SharedGroupTests {
     await luigi.update({ state: "ready" });
     await peach.update({ state: "ready" });
     await toad.update({ state: "ready" });
+
+    run = await helper.factories.run(null, {
+      creatorId: group.id,
+      creatorType: "group",
+    });
 
     return { group, run };
   }

--- a/core/__tests__/utils/prepareSharedGroupTest.ts
+++ b/core/__tests__/utils/prepareSharedGroupTest.ts
@@ -3,7 +3,6 @@ import { GrouparooRecord, Group, Run, Import, RecordProperty } from "../../src";
 import { specHelper } from "actionhero";
 
 export namespace SharedGroupTests {
-  let run: Run;
   let group: Group;
   let mario: GrouparooRecord;
   let luigi: GrouparooRecord;
@@ -96,12 +95,7 @@ export namespace SharedGroupTests {
     await peach.update({ state: "ready" });
     await toad.update({ state: "ready" });
 
-    run = await helper.factories.run(null, {
-      creatorId: group.id,
-      creatorType: "group",
-    });
-
-    return { group, run };
+    return { group };
   }
 
   export async function afterEach() {
@@ -111,7 +105,6 @@ export namespace SharedGroupTests {
     const members = await group.$get("groupMembers");
     for (const m of members) await m.destroy();
     await group.destroy();
-    await run.destroy();
     await Import.truncate();
   }
 }

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -566,7 +566,10 @@ export class Group extends LoggedModel<Group> {
           ).getTime();
         }
 
-        const topLevelWhere = { [topLevelGroupRule.column]: rawValueMatch };
+        const topLevelWhere = {
+          [topLevelGroupRule.column]: rawValueMatch,
+          modelId: this.modelId,
+        };
         localWhereGroup[Op.and] = [topLevelWhere];
       }
 

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -173,7 +173,7 @@ export default function Page(props) {
         ]}
       />
 
-      {grouparooUiEdition()! == "config" && (
+      {grouparooUiEdition() !== "config" && (
         <p>
           Total Records in this group: &nbsp;
           <Badge style={{ fontSize: 16 }} variant="info">


### PR DESCRIPTION
This PR fixes a bug in which Groups that used topLevelGroupRules (eg: Grouparoo Record Id exists) would incorrectly find records of other models.  These records would then fail to make GroupMembers, creating endless resque errors. 

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
