### PR TITLE
Schedule Filters UI cleanup

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
@@ -197,7 +197,7 @@ export default function Page(props) {
 
     _localFilters.push({
       key: filterOptions[0].key,
-      op: "exists",
+      op: filterOptions[0].ops[0],
       match: "",
     });
 

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -393,24 +393,21 @@ export default function Page(props) {
                     <hr />
                     <strong>Filters</strong>
                     <p>
-                      Are there any criteria where you’d want to filter out rows
-                      from being included in this Schedule?
+                      Only include rows that meet the following criteria when
+                      checking this Schedule:
                     </p>
 
                     <Table bordered size="sm">
                       <thead>
                         <tr>
-                          <td />
-                          <td>
+                          <th />
+                          <th>
                             <strong>Key</strong>
-                          </td>
-                          <td>
+                          </th>
+                          <th>
                             <strong>Operation</strong>
-                          </td>
-                          <td>
-                            <strong>Value</strong>
-                          </td>
-                          <td>&nbsp;</td>
+                          </th>
+                          <th />
                         </tr>
                       </thead>
 
@@ -438,6 +435,7 @@ export default function Page(props) {
                                   </Badge>
                                 </h5>
                               </td>
+                              {/* key */}
                               <td>
                                 <Form.Group
                                   controlId={`${localFilter.key}-key-${idx}`}
@@ -463,7 +461,7 @@ export default function Page(props) {
                                   </Form.Control>
                                 </Form.Group>
                               </td>
-
+                              {/* op */}
                               <td>
                                 <Form.Group
                                   controlId={`${localFilter.key}-op-${idx}`}
@@ -497,50 +495,53 @@ export default function Page(props) {
                                       : null}
                                   </Form.Control>
                                 </Form.Group>
-                              </td>
 
-                              <td>
-                                {localFilter.key === "occurredAt" ? (
-                                  <DatePicker
-                                    selected={
-                                      localFilter.match &&
-                                      localFilter.match !== "null"
-                                        ? new Date(
-                                            parseInt(
-                                              localFilter.match.toString()
+                                {!localFilter.op
+                                  .toLowerCase()
+                                  .includes("exist") &&
+                                  (localFilter.key === "occurredAt" ? (
+                                    <DatePicker
+                                      selected={
+                                        localFilter.match &&
+                                        localFilter.match !== "null"
+                                          ? new Date(
+                                              parseInt(
+                                                localFilter.match.toString()
+                                              )
                                             )
-                                          )
-                                        : new Date()
-                                    }
-                                    onChange={(d: Date) => {
-                                      const _localFilter = [...localFilters];
-                                      localFilter.match = d
-                                        .getTime()
-                                        .toString();
-                                      _localFilter[idx] = localFilter;
-                                      setLocalFilters(_localFilter);
-                                    }}
-                                  />
-                                ) : (
-                                  <Form.Group
-                                    controlId={`${localFilter.key}-match-${idx}`}
-                                  >
-                                    <Form.Control
-                                      required
-                                      type="text"
-                                      disabled={loading}
-                                      value={localFilter.match.toString()}
-                                      onChange={(e: any) => {
+                                          : new Date()
+                                      }
+                                      onChange={(d: Date) => {
                                         const _localFilter = [...localFilters];
-                                        localFilter.match = e.target.value;
+                                        localFilter.match = d
+                                          .getTime()
+                                          .toString();
                                         _localFilter[idx] = localFilter;
                                         setLocalFilters(_localFilter);
                                       }}
                                     />
-                                  </Form.Group>
-                                )}
+                                  ) : (
+                                    <Form.Group
+                                      controlId={`${localFilter.key}-match-${idx}`}
+                                    >
+                                      <Form.Control
+                                        required
+                                        type="text"
+                                        disabled={loading}
+                                        value={localFilter.match.toString()}
+                                        onChange={(e: any) => {
+                                          const _localFilter = [
+                                            ...localFilters,
+                                          ];
+                                          localFilter.match = e.target.value;
+                                          _localFilter[idx] = localFilter;
+                                          setLocalFilters(_localFilter);
+                                        }}
+                                      />
+                                    </Form.Group>
+                                  ))}
                               </td>
-
+                              {/* delete */}
                               <td>
                                 <Button
                                   variant="danger"


### PR DESCRIPTION
## Change description

Makes the UI for Schedule Filters match that of Property Filters.  Now, the "value" box only appears if the operation uses a match value.  

Also fixes the default option in the UI for adding a new Property Filter.  It was previously set to "Exists", however not all plugins support `Exist`/ `notExist` yet (I'm looking at you, Mongo).

Example:
<img width="1169" alt="Screen Shot 2022-01-06 at 9 27 33 AM" src="https://user-images.githubusercontent.com/63751206/148398304-f68fa2fc-2216-4eb4-9f99-0431ef7cfc52.png">

<img width="1180" alt="Screen Shot 2022-01-06 at 9 27 25 AM" src="https://user-images.githubusercontent.com/63751206/148398308-ceaee6f5-1de5-4e7f-b8ae-739ac8ea758b.png">

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
