### PR TITLE
Mark records and recordProps as `pending` when a property type changes

### DIFF
--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -364,7 +364,7 @@ export class Property extends LoggedModel<Property> {
   @AfterSave
   static async ensureRecordsMarkedPendingOnTypeChange(instance: Property) {
     // Check to see if type changed
-    if (instance.changed("type")) {
+    if (instance.changed("type") && instance.previous("type") != undefined) {
       //mark all relevant recordproperties as "pending"
       await RecordProperty.update(
         { state: "pending" },

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -379,7 +379,6 @@ export class Property extends LoggedModel<Property> {
         { state: "pending" },
         { where: { modelId: modelId } }
       );
-
     }
   }
 

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -361,6 +361,28 @@ export class Property extends LoggedModel<Property> {
     );
   }
 
+  @AfterSave
+  static async ensureRecordsMarkedPendingOnTypeChange(instance: Property) {
+    // Check to see if type changed
+    if (instance.changed("type")) {
+      //mark all relevant recordproperties as "pending"
+      await RecordProperty.update(
+        { state: "pending" },
+        { where: { propertyId: instance.id } }
+      );
+
+      const modelId = await (
+        await Source.findOne({ where: { id: instance.sourceId } })
+      ).modelId;
+
+      await GrouparooRecord.update(
+        { state: "pending" },
+        { where: { modelId: modelId } }
+      );
+
+    }
+  }
+
   // --- Class Methods --- //
 
   static async findById(id: string) {

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -364,20 +364,18 @@ export class Property extends LoggedModel<Property> {
   @AfterSave
   static async ensureRecordsMarkedPendingOnTypeChange(instance: Property) {
     // Check to see if type changed
-    if (instance.changed("type") && instance.previous("type") != undefined) {
+    if (instance.changed("type") && instance.state === "ready") {
       //mark all relevant recordproperties as "pending"
       await RecordProperty.update(
-        { state: "pending" },
+        { state: "pending", startedAt: null },
         { where: { propertyId: instance.id } }
       );
 
-      const modelId = await (
-        await Source.findOne({ where: { id: instance.sourceId } })
-      ).modelId;
+      const source = await instance.$get("source");
 
       await GrouparooRecord.update(
         { state: "pending" },
-        { where: { modelId: modelId } }
+        { where: { modelId: source.modelId } }
       );
     }
   }


### PR DESCRIPTION
## Change description

When an existing Property has its type modified, we should be checking existing data to see if it conforms to the new datatype.

Ex:
```
email (string) -> email (email)
balance (string) -> balance (float)
```

To enqueue the records for validation, we mark the affected RecordProperties and parent Records as`pending`. 

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
