### PR TITLE
Generate Sample Records when the primary Source goes ready in ui-config

### DIFF
--- a/core/__tests__/actions/sources/sampleRecodGeneartion.ts
+++ b/core/__tests__/actions/sources/sampleRecodGeneartion.ts
@@ -1,0 +1,201 @@
+import { helper } from "@grouparoo/spec-helper";
+import { Connection, specHelper, api } from "actionhero";
+import { ConfigWriter } from "../../../src/modules/configWriter";
+import {
+  Source,
+  App,
+  GrouparooModel,
+  GrouparooRecord,
+  GrouparooPlugin,
+  PluginConnection,
+  SourcePreviewMethod,
+} from "../../../src";
+import { SessionCreate } from "../../../src/actions/session";
+import {
+  SourceBootstrapUniqueProperty,
+  SourceEdit,
+} from "../../../src/actions/sources";
+import { ConfigUser } from "../../../src/modules/configUser";
+import fs from "fs";
+
+describe("actions/sources", () => {
+  let model: GrouparooModel;
+  let app: App;
+  let source: Source;
+  let connection: Connection;
+  let csrfToken: string;
+
+  helper.grouparooTestServer({
+    truncate: true,
+    enableTestPlugin: true,
+    resetSettings: true,
+  });
+
+  beforeAll(async () => {
+    await specHelper.runAction("team:initialize", {
+      firstName: "Mario",
+      lastName: "Mario",
+      password: "P@ssw0rd!",
+      email: "mario@example.com",
+    });
+
+    model = await helper.factories.model();
+    app = await helper.factories.app({ model });
+  });
+
+  beforeAll(async () => {
+    connection = await specHelper.buildConnection();
+    connection.params = { email: "mario@example.com", password: "P@ssw0rd!" };
+    const sessionResponse = await specHelper.runAction<SessionCreate>(
+      "session:create",
+      connection
+    );
+    csrfToken = sessionResponse.csrfToken;
+  });
+
+  beforeEach(async () => {
+    if (source) await source.destroy();
+    source = await helper.factories.source(app);
+
+    connection.params = {
+      csrfToken,
+      id: source.id,
+      key: "userId",
+      type: "integer",
+      mappedColumn: "id",
+    };
+    const { error: bootstrapError } =
+      await specHelper.runAction<SourceBootstrapUniqueProperty>(
+        "source:bootstrapUniqueProperty",
+        connection
+      );
+    expect(bootstrapError).toBeUndefined();
+
+    connection.params = {
+      csrfToken,
+      id: source.id,
+      options: { table: "users" },
+    };
+    const { error: optionsError } = await specHelper.runAction<SourceEdit>(
+      "source:edit",
+      connection
+    );
+    expect(optionsError).toBeUndefined();
+  });
+
+  describe("cli:run", () => {
+    beforeEach(() => (process.env.GROUPAROO_RUN_MODE = "cli:run"));
+
+    test("no sample records are created", async () => {
+      connection.params = {
+        csrfToken,
+        id: source.id,
+        mapping: { id: "userId" },
+        state: "ready",
+      };
+      const { error, source: sourceResponse } =
+        await specHelper.runAction<SourceEdit>("source:edit", connection);
+      expect(error).toBeUndefined();
+      expect(sourceResponse.state).toEqual("ready");
+
+      expect(await GrouparooRecord.count()).toBe(0);
+    });
+  });
+
+  describe("cli:config", () => {
+    let configSpy: jest.SpyInstance;
+    let testPluginConnection: PluginConnection;
+    let originalPreviewMethod: SourcePreviewMethod;
+
+    beforeAll(() => {
+      process.env.GROUPAROO_RUN_MODE = "cli:config";
+
+      ConfigUser.create({
+        email: "mario@example.com",
+        company: "MarioBros Plumbing",
+      });
+
+      configSpy = jest
+        .spyOn(ConfigWriter, "run")
+        .mockImplementation(() => null);
+
+      const testPlugin: GrouparooPlugin = api.plugins.plugins.find(
+        (a) => a.name === "@grouparoo/test-plugin"
+      );
+      testPluginConnection = testPlugin.connections.find(
+        (c) => c.name === "test-plugin-import"
+      );
+      originalPreviewMethod = testPluginConnection.methods.sourcePreview;
+    });
+
+    beforeEach(async () => {
+      await GrouparooRecord.truncate();
+    });
+
+    afterAll(async () => {
+      configSpy.mockClear();
+      fs.unlinkSync(await ConfigUser.localUserFilePath());
+      testPluginConnection.methods.sourcePreview = originalPreviewMethod;
+    });
+
+    test("sample records are created", async () => {
+      testPluginConnection.methods.sourcePreview = async () => [
+        { id: 1, fname: "mario", lname: "mario" },
+        { id: 2, fname: "luigi", lname: "mario" },
+        { id: 3, fname: "toad", lname: "toadstool" },
+        { id: 4, fname: "peach", lname: "toadstool" },
+      ];
+
+      connection.params = {
+        csrfToken,
+        id: source.id,
+        mapping: { id: "userId" },
+        state: "ready",
+      };
+      const { error, source: sourceResponse } =
+        await specHelper.runAction<SourceEdit>("source:edit", connection);
+      expect(error).toBeUndefined();
+      expect(sourceResponse.state).toEqual("ready");
+
+      expect(await GrouparooRecord.count()).toBe(3);
+    });
+
+    test("if there are some invalid preview records, as many as can will be created", async () => {
+      testPluginConnection.methods.sourcePreview = async () => [
+        { id: null, fname: "mario", lname: "mario" },
+        { id: 2, fname: "luigi", lname: "mario" },
+        { id: 3, fname: "toad", lname: "toadstool" },
+      ];
+
+      connection.params = {
+        csrfToken,
+        id: source.id,
+        mapping: { id: "userId" },
+        state: "ready",
+      };
+      const { error, source: sourceResponse } =
+        await specHelper.runAction<SourceEdit>("source:edit", connection);
+      expect(error).toBeUndefined();
+      expect(sourceResponse.state).toEqual("ready");
+
+      expect(await GrouparooRecord.count()).toBe(2);
+    });
+
+    test("with no samples, no records are created and the source still goes ready", async () => {
+      testPluginConnection.methods.sourcePreview = async () => [];
+
+      connection.params = {
+        csrfToken,
+        id: source.id,
+        mapping: { id: "userId" },
+        state: "ready",
+      };
+      const { error, source: sourceResponse } =
+        await specHelper.runAction<SourceEdit>("source:edit", connection);
+      expect(error).toBeUndefined();
+      expect(sourceResponse.state).toEqual("ready");
+
+      expect(await GrouparooRecord.count()).toBe(0);
+    });
+  });
+});

