### PR TITLE
Config UI filter object simplified

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/property/[propertyId]/edit.tsx
@@ -198,11 +198,10 @@ export default function Page(props) {
     _localFilters.push({
       key: filterOptions[0].key,
       op: filterOptions[0].ops[0],
-      match: "",
+      match: null,
     });
 
     setLocalFilters(_localFilters);
-    console.log(_localFilters);
   }
 
   function deleteRule(idx: number) {
@@ -678,9 +677,8 @@ export default function Page(props) {
                                               localFilter.op.includes("exist")
                                             }
                                             value={
-                                              localFilter.match
-                                                ? localFilter.match.toString()
-                                                : ""
+                                              localFilter.match?.toString() ||
+                                              ""
                                             }
                                             onChange={(e: any) => {
                                               const _localFilter = [

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -126,7 +126,6 @@ export default function Page(props) {
     _localFilters.push({
       key: filterOptions[0].key,
       op: filterOptions[0].ops[0],
-      match: "",
     });
 
     setLocalFilters(_localFilters);
@@ -528,7 +527,9 @@ export default function Page(props) {
                                         required
                                         type="text"
                                         disabled={loading}
-                                        value={localFilter.match.toString()}
+                                        value={
+                                          localFilter.match?.toString() || ""
+                                        }
                                         onChange={(e: any) => {
                                           const _localFilter = [
                                             ...localFilters,


### PR DESCRIPTION
## Change description

**BEFORE**:  Config UI would generate a `match` value of an empty string, even if the `op` didn't need a match (ie: for `"op": "exists"`).  This was true for Property and Schedule Filters.

<img width="200" alt="Screen Shot 2022-01-10 at 3 44 53 PM" src="https://user-images.githubusercontent.com/63751206/149008971-dde6af56-d72d-4faf-a91a-0dfb8bad2802.png">


**AFTER**:  The `match` value is only generated if the `op` being used needs one.

On a Schedule: 

<img width="200" alt="Screen Shot 2022-01-11 at 2 27 02 PM" src="https://user-images.githubusercontent.com/63751206/149008785-403873e1-6486-4acb-86bc-5034d2e70b02.png">


On a Property: 
<img width="200" alt="Screen Shot 2022-01-11 at 2 26 48 PM" src="https://user-images.githubusercontent.com/63751206/149008795-e87a8118-72b8-4abf-963a-7dd6915e1a65.png">


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
