### PR TITLE
Fix sample record generation bug and bootstrap issue in non-boostrappable sources in source edit page

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -135,7 +135,10 @@ const Page: NextPage<Props & InjectedProps> = ({
     event.preventDefault();
     setLoading(true);
 
-    const isBootstrappingUniqueProperty = !data.mapping?.propertyKey;
+    const isBootstrappingUniqueProperty =
+      source.previewAvailable &&
+      !source.connection.skipSourceMapping &&
+      !data.mapping?.propertyKey;
     let bootstrapSuccess = false;
     let mapping: Record<string, string>;
 

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -22,6 +22,7 @@ import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
 import FormMappingSelector from "../../../../../components/source/FormMappingSelector";
 import { createSchedule } from "../../../../../components/schedule/Add";
 import ManagedCard from "../../../../../components/lib/ManagedCard";
+import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 
 interface FormData {
   mapping?: {
@@ -207,7 +208,11 @@ const Page: NextPage<Props & InjectedProps> = ({
       sourceHandler.set(response.source);
 
       // we made the first source, and now should attempt to make sample properties
-      if (isBootstrappingUniqueProperty && response.source.state === "ready") {
+      if (
+        grouparooUiEdition() === "config" &&
+        isBootstrappingUniqueProperty &&
+        response.source.state === "ready"
+      ) {
         await execApi<Actions.SourceGenerateSampleRecords>(
           "post",
           `/source/${sourceId}/generateSampleRecords`,


### PR DESCRIPTION
## Change description

This fixes two issues in regards to the updated source edit page:

1. When creating a new source that is not bootstrapable (such as a query source), it should not attempt to bootstrap otherwise it will cause a crash
2. Generating sample records is only supported in UI config mode

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
