### PR TITLE
Add states to Imports

### DIFF
--- a/core/__tests__/actions/imports.ts
+++ b/core/__tests__/actions/imports.ts
@@ -106,7 +106,8 @@ describe("actions/imports", () => {
 
       expect(error).toBeFalsy();
       expect(imports.length).toBe(1);
-      expect(imports[0].id).toBeTruthy();
+      expect(imports[0].id).toBe(toadImport.id);
+      expect(imports[0].state).toBe("importing");
       expect(imports[0].data.email).toBe("toad@mushroom-kingdom.gov");
     });
   });

--- a/core/__tests__/actions/imports.ts
+++ b/core/__tests__/actions/imports.ts
@@ -98,7 +98,7 @@ describe("actions/imports", () => {
     });
 
     test("imports can be filtered by state", async () => {
-      connection.params = { csrfToken, state: "pending" };
+      connection.params = { csrfToken, state: "importing" };
       const { error, imports } = await specHelper.runAction<ImportsList>(
         "imports:list",
         connection

--- a/core/__tests__/actions/imports.ts
+++ b/core/__tests__/actions/imports.ts
@@ -22,6 +22,8 @@ describe("actions/imports", () => {
   describe("with session", () => {
     let connection;
     let csrfToken;
+    let toadImport: Import;
+    let peachImport: Import;
 
     beforeAll(async () => {
       await specHelper.runAction("team:initialize", {
@@ -42,7 +44,7 @@ describe("actions/imports", () => {
 
     beforeAll(async () => {
       const record = await helper.factories.record({ modelId: "mod_profiles" });
-      await helper.factories.import(
+      toadImport = await helper.factories.import(
         undefined,
         {
           email: "toad@mushroom-kingdom.gov",
@@ -50,23 +52,53 @@ describe("actions/imports", () => {
         },
         record.id
       );
+
+      const record2 = await helper.factories.record({
+        modelId: "mod_profiles",
+      });
+      peachImport = await helper.factories.import(
+        undefined,
+        {
+          email: "peach@mushroom-kingdom.gov",
+          something: "new",
+        },
+        record2.id
+      );
+      await peachImport.update({ state: "complete" });
     });
 
     test("an import can be viewed", async () => {
-      const i = await Import.findOne();
-      connection.params = { csrfToken, id: i.id };
+      connection.params = { csrfToken, id: toadImport.id };
       const { error, import: _import } = await specHelper.runAction<ImportView>(
         "import:view",
         connection
       );
 
       expect(error).toBeFalsy();
-      expect(_import.id).toBe(i.id);
+      expect(_import.id).toBe(toadImport.id);
       expect(_import.createdAt).toBeTruthy();
     });
 
     test("imports can be listed", async () => {
       connection.params = { csrfToken };
+      const { error, imports } = await specHelper.runAction<ImportsList>(
+        "imports:list",
+        connection
+      );
+
+      expect(error).toBeFalsy();
+      expect(imports.length).toBe(2);
+      expect(imports.map((i) => i.id).sort()).toEqual(
+        [peachImport.id, toadImport.id].sort()
+      );
+      expect(imports.map((i) => i.data.email).sort()).toEqual([
+        "peach@mushroom-kingdom.gov",
+        "toad@mushroom-kingdom.gov",
+      ]);
+    });
+
+    test("imports can be filtered by state", async () => {
+      connection.params = { csrfToken, state: "pending" };
       const { error, imports } = await specHelper.runAction<ImportsList>(
         "imports:list",
         connection

--- a/core/__tests__/models/import.ts
+++ b/core/__tests__/models/import.ts
@@ -28,16 +28,21 @@ describe("models/import", () => {
       creatorId: "",
     });
     expect(_import.recordId).toBeFalsy();
+    expect(_import.state).toBe("associating");
 
     await _import.associateRecord();
+    expect(_import.state).toBe("pending");
     expect(_import.recordId).toBe(record.id);
   });
 
   test("an error can be set", async () => {
     const _import = await helper.factories.import();
+    expect(_import.state).toBe("associating");
+
     await _import.setError(new Error("oh no"), "associate");
     await _import.reload();
 
+    expect(_import.state).toBe("failed");
     expect(_import.errorMessage).toMatch("oh no");
     expect(_import.errorMetadata).toMatch("oh no");
   });

--- a/core/__tests__/models/import.ts
+++ b/core/__tests__/models/import.ts
@@ -31,7 +31,7 @@ describe("models/import", () => {
     expect(_import.state).toBe("associating");
 
     await _import.associateRecord();
-    expect(_import.state).toBe("pending");
+    expect(_import.state).toBe("importing");
     expect(_import.recordId).toBe(record.id);
   });
 

--- a/core/__tests__/models/run/run.ts
+++ b/core/__tests__/models/run/run.ts
@@ -539,8 +539,7 @@ describe("models/run", () => {
         creatorType: "run",
         creatorId: run.id,
         recordAssociatedAt: new Date(),
-        recordUpdatedAt: new Date(),
-        groupsUpdatedAt: new Date(),
+        importedAt: new Date(),
         exportedAt: new Date(),
         createdRecord: true,
       });
@@ -552,8 +551,7 @@ describe("models/run", () => {
         creatorType: "run",
         creatorId: run.id,
         recordAssociatedAt: new Date(),
-        recordUpdatedAt: new Date(),
-        groupsUpdatedAt: new Date(),
+        importedAt: new Date(),
         exportedAt: new Date(),
       });
 
@@ -564,8 +562,7 @@ describe("models/run", () => {
         creatorType: "run",
         creatorId: run.id,
         recordAssociatedAt: new Date(),
-        recordUpdatedAt: new Date(),
-        groupsUpdatedAt: new Date(),
+        importedAt: new Date(),
         exportedAt: new Date(),
       });
 
@@ -585,22 +582,18 @@ describe("models/run", () => {
       const quantizedTimeline = await run.quantizedTimeline();
       expect(quantizedTimeline.length).toBe(25 + 4);
       let associateTotal = 0;
-      let updateTotal = 0;
-      let groupsTotal = 0;
+      let importTotal = 0;
       quantizedTimeline.map((q) => {
         expect(q.steps.associate).toBeLessThanOrEqual(1);
-        expect(q.steps.recordsUpdated).toBeLessThanOrEqual(1);
-        expect(q.steps.groupsUpdated).toBeLessThanOrEqual(1);
+        expect(q.steps.imported).toBeLessThanOrEqual(1);
         expect(q.steps.exported).toBeLessThanOrEqual(1);
 
         associateTotal += q.steps.associate;
-        updateTotal += q.steps.recordsUpdated;
-        groupsTotal += q.steps.groupsUpdated;
+        importTotal += q.steps.imported;
       });
 
       expect(associateTotal).toBe(3);
-      expect(updateTotal).toBe(3);
-      expect(groupsTotal).toBe(3);
+      expect(importTotal).toBe(3);
     });
   });
 

--- a/core/__tests__/modules/status.ts
+++ b/core/__tests__/modules/status.ts
@@ -519,8 +519,7 @@ describe("modules/status", () => {
           const now = new Date();
           await _import.update({
             recordAssociatedAt: now,
-            recordUpdatedAt: now,
-            groupsUpdatedAt: now,
+            importedAt: now,
           });
 
           await source.update({ state: sourceState });

--- a/core/__tests__/tasks/import/associateRecord.ts
+++ b/core/__tests__/tasks/import/associateRecord.ts
@@ -44,6 +44,7 @@ describe("tasks/import:associateRecord", () => {
         email: "toad@example.com",
         firstName: "Toad",
       });
+      expect(_import.state).toBe("associating");
       expect(_import.recordId).toBeFalsy();
       expect(_import.recordAssociatedAt).toBeFalsy();
 
@@ -59,6 +60,7 @@ describe("tasks/import:associateRecord", () => {
       expect(record).toBeTruthy();
       expect(_import.recordId).toBe(record.id);
       expect(_import.recordAssociatedAt).toBeTruthy();
+      expect(_import.state).toBe("importing");
 
       expect(_import.oldRecordProperties).toEqual({
         email: ["toad@example.com"],
@@ -96,6 +98,7 @@ describe("tasks/import:associateRecord", () => {
       await specHelper.runTask("import:associateRecord", found[0].args[0]);
 
       await _import.reload();
+      expect(_import.state).toBe("associating");
       expect(_import.errorMessage).toBeFalsy();
       found = await specHelper.findEnqueuedTasks("import:associateRecord");
       expect(found.length).toEqual(2);
@@ -105,6 +108,7 @@ describe("tasks/import:associateRecord", () => {
       await specHelper.runTask("import:associateRecord", found[1].args[0]);
 
       await _import.reload();
+      expect(_import.state).toBe("associating");
       expect(_import.errorMessage).toBeFalsy();
       found = await specHelper.findEnqueuedTasks("import:associateRecord");
       expect(found.length).toEqual(3);
@@ -114,6 +118,7 @@ describe("tasks/import:associateRecord", () => {
       await specHelper.runTask("import:associateRecord", found[2].args[0]);
 
       await _import.reload();
+      expect(_import.state).toBe("failed");
       expect(_import.errorMessage).toMatch(
         /there are no unique record properties provided in {"thing":"stuff"}/
       );
@@ -148,6 +153,7 @@ describe("tasks/import:associateRecord", () => {
         lastName: "Jr",
         someNonexistentProp: "Hi there",
       });
+      expect(_import.state).toBe("associating");
       expect(_import.recordId).toBeFalsy();
       expect(_import.recordAssociatedAt).toBeFalsy();
 
@@ -161,6 +167,7 @@ describe("tasks/import:associateRecord", () => {
       await _import.reload();
       const record = await GrouparooRecord.findOne();
       expect(record).toBeTruthy();
+      expect(_import.state).toBe("importing");
       expect(_import.recordId).toBe(record.id);
       expect(_import.recordAssociatedAt).toBeTruthy();
 
@@ -191,6 +198,7 @@ describe("tasks/import:associateRecord", () => {
       });
 
       await _import.reload();
+      expect(_import.state).toBe("failed");
       expect(_import.errorMessage).toMatch(
         /could not create a new record because no record property/
       );

--- a/core/__tests__/tasks/import/associateRecords.ts
+++ b/core/__tests__/tasks/import/associateRecords.ts
@@ -35,7 +35,11 @@ describe("tasks/import:associateRecords", () => {
   test("it will not include imports that have already been associated to a record", async () => {
     const _import = await helper.factories.import();
     await api.resque.queue.connection.redis.flushdb();
-    await _import.update({ recordId: "abc", recordAssociatedAt: new Date() });
+    await _import.update({
+      state: "pending",
+      recordId: "abc",
+      recordAssociatedAt: new Date(),
+    });
 
     await specHelper.runTask("import:associateRecords", {});
 
@@ -109,7 +113,7 @@ describe("tasks/import:associateRecords", () => {
     const _import = await helper.factories.import();
     await api.resque.queue.connection.redis.flushdb();
 
-    await _import.update({ errorMessage: "I broke" });
+    await _import.update({ state: "failed", errorMessage: "I broke" });
 
     await specHelper.runTask("import:associateRecords", {});
 

--- a/core/__tests__/tasks/import/associateRecords.ts
+++ b/core/__tests__/tasks/import/associateRecords.ts
@@ -36,7 +36,7 @@ describe("tasks/import:associateRecords", () => {
     const _import = await helper.factories.import();
     await api.resque.queue.connection.redis.flushdb();
     await _import.update({
-      state: "pending",
+      state: "importing",
       recordId: "abc",
       recordAssociatedAt: new Date(),
     });

--- a/core/__tests__/tasks/record/checkReady/checkReady.ts
+++ b/core/__tests__/tasks/record/checkReady/checkReady.ts
@@ -168,7 +168,7 @@ describe("tasks/record:checkReady", () => {
       expect(_importA.newRecordProperties.firstName).toEqual(["Super"]);
       expect(_importA.newRecordProperties.lastName).toEqual(["Mario"]);
       expect(_importA.newGroupIds).toEqual([group.id]);
-      expect(_importA.groupsUpdatedAt).toBeTruthy();
+      expect(_importA.importedAt).toBeTruthy();
       expect(_importA.exportedAt).toBeNull();
       expect(_importA.state).toBe("exporting");
 
@@ -176,7 +176,7 @@ describe("tasks/record:checkReady", () => {
       expect(_importB.newRecordProperties.firstName).toEqual(["Super"]);
       expect(_importB.newRecordProperties.lastName).toEqual(["Mario"]);
       expect(_importB.newGroupIds).toEqual([group.id]);
-      expect(_importB.groupsUpdatedAt).toBeTruthy();
+      expect(_importB.importedAt).toBeTruthy();
       expect(_importB.exportedAt).toBeNull();
       expect(_importB.state).toBe("exporting");
 
@@ -208,8 +208,7 @@ describe("tasks/record:checkReady", () => {
       expect(record.state).toBe("ready");
 
       await _importA.reload();
-      expect(_importA.groupsUpdatedAt).toBeTruthy();
-      expect(_importA.recordUpdatedAt).toBeTruthy();
+      expect(_importA.importedAt).toBeTruthy();
       expect(_importA.exportedAt).toBeTruthy();
       expect(_importA.state).toBe("complete");
 

--- a/core/__tests__/tasks/record/checkReady/checkReady.ts
+++ b/core/__tests__/tasks/record/checkReady/checkReady.ts
@@ -170,6 +170,7 @@ describe("tasks/record:checkReady", () => {
       expect(_importA.newGroupIds).toEqual([group.id]);
       expect(_importA.groupsUpdatedAt).toBeTruthy();
       expect(_importA.exportedAt).toBeNull();
+      expect(_importA.state).toBe("exporting");
 
       expect(_importB.newRecordProperties.email).toEqual(["mario@example.com"]);
       expect(_importB.newRecordProperties.firstName).toEqual(["Super"]);
@@ -177,6 +178,7 @@ describe("tasks/record:checkReady", () => {
       expect(_importB.newGroupIds).toEqual([group.id]);
       expect(_importB.groupsUpdatedAt).toBeTruthy();
       expect(_importB.exportedAt).toBeNull();
+      expect(_importB.state).toBe("exporting");
 
       expect(run.recordsCreated).toEqual(1);
       expect(run.recordsImported).toEqual(1);
@@ -209,6 +211,7 @@ describe("tasks/record:checkReady", () => {
       expect(_importA.groupsUpdatedAt).toBeTruthy();
       expect(_importA.recordUpdatedAt).toBeTruthy();
       expect(_importA.exportedAt).toBeTruthy();
+      expect(_importA.state).toBe("complete");
 
       process.env.GROUPAROO_DISABLE_EXPORTS = "false";
     });

--- a/core/__tests__/tasks/record/confirm/confirm.ts
+++ b/core/__tests__/tasks/record/confirm/confirm.ts
@@ -311,6 +311,7 @@ describe("tasks/records:confirm", () => {
     await _import.update({
       recordId: "someId",
       recordAssociatedAt: new Date(),
+      state: "importing",
     });
 
     // try to confirm again

--- a/core/__tests__/tasks/record/enqueueExports/enqueueExports.ts
+++ b/core/__tests__/tasks/record/enqueueExports/enqueueExports.ts
@@ -34,7 +34,7 @@ describe("tasks/records:enqueueExports", () => {
         record.id
       );
       await _import.update({
-        state: "complete",
+        state: "exporting",
         groupsUpdatedAt: new Date(),
         recordUpdatedAt: new Date(),
         exportedAt: null,
@@ -59,7 +59,7 @@ describe("tasks/records:enqueueExports", () => {
         record.id
       );
       await _import.update({
-        state: "complete",
+        state: "exporting",
         groupsUpdatedAt: new Date(),
         recordUpdatedAt: new Date(),
         exportedAt: null,
@@ -90,7 +90,7 @@ describe("tasks/records:enqueueExports", () => {
         mario.id
       );
       await marioImport.update({
-        state: "complete",
+        state: "exporting",
         groupsUpdatedAt: new Date(),
         recordUpdatedAt: new Date(),
         exportedAt: null,
@@ -121,7 +121,7 @@ describe("tasks/records:enqueueExports", () => {
         toad.id
       );
       await toadImport.update({
-        state: "complete",
+        state: "exporting",
         groupsUpdatedAt: new Date(),
         recordUpdatedAt: new Date(),
         exportedAt: null,

--- a/core/__tests__/tasks/record/enqueueExports/enqueueExports.ts
+++ b/core/__tests__/tasks/record/enqueueExports/enqueueExports.ts
@@ -35,8 +35,7 @@ describe("tasks/records:enqueueExports", () => {
       );
       await _import.update({
         state: "exporting",
-        groupsUpdatedAt: new Date(),
-        recordUpdatedAt: new Date(),
+        importedAt: new Date(),
         exportedAt: null,
       });
 
@@ -60,8 +59,7 @@ describe("tasks/records:enqueueExports", () => {
       );
       await _import.update({
         state: "exporting",
-        groupsUpdatedAt: new Date(),
-        recordUpdatedAt: new Date(),
+        importedAt: new Date(),
         exportedAt: null,
       });
 
@@ -91,8 +89,7 @@ describe("tasks/records:enqueueExports", () => {
       );
       await marioImport.update({
         state: "exporting",
-        groupsUpdatedAt: new Date(),
-        recordUpdatedAt: new Date(),
+        importedAt: new Date(),
         exportedAt: null,
       });
 
@@ -106,8 +103,7 @@ describe("tasks/records:enqueueExports", () => {
         luigi.id
       );
       await luigiImport.update({
-        groupsUpdatedAt: null,
-        recordUpdatedAt: null,
+        importedAt: null,
         exportedAt: null,
       });
 
@@ -122,8 +118,7 @@ describe("tasks/records:enqueueExports", () => {
       );
       await toadImport.update({
         state: "exporting",
-        groupsUpdatedAt: new Date(),
-        recordUpdatedAt: new Date(),
+        importedAt: new Date(),
         exportedAt: null,
       });
 

--- a/core/__tests__/tasks/record/enqueueExports/enqueueExports.ts
+++ b/core/__tests__/tasks/record/enqueueExports/enqueueExports.ts
@@ -34,6 +34,7 @@ describe("tasks/records:enqueueExports", () => {
         record.id
       );
       await _import.update({
+        state: "complete",
         groupsUpdatedAt: new Date(),
         recordUpdatedAt: new Date(),
         exportedAt: null,
@@ -58,6 +59,7 @@ describe("tasks/records:enqueueExports", () => {
         record.id
       );
       await _import.update({
+        state: "complete",
         groupsUpdatedAt: new Date(),
         recordUpdatedAt: new Date(),
         exportedAt: null,
@@ -88,6 +90,7 @@ describe("tasks/records:enqueueExports", () => {
         mario.id
       );
       await marioImport.update({
+        state: "complete",
         groupsUpdatedAt: new Date(),
         recordUpdatedAt: new Date(),
         exportedAt: null,
@@ -118,6 +121,7 @@ describe("tasks/records:enqueueExports", () => {
         toad.id
       );
       await toadImport.update({
+        state: "complete",
         groupsUpdatedAt: new Date(),
         recordUpdatedAt: new Date(),
         exportedAt: null,

--- a/core/__tests__/tasks/record/enqueueExports/smallerBatchSize.ts
+++ b/core/__tests__/tasks/record/enqueueExports/smallerBatchSize.ts
@@ -20,7 +20,7 @@ describe("tasks/records:enqueueExports", () => {
         mario.id
       );
       await marioImport.update({
-        state: "complete",
+        state: "exporting",
         groupsUpdatedAt: new Date(),
         recordUpdatedAt: new Date(),
         exportedAt: null,
@@ -35,7 +35,7 @@ describe("tasks/records:enqueueExports", () => {
         luigi.id
       );
       await luigiImport.update({
-        state: "complete",
+        state: "exporting",
         groupsUpdatedAt: new Date(),
         recordUpdatedAt: new Date(),
         exportedAt: null,

--- a/core/__tests__/tasks/record/enqueueExports/smallerBatchSize.ts
+++ b/core/__tests__/tasks/record/enqueueExports/smallerBatchSize.ts
@@ -21,8 +21,7 @@ describe("tasks/records:enqueueExports", () => {
       );
       await marioImport.update({
         state: "exporting",
-        groupsUpdatedAt: new Date(),
-        recordUpdatedAt: new Date(),
+        importedAt: new Date(),
         exportedAt: null,
       });
 
@@ -36,8 +35,7 @@ describe("tasks/records:enqueueExports", () => {
       );
       await luigiImport.update({
         state: "exporting",
-        groupsUpdatedAt: new Date(),
-        recordUpdatedAt: new Date(),
+        importedAt: new Date(),
         exportedAt: null,
       });
 

--- a/core/__tests__/tasks/record/enqueueExports/smallerBatchSize.ts
+++ b/core/__tests__/tasks/record/enqueueExports/smallerBatchSize.ts
@@ -20,6 +20,7 @@ describe("tasks/records:enqueueExports", () => {
         mario.id
       );
       await marioImport.update({
+        state: "complete",
         groupsUpdatedAt: new Date(),
         recordUpdatedAt: new Date(),
         exportedAt: null,
@@ -34,6 +35,7 @@ describe("tasks/records:enqueueExports", () => {
         luigi.id
       );
       await luigiImport.update({
+        state: "complete",
         groupsUpdatedAt: new Date(),
         recordUpdatedAt: new Date(),
         exportedAt: null,

--- a/core/__tests__/tasks/record/export.ts
+++ b/core/__tests__/tasks/record/export.ts
@@ -338,8 +338,6 @@ describe("tasks/record:export", () => {
             creatorType: "run",
             creatorId: run.id,
             recordId: record.id,
-            recordUpdatedAt: new Date(),
-            groupsUpdatedAt: new Date(),
             data: {},
             oldGroupIds: [],
             newGroupIds: [group.id],
@@ -347,6 +345,7 @@ describe("tasks/record:export", () => {
 
           await _import.update({
             state: "exporting",
+            importedAt: new Date(),
           });
 
           await record.import();

--- a/core/__tests__/tasks/record/export.ts
+++ b/core/__tests__/tasks/record/export.ts
@@ -332,6 +332,7 @@ describe("tasks/record:export", () => {
         it("applies errors to the imports and export", async () => {
           const run = await helper.factories.run();
           const _import = await Import.create({
+            state: "pending",
             creatorType: "run",
             creatorId: run.id,
             recordId: record.id,
@@ -340,6 +341,10 @@ describe("tasks/record:export", () => {
             data: {},
             oldGroupIds: [],
             newGroupIds: [group.id],
+          });
+
+          await _import.update({
+            state: "complete",
           });
 
           await record.import();

--- a/core/__tests__/tasks/record/export.ts
+++ b/core/__tests__/tasks/record/export.ts
@@ -332,7 +332,7 @@ describe("tasks/record:export", () => {
         it("applies errors to the imports and export", async () => {
           const run = await helper.factories.run();
           const _import = await Import.create({
-            state: "pending",
+            state: "importing",
             creatorType: "run",
             creatorId: run.id,
             recordId: record.id,
@@ -344,7 +344,7 @@ describe("tasks/record:export", () => {
           });
 
           await _import.update({
-            state: "complete",
+            state: "exporting",
           });
 
           await record.import();
@@ -360,6 +360,7 @@ describe("tasks/record:export", () => {
           expect(counter).toBe(1);
 
           await _import.reload();
+          expect(_import.state).toBe("failed");
           expect(_import.errorMessage).toMatch(/oh no/);
           const errorMetadata = JSON.parse(_import.errorMetadata);
           expect(errorMetadata.message).toMatch(/oh no/);

--- a/core/__tests__/tasks/record/export.ts
+++ b/core/__tests__/tasks/record/export.ts
@@ -234,6 +234,8 @@ describe("tasks/record:export", () => {
 
         await importA.reload();
         await importB.reload();
+        expect(importA.state).toBe("complete");
+        expect(importB.state).toBe("complete");
         expect(importA.exportedAt).toBeTruthy();
         expect(importB.exportedAt).toBeTruthy();
       });

--- a/core/__tests__/tasks/system/status/status.ts
+++ b/core/__tests__/tasks/system/status/status.ts
@@ -74,7 +74,7 @@ describe("tasks/status", () => {
       );
       await record.update({ state: "ready" });
       const _import = await helper.factories.import(null, null, record.id);
-      await _import.update({ exportedAt: new Date() });
+      await _import.update({ state: "complete" });
 
       await Status.setAll();
 
@@ -94,6 +94,7 @@ describe("tasks/status", () => {
       await record.update({ state: "ready" });
       const _import = await helper.factories.import(null, null, record.id);
       await _import.update({
+        state: "failed",
         exportedAt: null,
         errorMessage: "oh no!",
         errorMetadata: "errored",

--- a/core/src/actions/imports.ts
+++ b/core/src/actions/imports.ts
@@ -15,6 +15,7 @@ export class ImportsList extends AuthenticatedAction {
       recordId: { required: false },
       limit: { required: true, default: 100, formatter: APIData.ensureNumber },
       offset: { required: true, default: 0, formatter: APIData.ensureNumber },
+      state: { required: false },
       order: {
         required: false,
         formatter: APIData.ensureObject,
@@ -27,6 +28,7 @@ export class ImportsList extends AuthenticatedAction {
     const where = {};
     if (params.creatorId) where["creatorId"] = params.creatorId;
     if (params.recordId) where["recordId"] = params.recordId;
+    if (params.state) where["state"] = params.state;
 
     const search = {
       include: [GrouparooRecord],

--- a/core/src/migrations/000097-addStateToImports.ts
+++ b/core/src/migrations/000097-addStateToImports.ts
@@ -19,23 +19,23 @@ export default {
     });
 
     await queryInterface.sequelize.query(
-      `UPDATE "imports" SET "state"='associating' WHERE "recordAssociatedAt" IS NULL`
+      `UPDATE "imports" SET "state"='failed' WHERE "errorMessage" IS NOT NULL AND "state" IS NULL`
     );
 
     await queryInterface.sequelize.query(
-      `UPDATE "imports" SET "state"='importing' WHERE "recordAssociatedAt" IS NOT NULL AND "importedAt" IS NULL`
+      `UPDATE "imports" SET "state"='associating' WHERE "recordAssociatedAt" IS NULL AND "state" IS NULL`
     );
 
     await queryInterface.sequelize.query(
-      `UPDATE "imports" SET "state"='exporting' WHERE "recordAssociatedAt" IS NOT NULL AND "importedAt" IS NOT NULL AND "exportedAt" IS NULL`
+      `UPDATE "imports" SET "state"='importing' WHERE "recordAssociatedAt" IS NOT NULL AND "importedAt" IS NULL AND "state" IS NULL`
     );
 
     await queryInterface.sequelize.query(
-      `UPDATE "imports" SET "state"='complete' WHERE "recordAssociatedAt" IS NOT NULL AND "importedAt" IS NOT NULL AND "exportedAt" IS NOT NULL`
+      `UPDATE "imports" SET "state"='exporting' WHERE "recordAssociatedAt" IS NOT NULL AND "importedAt" IS NOT NULL AND "exportedAt" IS NULL AND "state" IS NULL`
     );
 
     await queryInterface.sequelize.query(
-      `UPDATE "imports" SET "state"='failed' WHERE "errorMessage" IS NOT NULL`
+      `UPDATE "imports" SET "state"='complete' WHERE "recordAssociatedAt" IS NOT NULL AND "importedAt" IS NOT NULL AND "exportedAt" IS NOT NULL AND "state" IS NULL`
     );
 
     await queryInterface.changeColumn("imports", "state", {

--- a/core/src/migrations/000097-addStateToImports.ts
+++ b/core/src/migrations/000097-addStateToImports.ts
@@ -1,0 +1,42 @@
+import Sequelize from "sequelize";
+
+export default {
+  up: async (
+    queryInterface: Sequelize.QueryInterface,
+    DataTypes: typeof Sequelize
+  ) => {
+    await queryInterface.addColumn("imports", "state", {
+      type: DataTypes.STRING(191),
+      allowNull: true,
+    });
+
+    await queryInterface.sequelize.query(
+      `UPDATE "imports" SET "state"='associating' WHERE "recordAssociatedAt" IS NULL`
+    );
+
+    await queryInterface.sequelize.query(
+      `UPDATE "imports" SET "state"='pending' WHERE "recordAssociatedAt" IS NOT NULL AND "groupsUpdatedAt" IS NULL`
+    );
+
+    await queryInterface.sequelize.query(
+      `UPDATE "imports" SET "state"='complete' WHERE "recordAssociatedAt" IS NOT NULL AND "groupsUpdatedAt" IS NOT NULL`
+    );
+
+    await queryInterface.sequelize.query(
+      `UPDATE "imports" SET "state"='failed' WHERE "errorMessage" IS NOT NULL`
+    );
+
+    await queryInterface.changeColumn("imports", "state", {
+      type: DataTypes.STRING(191),
+      allowNull: false,
+    });
+
+    await queryInterface.addIndex("imports", ["state"], {
+      fields: ["state"],
+    });
+  },
+
+  down: async (queryInterface: Sequelize.QueryInterface) => {
+    await queryInterface.removeColumn("imports", "state");
+  },
+};

--- a/core/src/migrations/000097-addStateToImports.ts
+++ b/core/src/migrations/000097-addStateToImports.ts
@@ -15,11 +15,15 @@ export default {
     );
 
     await queryInterface.sequelize.query(
-      `UPDATE "imports" SET "state"='pending' WHERE "recordAssociatedAt" IS NOT NULL AND "groupsUpdatedAt" IS NULL`
+      `UPDATE "imports" SET "state"='importing' WHERE "recordAssociatedAt" IS NOT NULL AND "groupsUpdatedAt" IS NULL`
     );
 
     await queryInterface.sequelize.query(
-      `UPDATE "imports" SET "state"='complete' WHERE "recordAssociatedAt" IS NOT NULL AND "groupsUpdatedAt" IS NOT NULL`
+      `UPDATE "imports" SET "state"='exporting' WHERE "recordAssociatedAt" IS NOT NULL AND "groupsUpdatedAt" IS NOT NULL AND "exportedAt" IS NULL`
+    );
+
+    await queryInterface.sequelize.query(
+      `UPDATE "imports" SET "state"='complete' WHERE "recordAssociatedAt" IS NOT NULL AND "groupsUpdatedAt" IS NOT NULL AND "exportedAt" IS NOT NULL`
     );
 
     await queryInterface.sequelize.query(

--- a/core/src/migrations/000097-addStateToImports.ts
+++ b/core/src/migrations/000097-addStateToImports.ts
@@ -5,6 +5,14 @@ export default {
     queryInterface: Sequelize.QueryInterface,
     DataTypes: typeof Sequelize
   ) => {
+    await queryInterface.renameColumn(
+      "imports",
+      "recordUpdatedAt",
+      "importedAt"
+    );
+
+    await queryInterface.removeColumn("imports", "groupsUpdatedAt");
+
     await queryInterface.addColumn("imports", "state", {
       type: DataTypes.STRING(191),
       allowNull: true,
@@ -15,15 +23,15 @@ export default {
     );
 
     await queryInterface.sequelize.query(
-      `UPDATE "imports" SET "state"='importing' WHERE "recordAssociatedAt" IS NOT NULL AND "groupsUpdatedAt" IS NULL`
+      `UPDATE "imports" SET "state"='importing' WHERE "recordAssociatedAt" IS NOT NULL AND "importedAt" IS NULL`
     );
 
     await queryInterface.sequelize.query(
-      `UPDATE "imports" SET "state"='exporting' WHERE "recordAssociatedAt" IS NOT NULL AND "groupsUpdatedAt" IS NOT NULL AND "exportedAt" IS NULL`
+      `UPDATE "imports" SET "state"='exporting' WHERE "recordAssociatedAt" IS NOT NULL AND "importedAt" IS NOT NULL AND "exportedAt" IS NULL`
     );
 
     await queryInterface.sequelize.query(
-      `UPDATE "imports" SET "state"='complete' WHERE "recordAssociatedAt" IS NOT NULL AND "groupsUpdatedAt" IS NOT NULL AND "exportedAt" IS NOT NULL`
+      `UPDATE "imports" SET "state"='complete' WHERE "recordAssociatedAt" IS NOT NULL AND "importedAt" IS NOT NULL AND "exportedAt" IS NOT NULL`
     );
 
     await queryInterface.sequelize.query(
@@ -40,7 +48,24 @@ export default {
     });
   },
 
-  down: async (queryInterface: Sequelize.QueryInterface) => {
+  down: async (
+    queryInterface: Sequelize.QueryInterface,
+    DataTypes: typeof Sequelize
+  ) => {
     await queryInterface.removeColumn("imports", "state");
+    await queryInterface.renameColumn(
+      "imports",
+      "importedAt",
+      "recordUpdatedAt"
+    );
+
+    await queryInterface.addColumn("imports", "groupsUpdatedAt", {
+      type: DataTypes.DATE,
+      allowNull: true,
+    });
+
+    await queryInterface.sequelize.query(
+      `UPDATE "imports" SET "groupsUpdatedAt"="recordUpdatedAt"`
+    );
   },
 };

--- a/core/src/models/Import.ts
+++ b/core/src/models/Import.ts
@@ -32,13 +32,22 @@ export interface ImportRecordProperties {
 
 const IMPORT_CREATORS = ["run"] as const;
 
-const STATES = ["associating", "pending", "failed", "complete"] as const;
+const STATES = [
+  "associating",
+  "importing",
+  "exporting",
+  "failed",
+  "complete",
+] as const;
 
 const STATE_TRANSITIONS = [
   { from: "associating", to: "failed", checks: [] },
-  { from: "associating", to: "pending", checks: [] },
-  { from: "pending", to: "failed", checks: [] },
-  { from: "pending", to: "complete", checks: [] },
+  { from: "associating", to: "importing", checks: [] },
+  { from: "importing", to: "failed", checks: [] },
+  { from: "importing", to: "complete", checks: [] },
+  { from: "importing", to: "exporting", checks: [] },
+  { from: "exporting", to: "failed", checks: [] },
+  { from: "exporting", to: "complete", checks: [] },
 ];
 
 @Table({ tableName: "imports", paranoid: false })

--- a/core/src/models/Import.ts
+++ b/core/src/models/Import.ts
@@ -173,6 +173,8 @@ export class Import extends CommonModel<Import> {
     const record = await this.$get("record");
 
     return {
+      state: this.state,
+
       // IDs
       id: this.id,
       creatorType: this.creatorType,

--- a/core/src/models/Import.ts
+++ b/core/src/models/Import.ts
@@ -155,10 +155,7 @@ export class Import extends CommonModel<Import> {
   recordAssociatedAt: Date;
 
   @Column
-  recordUpdatedAt: Date;
-
-  @Column
-  groupsUpdatedAt: Date;
+  importedAt: Date;
 
   @Column
   exportedAt: Date;
@@ -199,8 +196,7 @@ export class Import extends CommonModel<Import> {
       createdAt: APIData.formatDate(this.createdAt),
       startedAt: APIData.formatDate(this.startedAt),
       recordAssociatedAt: APIData.formatDate(this.recordAssociatedAt),
-      recordUpdatedAt: APIData.formatDate(this.recordUpdatedAt),
-      groupsUpdatedAt: APIData.formatDate(this.groupsUpdatedAt),
+      importedAt: APIData.formatDate(this.importedAt),
       exportedAt: APIData.formatDate(this.exportedAt),
 
       // data before and after

--- a/core/src/modules/ops/group.ts
+++ b/core/src/modules/ops/group.ts
@@ -20,6 +20,7 @@ export namespace GroupOps {
     const bulkData = [];
     for (const recordId of recordIds) {
       bulkData.push({
+        state: "pending",
         rawData: destinationId ? { _meta: { destinationId } } : {},
         data: destinationId ? { _meta: { destinationId } } : {},
         creatorType,

--- a/core/src/modules/ops/group.ts
+++ b/core/src/modules/ops/group.ts
@@ -20,7 +20,7 @@ export namespace GroupOps {
     const bulkData = [];
     for (const recordId of recordIds) {
       bulkData.push({
-        state: "pending",
+        state: "importing",
         rawData: destinationId ? { _meta: { destinationId } } : {},
         data: destinationId ? { _meta: { destinationId } } : {},
         creatorType,

--- a/core/src/modules/ops/import.ts
+++ b/core/src/modules/ops/import.ts
@@ -24,8 +24,7 @@ export namespace ImportOps {
 
     const imports = await Import.findAll({
       where: {
-        recordId: null,
-        errorMessage: null,
+        state: "associating",
         startedAt: {
           [Op.or]: [null, { [Op.lt]: new Date().getTime() - delayMs }],
         },
@@ -90,6 +89,7 @@ export namespace ImportOps {
     const oldRecordProperties = await record.simplifiedProperties();
     const oldGroups = await record.$get("groups");
 
+    _import.state = "pending";
     _import.createdRecord = isNew;
     _import.recordId = record.id;
     _import.recordAssociatedAt = new Date();

--- a/core/src/modules/ops/import.ts
+++ b/core/src/modules/ops/import.ts
@@ -89,7 +89,7 @@ export namespace ImportOps {
     const oldRecordProperties = await record.simplifiedProperties();
     const oldGroups = await record.$get("groups");
 
-    _import.state = "pending";
+    _import.state = "importing";
     _import.createdRecord = isNew;
     _import.recordId = record.id;
     _import.recordAssociatedAt = new Date();

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -1111,7 +1111,7 @@ export namespace RecordOps {
       },
       include: [
         { model: RecordProperty, required: true },
-        { model: Import, required: false, where: { recordUpdatedAt: null } },
+        { model: Import, required: false, where: { state: "importing" } },
       ],
     });
     if (!records.length) {
@@ -1135,9 +1135,8 @@ export namespace RecordOps {
           {
             state: toExport ? "exporting" : "complete",
             newRecordProperties: newRecordProperties,
-            recordUpdatedAt: now,
             newGroupIds: newGroupIds,
-            groupsUpdatedAt: now,
+            importedAt: now,
             exportedAt: toExport ? undefined : now, // we want to indicate that the import's lifecycle is complete
           },
           {

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -1133,7 +1133,7 @@ export namespace RecordOps {
 
         await Import.update(
           {
-            state: "complete",
+            state: toExport ? "exporting" : "complete",
             newRecordProperties: newRecordProperties,
             recordUpdatedAt: now,
             newGroupIds: newGroupIds,

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -1133,6 +1133,7 @@ export namespace RecordOps {
 
         await Import.update(
           {
+            state: "complete",
             newRecordProperties: newRecordProperties,
             recordUpdatedAt: now,
             newGroupIds: newGroupIds,

--- a/core/src/modules/ops/runs.ts
+++ b/core/src/modules/ops/runs.ts
@@ -80,7 +80,7 @@ export namespace RunOps {
 
     const lastImportedImport = await Import.findOne({
       where: { creatorId: run.id },
-      order: [["recordUpdatedAt", "desc"]],
+      order: [["importedAt", "desc"]],
       limit: 1,
     });
 
@@ -111,17 +111,9 @@ export namespace RunOps {
               },
             },
           }),
-          recordsUpdated: await run.$count("imports", {
+          imported: await run.$count("imports", {
             where: {
-              recordUpdatedAt: {
-                [Op.gte]: lastBoundary,
-                [Op.lt]: nextBoundary,
-              },
-            },
-          }),
-          groupsUpdated: await run.$count("imports", {
-            where: {
-              groupsUpdatedAt: {
+              importedAt: {
                 [Op.gte]: lastBoundary,
                 [Op.lt]: nextBoundary,
               },
@@ -163,7 +155,7 @@ export namespace RunOps {
       where: { creatorId: run.id, createdRecord: true },
     });
     const recordsImported = await Import.count({
-      where: { creatorId: run.id, recordUpdatedAt: { [Op.ne]: null } },
+      where: { creatorId: run.id, importedAt: { [Op.ne]: null } },
       distinct: true,
       col: "recordId",
     });

--- a/core/src/modules/statusReporters.ts
+++ b/core/src/modules/statusReporters.ts
@@ -318,13 +318,12 @@ export namespace StatusReporters {
     }
 
     export async function pendingImports(): Promise<StatusMetric> {
-      // TODO
       return {
         collection: "pending",
         topic: "Import",
         aggregation: "count",
         count: await Import.count({
-          where: { exportedAt: null, errorMessage: null },
+          where: { state: { [Op.notIn]: ["complete", "failed"] } },
         }),
       };
     }

--- a/core/src/modules/statusReporters.ts
+++ b/core/src/modules/statusReporters.ts
@@ -318,6 +318,7 @@ export namespace StatusReporters {
     }
 
     export async function pendingImports(): Promise<StatusMetric> {
+      // TODO
       return {
         collection: "pending",
         topic: "Import",

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -90,7 +90,7 @@ export class RunGroup extends CLSTask {
     });
 
     const pendingImports = await run.$count("imports", {
-      where: { groupsUpdatedAt: null },
+      where: { state: "pending" },
     });
 
     // we don't want to denote the group as ready until all the imports are imported

--- a/core/src/tasks/group/run.ts
+++ b/core/src/tasks/group/run.ts
@@ -90,7 +90,7 @@ export class RunGroup extends CLSTask {
     });
 
     const pendingImports = await run.$count("imports", {
-      where: { state: "pending" },
+      where: { state: "importing" },
     });
 
     // we don't want to denote the group as ready until all the imports are imported

--- a/core/src/tasks/grouparooModel/run.ts
+++ b/core/src/tasks/grouparooModel/run.ts
@@ -59,7 +59,7 @@ export class RunModel extends CLSTask {
     });
 
     const pendingImports = await run.$count("imports", {
-      where: { state: "pending" },
+      where: { state: "importing" },
     });
 
     // we don't want to denote the run as ready until all the imports are imported

--- a/core/src/tasks/grouparooModel/run.ts
+++ b/core/src/tasks/grouparooModel/run.ts
@@ -7,7 +7,7 @@ import { CLSTask } from "../../classes/tasks/clsTask";
 import { GroupMember } from "../../models/GroupMember";
 import { GroupOps } from "../../modules/ops/group";
 
-export class RunInternalRun extends CLSTask {
+export class RunModel extends CLSTask {
   constructor() {
     super();
     this.name = "grouparooModel:run";
@@ -59,7 +59,7 @@ export class RunInternalRun extends CLSTask {
     });
 
     const pendingImports = await run.$count("imports", {
-      where: { groupsUpdatedAt: null },
+      where: { state: "pending" },
     });
 
     // we don't want to denote the run as ready until all the imports are imported

--- a/core/src/tasks/record/confirm.ts
+++ b/core/src/tasks/record/confirm.ts
@@ -42,9 +42,8 @@ export class GrouparooRecordsConfirm extends CLSTask {
       const latestRun = schedule.runs[0];
       if (!latestRun) continue;
 
-      // TODO
       const pendingImports = await latestRun.$count("imports", {
-        where: { recordAssociatedAt: null },
+        where: { state: "associating" },
       });
 
       if (pendingImports !== 0) continue;

--- a/core/src/tasks/record/confirm.ts
+++ b/core/src/tasks/record/confirm.ts
@@ -42,6 +42,7 @@ export class GrouparooRecordsConfirm extends CLSTask {
       const latestRun = schedule.runs[0];
       if (!latestRun) continue;
 
+      // TODO
       const pendingImports = await latestRun.$count("imports", {
         where: { recordAssociatedAt: null },
       });

--- a/core/src/tasks/record/enqueueExports.ts
+++ b/core/src/tasks/record/enqueueExports.ts
@@ -26,8 +26,7 @@ export class GrouparooRecordsEnqueueExports extends CLSTask {
         [Sequelize.fn("DISTINCT", Sequelize.col("recordId")), "recordId"],
       ],
       where: {
-        recordUpdatedAt: { [Op.not]: null },
-        groupsUpdatedAt: { [Op.not]: null },
+        state: "complete",
         exportedAt: null,
       },
       group: ["recordId"],

--- a/core/src/tasks/record/enqueueExports.ts
+++ b/core/src/tasks/record/enqueueExports.ts
@@ -26,8 +26,7 @@ export class GrouparooRecordsEnqueueExports extends CLSTask {
         [Sequelize.fn("DISTINCT", Sequelize.col("recordId")), "recordId"],
       ],
       where: {
-        state: "complete",
-        exportedAt: null,
+        state: "exporting",
       },
       group: ["recordId"],
       limit,

--- a/core/src/tasks/record/export.ts
+++ b/core/src/tasks/record/export.ts
@@ -31,9 +31,8 @@ export class RecordExport extends RetryableTask {
 
     const imports = await Import.findAll({
       where: {
+        state: "complete",
         recordId: record.id,
-        recordUpdatedAt: { [Op.not]: null },
-        groupsUpdatedAt: { [Op.not]: null },
         exportedAt: null,
       },
       order: [["createdAt", "asc"]],

--- a/core/src/tasks/record/export.ts
+++ b/core/src/tasks/record/export.ts
@@ -31,9 +31,8 @@ export class RecordExport extends RetryableTask {
 
     const imports = await Import.findAll({
       where: {
-        state: "complete",
+        state: "exporting",
         recordId: record.id,
-        exportedAt: null,
       },
       order: [["createdAt", "asc"]],
     });
@@ -88,7 +87,7 @@ export class RecordExport extends RetryableTask {
 
       if (imports.length > 0) {
         await Import.update(
-          { exportedAt: new Date() },
+          { exportedAt: new Date(), state: "complete" },
           { where: { id: imports.map((i) => i.id) } }
         );
       }

--- a/core/src/tasks/run/internalRun.ts
+++ b/core/src/tasks/run/internalRun.ts
@@ -75,6 +75,7 @@ export class RunInternalRun extends CLSTask {
         const oldGroupIds = record.groupMembers.map((gm) => gm.groupId);
 
         bulkImports.push({
+          state: "pending",
           recordId: record.id,
           recordAssociatedAt: now,
           oldRecordProperties,

--- a/core/src/tasks/run/internalRun.ts
+++ b/core/src/tasks/run/internalRun.ts
@@ -75,7 +75,7 @@ export class RunInternalRun extends CLSTask {
         const oldGroupIds = record.groupMembers.map((gm) => gm.groupId);
 
         bulkImports.push({
-          state: "pending",
+          state: "importing",
           recordId: record.id,
           recordAssociatedAt: now,
           oldRecordProperties,

--- a/plugins/@grouparoo/spec-helper/src/lib/factories/import.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/factories/import.ts
@@ -12,6 +12,7 @@ export default async (run?, props: { [key: string]: any } = {}, recordId?) => {
     creatorType: "run",
     creatorId: run.id,
     recordId,
+    state: recordId ? "pending" : "associating",
   }) as Import;
 
   await instance.save();

--- a/plugins/@grouparoo/spec-helper/src/lib/factories/import.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/factories/import.ts
@@ -12,7 +12,7 @@ export default async (run?, props: { [key: string]: any } = {}, recordId?) => {
     creatorType: "run",
     creatorId: run.id,
     recordId,
-    state: recordId ? "pending" : "associating",
+    state: recordId ? "importing" : "associating",
   }) as Import;
 
   await instance.save();

--- a/ui/ui-components/components/import/Diff.tsx
+++ b/ui/ui-components/components/import/Diff.tsx
@@ -11,7 +11,7 @@ export function ImportRecordPropertiesDiff({
 }: {
   _import: Models.ImportType;
 }) {
-  const imported = _import.recordUpdatedAt && _import.groupsUpdatedAt;
+  const imported = Boolean(_import.importedAt);
 
   if (!imported) {
     return (
@@ -95,7 +95,7 @@ export function ImportGroupsDiff({
   _import: Models.ImportType;
   groups: Models.GroupType[];
 }) {
-  const imported = _import.recordUpdatedAt && _import.groupsUpdatedAt;
+  const imported = Boolean(_import.importedAt);
 
   if (!imported) {
     return (

--- a/ui/ui-components/components/import/Diff.tsx
+++ b/ui/ui-components/components/import/Diff.tsx
@@ -11,9 +11,7 @@ export function ImportRecordPropertiesDiff({
 }: {
   _import: Models.ImportType;
 }) {
-  const complete = _import.recordUpdatedAt && _import.groupsUpdatedAt;
-
-  if (!complete) {
+  if (_import.state !== "complete") {
     return (
       <>
         <ul>
@@ -95,9 +93,7 @@ export function ImportGroupsDiff({
   _import: Models.ImportType;
   groups: Models.GroupType[];
 }) {
-  const complete = _import.recordUpdatedAt && _import.groupsUpdatedAt;
-
-  if (!complete) {
+  if (_import.state !== "complete") {
     return (
       <>
         <ul>

--- a/ui/ui-components/components/import/Diff.tsx
+++ b/ui/ui-components/components/import/Diff.tsx
@@ -11,7 +11,9 @@ export function ImportRecordPropertiesDiff({
 }: {
   _import: Models.ImportType;
 }) {
-  if (_import.state !== "complete") {
+  const imported = _import.recordUpdatedAt && _import.groupsUpdatedAt;
+
+  if (!imported) {
     return (
       <>
         <ul>
@@ -93,7 +95,9 @@ export function ImportGroupsDiff({
   _import: Models.ImportType;
   groups: Models.GroupType[];
 }) {
-  if (_import.state !== "complete") {
+  const imported = _import.recordUpdatedAt && _import.groupsUpdatedAt;
+
+  if (!imported) {
     return (
       <>
         <ul>

--- a/ui/ui-components/components/import/List.tsx
+++ b/ui/ui-components/components/import/List.tsx
@@ -21,7 +21,9 @@ const states = [
   "exporting",
   "complete",
   "failed",
-];
+] as const;
+
+type ImportStateOption = typeof states[number];
 
 export default function ImportList(props) {
   const {
@@ -37,7 +39,9 @@ export default function ImportList(props) {
   // pagination
   const limit = 100;
   const { offset, setOffset } = useOffset();
-  const [state, setState] = useState(router.query.state?.toString() || "all");
+  const [state, setState] = useState<ImportStateOption>(
+    (router.query.state?.toString() as ImportStateOption) || "all"
+  );
 
   let recordId = router.query.recordId;
   let creatorId: string;

--- a/ui/ui-components/components/import/List.tsx
+++ b/ui/ui-components/components/import/List.tsx
@@ -214,13 +214,14 @@ export default function ImportList(props) {
 
 ImportList.hydrate = async (ctx) => {
   const { execApi } = UseApi(ctx);
-  const { creatorId, limit, offset, recordId } = ctx.query;
+  const { creatorId, limit, offset, state, recordId } = ctx.query;
 
   const { imports, total } = await execApi("get", `/imports`, {
     limit,
     offset,
     creatorId,
     recordId,
+    state: state === "all" ? undefined : state,
   });
 
   const { groups } = await execApi("get", `/groups`);

--- a/ui/ui-components/components/import/List.tsx
+++ b/ui/ui-components/components/import/List.tsx
@@ -14,7 +14,14 @@ import { ImportRecordPropertiesDiff, ImportGroupsDiff } from "./Diff";
 import StateBadge from "../badges/StateBadge";
 import { capitalize } from "../../utils/languageHelper";
 
-const states = ["all", "pending", "failed", "complete"];
+const states = [
+  "all",
+  "associating",
+  "importing",
+  "exporting",
+  "failed",
+  "complete",
+];
 
 export default function ImportList(props) {
   const {
@@ -92,6 +99,9 @@ export default function ImportList(props) {
           </ButtonGroup>
         </Col>
       </Row>
+
+      <hr />
+      <br />
 
       <Pagination
         total={total}

--- a/ui/ui-components/components/import/List.tsx
+++ b/ui/ui-components/components/import/List.tsx
@@ -160,13 +160,13 @@ export default function ImportList(props) {
                     {_import.recordAssociatedAt
                       ? formatTimestamp(_import.recordAssociatedAt)
                       : "pending"}
-                    <br /> Record Updated:{" "}
-                    {_import.recordUpdatedAt
-                      ? formatTimestamp(_import.recordUpdatedAt)
+                    <br /> Imported:{" "}
+                    {_import.importedAt
+                      ? formatTimestamp(_import.importedAt)
                       : "pending"}
-                    <br /> Groups Updated:{" "}
-                    {_import.groupsUpdatedAt
-                      ? formatTimestamp(_import.groupsUpdatedAt)
+                    <br /> Exported:{" "}
+                    {_import.exportedAt
+                      ? formatTimestamp(_import.exportedAt)
                       : "pending"}
                   </td>
                   <td>

--- a/ui/ui-components/components/import/List.tsx
+++ b/ui/ui-components/components/import/List.tsx
@@ -126,11 +126,12 @@ export default function ImportList(props) {
               <Fragment key={`import-${_import.id}`}>
                 <tr>
                   <td>
-                    State: <StateBadge state={_import.state} marginBottom={0} />
-                    <br /> Id:
+                    Id:
                     <Link href={`/import/${_import.id}/edit`}>
                       <a> {_import.id}</a>
                     </Link>
+                    <br /> State:{" "}
+                    <StateBadge state={_import.state} marginBottom={0} />
                     <br /> Record:{" "}
                     {_import.recordId ? (
                       <Link href={`/object/${_import.recordId}`}>

--- a/ui/ui-components/components/import/List.tsx
+++ b/ui/ui-components/components/import/List.tsx
@@ -19,8 +19,8 @@ const states = [
   "associating",
   "importing",
   "exporting",
-  "failed",
   "complete",
+  "failed",
 ];
 
 export default function ImportList(props) {

--- a/ui/ui-components/pages/import/[id]/edit.tsx
+++ b/ui/ui-components/pages/import/[id]/edit.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../components/import/Diff";
 import { DurationTime } from "../../../components/DurationTime";
 import { formatTimestamp } from "../../../utils/formatTimestamp";
+import StateBadge from "../../../components/badges/StateBadge";
 
 export default function Page(props) {
   const {
@@ -38,6 +39,8 @@ export default function Page(props) {
         <Card.Body>
           <h2>Details</h2>
           <p>
+            State: <StateBadge state={_import.state} marginBottom={0} />
+            <br />
             Model:{" "}
             <Link href={`/model/${_import.modelId}/edit`}>
               <a>{_import.modelId}</a>

--- a/ui/ui-components/pages/import/[id]/edit.tsx
+++ b/ui/ui-components/pages/import/[id]/edit.tsx
@@ -119,7 +119,7 @@ export default function Page(props) {
             <strong>
               <DurationTime
                 start={_import.createdAt}
-                end={_import.groupsUpdatedAt}
+                end={_import.exportedAt}
               />
             </strong>
           </p>
@@ -157,32 +157,32 @@ export default function Page(props) {
                 </td>
               </tr>
               <tr>
-                <td>Record Updated</td>
+                <td>Imported</td>
                 <td>
-                  {_import.recordUpdatedAt
-                    ? formatTimestamp(_import.recordUpdatedAt)
+                  {_import.importedAt
+                    ? formatTimestamp(_import.importedAt)
                     : "pending"}
                 </td>
                 <td>
                   ⇣
                   <DurationTime
                     start={_import.recordAssociatedAt}
-                    end={_import.recordUpdatedAt}
+                    end={_import.importedAt}
                   />
                 </td>
               </tr>
               <tr>
-                <td>Groups Updated</td>
+                <td>Exports Created</td>
                 <td>
-                  {_import.groupsUpdatedAt
-                    ? formatTimestamp(_import.groupsUpdatedAt)
+                  {_import.exportedAt
+                    ? formatTimestamp(_import.exportedAt)
                     : "pending"}
                 </td>
                 <td>
                   ⇣
                   <DurationTime
-                    start={_import.recordUpdatedAt}
-                    end={_import.groupsUpdatedAt}
+                    start={_import.importedAt}
+                    end={_import.exportedAt}
                   />
                 </td>
               </tr>


### PR DESCRIPTION
## Change description

- Imports now have states: `associating`, `importing`, `exporting`, `complete`, `failed`
- Updated logic in multiple places to use these states instead of timestamps to determine where in the lifecycle the import was at
- Updated import list views to allow filtering by states
- `recordUpdatedAt` and `groupsUpdatedAt` timestamps were always set at the same time, so rolled those up into one `importedAt` matching state name

![image](https://user-images.githubusercontent.com/4368928/148288483-71ea4ef7-e302-4cd3-ae9e-63d10f05eeb7.png)

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
