### PR TITLE
Lock `@types/node` to v16.x (also fixes mongo)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "prettier": "2.5.1",
     "ts-node": "10.4.0",
     "type-fest": "2.8.0",

--- a/core/package.json
+++ b/core/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@types/fs-extra": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "@types/validator": "*",
     "actionhero": "28.1.1",
     "ah-sequelize-plugin": "3.2.0",

--- a/plugins/@grouparoo/airtable/package.json
+++ b/plugins/@grouparoo/airtable/package.json
@@ -39,7 +39,7 @@
     "@grouparoo/core": "0.8.0-alpha.2",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/app-templates/package.json
+++ b/plugins/@grouparoo/app-templates/package.json
@@ -31,7 +31,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "@types/uuid": "*",
     "actionhero": "28.1.1",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/bigquery/package.json
+++ b/plugins/@grouparoo/bigquery/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/braze/package.json
+++ b/plugins/@grouparoo/braze/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/calculated-property/package.json
+++ b/plugins/@grouparoo/calculated-property/package.json
@@ -31,7 +31,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "jest": "27.4.5",
     "prettier": "2.5.1",

--- a/plugins/@grouparoo/clickhouse/package.json
+++ b/plugins/@grouparoo/clickhouse/package.json
@@ -37,7 +37,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "csv-parse": "4.16.3",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/cloudwatch/package.json
+++ b/plugins/@grouparoo/cloudwatch/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "jest": "27.4.5",
     "prettier": "2.5.1",

--- a/plugins/@grouparoo/csv/package.json
+++ b/plugins/@grouparoo/csv/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "jest": "27.4.5",
     "prettier": "2.5.1",

--- a/plugins/@grouparoo/customerio/package.json
+++ b/plugins/@grouparoo/customerio/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "axios": "0.24.0",
     "dotenv": "10.0.0",

--- a/plugins/@grouparoo/dbt/package.json
+++ b/plugins/@grouparoo/dbt/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "jest": "27.4.5",
     "nock": "13.2.1",

--- a/plugins/@grouparoo/demo/package.json
+++ b/plugins/@grouparoo/demo/package.json
@@ -47,7 +47,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/glob": "7.2.0",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "jest": "27.4.5",
     "ts-jest": "27.1.2",

--- a/plugins/@grouparoo/eloqua/package.json
+++ b/plugins/@grouparoo/eloqua/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/facebook/package.json
+++ b/plugins/@grouparoo/facebook/package.json
@@ -38,7 +38,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/google-sheets/package.json
+++ b/plugins/@grouparoo/google-sheets/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/hubspot/package.json
+++ b/plugins/@grouparoo/hubspot/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/intercom/package.json
+++ b/plugins/@grouparoo/intercom/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/iterable/package.json
+++ b/plugins/@grouparoo/iterable/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/logger/package.json
+++ b/plugins/@grouparoo/logger/package.json
@@ -34,7 +34,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "jest": "27.4.5",
     "prettier": "2.5.1",

--- a/plugins/@grouparoo/mailchimp/package.json
+++ b/plugins/@grouparoo/mailchimp/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/mailjet/package.json
+++ b/plugins/@grouparoo/mailjet/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/marketo/package.json
+++ b/plugins/@grouparoo/marketo/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/mixpanel/package.json
+++ b/plugins/@grouparoo/mixpanel/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/mongo/package.json
+++ b/plugins/@grouparoo/mongo/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/mysql/package.json
+++ b/plugins/@grouparoo/mysql/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
     "@types/mysql": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "csv-parse": "4.16.3",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/newrelic/package.json
+++ b/plugins/@grouparoo/newrelic/package.json
@@ -34,7 +34,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "jest": "27.4.5",
     "prettier": "2.5.1",

--- a/plugins/@grouparoo/onesignal/package.json
+++ b/plugins/@grouparoo/onesignal/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/pardot/package.json
+++ b/plugins/@grouparoo/pardot/package.json
@@ -37,7 +37,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/pipedrive/package.json
+++ b/plugins/@grouparoo/pipedrive/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/postgres/package.json
+++ b/plugins/@grouparoo/postgres/package.json
@@ -38,7 +38,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "@types/pg": "*",
     "actionhero": "28.1.1",
     "csv-parse": "4.16.3",

--- a/plugins/@grouparoo/prometheus/package.json
+++ b/plugins/@grouparoo/prometheus/package.json
@@ -22,7 +22,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "axios": "0.24.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/redshift/package.json
+++ b/plugins/@grouparoo/redshift/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "@types/pg": "*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",

--- a/plugins/@grouparoo/sailthru/package.json
+++ b/plugins/@grouparoo/sailthru/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/salesforce/package.json
+++ b/plugins/@grouparoo/salesforce/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/sendgrid/package.json
+++ b/plugins/@grouparoo/sendgrid/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/sentry/package.json
+++ b/plugins/@grouparoo/sentry/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "jest": "27.4.5",
     "prettier": "2.5.1",

--- a/plugins/@grouparoo/snowflake/package.json
+++ b/plugins/@grouparoo/snowflake/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/spec-helper/package.json
+++ b/plugins/@grouparoo/spec-helper/package.json
@@ -41,7 +41,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@types/faker": "*",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "jest": "27.4.5",
     "ts-jest": "27.1.2",

