### PR TITLE
Rebuild state from props when changing from one property edit page to another

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
@@ -66,8 +66,11 @@ export default function Page(props) {
   if (hydrationError) errorHandler.set({ message: hydrationError });
 
   useEffect(() => {
+    setProperty(props.property);
+    setPluginOptions(props.pluginOptions);
+    setLocalFilters(makeLocal(props.property.filters));
     newRuleDefaults();
-  }, []);
+  }, [propertyId]);
 
   useEffect(() => {
     updatePluginOptions();
@@ -75,7 +78,7 @@ export default function Page(props) {
     return () => {
       clearTimeout(timer);
     };
-  }, [JSON.stringify(property.options)]);
+  }, [property.id, JSON.stringify(property.options)]);
 
   async function onSubmit(event) {
     event.preventDefault();
@@ -205,7 +208,7 @@ export default function Page(props) {
     setLocalFilters(_localFilters);
   }
 
-  if (property.id === "") {
+  if (!property?.id) {
     return <Loader />;
   }
 


### PR DESCRIPTION
Fixes a bug when using the new Property Preview widget when switching from one property page to another.  We store the initial page props in local state variables (so they can be edited by the user), and we need to reset those with the new props.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
