### PR TITLE
Hide parts of the sign-in page during oAuth flow

### DIFF
--- a/ui/ui-components/components/session/SignIn.tsx
+++ b/ui/ui-components/components/session/SignIn.tsx
@@ -28,6 +28,7 @@ export default function SignInForm(props) {
   const [showModal, setShowModal] = useState(false);
   const [providers, setProviders] = useState<OAuth.oAuthProviderType[]>([]);
   const [loadingOauthProviders, setLoadingOauthProviders] = useState(false);
+  const [confirmingOauthRequest, setConfirmingOauthRequest] = useState(false);
   const [oAuthRequest, setOAuthRequest] =
     useState<Models.OAuthRequestType>(null);
   const { nextPage, requestId } = router.query;
@@ -75,27 +76,29 @@ export default function SignInForm(props) {
   };
 
   const loadOAuthRequest = async () => {
-    if (!requestId) return;
-    setLoadingOAuth(true);
-    const response: Actions.OAuthClientView = await execApi(
-      "get",
-      `/oauth/client/request/${requestId}/view`
-    );
+    if (requestId) {
+      const response: Actions.OAuthClientView = await execApi(
+        "get",
+        `/oauth/client/request/${requestId}/view`
+      );
 
-    if (response.oAuthRequest) {
-      setOAuthRequest(response.oAuthRequest);
-      if (response.oAuthRequest.identities.length === 0) {
-        router.replace("/session/sign-in", undefined, { shallow: true });
-        errorHandler.set({
-          message: `No identities returned from ${response.oAuthRequest.provider}`,
-        });
-      } else if (response.oAuthRequest.identities.length === 1) {
-        onSubmit(response.oAuthRequest.identities[0], "requestId");
-      } else {
-        setShowModal(true);
+      if (response.oAuthRequest) {
+        setOAuthRequest(response.oAuthRequest);
+        if (response.oAuthRequest.identities.length === 0) {
+          router.replace("/session/sign-in", undefined, { shallow: true });
+          errorHandler.set({
+            message: `No identities returned from ${response.oAuthRequest.provider}`,
+          });
+          setConfirmingOauthRequest(false);
+        } else if (response.oAuthRequest.identities.length === 1) {
+          onSubmit(response.oAuthRequest.identities[0], "requestId");
+        } else {
+          setShowModal(true);
+        }
       }
+    } else {
+      setConfirmingOauthRequest(false);
     }
-    setLoadingOAuth(false);
   };
 
   const onSubmit = async (
@@ -122,6 +125,9 @@ export default function SignInForm(props) {
           router.push("/setup");
         }
       }
+    } else {
+      setShowModal(false);
+      setConfirmingOauthRequest(false);
     }
   };
 
@@ -134,104 +140,116 @@ export default function SignInForm(props) {
   };
 
   useEffect(() => {
+    setConfirmingOauthRequest(true);
     loadOauthOptions();
     loadOAuthRequest();
   }, []);
 
   return (
     <>
-      <Row>
-        <Col>
-          <h1>Sign In</h1>
-        </Col>
-      </Row>
-      <Row>
-        <Col className="border-right">
-          <Form
-            id="form"
-            onSubmit={handleSubmit((data) => onSubmit(data, "password"))}
-          >
-            <fieldset disabled={loadingEmail || loadingOAuth}>
-              <Form.Group>
-                <Form.Label>Email Address</Form.Label>
-                <Form.Control
-                  autoFocus
-                  required
-                  name="email"
-                  type="email"
-                  placeholder="Email Address"
-                  ref={register}
-                />
-                <Form.Control.Feedback type="invalid">
-                  Email is required
-                </Form.Control.Feedback>
-              </Form.Group>
-
-              <Form.Group>
-                <Form.Label>Password</Form.Label>
-                <Form.Control
-                  required
-                  name="password"
-                  type="password"
-                  placeholder="Password"
-                  ref={register}
-                />
-                <Form.Control.Feedback type="invalid">
-                  A password is required
-                </Form.Control.Feedback>
-              </Form.Group>
-
-              <LoadingButton
-                loading={loadingEmail}
-                variant="primary"
-                type="submit"
+      {/* If we are loading the results of an oAuth request, hide the UI entirely so it doesn't "pop" in and out */}
+      {confirmingOauthRequest ? null : (
+        <>
+          <Row>
+            <Col>
+              <h1>Sign In</h1>
+            </Col>
+          </Row>
+          <Row>
+            <Col className="border-right">
+              <Form
+                id="form"
+                onSubmit={handleSubmit((data) => onSubmit(data, "password"))}
               >
-                Sign In
-              </LoadingButton>
-            </fieldset>
-          </Form>
-        </Col>
-
-        <Col style={{ textAlign: "center" }}>
-          {loadingOauthProviders ? (
-            <>
-              <br />
-              <br />
-              <Loader />
-            </>
-          ) : null}
-
-          <br />
-
-          {loadingOauthProviders === false && providers.length === 0 ? (
-            <p>Could not load OAuth providers</p>
-          ) : null}
-
-          <div className="d-flex justify-content-center">
-            <ButtonGroup vertical style={{ width: "100%" }}>
-              {providers.map((provider) => (
-                <Fragment key={`provider-${provider.name}`}>
-                  <LoadingButton
-                    size="sm"
-                    disabled={loadingEmail || loadingOAuth}
-                    loading={loadingOAuth}
-                    variant="outline-primary"
-                    onClick={() => startOauthLogin(provider.name, "user")}
-                  >
-                    {provider.description}
-                    <img
-                      style={{ margin: 10, height: 40, width: 40 }}
-                      src={provider.icon}
+                <fieldset disabled={loadingEmail || loadingOAuth}>
+                  <Form.Group>
+                    <Form.Label>Email Address</Form.Label>
+                    <Form.Control
+                      autoFocus
+                      required
+                      name="email"
+                      type="email"
+                      placeholder="Email Address"
+                      ref={register}
                     />
-                  </LoadingButton>
-                </Fragment>
-              ))}
-            </ButtonGroup>
-          </div>
-        </Col>
-      </Row>
+                    <Form.Control.Feedback type="invalid">
+                      Email is required
+                    </Form.Control.Feedback>
+                  </Form.Group>
 
-      <Modal show={showModal} onHide={() => setShowModal(false)}>
+                  <Form.Group>
+                    <Form.Label>Password</Form.Label>
+                    <Form.Control
+                      required
+                      name="password"
+                      type="password"
+                      placeholder="Password"
+                      ref={register}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                      A password is required
+                    </Form.Control.Feedback>
+                  </Form.Group>
+
+                  <LoadingButton
+                    loading={loadingEmail}
+                    variant="primary"
+                    type="submit"
+                  >
+                    Sign In
+                  </LoadingButton>
+                </fieldset>
+              </Form>
+            </Col>
+
+            <Col style={{ textAlign: "center" }}>
+              {loadingOauthProviders ? (
+                <>
+                  <br />
+                  <br />
+                  <Loader />
+                </>
+              ) : null}
+
+              <br />
+
+              {loadingOauthProviders === false && providers.length === 0 ? (
+                <p>Could not load OAuth providers</p>
+              ) : null}
+
+              <div className="d-flex justify-content-center">
+                <ButtonGroup vertical style={{ width: "100%" }}>
+                  {providers.map((provider) => (
+                    <Fragment key={`provider-${provider.name}`}>
+                      <LoadingButton
+                        size="sm"
+                        disabled={loadingEmail || loadingOAuth}
+                        loading={loadingOAuth}
+                        variant="outline-primary"
+                        onClick={() => startOauthLogin(provider.name, "user")}
+                      >
+                        {provider.description}
+                        <img
+                          style={{ margin: 10, height: 40, width: 40 }}
+                          src={provider.icon}
+                        />
+                      </LoadingButton>
+                    </Fragment>
+                  ))}
+                </ButtonGroup>
+              </div>
+            </Col>
+          </Row>
+        </>
+      )}
+
+      <Modal
+        show={showModal}
+        onHide={() => {
+          setShowModal(false);
+          setConfirmingOauthRequest(false);
+        }}
+      >
         {oAuthRequest ? (
           <>
             <Modal.Header closeButton>
@@ -244,7 +262,6 @@ export default function SignInForm(props) {
                     variant="outline-primary"
                     key={`identity-${idx}`}
                     onClick={() => {
-                      setShowModal(false);
                       onSubmit(identity, "requestId");
                     }}
                   >
@@ -254,7 +271,13 @@ export default function SignInForm(props) {
               </ButtonGroup>
             </Modal.Body>
             <Modal.Footer>
-              <Button variant="secondary" onClick={() => setShowModal(false)}>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  setShowModal(false);
+                  setConfirmingOauthRequest(false);
+                }}
+              >
                 Close
               </Button>
             </Modal.Footer>


### PR DESCRIPTION
To make things clearer for folks:
* If you come back to the sign in page after the oAuth login flow, don't render the initial UI while we are loading the request details.  Just show a spinner.
  * If there's a modal to choose an identity, just show the modal
  * If something goes wrong, then show the initial UI

This has the effect of the user not seeing the initial sign in form again if they log in successfully with one identity. 


https://user-images.githubusercontent.com/303226/147277837-7648075b-0496-4212-9f75-c209a879e8e3.mov



## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
