### PR TITLE
Ignore empty strings when setting options

### DIFF
--- a/core/__tests__/models/option.ts
+++ b/core/__tests__/models/option.ts
@@ -140,6 +140,15 @@ describe("models/option", () => {
       expect(await OptionHelper.getOptions(app)).toEqual(opts);
     });
 
+    test("empty options will be ignored", async () => {
+      const opts = { fileId: "abcdba", password: "" };
+      await OptionHelper.setOptions(app, opts);
+
+      const options = await OptionHelper.getOptions(app);
+      expect(options["fileId"]).toEqual(opts.fileId);
+      expect(options["password"]).toBeUndefined();
+    });
+
     test("I will see passwords by default for Apps", async () => {
       const opts = { fileId: "abc123", password: "SECRET" };
       await OptionHelper.setOptions(app, opts);

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -67,9 +67,10 @@ export namespace OptionHelper {
   ) {
     delete instance.__options;
 
+    const filteredOptions = filterEmptyOptions(options);
     const sanitizedOptions = await replaceObfuscatedPasswords(
       instance,
-      options,
+      filteredOptions,
       false
     );
 
@@ -410,6 +411,16 @@ export namespace OptionHelper {
     }
 
     return defaultOptions;
+  }
+
+  export function filterEmptyOptions(options: SimpleOptions) {
+    const opts = Object.assign({}, options);
+
+    Object.keys(opts).forEach((k) => {
+      if (opts[k] === "") delete opts[k];
+    });
+
+    return opts;
   }
 
   export async function getOptionsToObfuscate(

--- a/ui/ui-components/pages/app/[id]/edit.tsx
+++ b/ui/ui-components/pages/app/[id]/edit.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { useState } from "react";
+import { useState, Fragment } from "react";
 import { UseApi } from "../../../hooks/useApi";
 import { Row, Col, Form, Badge, Alert } from "react-bootstrap";
 import { Typeahead } from "react-bootstrap-typeahead";
@@ -176,11 +176,9 @@ export default function Page(props) {
                       <p className="mb-0">
                         Available environment variables for apps:{" "}
                         {environmentVariableOptions.sort().map((envOpt) => (
-                          <>
-                            <Badge key={`envOpt-${envOpt}`} variant="info">
-                              {envOpt}
-                            </Badge>{" "}
-                          </>
+                          <Fragment key={`envOpt-${envOpt}`}>
+                            <Badge variant="info">{envOpt}</Badge>{" "}
+                          </Fragment>
                         ))}
                       </p>
                     )}


### PR DESCRIPTION
## Change description

When manually deleting option values through the UI, an empty string was being saved. This meant that things like default values were not being applied in these cases, because there was technically a value. 

This changes the behavior so when setting options to any of the supported models, empty strings are ignored.

There's also a fix for a `missing key` error on the app edit page that was introduced by #2668 (the key had to be moved up to the fragment)

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
