### PR TITLE
add ui edition to preview record localstorage token

### DIFF
--- a/ui/ui-components/components/record/SampleRecordCard.tsx
+++ b/ui/ui-components/components/record/SampleRecordCard.tsx
@@ -46,17 +46,24 @@ export interface SampleRecordCardProps {
 const isConfigUI = grouparooUiEdition() === "config";
 
 const getCachedSampleRecordId = (modelId: string): string => {
-  return globalThis.localStorage?.getItem(`sampleRecord:${modelId}`);
+  return globalThis.localStorage?.getItem(
+    `sampleRecord:${grouparooUiEdition()}:${modelId}`
+  );
 };
 
 const setCachedSampleRecordId = (modelId: string, recordId: string): void => {
   if (recordId) {
-    globalThis.localStorage?.setItem(`sampleRecord:${modelId}`, recordId);
+    globalThis.localStorage?.setItem(
+      `sampleRecord:${grouparooUiEdition()}:${modelId}`,
+      recordId
+    );
   }
 };
 
 const clearCachedSampleRecordId = (modelId: string): void => {
-  globalThis.localStorage?.removeItem(`sampleRecord:${modelId}`);
+  globalThis.localStorage?.removeItem(
+    `sampleRecord:${grouparooUiEdition()}:${modelId}`
+  );
 };
 
 const SampleRecordCard: React.FC<SampleRecordCardProps> = ({


### PR DESCRIPTION
## Change description

Previously, when adding a sample record in Config UI and then switching to Community or Enterprise UI, the preview record would throw an error that it could not be found (because the record Ids are different for the config ui sample records).

This PR adds the UI edition to the localstorage token so that we are always referencing a record from the correct scope.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