--- a/core/__tests__/actions/sources/sources.ts
+++ b/core/__tests__/actions/sources/sources.ts
@@ -1,7 +1,7 @@
 import { helper } from "@grouparoo/spec-helper";
-import { Connection, specHelper } from "actionhero";
-import { Option, Source, App, GrouparooModel } from "../../src";
-import { SessionCreate } from "../../src/actions/session";
+import { specHelper, Connection } from "actionhero";
+import { Option, Source, App, GrouparooModel } from "../../../src";
+import { SessionCreate } from "../../../src/actions/session";
 import {
   SourceBootstrapUniqueProperty,
   SourceConnectionApps,
@@ -13,9 +13,9 @@ import {
   SourcePreview,
   SourcesList,
   SourceView,
-} from "../../src/actions/sources";
-import { PropertyDestroy } from "../../src/actions/properties";
-import { ConfigWriter } from "../../src/modules/configWriter";
+} from "../../../src/actions/sources";
+import { PropertyDestroy } from "../../../src/actions/properties";
+import { ConfigWriter } from "../../../src/modules/configWriter";
 
 describe("actions/sources", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -295,7 +295,7 @@ describe("actions/sources", () => {
       expect(configSpy).toBeCalledTimes(1);
     });
 
-    test("a source can be made active", async () => {
+    test("a source can be made ready", async () => {
       connection.params = {
         csrfToken,
         id,

--- a/core/__tests__/actions/status.ts
+++ b/core/__tests__/actions/status.ts
@@ -6,7 +6,6 @@ import { ConfigUser } from "../../src/modules/configUser";
 import { Status } from "../../src/modules/status";
 import { PrivateStatus, PublicStatus } from "../../src/actions/status";
 import { SessionCreate } from "../../src/actions/session";
-import { Team } from "../../src";
 
 const workerId = process.env.JEST_WORKER_ID;
 const configDir = `${os.tmpdir()}/test/${workerId}/configUser/config`;

--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -120,6 +120,7 @@ export const DEFAULT: { [namespace]: () => RoutesConfig } = {
         { path: "/v:apiVersion/oauth/:provider/client/start", action: "oAuth:client:start" },
         { path: "/v:apiVersion/source", action: "source:create" },
         { path: "/v:apiVersion/source/:id/bootstrapUniqueProperty", action: "source:bootstrapUniqueProperty" },
+        { path: "/v:apiVersion/source/:id/generateSampleRecords", action: "source:generateSampleRecords" },
         { path: "/v:apiVersion/team", action: "team:create" },
         { path: "/v:apiVersion/team/initialize", action: "team:initialize" },
         { path: "/v:apiVersion/team/member", action: "teamMember:create" },

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -203,6 +203,15 @@ const Page: NextPage<Props & InjectedProps> = ({
       setSource(response.source);
       sourceHandler.set(response.source);
 
+      // we made the first source, and now should attempt to make sample properties
+      if (isBootstrappingUniqueProperty && response.source.state === "ready") {
+        await execApi<Actions.SourceGenerateSampleRecords>(
+          "post",
+          `/source/${sourceId}/generateSampleRecords`,
+          { id: sourceId }
+        );
+      }
+
       // this source can have a schedule, and we have no schedules yet
       if (scheduleCount === 0 && response.source.scheduleAvailable) {
         await createSchedule({

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -282,6 +282,7 @@ import {
   SourceView,
   SourcesList,
   SourceConnectionOptions,
+  SourceGenerateSampleRecords,
   SourceDefaultPropertyOptions,
   SourcePreview,
 } from "@grouparoo/core/src/actions/sources";
@@ -739,6 +740,9 @@ export namespace Actions {
   >;
   export type SourceConnectionOptions = AsyncReturnType<
     typeof SourceConnectionOptions.prototype.runWithinTransaction
+  >;
+  export type SourceGenerateSampleRecords = AsyncReturnType<
+    typeof SourceGenerateSampleRecords.prototype.runWithinTransaction
   >;
   export type SourceDefaultPropertyOptions = AsyncReturnType<
     typeof SourceDefaultPropertyOptions.prototype.runWithinTransaction


### PR DESCRIPTION
In `ui-config`, the first time a Model's Primary Source goes ready, we will automatically generate 3 Sample Records

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
