### PR TITLE
Primary Source creation UI bug fixes

### DIFF
--- a/ui/ui-components/components/source/FormMappingSelector.tsx
+++ b/ui/ui-components/components/source/FormMappingSelector.tsx
@@ -111,7 +111,7 @@ const FormMappingSelector: React.FC<Props> = ({
 
   return (
     <Row>
-      <Col md={hasAvailableProperties ? 6 : 12} xl={12}>
+      <Col md={!mappingDisabled && hasAvailableProperties ? 6 : 12} xl={12}>
         <FormInputContainer
           controlId="mapping_source_column"
           label="Source Column"
@@ -140,46 +140,44 @@ const FormMappingSelector: React.FC<Props> = ({
         </FormInputContainer>
         {columnExample && renderExamples(columnExample)}
       </Col>
-      {!mappingDisabled && (
+      {!mappingDisabled && hasAvailableProperties && (
         <Col>
-          {hasAvailableProperties && (
-            <>
-              <FormInputContainer
-                controlId="mapping_property"
-                label="Mapped to Grouparoo Property"
+          <>
+            <FormInputContainer
+              controlId="mapping_property"
+              label="Mapped to Grouparoo Property"
+              required
+            >
+              <Form.Control
+                as="select"
                 required
+                disabled={disabled}
+                value={selectedProperty?.key}
+                onChange={(e) => {
+                  setSelectedProperty(
+                    availableProperties.find(
+                      ({ key }) => key === e.target.value
+                    )
+                  );
+                }}
+                name="mapping.propertyKey"
+                ref={register}
               >
-                <Form.Control
-                  as="select"
-                  required
-                  disabled={disabled}
-                  value={selectedProperty?.key}
-                  onChange={(e) => {
-                    setSelectedProperty(
-                      availableProperties.find(
-                        ({ key }) => key === e.target.value
-                      )
-                    );
-                  }}
-                  name="mapping.propertyKey"
-                  ref={register}
-                >
-                  <option value={""} disabled>
-                    Select an option
+                <option value={""} disabled>
+                  Select an option
+                </option>
+                {availableProperties.map((property) => (
+                  <option
+                    key={`mapping-property-${property.key}`}
+                    value={property.key}
+                  >
+                    {property.key} {property.unique && "(unique)"}
                   </option>
-                  {availableProperties.map((property) => (
-                    <option
-                      key={`mapping-property-${property.key}`}
-                      value={property.key}
-                    >
-                      {property.key} {property.unique && "(unique)"}
-                    </option>
-                  ))}
-                </Form.Control>
-              </FormInputContainer>
-              {!!availableProperties.length && renderExamples(propertyExample)}
-            </>
-          )}
+                ))}
+              </Form.Control>
+            </FormInputContainer>
+            {!!availableProperties.length && renderExamples(propertyExample)}
+          </>
         </Col>
       )}
     </Row>

--- a/ui/ui-components/components/source/FormMappingSelector.tsx
+++ b/ui/ui-components/components/source/FormMappingSelector.tsx
@@ -19,7 +19,7 @@ interface Props {
   propertyExamples: Record<string, string[]>;
   source: Models.SourceType;
   register: ReturnType<typeof useForm>["register"];
-  isPrimarySource?: boolean;
+  mappingDisabled?: boolean;
 }
 
 const FormMappingSelector: React.FC<Props> = ({
@@ -31,7 +31,7 @@ const FormMappingSelector: React.FC<Props> = ({
   propertyExamples,
   register,
   source,
-  isPrimarySource,
+  mappingDisabled,
 }) => {
   const [selectedProperty, setSelectedProperty] = useState<Models.PropertyType>(
     () =>
@@ -140,46 +140,48 @@ const FormMappingSelector: React.FC<Props> = ({
         </FormInputContainer>
         {columnExample && renderExamples(columnExample)}
       </Col>
-      <Col>
-        {hasAvailableProperties && !isPrimarySource && (
-          <>
-            <FormInputContainer
-              controlId="mapping_property"
-              label="Mapped to Grouparoo Property"
-              required
-            >
-              <Form.Control
-                as="select"
+      {!mappingDisabled && (
+        <Col>
+          {hasAvailableProperties && (
+            <>
+              <FormInputContainer
+                controlId="mapping_property"
+                label="Mapped to Grouparoo Property"
                 required
-                disabled={disabled}
-                value={selectedProperty?.key}
-                onChange={(e) => {
-                  setSelectedProperty(
-                    availableProperties.find(
-                      ({ key }) => key === e.target.value
-                    )
-                  );
-                }}
-                name="mapping.propertyKey"
-                ref={register}
               >
-                <option value={""} disabled>
-                  Select an option
-                </option>
-                {availableProperties.map((property) => (
-                  <option
-                    key={`mapping-property-${property.key}`}
-                    value={property.key}
-                  >
-                    {property.key} {property.unique && "(unique)"}
+                <Form.Control
+                  as="select"
+                  required
+                  disabled={disabled}
+                  value={selectedProperty?.key}
+                  onChange={(e) => {
+                    setSelectedProperty(
+                      availableProperties.find(
+                        ({ key }) => key === e.target.value
+                      )
+                    );
+                  }}
+                  name="mapping.propertyKey"
+                  ref={register}
+                >
+                  <option value={""} disabled>
+                    Select an option
                   </option>
-                ))}
-              </Form.Control>
-            </FormInputContainer>
-            {!!availableProperties.length && renderExamples(propertyExample)}
-          </>
-        )}
-      </Col>
+                  {availableProperties.map((property) => (
+                    <option
+                      key={`mapping-property-${property.key}`}
+                      value={property.key}
+                    >
+                      {property.key} {property.unique && "(unique)"}
+                    </option>
+                  ))}
+                </Form.Control>
+              </FormInputContainer>
+              {!!availableProperties.length && renderExamples(propertyExample)}
+            </>
+          )}
+        </Col>
+      )}
     </Row>
   );
 };

--- a/ui/ui-components/components/source/FormMappingSelector.tsx
+++ b/ui/ui-components/components/source/FormMappingSelector.tsx
@@ -19,6 +19,7 @@ interface Props {
   propertyExamples: Record<string, string[]>;
   source: Models.SourceType;
   register: ReturnType<typeof useForm>["register"];
+  isPrimarySource?: boolean;
 }
 
 const FormMappingSelector: React.FC<Props> = ({
@@ -30,6 +31,7 @@ const FormMappingSelector: React.FC<Props> = ({
   propertyExamples,
   register,
   source,
+  isPrimarySource,
 }) => {
   const [selectedProperty, setSelectedProperty] = useState<Models.PropertyType>(
     () =>
@@ -139,7 +141,7 @@ const FormMappingSelector: React.FC<Props> = ({
         {columnExample && renderExamples(columnExample)}
       </Col>
       <Col>
-        {hasAvailableProperties && (
+        {hasAvailableProperties && !isPrimarySource && (
           <>
             <FormInputContainer
               controlId="mapping_property"

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -220,10 +220,6 @@ const Page: NextPage<Props & InjectedProps> = ({
           source: response.source,
           setLoading: () => {},
         });
-        router.push(
-          "/model/[modelId]/source/[sourceId]/schedule",
-          `/model/${response.source.modelId}/source/${sourceId}/schedule`
-        );
       } else if (
         response.source.state === "ready" &&
         source.state === "draft"
@@ -236,7 +232,6 @@ const Page: NextPage<Props & InjectedProps> = ({
         successHandler.set({ message: "Source updated" });
       }
     }
-
     setLoading(false);
   };
 
@@ -526,34 +521,40 @@ const Page: NextPage<Props & InjectedProps> = ({
                 </Row>
               ) : null}
 
-              {source.previewAvailable && (
-                <>
-                  <hr />
-                  <h3>{isPrimarySource ? "Primary Key Mapping" : "Mapping"}</h3>
-                  {isPrimarySource ? (
-                    <p>
-                      Select a column that uniquely identifies each record in
-                      this Source. The Property mapped to this column will be
-                      assigned as the Model's Primary Key.
-                    </p>
-                  ) : (
-                    <p>
-                      Select a column that relates each record in this Source
-                      back to the Model's Primary Source. You can map the column
-                      to any Property in another Source in the Model.
-                    </p>
-                  )}
+              {loading ? (
+                <Loader />
+              ) : (
+                source.previewAvailable && (
+                  <>
+                    <hr />
+                    <h3>
+                      {isPrimarySource ? "Primary Key Mapping" : "Mapping"}
+                    </h3>
+                    {isPrimarySource ? (
+                      <p>
+                        Select a column that uniquely identifies each record in
+                        this Source. The Property mapped to this column will be
+                        assigned as the Model's Primary Key.
+                      </p>
+                    ) : (
+                      <p>
+                        Select a column that relates each record in this Source
+                        back to the Model's Primary Source. You can map the
+                        column to any Property in another Source in the Model.
+                      </p>
+                    )}
 
-                  <FormMappingSelector
-                    columnName={mappingColumn}
-                    propertyKey={mappingPropertyKey}
-                    preview={preview}
-                    properties={properties}
-                    propertyExamples={propertyExamples}
-                    register={register}
-                    source={source}
-                  />
-                </>
+                    <FormMappingSelector
+                      columnName={mappingColumn}
+                      propertyKey={mappingPropertyKey}
+                      preview={preview}
+                      properties={properties}
+                      propertyExamples={propertyExamples}
+                      register={register}
+                      source={source}
+                    />
+                  </>
+                )
               )}
 
               <hr />

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -521,41 +521,35 @@ const Page: NextPage<Props & InjectedProps> = ({
                 </Row>
               ) : null}
 
-              {loading ? (
-                <Loader />
-              ) : (
-                source.previewAvailable && (
-                  <>
-                    <hr />
-                    <h3>
-                      {isPrimarySource ? "Primary Key Mapping" : "Mapping"}
-                    </h3>
-                    {isPrimarySource ? (
-                      <p>
-                        Select a column that uniquely identifies each record in
-                        this Source. The Property mapped to this column will be
-                        assigned as the Model's Primary Key.
-                      </p>
-                    ) : (
-                      <p>
-                        Select a column that relates each record in this Source
-                        back to the Model's Primary Source. You can map the
-                        column to any Property in another Source in the Model.
-                      </p>
-                    )}
+              {source.previewAvailable && (
+                <>
+                  <hr />
+                  <h3>{isPrimarySource ? "Primary Key Mapping" : "Mapping"}</h3>
+                  {isPrimarySource ? (
+                    <p>
+                      Select a column that uniquely identifies each record in
+                      this Source. The Property mapped to this column will be
+                      assigned as the Model's Primary Key.
+                    </p>
+                  ) : (
+                    <p>
+                      Select a column that relates each record in this Source
+                      back to the Model's Primary Source. You can map the column
+                      to any Property in another Source in the Model.
+                    </p>
+                  )}
 
-                    <FormMappingSelector
-                      columnName={mappingColumn}
-                      propertyKey={mappingPropertyKey}
-                      preview={preview}
-                      properties={properties}
-                      propertyExamples={propertyExamples}
-                      register={register}
-                      source={source}
-                      isPrimarySource={isPrimarySource}
-                    />
-                  </>
-                )
+                  <FormMappingSelector
+                    columnName={mappingColumn}
+                    propertyKey={mappingPropertyKey}
+                    preview={preview}
+                    properties={properties}
+                    propertyExamples={propertyExamples}
+                    register={register}
+                    source={source}
+                    isPrimarySource={isPrimarySource}
+                  />
+                </>
               )}
 
               <hr />

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -83,9 +83,10 @@ const Page: NextPage<Props & InjectedProps> = ({
   );
   const isPrimarySource = useMemo(
     () =>
+      totalSources === 1 ||
       properties.filter(
         ({ isPrimaryKey, sourceId }) => isPrimaryKey && sourceId === source.id
-      ).length > 0 || totalSources === 1,
+      ).length > 0,
     [properties, source]
   );
 
@@ -220,6 +221,7 @@ const Page: NextPage<Props & InjectedProps> = ({
       "get",
       `/properties`,
       {
+        unique: true,
         includeExamples: true,
         state: "ready",
         modelId: source?.modelId,

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -552,6 +552,7 @@ const Page: NextPage<Props & InjectedProps> = ({
                       propertyExamples={propertyExamples}
                       register={register}
                       source={source}
+                      isPrimarySource={isPrimarySource}
                     />
                   </>
                 )


### PR DESCRIPTION
## Change description

Fixes two bugs:

(1) We had a double `router.push()` to `.../schedules` after creating a source that would leave us with a suspended loading bar at the top of the page.  One has been removed, so NextJS knows when the route change is complete now.

(2) Update to the order of a few things when bootstrapping a property for Primary Sources and the redirect that follows that.  this also involved updating how we track a primary source and whether it's currently bootstrapping a property.  Of note: no more flashing form before redirecting. (thanks @krishnaglick!)

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