--- a/plugins/@grouparoo/sqlite/package.json
+++ b/plugins/@grouparoo/sqlite/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "@types/pg": "*",
     "actionhero": "28.1.1",
     "csv-parse": "4.16.3",

--- a/plugins/@grouparoo/zendesk/package.json
+++ b/plugins/@grouparoo/zendesk/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/core": "0.8.0-alpha.3",
     "@grouparoo/spec-helper": "0.8.0-alpha.3",
     "@types/jest": "*",
-    "@types/node": "*",
+    "@types/node": "16.*.*",
     "actionhero": "28.1.1",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,7 +208,7 @@ importers:
   cli:
     specifiers:
       '@types/fs-extra': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       chalk: 4.1.2
       commander: 8.3.0
       fs-extra: 10.0.0
@@ -244,7 +244,7 @@ importers:
       '@types/fs-extra': '*'
       '@types/isomorphic-fetch': 0.0.35
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       '@types/pacote': 11.1.2
       '@types/pluralize': 0.0.29
       '@types/semver': 7.3.9
@@ -359,7 +359,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       airtable: 0.11.1
       axios: 0.24.0
@@ -399,7 +399,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       '@types/uuid': '*'
       actionhero: 28.1.1
       jest: 27.4.5
@@ -429,7 +429,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -463,7 +463,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       axios: 0.24.0
       dotenv: 10.0.0
@@ -499,7 +499,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       jest: 27.4.5
       prettier: 2.5.1
@@ -526,7 +526,7 @@ importers:
       '@grouparoo/mysql': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       clickhouse: 2.4.2
       csv-parse: 4.16.3
@@ -559,7 +559,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       aws-sdk: 2.1049.0
       jest: 27.4.5
@@ -590,7 +590,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       axios: 0.24.0
       csv-parser: 3.0.0
@@ -624,7 +624,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       axios: 0.24.0
       customerio-node: 3.1.0
@@ -660,7 +660,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       jest: 27.4.5
       js-yaml: 4.1.0
@@ -688,7 +688,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/glob': 7.2.0
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       csv-parse: 4.16.3
       dotenv: 10.0.0
@@ -737,7 +737,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       axios: 0.24.0
       dotenv: 10.0.0
@@ -772,7 +772,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       currency-codes: 2.1.0
       dotenv: 10.0.0
@@ -813,7 +813,7 @@ importers:
       '@grouparoo/csv': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       csv-write-stream: 2.0.0
       dotenv: 10.0.0
@@ -854,7 +854,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       axios: 0.24.0
       dotenv: 10.0.0
@@ -893,7 +893,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -928,7 +928,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -963,7 +963,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       jest: 27.4.5
       prettier: 2.5.1
@@ -990,7 +990,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -1027,7 +1027,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       axios: 0.24.0
       dotenv: 10.0.0
@@ -1067,7 +1067,7 @@ importers:
       '@grouparoo/node-marketo-rest': 0.7.10
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -1101,7 +1101,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       axios: 0.24.0
       dotenv: 10.0.0
@@ -1136,7 +1136,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -1170,7 +1170,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
       '@types/mysql': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       csv-parse: 4.16.3
       jest: 27.4.5
@@ -1201,7 +1201,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       jest: 27.4.5
       newrelic: 8.6.0
@@ -1227,7 +1227,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -1262,7 +1262,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       axios: 0.24.0
       dotenv: 10.0.0
@@ -1301,7 +1301,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       axios: 0.24.0
       dotenv: 10.0.0
@@ -1336,7 +1336,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       '@types/pg': '*'
       actionhero: 28.1.1
       csv-parse: 4.16.3
@@ -1376,7 +1376,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       axios: 0.24.0
       jest: 27.4.5
@@ -1403,7 +1403,7 @@ importers:
       '@grouparoo/postgres': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       '@types/pg': '*'
       actionhero: 28.1.1
       dotenv: 10.0.0
@@ -1435,7 +1435,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -1470,7 +1470,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -1506,7 +1506,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@sendgrid/client': 7.6.0
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -1541,7 +1541,7 @@ importers:
       '@sentry/node': 6.16.1
       '@sentry/tracing': 6.16.1
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       jest: 27.4.5
       prettier: 2.5.1
@@ -1567,7 +1567,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -1603,7 +1603,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@types/faker': '*'
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       axios: 0.24.0
       faker: 5.5.3
@@ -1639,7 +1639,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       '@types/pg': '*'
       '@types/sqlite3': 3.1.8
       actionhero: 28.1.1
@@ -1678,7 +1678,7 @@ importers:
       '@grouparoo/core': 0.8.0-alpha.3
       '@grouparoo/spec-helper': 0.8.0-alpha.3
       '@types/jest': '*'
-      '@types/node': '*'
+      '@types/node': 16.*.*
       actionhero: 28.1.1
       dotenv: 10.0.0
       fs-extra: 10.0.0


### PR DESCRIPTION
Locked the version of `@types/node` that we use to the v16 version (because that's the version of node we use).  Mongo introduced an incompatibility (https://github.com/mongodb/node-mongodb-native/pull/3088) with v17 of `@types/node`.  They are fixing it soon, but regardless, we should have locked the `@types` package to the latest major version of node Grouparoo supports. 

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
