### PR TITLE
Rename Import `exporting` state to `processing`

### DIFF
--- a/core/__tests__/models/run/run.ts
+++ b/core/__tests__/models/run/run.ts
@@ -540,7 +540,7 @@ describe("models/run", () => {
         creatorId: run.id,
         recordAssociatedAt: new Date(),
         importedAt: new Date(),
-        exportedAt: new Date(),
+        processedAt: new Date(),
         createdRecord: true,
       });
 
@@ -552,7 +552,7 @@ describe("models/run", () => {
         creatorId: run.id,
         recordAssociatedAt: new Date(),
         importedAt: new Date(),
-        exportedAt: new Date(),
+        processedAt: new Date(),
       });
 
       await utils.sleep(100);
@@ -563,7 +563,7 @@ describe("models/run", () => {
         creatorId: run.id,
         recordAssociatedAt: new Date(),
         importedAt: new Date(),
-        exportedAt: new Date(),
+        processedAt: new Date(),
       });
 
       await utils.sleep(100);

--- a/core/__tests__/models/run/run.ts
+++ b/core/__tests__/models/run/run.ts
@@ -586,7 +586,7 @@ describe("models/run", () => {
       quantizedTimeline.map((q) => {
         expect(q.steps.associate).toBeLessThanOrEqual(1);
         expect(q.steps.imported).toBeLessThanOrEqual(1);
-        expect(q.steps.exported).toBeLessThanOrEqual(1);
+        expect(q.steps.processed).toBeLessThanOrEqual(1);
 
         associateTotal += q.steps.associate;
         importTotal += q.steps.imported;

--- a/core/__tests__/tasks/record/checkReady/checkReady.ts
+++ b/core/__tests__/tasks/record/checkReady/checkReady.ts
@@ -169,16 +169,16 @@ describe("tasks/record:checkReady", () => {
       expect(_importA.newRecordProperties.lastName).toEqual(["Mario"]);
       expect(_importA.newGroupIds).toEqual([group.id]);
       expect(_importA.importedAt).toBeTruthy();
-      expect(_importA.exportedAt).toBeNull();
-      expect(_importA.state).toBe("exporting");
+      expect(_importA.processedAt).toBeNull();
+      expect(_importA.state).toBe("processing");
 
       expect(_importB.newRecordProperties.email).toEqual(["mario@example.com"]);
       expect(_importB.newRecordProperties.firstName).toEqual(["Super"]);
       expect(_importB.newRecordProperties.lastName).toEqual(["Mario"]);
       expect(_importB.newGroupIds).toEqual([group.id]);
       expect(_importB.importedAt).toBeTruthy();
-      expect(_importB.exportedAt).toBeNull();
-      expect(_importB.state).toBe("exporting");
+      expect(_importB.processedAt).toBeNull();
+      expect(_importB.state).toBe("processing");
 
       expect(run.recordsCreated).toEqual(1);
       expect(run.recordsImported).toEqual(1);
@@ -209,7 +209,7 @@ describe("tasks/record:checkReady", () => {
 
       await _importA.reload();
       expect(_importA.importedAt).toBeTruthy();
-      expect(_importA.exportedAt).toBeTruthy();
+      expect(_importA.processedAt).toBeTruthy();
       expect(_importA.state).toBe("complete");
 
       process.env.GROUPAROO_DISABLE_EXPORTS = "false";

--- a/core/__tests__/tasks/record/enqueueExports/enqueueExports.ts
+++ b/core/__tests__/tasks/record/enqueueExports/enqueueExports.ts
@@ -34,9 +34,9 @@ describe("tasks/records:enqueueExports", () => {
         record.id
       );
       await _import.update({
-        state: "exporting",
+        state: "processing",
         importedAt: new Date(),
-        exportedAt: null,
+        processedAt: null,
       });
 
       await specHelper.runTask("records:enqueueExports", {});
@@ -58,9 +58,9 @@ describe("tasks/records:enqueueExports", () => {
         record.id
       );
       await _import.update({
-        state: "exporting",
+        state: "processing",
         importedAt: new Date(),
-        exportedAt: null,
+        processedAt: null,
       });
 
       const emailProperty = await Property.findOne({ where: { key: "email" } });
@@ -88,9 +88,9 @@ describe("tasks/records:enqueueExports", () => {
         mario.id
       );
       await marioImport.update({
-        state: "exporting",
+        state: "processing",
         importedAt: new Date(),
-        exportedAt: null,
+        processedAt: null,
       });
 
       // luigi is ready, but his import has not been marked completed yet
@@ -104,7 +104,7 @@ describe("tasks/records:enqueueExports", () => {
       );
       await luigiImport.update({
         importedAt: null,
-        exportedAt: null,
+        processedAt: null,
       });
 
       // toad has a pending import, but is not ready
@@ -117,9 +117,9 @@ describe("tasks/records:enqueueExports", () => {
         toad.id
       );
       await toadImport.update({
-        state: "exporting",
+        state: "processing",
         importedAt: new Date(),
-        exportedAt: null,
+        processedAt: null,
       });
 
       await specHelper.runTask("records:enqueueExports", {});

--- a/core/__tests__/tasks/record/enqueueExports/smallerBatchSize.ts
+++ b/core/__tests__/tasks/record/enqueueExports/smallerBatchSize.ts
@@ -20,9 +20,9 @@ describe("tasks/records:enqueueExports", () => {
         mario.id
       );
       await marioImport.update({
-        state: "exporting",
+        state: "processing",
         importedAt: new Date(),
-        exportedAt: null,
+        processedAt: null,
       });
 
       const luigi: GrouparooRecord = await helper.factories.record();
@@ -34,9 +34,9 @@ describe("tasks/records:enqueueExports", () => {
         luigi.id
       );
       await luigiImport.update({
-        state: "exporting",
+        state: "processing",
         importedAt: new Date(),
-        exportedAt: null,
+        processedAt: null,
       });
 
       await specHelper.runTask("records:enqueueExports", {});

--- a/core/__tests__/tasks/record/export.ts
+++ b/core/__tests__/tasks/record/export.ts
@@ -236,8 +236,8 @@ describe("tasks/record:export", () => {
         await importB.reload();
         expect(importA.state).toBe("complete");
         expect(importB.state).toBe("complete");
-        expect(importA.exportedAt).toBeTruthy();
-        expect(importB.exportedAt).toBeTruthy();
+        expect(importA.processedAt).toBeTruthy();
+        expect(importB.processedAt).toBeTruthy();
       });
 
       test("it will append destinationIds from imports", async () => {
@@ -344,7 +344,7 @@ describe("tasks/record:export", () => {
           });
 
           await _import.update({
-            state: "exporting",
+            state: "processing",
             importedAt: new Date(),
           });
 

--- a/core/__tests__/tasks/system/status/status.ts
+++ b/core/__tests__/tasks/system/status/status.ts
@@ -95,7 +95,7 @@ describe("tasks/status", () => {
       const _import = await helper.factories.import(null, null, record.id);
       await _import.update({
         state: "failed",
-        exportedAt: null,
+        processedAt: null,
         errorMessage: "oh no!",
         errorMetadata: "errored",
       });

--- a/core/src/migrations/000098-renameImportStateExportingToProcessing.ts
+++ b/core/src/migrations/000098-renameImportStateExportingToProcessing.ts
@@ -1,0 +1,19 @@
+import Sequelize from "sequelize";
+
+export default {
+  up: async (queryInterface: Sequelize.QueryInterface) => {
+    await queryInterface.renameColumn("imports", "exportedAt", "processedAt");
+
+    await queryInterface.sequelize.query(
+      `UPDATE "imports" SET "state"='processing' WHERE "state"='exporting'`
+    );
+  },
+
+  down: async (queryInterface: Sequelize.QueryInterface) => {
+    await queryInterface.renameColumn("imports", "processedAt", "exportedAt");
+
+    await queryInterface.sequelize.query(
+      `UPDATE "imports" SET "state"='exporting' WHERE "state"='processing'`
+    );
+  },
+};

--- a/core/src/models/Import.ts
+++ b/core/src/models/Import.ts
@@ -35,7 +35,7 @@ const IMPORT_CREATORS = ["run"] as const;
 const STATES = [
   "associating",
   "importing",
-  "exporting",
+  "processing",
   "failed",
   "complete",
 ] as const;
@@ -45,9 +45,9 @@ const STATE_TRANSITIONS = [
   { from: "associating", to: "importing", checks: [] },
   { from: "importing", to: "failed", checks: [] },
   { from: "importing", to: "complete", checks: [] },
-  { from: "importing", to: "exporting", checks: [] },
-  { from: "exporting", to: "failed", checks: [] },
-  { from: "exporting", to: "complete", checks: [] },
+  { from: "importing", to: "processing", checks: [] },
+  { from: "processing", to: "failed", checks: [] },
+  { from: "processing", to: "complete", checks: [] },
 ];
 
 @Table({ tableName: "imports", paranoid: false })
@@ -158,7 +158,7 @@ export class Import extends CommonModel<Import> {
   importedAt: Date;
 
   @Column
-  exportedAt: Date;
+  processedAt: Date;
 
   @Column
   errorMessage: string;
@@ -197,7 +197,7 @@ export class Import extends CommonModel<Import> {
       startedAt: APIData.formatDate(this.startedAt),
       recordAssociatedAt: APIData.formatDate(this.recordAssociatedAt),
       importedAt: APIData.formatDate(this.importedAt),
-      exportedAt: APIData.formatDate(this.exportedAt),
+      processedAt: APIData.formatDate(this.processedAt),
 
       // data before and after
       createdRecord: this.createdRecord,

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -1133,11 +1133,11 @@ export namespace RecordOps {
 
         await Import.update(
           {
-            state: toExport ? "exporting" : "complete",
+            state: toExport ? "processing" : "complete",
             newRecordProperties: newRecordProperties,
             newGroupIds: newGroupIds,
             importedAt: now,
-            exportedAt: toExport ? undefined : now, // we want to indicate that the import's lifecycle is complete
+            processedAt: toExport ? undefined : now, // we want to indicate that the import's lifecycle is complete
           },
           {
             where: { id: { [Op.in]: imports.map((i) => i.id) } },

--- a/core/src/modules/ops/runs.ts
+++ b/core/src/modules/ops/runs.ts
@@ -72,9 +72,9 @@ export namespace RunOps {
     const data = [];
     const start = run.createdAt.getTime();
 
-    const lastExportedImport = await Import.findOne({
+    const lastProcessedImport = await Import.findOne({
       where: { creatorId: run.id },
-      order: [["exportedAt", "desc"]],
+      order: [["processedAt", "desc"]],
       limit: 1,
     });
 
@@ -85,8 +85,8 @@ export namespace RunOps {
     });
 
     const end =
-      lastExportedImport?.exportedAt?.getTime() ||
-      lastImportedImport?.exportedAt?.getTime() ||
+      lastProcessedImport?.processedAt?.getTime() ||
+      lastImportedImport?.processedAt?.getTime() ||
       run?.completedAt?.getTime() ||
       new Date().getTime();
 
@@ -119,9 +119,9 @@ export namespace RunOps {
               },
             },
           }),
-          exported: await run.$count("imports", {
+          processed: await run.$count("imports", {
             where: {
-              exportedAt: {
+              processedAt: {
                 [Op.gte]: lastBoundary,
                 [Op.lt]: nextBoundary,
               },

--- a/core/src/tasks/record/enqueueExports.ts
+++ b/core/src/tasks/record/enqueueExports.ts
@@ -26,7 +26,7 @@ export class GrouparooRecordsEnqueueExports extends CLSTask {
         [Sequelize.fn("DISTINCT", Sequelize.col("recordId")), "recordId"],
       ],
       where: {
-        state: "exporting",
+        state: "processing",
       },
       group: ["recordId"],
       limit,

--- a/core/src/tasks/record/export.ts
+++ b/core/src/tasks/record/export.ts
@@ -31,7 +31,7 @@ export class RecordExport extends RetryableTask {
 
     const imports = await Import.findAll({
       where: {
-        state: "exporting",
+        state: "processing",
         recordId: record.id,
       },
       order: [["createdAt", "asc"]],
@@ -87,7 +87,7 @@ export class RecordExport extends RetryableTask {
 
       if (imports.length > 0) {
         await Import.update(
-          { exportedAt: new Date(), state: "complete" },
+          { processedAt: new Date(), state: "complete" },
           { where: { id: imports.map((i) => i.id) } }
         );
       }

--- a/ui/ui-components/components/import/List.tsx
+++ b/ui/ui-components/components/import/List.tsx
@@ -18,7 +18,7 @@ const states = [
   "all",
   "associating",
   "importing",
-  "exporting",
+  "processing",
   "complete",
   "failed",
 ] as const;
@@ -169,9 +169,9 @@ export default function ImportList(props) {
                     {_import.importedAt
                       ? formatTimestamp(_import.importedAt)
                       : "pending"}
-                    <br /> Exported:{" "}
-                    {_import.exportedAt
-                      ? formatTimestamp(_import.exportedAt)
+                    <br /> Processed:{" "}
+                    {_import.processedAt
+                      ? formatTimestamp(_import.processedAt)
                       : "pending"}
                   </td>
                   <td>

--- a/ui/ui-components/pages/import/[id]/edit.tsx
+++ b/ui/ui-components/pages/import/[id]/edit.tsx
@@ -119,7 +119,7 @@ export default function Page(props) {
             <strong>
               <DurationTime
                 start={_import.createdAt}
-                end={_import.exportedAt}
+                end={_import.processedAt}
               />
             </strong>
           </p>
@@ -172,17 +172,17 @@ export default function Page(props) {
                 </td>
               </tr>
               <tr>
-                <td>Exports Created</td>
+                <td>Processed</td>
                 <td>
-                  {_import.exportedAt
-                    ? formatTimestamp(_import.exportedAt)
+                  {_import.processedAt
+                    ? formatTimestamp(_import.processedAt)
                     : "pending"}
                 </td>
                 <td>
                   ⇣
                   <DurationTime
                     start={_import.importedAt}
-                    end={_import.exportedAt}
+                    end={_import.processedAt}
                   />
                 </td>
               </tr>


### PR DESCRIPTION
## Change description

The `exporting` state introduced in #2751 didn't quite represent what was going on accurately, since exports are only being _created_ and the import does not wait for exports to be fully completed. The "exporting" name could cause users to expect to see imports in that state until they've been exported.

This also changes the timestamp to match the new name, since `exportedAt` was also not quite accurate and could cause confusion.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
