### PR TITLE
Group Rules page bug fix

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -435,7 +435,7 @@ export default function Page(props) {
                               }}
                               options={
                                 autocompleteResults[rule.key]?.map((v) =>
-                                  v.toString()
+                                  v?.toString()
                                 ) || []
                               }
                               onSearch={(_match) => {


### PR DESCRIPTION
## Change description

Previously, the group rules page would crash in Config UI if two or more group rules had identical keys (property IDs), but one had a match and the other did not.

Hitting "Update" when adding a rule like the one below would cause React to crash.

<img width="853" alt="Screen Shot 2022-01-12 at 1 20 59 PM" src="https://user-images.githubusercontent.com/63751206/149199524-928c9129-dcf4-49d3-9e30-6a63bcfc3308.png">

Now, no crash.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
