### PR TITLE
Redirect to the record/edit page in community edition

### DIFF
--- a/ui/ui-components/pages/object/[id].tsx
+++ b/ui/ui-components/pages/object/[id].tsx
@@ -33,31 +33,34 @@ export default function FindObject(props) {
     schedules: redirectSchedule,
   };
 
+  const editPagesForCommunityEdition = ["records"];
+
   useEffect(() => {
     load();
   }, []);
 
   async function load() {
     const response: Actions.ObjectFind = await execApi("get", `/object/${id}`);
+    const table = response.records[0].tableName.toLowerCase();
     if (response.records.length === 0) {
       setError(`Cannot find object "${id}"`);
     } else if (
       response.records.length === 1 &&
-      grouparooUiEdition() === "enterprise"
+      (grouparooUiEdition() === "enterprise" ||
+        editPagesForCommunityEdition.includes(table))
     ) {
-      const table = response.records[0].tableName.toLowerCase();
       const detailPage = detailPages[table] || "edit";
       if (typeof detailPage === "function") {
         await detailPage(id);
       } else {
-        router.push(`/${singular(table)}/${id}/${detailPage}`);
+        router.replace(`/${singular(table)}/${id}/${detailPage}`);
       }
     } else if (
       response.records.length === 1 &&
       grouparooUiEdition() === "community"
     ) {
-      const listPage = getListPage(response.records[0].tableName.toLowerCase());
-      router.push(listPage);
+      const listPage = getListPage(table);
+      router.replace(listPage);
     } else {
       setRecords(response.records.map((r) => r.tableName.toLowerCase()));
     }

--- a/ui/ui-components/pages/object/[id].tsx
+++ b/ui/ui-components/pages/object/[id].tsx
@@ -41,11 +41,12 @@ export default function FindObject(props) {
 
   async function load() {
     const response: Actions.ObjectFind = await execApi("get", `/object/${id}`);
-    const table = response.records[0].tableName.toLowerCase();
-    if (response.records.length === 0) {
+    const table = response?.records[0]?.tableName?.toLowerCase();
+    const itemsFound = response?.records?.length ?? 0;
+    if (itemsFound === 0) {
       setError(`Cannot find object "${id}"`);
     } else if (
-      response.records.length === 1 &&
+      itemsFound === 1 &&
       (grouparooUiEdition() === "enterprise" ||
         editPagesForCommunityEdition.includes(table))
     ) {
@@ -55,10 +56,7 @@ export default function FindObject(props) {
       } else {
         router.replace(`/${singular(table)}/${id}/${detailPage}`);
       }
-    } else if (
-      response.records.length === 1 &&
-      grouparooUiEdition() === "community"
-    ) {
+    } else if (itemsFound === 1 && grouparooUiEdition() === "community") {
       const listPage = getListPage(table);
       router.replace(listPage);
     } else {


### PR DESCRIPTION
Allows the `/object/id` redirect page to take users to Record detail pages in UI-Community

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
