### PR TITLE
Show Pending Properties on Sample Records when a new Property is created

### DIFF
--- a/apps/staging-config/.env.example
+++ b/apps/staging-config/.env.example
@@ -36,8 +36,8 @@ REDIS_URL="redis://mock"
 ##############
 
 # To use sqlite
-DATABASE_URL="sqlite://grouparoo_development.sqlite"
-CONFIG_DATABASE_URL = "sqlite://grouparoo_config.sqlite"
+DATABASE_URL="sqlite://memory"
+CONFIG_DATABASE_URL = "sqlite://memory"
 
 # To use Postgres without a username or password
 # DATABASE_URL="postgresql://localhost:5432/grouparoo_development"

--- a/apps/staging-config/package.json
+++ b/apps/staging-config/package.json
@@ -22,7 +22,7 @@
     "jest": "27.4.5"
   },
   "scripts": {
-    "dev": "rm -f grouparoo_config.sqlite && cd node_modules/@grouparoo/core && DATABASE_URL=\"sqlite://grouparoo_config.sqlite\" NEXT_DEVELOPMENT_MODE=true GROUPAROO_RUN_MODE=\"cli:config\" WORKERS=0 ./bin/dev",
+    "dev": "cd node_modules/@grouparoo/core && NEXT_DEVELOPMENT_MODE=true GROUPAROO_RUN_MODE=\"cli:config\" WORKERS=0 ./bin/dev",
     "demo": "./node_modules/.bin/grouparoo demo --config",
     "debug": "cd node_modules/@grouparoo/core && ./bin/debug"
   },

--- a/core/__tests__/actions/config.ts
+++ b/core/__tests__/actions/config.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { Connection, specHelper } from "actionhero";
+import { Connection, specHelper, rebuildConfig } from "actionhero";
 import { ConfigUserCreate } from "../../src/actions/config";
 import os from "os";
 
@@ -28,14 +28,17 @@ describe("actions/config", () => {
 
   beforeEach(async () => {
     process.env.GROUPAROO_RUN_MODE = "cli:config";
+    rebuildConfig();
   });
 
   afterEach(async () => {
     process.env.GROUPAROO_RUN_MODE = undefined;
+    rebuildConfig();
   });
 
   test("throws an error unless in config mode", async () => {
     process.env.GROUPAROO_RUN_MODE = undefined;
+    rebuildConfig();
     const { error } = await specHelper.runAction(
       "config:user:create",
       connection

--- a/core/__tests__/actions/navigation.ts
+++ b/core/__tests__/actions/navigation.ts
@@ -1,6 +1,6 @@
 import os from "os";
 import { helper } from "@grouparoo/spec-helper";
-import { specHelper } from "actionhero";
+import { rebuildConfig, specHelper } from "actionhero";
 import { GrouparooModel } from "../../dist";
 import { ConfigUserCreate } from "../../src/actions/config";
 import { NavigationList } from "../../src/actions/navigation";
@@ -171,6 +171,8 @@ describe("actions/navigation", () => {
       });
 
       process.env.GROUPAROO_RUN_MODE = "cli:config";
+      rebuildConfig();
+
       process.env.GROUPAROO_CONFIG_DIR = `${os.tmpdir()}/test/${
         process.env.JEST_WORKER_ID
       }/config/navigation`;

--- a/core/__tests__/actions/sources/generateSampleRecords.ts
+++ b/core/__tests__/actions/sources/generateSampleRecords.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { Connection, specHelper, api } from "actionhero";
+import { Connection, specHelper, api, rebuildConfig } from "actionhero";
 import { ConfigWriter } from "../../../src/modules/configWriter";
 import {
   Source,
@@ -88,7 +88,10 @@ describe("actions/sources/generateSampleRecords", () => {
   });
 
   describe("cli:run", () => {
-    beforeEach(() => (process.env.GROUPAROO_RUN_MODE = "cli:run"));
+    beforeEach(() => {
+      process.env.GROUPAROO_RUN_MODE = "cli:run";
+      rebuildConfig();
+    });
 
     test("no sample records are created", async () => {
       connection.params = {
@@ -116,6 +119,7 @@ describe("actions/sources/generateSampleRecords", () => {
 
     beforeAll(() => {
       process.env.GROUPAROO_RUN_MODE = "cli:config";
+      rebuildConfig();
 
       ConfigUser.create({
         email: "mario@example.com",

--- a/core/__tests__/actions/status.ts
+++ b/core/__tests__/actions/status.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { Connection, specHelper } from "actionhero";
+import { Connection, rebuildConfig, specHelper } from "actionhero";
 import os from "os";
 import fs from "fs";
 import { ConfigUser } from "../../src/modules/configUser";
@@ -51,6 +51,8 @@ describe("actions/status", () => {
 
         beforeEach(async () => {
           process.env.GROUPAROO_RUN_MODE = "cli:config";
+          rebuildConfig();
+
           await ConfigUser.create({
             email: "mario@example.com",
             company: "Nintendo",
@@ -58,12 +60,16 @@ describe("actions/status", () => {
         });
         afterEach(async () => {
           process.env.GROUPAROO_RUN_MODE = undefined;
+          rebuildConfig();
+
           if (fs.existsSync(localFile)) fs.rmSync(localFile);
           await helper.resetSettings();
         });
 
         test("cannot use status:private with a local users file in run mode", async () => {
           process.env.GROUPAROO_RUN_MODE = "cli:run";
+          rebuildConfig();
+
           const { error, metrics } = await specHelper.runAction<PrivateStatus>(
             "status:private"
           );

--- a/core/__tests__/initializers/environment.ts
+++ b/core/__tests__/initializers/environment.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { specHelper, api, task, config } from "actionhero";
+import { config, rebuildConfig } from "actionhero";
 import { Environment } from "../../src/initializers/environment";
 
 describe("initializers/environment", () => {
@@ -14,6 +14,7 @@ describe("initializers/environment", () => {
     config.sequelize.dialect = initialDialect;
     process.env.NODE_ENV = initialEnv;
     process.env.GROUPAROO_RUN_MODE = initialRunMode;
+    rebuildConfig();
   });
 
   describe("SQLite checks", () => {
@@ -22,6 +23,7 @@ describe("initializers/environment", () => {
       async (runMode) => {
         process.env.NODE_ENV = "production";
         process.env.GROUPAROO_RUN_MODE = runMode;
+        rebuildConfig();
         config.sequelize.dialect = "sqlite";
 
         expect(instance.initialize()).rejects.toThrow(
@@ -35,6 +37,7 @@ describe("initializers/environment", () => {
       async (runMode) => {
         process.env.NODE_ENV = "production";
         process.env.GROUPAROO_RUN_MODE = runMode;
+        rebuildConfig();
         config.sequelize.dialect = "sqlite";
 
         const res = await instance.initialize();
@@ -51,6 +54,7 @@ describe("initializers/environment", () => {
     ])("it will not throw if in dev mode with %p run mode", async (runMode) => {
       process.env.NODE_ENV = "development";
       process.env.GROUPAROO_RUN_MODE = runMode;
+      rebuildConfig();
       config.sequelize.dialect = "sqlite";
 
       const res = await instance.initialize();
@@ -68,6 +72,7 @@ describe("initializers/environment", () => {
       async (runMode) => {
         process.env.NODE_ENV = "production";
         process.env.GROUPAROO_RUN_MODE = runMode;
+        rebuildConfig();
         config.sequelize.dialect = "postgres";
 
         const res = await instance.initialize();

--- a/core/__tests__/models/group/calculations.ts
+++ b/core/__tests__/models/group/calculations.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { specHelper, config } from "actionhero";
+import { specHelper, config, rebuildConfig } from "actionhero";
 import {
   Log,
   GrouparooRecord,
@@ -41,6 +41,7 @@ describe("models/group", () => {
       await SharedGroupTests.afterEach();
       await run.destroy();
       process.env.GROUPAROO_RUN_MODE = undefined;
+      rebuildConfig();
     });
 
     test("an empty group can be created", async () => {
@@ -95,6 +96,7 @@ describe("models/group", () => {
 
     test("groups with at least one rule are set to ready in config mode", async () => {
       process.env.GROUPAROO_RUN_MODE = "cli:config";
+      rebuildConfig();
       expect(group.state).toBe("draft");
       await group.setRules([
         { key: "firstName", match: "nobody", operation: { op: "eq" } },

--- a/core/__tests__/models/group/group.ts
+++ b/core/__tests__/models/group/group.ts
@@ -1,4 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
+import { rebuildConfig } from "actionhero";
 import {
   Destination,
   Group,
@@ -130,7 +131,9 @@ describe("models/group", () => {
 
     afterEach(async () => {
       process.env.GROUPAROO_RUN_MODE = undefined;
+      rebuildConfig();
     });
+
     test("creates a run and sets state to initialized", async () => {
       const group = await Group.create({
         name: "group that will create a run",
@@ -145,6 +148,7 @@ describe("models/group", () => {
     });
     test("does not create a run when in config mode", async () => {
       process.env.GROUPAROO_RUN_MODE = "cli:config";
+      rebuildConfig();
 
       const group = await Group.create({
         name: "group that will not create a run",

--- a/core/__tests__/models/setupStep.ts
+++ b/core/__tests__/models/setupStep.ts
@@ -1,4 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
+import { rebuildConfig } from "actionhero";
 import { SetupStep, plugin } from "../../src";
 import { getSetupStepDescriptions } from "../../src/modules/ops/setupSteps";
 
@@ -11,6 +12,7 @@ describe("models/setupStep", () => {
 
   beforeEach(async () => {
     process.env.GROUPAROO_RUN_MODE = "cli:start";
+    rebuildConfig();
   });
 
   test("setupSteps will be created when the server boots", async () => {
@@ -44,6 +46,7 @@ describe("models/setupStep", () => {
 
   test("setupSteps ops returns config versions when in config mode", async () => {
     process.env.GROUPAROO_RUN_MODE = "cli:config";
+    rebuildConfig();
     const setupSteps = getSetupStepDescriptions();
     expect(setupSteps[0].key).toEqual("install_grouparoo");
     expect(setupSteps[1].key).toEqual("add_an_app");

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { api, specHelper } from "actionhero";
+import { api, rebuildConfig, specHelper } from "actionhero";
 import path from "path";
 import {
   ApiKey,
@@ -1132,6 +1132,7 @@ describe("modules/codeConfig", () => {
         await helper.truncate();
 
         process.env.GROUPAROO_RUN_MODE = "cli:config";
+        rebuildConfig();
         api.codeConfig.allowLockedModelChanges = true;
         const { errors, seenIds, deletedIds } = await loadConfigDirectory(
           path.join(__dirname, "..", "..", "fixtures", "codeConfig", "records")
@@ -1203,6 +1204,7 @@ describe("modules/codeConfig", () => {
         await helper.truncate();
 
         process.env.GROUPAROO_RUN_MODE = "cli:config";
+        rebuildConfig();
         api.codeConfig.allowLockedModelChanges = true;
         const { errors, seenIds, deletedIds } = await loadConfigDirectory(
           path.join(__dirname, "..", "..", "fixtures", "codeConfig", "initial")
@@ -1244,6 +1246,7 @@ describe("modules/codeConfig", () => {
       afterAll(async () => {
         await helper.truncate();
         process.env.GROUPAROO_RUN_MODE = undefined;
+        rebuildConfig();
       });
 
       test('settings are locked with "config:code"', async () => {
@@ -1538,6 +1541,7 @@ describe("modules/codeConfig", () => {
     describe("record", () => {
       beforeAll(async () => {
         process.env.GROUPAROO_RUN_MODE = "cli:config";
+        rebuildConfig();
         api.codeConfig.allowLockedModelChanges = true;
       });
 
@@ -1579,6 +1583,7 @@ describe("modules/codeConfig", () => {
 
       afterAll(() => {
         process.env.GROUPAROO_RUN_MODE = undefined;
+        rebuildConfig();
       });
     });
   });

--- a/core/__tests__/modules/configUser.ts
+++ b/core/__tests__/modules/configUser.ts
@@ -4,6 +4,7 @@ import { helper } from "@grouparoo/spec-helper";
 
 import { ConfigUser } from "../../src/modules/configUser";
 import { Setting, plugin } from "../../src";
+import { rebuildConfig } from "actionhero";
 
 const workerId = process.env.JEST_WORKER_ID;
 const configDir = `${os.tmpdir()}/test/${workerId}/configUser/config`;
@@ -15,6 +16,8 @@ describe("modules/ConfigUser", () => {
 
   beforeEach(async () => {
     process.env.GROUPAROO_RUN_MODE = "cli:config";
+    rebuildConfig();
+
     const localFile = await ConfigUser.localUserFilePath();
     if (fs.existsSync(localFile)) fs.rmSync(localFile);
     await Setting.truncate();
@@ -22,12 +25,14 @@ describe("modules/ConfigUser", () => {
 
   afterEach(async () => {
     process.env.GROUPAROO_RUN_MODE = undefined;
+    rebuildConfig();
     const localFile = await ConfigUser.localUserFilePath();
     if (fs.existsSync(localFile)) fs.rmSync(localFile);
   });
 
   test("does nothing unless in cli:config mode", async () => {
     process.env.GROUPAROO_RUN_MODE = undefined;
+    rebuildConfig();
     expect(fs.existsSync(await ConfigUser.localUserFilePath())).toEqual(false);
     await ConfigUser.create({
       email: "demo@grouparoo.com",

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -344,6 +344,11 @@ describe("modules/configWriter", () => {
         configObject = await app.getConfigObject();
       });
 
+      afterEach(() => {
+        process.env.GROUPAROO_RUN_MODE = undefined;
+        rebuildConfig();
+      });
+
       test('returns "config:writer" for JS files (LOCKED)', async () => {
         process.env.GROUPAROO_RUN_MODE = "cli:config";
         rebuildConfig();
@@ -356,9 +361,8 @@ describe("modules/configWriter", () => {
           objects: [configObject],
         });
         expect(ConfigWriter.getLockKey(configObject)).toEqual("config:writer");
-        process.env.GROUPAROO_RUN_MODE = undefined;
-        rebuildConfig();
       });
+
       test("returns null for JSON files (UNLOCKED)", async () => {
         process.env.GROUPAROO_RUN_MODE = "cli:config";
         rebuildConfig();
@@ -371,15 +375,12 @@ describe("modules/configWriter", () => {
           objects: [configObject],
         });
         expect(ConfigWriter.getLockKey(configObject)).toEqual(null);
-        process.env.GROUPAROO_RUN_MODE = undefined;
-        rebuildConfig();
       });
+
       test('returns "code:config" when in start mode', async () => {
         process.env.GROUPAROO_RUN_MODE = "cli:start";
         rebuildConfig();
         expect(ConfigWriter.getLockKey(configObject)).toEqual("config:code");
-        process.env.GROUPAROO_RUN_MODE = undefined;
-        rebuildConfig();
       });
     });
   });

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -24,6 +24,7 @@ import {
   ScheduleConfigurationObject,
   SourceConfigurationObject,
 } from "../../src/classes/codeConfig";
+import { rebuildConfig } from "actionhero";
 
 const workerId = process.env.JEST_WORKER_ID;
 const configDir = `${os.tmpdir()}/test/${workerId}/configWriter`;
@@ -59,10 +60,12 @@ describe("modules/configWriter", () => {
 
   beforeEach(async () => {
     process.env.GROUPAROO_RUN_MODE = "cli:config";
+    rebuildConfig();
   });
 
   afterEach(async () => {
     process.env.GROUPAROO_RUN_MODE = undefined;
+    rebuildConfig();
   });
 
   // ---------------------------------------- | ConfigWriter.generateId()
@@ -147,11 +150,13 @@ describe("modules/configWriter", () => {
       );
 
       process.env.GROUPAROO_RUN_MODE = "x";
+      rebuildConfig();
       await ConfigWriter.run();
       let files = glob.sync(configFilePattern);
       expect(files).toEqual([]);
 
       process.env.GROUPAROO_RUN_MODE = "cli:config";
+      rebuildConfig();
       await ConfigWriter.run();
       files = glob.sync(configFilePattern);
       expect(files).toContain(appFilePath);
@@ -341,6 +346,7 @@ describe("modules/configWriter", () => {
 
       test('returns "config:writer" for JS files (LOCKED)', async () => {
         process.env.GROUPAROO_RUN_MODE = "cli:config";
+        rebuildConfig();
         const absFilePath = path.join(
           configDir,
           `apps/${app.getConfigId()}.js`
@@ -351,9 +357,11 @@ describe("modules/configWriter", () => {
         });
         expect(ConfigWriter.getLockKey(configObject)).toEqual("config:writer");
         process.env.GROUPAROO_RUN_MODE = undefined;
+        rebuildConfig();
       });
       test("returns null for JSON files (UNLOCKED)", async () => {
         process.env.GROUPAROO_RUN_MODE = "cli:config";
+        rebuildConfig();
         const absFilePath = path.join(
           configDir,
           `apps/${app.getConfigId()}.json`
@@ -364,11 +372,14 @@ describe("modules/configWriter", () => {
         });
         expect(ConfigWriter.getLockKey(configObject)).toEqual(null);
         process.env.GROUPAROO_RUN_MODE = undefined;
+        rebuildConfig();
       });
       test('returns "code:config" when in start mode', async () => {
         process.env.GROUPAROO_RUN_MODE = "cli:start";
+        rebuildConfig();
         expect(ConfigWriter.getLockKey(configObject)).toEqual("config:code");
         process.env.GROUPAROO_RUN_MODE = undefined;
+        rebuildConfig();
       });
     });
   });

--- a/core/__tests__/modules/status.ts
+++ b/core/__tests__/modules/status.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { api, utils, config } from "actionhero";
+import { api, utils, config, rebuildConfig } from "actionhero";
 import {
   StatusMetric,
   FinalSummaryReporters,
@@ -20,6 +20,7 @@ describe("modules/status", () => {
 
   beforeAll(async () => {
     process.env.GROUPAROO_RUN_MODE = "x";
+    rebuildConfig();
     await helper.factories.properties();
   });
 

--- a/core/__tests__/modules/telemetry.ts
+++ b/core/__tests__/modules/telemetry.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { api, config } from "actionhero";
+import { api, config, rebuildConfig } from "actionhero";
 import fetch, { enableFetchMocks } from "jest-fetch-mock";
 
 import { Telemetry } from "../../src/modules/telemetry";
@@ -17,8 +17,9 @@ describe("modules/status", () => {
   beforeEach(async () => {
     await helper.truncate();
     await api.resque.queue.connection.redis.flushdb();
-    config.telemetry.enabled = true;
     process.env.GROUPAROO_RUN_MODE = "x";
+    rebuildConfig();
+    config.telemetry.enabled = true;
   });
 
   afterEach(() => {
@@ -183,6 +184,8 @@ describe("modules/status", () => {
   describe("telemetry initializer", () => {
     test("will send telemetry when running via the CLI", async () => {
       process.env.GROUPAROO_RUN_MODE = "cli:run";
+      rebuildConfig();
+      config.telemetry.enabled = true;
       fetch.mockResponseOnce(JSON.stringify({ response: "FROM TEST" }));
 
       const instance = new TelemetryInitializer();

--- a/core/__tests__/tasks/system/status/status.ts
+++ b/core/__tests__/tasks/system/status/status.ts
@@ -1,6 +1,6 @@
 import { helper } from "@grouparoo/spec-helper";
 import { Import, GrouparooRecord, RecordProperty, Run } from "../../../../src";
-import { api, task, specHelper } from "actionhero";
+import { api, task, specHelper, rebuildConfig } from "actionhero";
 import { StatusTask } from "../../../../src/tasks/system/status/status";
 import { Status } from "../../../../src/modules/status";
 
@@ -16,6 +16,7 @@ describe("tasks/status", () => {
 
     beforeEach(() => {
       process.env.GROUPAROO_RUN_MODE = "test";
+      rebuildConfig();
     });
 
     test("it can be enqueued", async () => {
@@ -29,6 +30,7 @@ describe("tasks/status", () => {
       await Status.setAll();
 
       process.env.GROUPAROO_RUN_MODE = "cli:run";
+      rebuildConfig();
       const instance = new StatusTask();
       const samples = await instance.getSamples();
       const complete = await instance.checkForComplete(samples);
@@ -42,6 +44,7 @@ describe("tasks/status", () => {
       await Status.setAll();
 
       process.env.GROUPAROO_RUN_MODE = "cli:run";
+      rebuildConfig();
       const instance = new StatusTask();
       const samples = await instance.getSamples();
       expect(await instance.checkForComplete(samples)).toBe(false);
@@ -60,6 +63,7 @@ describe("tasks/status", () => {
       await Status.setAll();
 
       process.env.GROUPAROO_RUN_MODE = "cli:run";
+      rebuildConfig();
       const instance = new StatusTask();
       const samples = await instance.getSamples();
       expect(await instance.checkForComplete(samples)).toBe(false);
@@ -79,6 +83,7 @@ describe("tasks/status", () => {
       await Status.setAll();
 
       process.env.GROUPAROO_RUN_MODE = "cli:run";
+      rebuildConfig();
       const instance = new StatusTask();
       const samples = await instance.getSamples();
       expect(await instance.checkForComplete(samples)).toBe(true);
@@ -103,6 +108,7 @@ describe("tasks/status", () => {
       await Status.setAll();
 
       process.env.GROUPAROO_RUN_MODE = "cli:run";
+      rebuildConfig();
       const instance = new StatusTask();
       const samples = await instance.getSamples();
       expect(await instance.checkForComplete(samples)).toBe(true);
@@ -122,6 +128,7 @@ describe("tasks/status", () => {
       await Status.setAll();
 
       process.env.GROUPAROO_RUN_MODE = "cli:run";
+      rebuildConfig();
       const instance = new StatusTask();
       const samples = await instance.getSamples();
       expect(await instance.checkForComplete(samples)).toBe(false);
@@ -134,6 +141,7 @@ describe("tasks/status", () => {
       await Status.setAll();
 
       process.env.GROUPAROO_RUN_MODE = "cli:run";
+      rebuildConfig();
       const instance = new StatusTask();
       const samples = await instance.getSamples();
       expect(await instance.checkForComplete(samples)).toBe(false);
@@ -154,6 +162,7 @@ describe("tasks/status", () => {
       await Status.setAll();
 
       process.env.GROUPAROO_RUN_MODE = "cli:run";
+      rebuildConfig();
       const instance = new StatusTask();
       const samples = await instance.getSamples();
       expect(await instance.checkForComplete(samples)).toBe(false);

--- a/core/package.json
+++ b/core/package.json
@@ -36,7 +36,7 @@
     "@types/fs-extra": "*",
     "@types/node": "16.*.*",
     "@types/validator": "*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "ah-sequelize-plugin": "5.0.2",
     "bcryptjs": "2.4.3",
     "cls-hooked": "4.2.2",

--- a/core/src/actions/config.ts
+++ b/core/src/actions/config.ts
@@ -1,3 +1,4 @@
+import { config, ParamsFrom } from "actionhero";
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { OptionallyAuthenticatedAction } from "../classes/actions/optionallyAuthenticatedAction";
 import { spawnPromise } from "../modules/spawnPromise";
@@ -5,7 +6,6 @@ import { ConfigUser } from "../modules/configUser";
 import { ConfigWriter } from "../modules/configWriter";
 import { APIData } from "../modules/apiData";
 import { ActionPermission } from "../models/Permission";
-import { ParamsFrom } from "actionhero";
 
 export class ConfigValidate extends AuthenticatedAction {
   name = "config:validate";
@@ -88,7 +88,7 @@ export class ConfigUserCreate extends OptionallyAuthenticatedAction {
   }: {
     params: ParamsFrom<ConfigUserCreate>;
   }) {
-    if (process.env.GROUPAROO_RUN_MODE !== "cli:config") {
+    if (config.general.runMode !== "cli:config") {
       throw new Error("Action only available in config mode.");
     }
     await ConfigUser.create(params);

--- a/core/src/actions/navigation.ts
+++ b/core/src/actions/navigation.ts
@@ -1,3 +1,4 @@
+import { config } from "actionhero";
 import { OptionallyAuthenticatedAction } from "../classes/actions/optionallyAuthenticatedAction";
 import { GrouparooModel } from "../models/GrouparooModel";
 import { ActionPermission } from "../models/Permission";
@@ -37,12 +38,12 @@ export class NavigationList extends OptionallyAuthenticatedAction {
     params: { modelId: string };
   }) {
     let configUser: ConfigUser.ConfigUserType;
-    if (process.env.GROUPAROO_RUN_MODE === "cli:config") {
+    if (config.general.runMode === "cli:config") {
       configUser = await ConfigUser.get();
     }
 
     const navigationMode: NavigationMode =
-      process.env.GROUPAROO_RUN_MODE === "cli:config"
+      config.general.runMode === "cli:config"
         ? configUser
           ? "config:authenticated"
           : "config:unauthenticated"

--- a/core/src/actions/properties.ts
+++ b/core/src/actions/properties.ts
@@ -168,7 +168,7 @@ export class PropertyCreate extends AuthenticatedAction {
     key: { required: false },
     type: { required: true },
     unique: { required: false, formatter: APIData.ensureBoolean },
-    isArray: { required: false },
+    isArray: { required: false, formatter: APIData.ensureBoolean },
     state: { required: false },
     sourceId: { required: false },
     options: { required: false, formatter: APIData.ensureObject },

--- a/core/src/actions/sources.ts
+++ b/core/src/actions/sources.ts
@@ -1,4 +1,4 @@
-import { api, ParamsFrom, log } from "actionhero";
+import { api, ParamsFrom, config, log } from "actionhero";
 import { AuthenticatedAction } from "../classes/actions/authenticatedAction";
 import { App } from "../models/App";
 import { Source } from "../models/Source";
@@ -205,7 +205,7 @@ export class SourceGenerateSampleRecords extends AuthenticatedAction {
   }) {
     const source = await Source.findById(params.id);
 
-    if (process.env.GROUPAROO_RUN_MODE !== "cli:config")
+    if (config.general.runMode !== "cli:config")
       throw new Error(`this action is only valid in cli:config mode`);
     if (source.state !== "ready") throw new Error(`source is not ready`);
     if (!(await source.previewAvailable()))

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -59,7 +59,7 @@ export class RunCLI extends CLI {
     this.checkWorkers();
 
     if (!params.web) GrouparooCLI.disableWebServer();
-    if (params.reset) await Reset.data(process.env.GROUPAROO_RUN_MODE);
+    if (params.reset) await Reset.data(config.general.runMode);
     if (params.resetHighWatermarks) await Reset.resetHighWatermarks();
     process.env.GROUPAROO_DISABLE_EXPORTS = String(
       params.export?.toString()?.toLowerCase() !== "true"

--- a/core/src/config/api.ts
+++ b/core/src/config/api.ts
@@ -25,6 +25,12 @@ export const DEFAULT = {
       serverName: packageJSON.name,
       // you can manually set the server id (not recommended)
       id: undefined as string,
+      runMode: process.env.GROUPAROO_RUN_MODE as
+        | "cli:run"
+        | "cli:start"
+        | "cli:config"
+        | "cli:apply"
+        | "cli:validate",
       welcomeMessage: `Welcome to the ${packageJSON.name} api`,
       // A unique token to your application that servers will use to authenticate to each other
       serverToken: process.env.SERVER_TOKEN ? process.env.SERVER_TOKEN : null,

--- a/core/src/initializers/codeConfig.ts
+++ b/core/src/initializers/codeConfig.ts
@@ -1,4 +1,4 @@
-import { api, log, Initializer } from "actionhero";
+import { api, log, config, Initializer } from "actionhero";
 import { loadConfigDirectory } from "../modules/configLoaders";
 import { getConfigDir } from "../modules/pluginDetails";
 import { GrouparooModel } from "../models/GrouparooModel";
@@ -31,7 +31,7 @@ export class CodeConfig extends Initializer {
   async start() {
     await CLS.wrap(async () => {
       const configDir = await getConfigDir(
-        process.env.GROUPAROO_RUN_MODE === "cli:config"
+        config.general.runMode === "cli:config"
       );
       const { errors } = await loadConfigDirectory(configDir);
       if (errors.length > 0)
@@ -46,7 +46,7 @@ export class CodeConfig extends Initializer {
 }
 
 async function loadSampleProfiles() {
-  if (process.env.GROUPAROO_RUN_MODE !== "cli:config") return;
+  if (config.general.runMode !== "cli:config") return;
 
   const models = await GrouparooModel.findAll();
   for (const model of models) {

--- a/core/src/initializers/plugins.ts
+++ b/core/src/initializers/plugins.ts
@@ -1,4 +1,4 @@
-import { Initializer, api, log, utils } from "actionhero";
+import { Initializer, config, api, log, utils } from "actionhero";
 import { GrouparooPlugin } from "../classes/plugin";
 import { plugin } from "../modules/plugin";
 import { App } from "../models/App";
@@ -73,9 +73,7 @@ export class Plugins extends Initializer {
     if (uiPlugins) {
       const relevantUiPlugin =
         uiPlugins[
-          process.env.GROUPAROO_RUN_MODE === "ui:config"
-            ? uiPlugins.length - 1
-            : 0
+          config.general.runMode === "cli:config" ? uiPlugins.length - 1 : 0
         ];
       if (relevantUiPlugin) {
         this.registerPlugin({

--- a/core/src/initializers/telemetry.ts
+++ b/core/src/initializers/telemetry.ts
@@ -1,6 +1,6 @@
 import { CLSInitializer } from "../classes/initializers/clsInitializer";
 import { Telemetry } from "../modules/telemetry";
-import { api } from "actionhero";
+import { api, config } from "actionhero";
 
 export class TelemetryInitializer extends CLSInitializer {
   constructor() {
@@ -12,8 +12,7 @@ export class TelemetryInitializer extends CLSInitializer {
   async startWithinTransaction() {}
 
   async stopWithinTransaction() {
-    const runMode = process.env.GROUPAROO_RUN_MODE;
-    if (runMode === "cli:run")
+    if (config.general.runMode === "cli:run")
       await Telemetry.send("cli_run", api.process.stopReasons);
   }
 }

--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -278,9 +278,7 @@ export class Group extends LoggedModel<Group> {
 
     if (this.state !== "deleted" && rules.length > 0) {
       this.state =
-        process.env.GROUPAROO_RUN_MODE === "cli:config"
-          ? "ready"
-          : "initializing";
+        config.general.runMode === "cli:config" ? "ready" : "initializing";
       this.changed("updatedAt", true);
       await this.save();
       return this.run();

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -569,9 +569,11 @@ export class Property extends LoggedModel<Property> {
   @AfterSave
   static async updateSampleRecords(instance: Property) {
     if (config.general.runMode !== "cli:config") return;
+    if (instance.state !== "ready") return;
 
     const source = await instance.$get("source");
     if (!source) return;
+
     const records = await GrouparooRecord.findAll({
       where: { modelId: source.modelId },
     });

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -568,7 +568,7 @@ export class Property extends LoggedModel<Property> {
 
   @AfterSave
   static async updateSampleRecords(instance: Property) {
-    if (process.env.GROUPAROO_RUN_MODE !== "cli:config") return;
+    if (config.general.runMode !== "cli:config") return;
 
     const source = await instance.$get("source");
     if (!source) return;

--- a/core/src/modules/configLoaders/record.ts
+++ b/core/src/modules/configLoaders/record.ts
@@ -1,3 +1,4 @@
+import { config } from "actionhero";
 import {
   RecordConfigurationObject,
   validateConfigObjectKeys,
@@ -12,7 +13,7 @@ export async function loadRecord(
   externallyValidate: boolean,
   validate = false
 ) {
-  if (process.env.GROUPAROO_RUN_MODE !== "cli:config") return;
+  if (config.general.runMode !== "cli:config") return;
 
   validateConfigObjectKeys(GrouparooRecord, configObject, ["properties"]);
 

--- a/core/src/modules/configUser.ts
+++ b/core/src/modules/configUser.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-
+import { config } from "actionhero";
 import { getConfigDir } from "../modules/pluginDetails";
 import { GrouparooSubscription } from "./grouparooSubscription";
 import { plugin } from "../modules/plugin";
@@ -53,7 +53,7 @@ export namespace ConfigUser {
     subscribed?: boolean;
     company: string;
   }) {
-    if (process.env.GROUPAROO_RUN_MODE !== "cli:config") return;
+    if (config.general.runMode !== "cli:config") return;
     await store();
     if (subscribed) await subscribe(email, subscribed);
     await storeCompanyName(company);

--- a/core/src/modules/configWriter.ts
+++ b/core/src/modules/configWriter.ts
@@ -1,4 +1,4 @@
-import { api } from "actionhero";
+import { api, config } from "actionhero";
 import fs from "fs";
 import path from "path";
 import prettier from "prettier";
@@ -84,7 +84,7 @@ export namespace ConfigWriter {
 
   export async function run() {
     // If we're not in config mode, do nothing.
-    if (process.env.GROUPAROO_RUN_MODE !== "cli:config") return;
+    if (config.general.runMode !== "cli:config") return;
     // Any models we see before starting would be from existing code config
     // files.
     if (!api.process.started) return;
@@ -170,7 +170,7 @@ export namespace ConfigWriter {
   export function getLockKey(
     configObject: AnyConfigurationObject
   ): string | null {
-    if (process.env.GROUPAROO_RUN_MODE !== "cli:config") {
+    if (config.general.runMode !== "cli:config") {
       return getCodeConfigLockKey();
     }
     if (isLockable(configObject)) {

--- a/core/src/modules/middleware/authentication.ts
+++ b/core/src/modules/middleware/authentication.ts
@@ -133,7 +133,7 @@ async function authenticateTeamMember(
   let error: Error & { code?: string };
 
   if (
-    process.env.GROUPAROO_RUN_MODE === "cli:config" &&
+    config.general.runMode === "cli:config" &&
     ["development", "test"].includes(env)
   ) {
     error = await authenticateConfigUser(data, optional);
@@ -195,12 +195,7 @@ async function authenticateTeamMemberInRoom(
     roomNameParts[0] === "model" ? roomNameParts[1] : roomNameParts[0]
   ) as ActionPermissionTopic;
 
-  if (
-    process.env.GROUPAROO_RUN_MODE === "cli:config" &&
-    env === "development"
-  ) {
-    return;
-  }
+  if (config.general.runMode === "cli:config" && env === "development") return;
 
   await CLS.wrap(async () => {
     const session = await api.session.load(connection);

--- a/core/src/modules/ops/property.ts
+++ b/core/src/modules/ops/property.ts
@@ -1,3 +1,4 @@
+import { config } from "actionhero";
 import { Property, SimplePropertyOptions } from "../../models/Property";
 import { Group } from "../../models/Group";
 import { Option } from "../../models/Option";
@@ -12,7 +13,7 @@ export namespace PropertyOps {
    * Enqueue Runs to update all Groups that rely on this Property
    */
   export async function enqueueRuns(property: Property) {
-    if (process.env.GROUPAROO_RUN_MODE === "cli:validate") return;
+    if (config.general.runMode === "cli:validate") return;
 
     await internalRun("property", property.id); // update *all* records
 

--- a/core/src/modules/ops/property.ts
+++ b/core/src/modules/ops/property.ts
@@ -5,7 +5,6 @@ import { Mapping } from "../../models/Mapping";
 import { GroupRule } from "../../models/GroupRule";
 import { internalRun } from "../internalRun";
 import { PluginOptionType } from "../../classes/plugin";
-import { Op } from "sequelize";
 import Mustache from "mustache";
 
 export namespace PropertyOps {

--- a/core/src/modules/ops/runs.ts
+++ b/core/src/modules/ops/runs.ts
@@ -1,3 +1,4 @@
+import { config, log, api, task } from "actionhero";
 import { Run } from "../../models/Run";
 import { GrouparooRecord } from "../../models/GrouparooRecord";
 import { Group } from "../../models/Group";
@@ -7,7 +8,6 @@ import { GrouparooModel } from "../../models/GrouparooModel";
 import { Property } from "../../models/Property";
 import { Import } from "../../models/Import";
 import { Op } from "sequelize";
-import { log, api, task } from "actionhero";
 import { Log } from "../../models/Log";
 import { TaskInputs } from "actionhero/dist/classes/task";
 
@@ -19,8 +19,8 @@ export namespace RunOps {
     creator: Group | GrouparooModel,
     destinationId?: string
   ) {
-    if (process.env.GROUPAROO_RUN_MODE === "cli:validate") return;
-    if (process.env.GROUPAROO_RUN_MODE === "cli:config") return;
+    if (config.general.runMode === "cli:validate") return;
+    if (config.general.runMode === "cli:config") return;
 
     await stopPreviousRuns(creator);
 

--- a/core/src/modules/ops/setupSteps.ts
+++ b/core/src/modules/ops/setupSteps.ts
@@ -1,3 +1,4 @@
+import { config } from "actionhero";
 import { plugin } from "../plugin";
 import { GrouparooModel } from "../../models/GrouparooModel";
 import { App } from "../../models/App";
@@ -120,7 +121,7 @@ export const getSetupStepDescriptions = (modelId?: string) => {
 
   return allSetupStepDescriptions
     .filter((ssd) =>
-      ssd.runModes.includes(process.env.GROUPAROO_RUN_MODE ?? "cli:start")
+      ssd.runModes.includes(config.general.runMode ?? "cli:start")
     )
     .map((ssd, idx) => {
       return { ...ssd, position: idx + 1 };

--- a/core/src/modules/telemetry.ts
+++ b/core/src/modules/telemetry.ts
@@ -39,7 +39,9 @@ export namespace Telemetry {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(await generateErrorPayload(error, trigger)),
         });
-      } catch (newError) {}
+      } catch (newError) {
+        console.error(newError);
+      }
 
       if (toThrowOnError) {
         throw error;

--- a/core/src/tasks/appRefreshQuery/check.ts
+++ b/core/src/tasks/appRefreshQuery/check.ts
@@ -1,3 +1,4 @@
+import { config } from "actionhero";
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { App } from "../../models/App";
 import { AppRefreshQuery } from "../../models/AppRefreshQuery";
@@ -6,7 +7,7 @@ import { CLS } from "../../modules/cls";
 export class AppRefreshQueriesCheck extends CLSTask {
   name = "appRefreshQueries:check";
   description = "check all appRefreshQueries and run them";
-  frequency = process.env.GROUPAROO_RUN_MODE === "cli:run" ? 0 : 1000 * 60; // Run every minute
+  frequency = config.general.runMode === "cli:run" ? 0 : 1000 * 60; // Run every minute
   queue = "apps";
   inputs = {};
 

--- a/core/src/tasks/group/updateCalculatedGroups.ts
+++ b/core/src/tasks/group/updateCalculatedGroups.ts
@@ -1,3 +1,4 @@
+import { config } from "actionhero";
 import { Group } from "../../models/Group";
 import { Run } from "../../models/Run";
 import { plugin } from "../../modules/plugin";
@@ -7,7 +8,7 @@ import { CLSTask } from "../../classes/tasks/clsTask";
 export class GroupsUpdateCalculatedGroups extends CLSTask {
   name = "group:updateCalculatedGroups";
   description = "enqueue an update of groups that to be updated";
-  frequency = process.env.GROUPAROO_RUN_MODE === "cli:run" ? 0 : 1000 * 60 * 5; // Run every 5 minutes
+  frequency = config.general.runMode === "cli:run" ? 0 : 1000 * 60 * 5; // Run every 5 minutes
   queue = "groups";
 
   async runWithinTransaction() {

--- a/core/src/tasks/run/recurringInternalRun.ts
+++ b/core/src/tasks/run/recurringInternalRun.ts
@@ -1,3 +1,4 @@
+import { config } from "actionhero";
 import { Setting } from "../../models/Setting";
 import { Run } from "../../models/Run";
 import { internalRun } from "../../modules/internalRun";
@@ -6,7 +7,7 @@ import { CLSTask } from "../../classes/tasks/clsTask";
 export class RunRecurringInternalRun extends CLSTask {
   name = "run:recurringInternalRun";
   description = "check if we should run an internal import on a frequency";
-  frequency = process.env.GROUPAROO_RUN_MODE === "cli:run" ? 0 : 1000 * 60 * 10; // 10 minutes
+  frequency = config.general.runMode === "cli:run" ? 0 : 1000 * 60 * 10; // 10 minutes
   queue = "runs";
 
   async runWithinTransaction() {

--- a/core/src/tasks/schedule/enqueueRuns.ts
+++ b/core/src/tasks/schedule/enqueueRuns.ts
@@ -1,12 +1,12 @@
+import { config, ParamsFrom } from "actionhero";
 import { Schedule } from "../../models/Schedule";
 import { CLSTask } from "../../classes/tasks/clsTask";
-import { ParamsFrom } from "actionhero";
 import { APIData } from "../../modules/apiData";
 
 export class ScheduleEnqueueRuns extends CLSTask {
   name = "schedules:enqueueRuns";
   description = "check all schedules and run them if it is time";
-  frequency = process.env.GROUPAROO_RUN_MODE === "cli:run" ? 0 : 1000 * 60; // Run every minute
+  frequency = config.general.runMode === "cli:run" ? 0 : 1000 * 60; // Run every minute
   queue = "schedules";
   inputs = {
     ignoreDeltas: {

--- a/core/src/tasks/system/status/status.ts
+++ b/core/src/tasks/system/status/status.ts
@@ -1,4 +1,4 @@
-import { api, log, task, env, ParamsFrom } from "actionhero";
+import { api, log, task, env, config, ParamsFrom } from "actionhero";
 import { GrouparooCLI } from "../../../modules/cli";
 import { APM } from "../../../modules/apm";
 import { Status, FinalSummary } from "../../../modules/status";
@@ -22,7 +22,7 @@ export class StatusTask extends CLSTask {
     worker: Worker
   ) {
     return APM.wrap(this.name, "task", worker, async () => {
-      const runMode = process.env.GROUPAROO_RUN_MODE;
+      const runMode = config.general.runMode;
 
       if (runMode === "cli:run") {
         // calculate stats inline

--- a/core/src/tasks/system/telemetry/telemetry.ts
+++ b/core/src/tasks/system/telemetry/telemetry.ts
@@ -1,4 +1,4 @@
-import { ParamsFrom } from "actionhero";
+import { config, ParamsFrom } from "actionhero";
 import { RetryableTask } from "../../../classes/tasks/retryableTask";
 import { APIData } from "../../../modules/apiData";
 import { Telemetry } from "../../../modules/telemetry";
@@ -6,8 +6,7 @@ import { Telemetry } from "../../../modules/telemetry";
 export class TelemetryTask extends RetryableTask {
   name = "telemetry";
   description = "send telemetry information about this cluster (recurring)";
-  frequency =
-    process.env.GROUPAROO_RUN_MODE === "cli:run" ? 0 : 1000 * 60 * 60 * 24; // every 24 hours
+  frequency = config.general.runMode === "cli:run" ? 0 : 1000 * 60 * 60 * 24; // every 24 hours
   queue = "system";
   inputs = {
     trigger: {

--- a/plugins/@grouparoo/airtable/package.json
+++ b/plugins/@grouparoo/airtable/package.json
@@ -39,7 +39,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/app-templates/package.json
+++ b/plugins/@grouparoo/app-templates/package.json
@@ -33,7 +33,7 @@
     "@types/jest": "*",
     "@types/node": "16.*.*",
     "@types/uuid": "*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "jest": "27.4.5",
     "nock": "13.2.1",
     "prettier": "2.5.1",

--- a/plugins/@grouparoo/bigquery/package.json
+++ b/plugins/@grouparoo/bigquery/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/braze/package.json
+++ b/plugins/@grouparoo/braze/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/calculated-property/package.json
+++ b/plugins/@grouparoo/calculated-property/package.json
@@ -32,7 +32,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "jest": "27.4.5",
     "prettier": "2.5.1",
     "ts-jest": "27.1.2",

--- a/plugins/@grouparoo/clickhouse/package.json
+++ b/plugins/@grouparoo/clickhouse/package.json
@@ -38,7 +38,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "csv-parse": "4.16.3",
     "jest": "27.4.5",
     "prettier": "2.5.1",

--- a/plugins/@grouparoo/cloudwatch/package.json
+++ b/plugins/@grouparoo/cloudwatch/package.json
@@ -37,7 +37,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "jest": "27.4.5",
     "prettier": "2.5.1",
     "ts-jest": "27.1.2",

--- a/plugins/@grouparoo/csv/package.json
+++ b/plugins/@grouparoo/csv/package.json
@@ -37,7 +37,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "jest": "27.4.5",
     "prettier": "2.5.1",
     "sequelize": "6.11.0",

--- a/plugins/@grouparoo/customerio/package.json
+++ b/plugins/@grouparoo/customerio/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "axios": "0.24.0",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",

--- a/plugins/@grouparoo/dbt/package.json
+++ b/plugins/@grouparoo/dbt/package.json
@@ -37,7 +37,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "jest": "27.4.5",
     "nock": "13.2.1",
     "prettier": "2.5.1",

--- a/plugins/@grouparoo/demo/package.json
+++ b/plugins/@grouparoo/demo/package.json
@@ -48,7 +48,7 @@
     "@types/glob": "7.2.0",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "jest": "27.4.5",
     "ts-jest": "27.1.2",
     "typescript": "4.5.4"

--- a/plugins/@grouparoo/eloqua/package.json
+++ b/plugins/@grouparoo/eloqua/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/facebook/package.json
+++ b/plugins/@grouparoo/facebook/package.json
@@ -39,7 +39,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/google-sheets/package.json
+++ b/plugins/@grouparoo/google-sheets/package.json
@@ -37,7 +37,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/hubspot/package.json
+++ b/plugins/@grouparoo/hubspot/package.json
@@ -37,7 +37,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/intercom/package.json
+++ b/plugins/@grouparoo/intercom/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/iterable/package.json
+++ b/plugins/@grouparoo/iterable/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/klaviyo/package.json
+++ b/plugins/@grouparoo/klaviyo/package.json
@@ -37,7 +37,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/logger/package.json
+++ b/plugins/@grouparoo/logger/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "jest": "27.4.5",
     "prettier": "2.5.1",
     "sequelize": "6.11.0",

--- a/plugins/@grouparoo/mailchimp/package.json
+++ b/plugins/@grouparoo/mailchimp/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/mailjet/package.json
+++ b/plugins/@grouparoo/mailjet/package.json
@@ -37,7 +37,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/marketo/package.json
+++ b/plugins/@grouparoo/marketo/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/mixpanel/package.json
+++ b/plugins/@grouparoo/mixpanel/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/mongo/package.json
+++ b/plugins/@grouparoo/mongo/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/mysql/package.json
+++ b/plugins/@grouparoo/mysql/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "*",
     "@types/mysql": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "csv-parse": "4.16.3",
     "jest": "27.4.5",
     "prettier": "2.5.1",

--- a/plugins/@grouparoo/newrelic/package.json
+++ b/plugins/@grouparoo/newrelic/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "jest": "27.4.5",
     "prettier": "2.5.1",
     "ts-jest": "27.1.2",

--- a/plugins/@grouparoo/onesignal/package.json
+++ b/plugins/@grouparoo/onesignal/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/pardot/package.json
+++ b/plugins/@grouparoo/pardot/package.json
@@ -38,7 +38,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/pipedrive/package.json
+++ b/plugins/@grouparoo/pipedrive/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/postgres/package.json
+++ b/plugins/@grouparoo/postgres/package.json
@@ -40,7 +40,7 @@
     "@types/jest": "*",
     "@types/node": "16.*.*",
     "@types/pg": "*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "csv-parse": "4.16.3",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/prometheus/package.json
+++ b/plugins/@grouparoo/prometheus/package.json
@@ -23,7 +23,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "axios": "0.24.0",
     "jest": "27.4.5",
     "ts-jest": "27.1.2",

--- a/plugins/@grouparoo/redshift/package.json
+++ b/plugins/@grouparoo/redshift/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "*",
     "@types/node": "16.*.*",
     "@types/pg": "*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "jest": "27.4.5",
     "prettier": "2.5.1",

--- a/plugins/@grouparoo/rollbar/package.json
+++ b/plugins/@grouparoo/rollbar/package.json
@@ -35,7 +35,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "jest": "27.4.5",
     "prettier": "2.5.1",
     "ts-jest": "27.1.2",

--- a/plugins/@grouparoo/sailthru/package.json
+++ b/plugins/@grouparoo/sailthru/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/salesforce/package.json
+++ b/plugins/@grouparoo/salesforce/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/sendgrid/package.json
+++ b/plugins/@grouparoo/sendgrid/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/sentry/package.json
+++ b/plugins/@grouparoo/sentry/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "jest": "27.4.5",
     "prettier": "2.5.1",
     "ts-jest": "27.1.2",

--- a/plugins/@grouparoo/snowflake/package.json
+++ b/plugins/@grouparoo/snowflake/package.json
@@ -37,7 +37,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/spec-helper/package.json
+++ b/plugins/@grouparoo/spec-helper/package.json
@@ -42,7 +42,7 @@
     "@types/faker": "*",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "jest": "27.4.5",
     "ts-jest": "27.1.2",
     "typescript": "4.5.4"

--- a/plugins/@grouparoo/sqlite/package.json
+++ b/plugins/@grouparoo/sqlite/package.json
@@ -38,7 +38,7 @@
     "@types/jest": "*",
     "@types/node": "16.*.*",
     "@types/pg": "*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "csv-parse": "4.16.3",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/vero/package.json
+++ b/plugins/@grouparoo/vero/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/plugins/@grouparoo/zendesk/package.json
+++ b/plugins/@grouparoo/zendesk/package.json
@@ -36,7 +36,7 @@
     "@grouparoo/spec-helper": "0.8.0-alpha.5",
     "@types/jest": "*",
     "@types/node": "16.*.*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "dotenv": "10.0.0",
     "fs-extra": "10.0.0",
     "jest": "27.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,7 +263,7 @@ importers:
       '@types/semver': 7.3.9
       '@types/tar': 6.1.1
       '@types/validator': '*'
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       ah-sequelize-plugin: 5.0.2
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
@@ -311,8 +311,8 @@ importers:
       '@types/fs-extra': 9.0.12
       '@types/node': 16.9.1
       '@types/validator': 13.6.3
-      actionhero: 28.1.3
-      ah-sequelize-plugin: 5.0.2_f5d7d235443044d91bb67c343aa8c892
+      actionhero: 28.1.4
+      ah-sequelize-plugin: 5.0.2_f29751961d501bdbc450ca676b95fe81
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
       colors: 1.4.0
@@ -374,7 +374,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       airtable: 0.11.1
       axios: 0.24.0
       dotenv: 10.0.0
@@ -396,7 +396,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -415,7 +415,7 @@ importers:
       '@types/jest': '*'
       '@types/node': 16.*.*
       '@types/uuid': '*'
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       nock: 13.2.1
       prettier: 2.5.1
@@ -428,7 +428,7 @@ importers:
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
       '@types/uuid': 8.3.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       nock: 13.2.1
       prettier: 2.5.1
@@ -444,7 +444,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -461,7 +461,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -478,7 +478,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -497,7 +497,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -514,7 +514,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       prettier: 2.5.1
       ts-jest: 27.1.2
@@ -527,7 +527,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       prettier: 2.5.1
       ts-jest: 27.1.2_7d0b94f8a3f5aee865ab4c59ede8c0bf
@@ -541,7 +541,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       clickhouse: 2.4.2
       csv-parse: 4.16.3
       jest: 27.4.5
@@ -560,7 +560,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       csv-parse: 4.16.3
       jest: 27.4.5
       prettier: 2.5.1
@@ -574,7 +574,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       aws-sdk: 2.1049.0
       jest: 27.4.5
       prettier: 2.5.1
@@ -592,7 +592,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       prettier: 2.5.1
       ts-jest: 27.1.2_7d0b94f8a3f5aee865ab4c59ede8c0bf
@@ -605,7 +605,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       csv-parser: 3.0.0
       fs-extra: 10.0.0
@@ -624,7 +624,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       prettier: 2.5.1
       sequelize: 6.11.0
@@ -639,7 +639,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       customerio-node: 3.1.0
       dotenv: 10.0.0
@@ -658,7 +658,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -675,7 +675,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       js-yaml: 4.1.0
       nock: 13.2.1
@@ -689,7 +689,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       nock: 13.2.1
       prettier: 2.5.1
@@ -703,7 +703,7 @@ importers:
       '@types/glob': 7.2.0
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       csv-parse: 4.16.3
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -740,7 +740,7 @@ importers:
       '@types/glob': 7.2.0
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       ts-jest: 27.1.2_7d0b94f8a3f5aee865ab4c59ede8c0bf
       typescript: 4.5.4
@@ -752,7 +752,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -770,7 +770,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -787,7 +787,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       currency-codes: 2.1.0
       dotenv: 10.0.0
       facebook-nodejs-business-sdk: 12.0.1
@@ -811,7 +811,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -828,7 +828,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       csv-write-stream: 2.0.0
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -850,7 +850,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -869,7 +869,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -890,7 +890,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -908,7 +908,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       intercom-client: 2.11.2
@@ -926,7 +926,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -943,7 +943,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -961,7 +961,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -978,7 +978,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -998,7 +998,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1015,7 +1015,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       prettier: 2.5.1
       sequelize: 6.11.0
@@ -1028,7 +1028,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       prettier: 2.5.1
       sequelize: 6.11.0
@@ -1042,7 +1042,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1061,7 +1061,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1079,7 +1079,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -1100,7 +1100,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1119,7 +1119,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1136,7 +1136,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1153,7 +1153,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -1171,7 +1171,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1188,7 +1188,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1205,7 +1205,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1222,7 +1222,7 @@ importers:
       '@types/jest': '*'
       '@types/mysql': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       csv-parse: 4.16.3
       jest: 27.4.5
       mysql: 2.18.1
@@ -1239,7 +1239,7 @@ importers:
       '@types/jest': 27.0.1
       '@types/mysql': 2.15.19
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       csv-parse: 4.16.3
       jest: 27.4.5
       prettier: 2.5.1
@@ -1253,7 +1253,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       newrelic: 8.6.0
       prettier: 2.5.1
@@ -1266,7 +1266,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       prettier: 2.5.1
       ts-jest: 27.1.2_7d0b94f8a3f5aee865ab4c59ede8c0bf
@@ -1279,7 +1279,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1297,7 +1297,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1314,7 +1314,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       dotenv: 10.0.0
       form-data: 4.0.0
@@ -1336,7 +1336,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1353,7 +1353,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -1371,7 +1371,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1389,7 +1389,7 @@ importers:
       '@types/jest': '*'
       '@types/node': 16.*.*
       '@types/pg': '*'
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       csv-parse: 4.16.3
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1413,7 +1413,7 @@ importers:
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
       '@types/pg': 8.6.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       csv-parse: 4.16.3
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1428,7 +1428,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       jest: 27.4.5
       prom-client: 14.0.1
@@ -1441,7 +1441,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       jest: 27.4.5
       ts-jest: 27.1.2_7d0b94f8a3f5aee865ab4c59ede8c0bf
@@ -1456,7 +1456,7 @@ importers:
       '@types/jest': '*'
       '@types/node': 16.*.*
       '@types/pg': '*'
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       jest: 27.4.5
       prettier: 2.5.1
@@ -1472,7 +1472,7 @@ importers:
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
       '@types/pg': 8.6.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       jest: 27.4.5
       prettier: 2.5.1
@@ -1486,7 +1486,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       prettier: 2.5.1
       rollbar: 2.24.0
@@ -1499,7 +1499,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       prettier: 2.5.1
       ts-jest: 27.1.2_7d0b94f8a3f5aee865ab4c59ede8c0bf
@@ -1512,7 +1512,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1530,7 +1530,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1547,7 +1547,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1565,7 +1565,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1583,7 +1583,7 @@ importers:
       '@sendgrid/client': 7.6.0
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1600,7 +1600,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1618,7 +1618,7 @@ importers:
       '@sentry/tracing': 6.16.1
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       prettier: 2.5.1
       ts-jest: 27.1.2
@@ -1631,7 +1631,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       prettier: 2.5.1
       ts-jest: 27.1.2_7d0b94f8a3f5aee865ab4c59ede8c0bf
@@ -1644,7 +1644,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1664,7 +1664,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1680,7 +1680,7 @@ importers:
       '@types/faker': '*'
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       faker: 5.5.3
       fs-extra: 10.0.0
@@ -1704,7 +1704,7 @@ importers:
       '@types/faker': 5.5.8
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       jest: 27.4.5
       ts-jest: 27.1.2_7d0b94f8a3f5aee865ab4c59ede8c0bf
       typescript: 4.5.4
@@ -1718,7 +1718,7 @@ importers:
       '@types/node': 16.*.*
       '@types/pg': '*'
       '@types/sqlite3': 3.1.8
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       csv-parse: 4.16.3
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1738,7 +1738,7 @@ importers:
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
       '@types/pg': 8.6.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       csv-parse: 4.16.3
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1755,7 +1755,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       axios: 0.24.0
       dotenv: 10.0.0
       fs-extra: 10.0.0
@@ -1773,7 +1773,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1790,7 +1790,7 @@ importers:
       '@grouparoo/spec-helper': 0.8.0-alpha.5
       '@types/jest': '*'
       '@types/node': 16.*.*
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1808,7 +1808,7 @@ importers:
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       fs-extra: 10.0.0
       jest: 27.4.5
@@ -1826,7 +1826,7 @@ importers:
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       enzyme: 3.11.0
       eslint: 8.6.0
@@ -1856,7 +1856,7 @@ importers:
       '@types/jest': 27.0.1
       '@types/react': 17.0.20
       '@types/react-dom': 17.0.9
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       enzyme: 3.11.0
       eslint: 8.6.0
       eslint-config-next: 12.0.7_7d5ff8d8e1054d856b46ec86cec9a25f
@@ -1954,7 +1954,7 @@ importers:
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       ansi-to-html: 0.7.2
       bluebird: 3.7.2
       dotenv: 10.0.0
@@ -1990,7 +1990,7 @@ importers:
       '@types/jest': 27.0.1
       '@types/react': 17.0.20
       '@types/react-dom': 17.0.9
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       enzyme: 3.11.0
       eslint: 8.6.0
       eslint-config-next: 12.0.7_7d5ff8d8e1054d856b46ec86cec9a25f
@@ -2009,7 +2009,7 @@ importers:
       '@types/jest': '*'
       '@types/react': '*'
       '@types/react-dom': '*'
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       dotenv: 10.0.0
       enzyme: 3.11.0
       eslint: 8.6.0
@@ -2039,7 +2039,7 @@ importers:
       '@types/jest': 27.0.1
       '@types/react': 17.0.20
       '@types/react-dom': 17.0.9
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       enzyme: 3.11.0
       eslint: 8.6.0
       eslint-config-next: 12.0.7_7d5ff8d8e1054d856b46ec86cec9a25f
@@ -4777,8 +4777,8 @@ packages:
     hasBin: true
     dev: true
 
-  /actionhero/28.1.3:
-    resolution: {integrity: sha512-qZFq5l84GX4MNeRdFlOzdTeK1lzqqSnyKTqEJx2VEMDAn1CGPCpX5YWVwrWDMh5qvMX62sFs6C8sUGEhrVkI4g==}
+  /actionhero/28.1.4:
+    resolution: {integrity: sha512-lOEOj8INYQo86bWRnQA2zn4xk720x1Qu8svwqUtIzwEY2q88qNg8LKmolw8ib1oUZ4A8GquQIU2ZchbzK6oZ/w==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     requiresBuild: true
@@ -4840,7 +4840,7 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ah-sequelize-plugin/5.0.2_f5d7d235443044d91bb67c343aa8c892:
+  /ah-sequelize-plugin/5.0.2_f29751961d501bdbc450ca676b95fe81:
     resolution: {integrity: sha512-VypFqPeJrP3e3MBYGwr9OEGuAQ7uU1ewe+NEsZmPHyhsBYaYyKdwPF6zXE6TVu5McmKM2EpdXfoBbWpLFTRi+w==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -4848,7 +4848,7 @@ packages:
       sequelize: '>=6.4.0'
       sequelize-typescript: '>=2.0.0'
     dependencies:
-      actionhero: 28.1.3
+      actionhero: 28.1.4
       sequelize: 6.11.0_98f032adade92d92d5295670c0365597
       sequelize-typescript: 2.1.2_da14a5dc29bdc739bd46c44883ffb3aa
       umzug: 3.0.0

--- a/ui/ui-community/package.json
+++ b/ui/ui-community/package.json
@@ -43,7 +43,7 @@
     "@types/jest": "*",
     "@types/react": "*",
     "@types/react-dom": "*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "enzyme": "3.11.0",
     "eslint": "8.6.0",
     "eslint-config-next": "12.0.7",

--- a/ui/ui-config/package.json
+++ b/ui/ui-config/package.json
@@ -46,7 +46,7 @@
     "@types/jest": "*",
     "@types/react": "*",
     "@types/react-dom": "*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "enzyme": "3.11.0",
     "eslint": "8.6.0",
     "eslint-config-next": "12.0.7",

--- a/ui/ui-enterprise/package.json
+++ b/ui/ui-enterprise/package.json
@@ -43,7 +43,7 @@
     "@types/jest": "*",
     "@types/react": "*",
     "@types/react-dom": "*",
-    "actionhero": "28.1.3",
+    "actionhero": "28.1.4",
     "enzyme": "3.11.0",
     "eslint": "8.6.0",
     "eslint-config-next": "12.0.7",


### PR DESCRIPTION
When using `grouparoo config`, after creating a new Property, Sample Records prior to this PR did not properly show that there was a pending property.... now they do!  Having this badge that something is pending will be a good motivator for the user to hit that 'import' button again.

<img width="1176" alt="Screen Shot 2022-01-12 at 10 54 00 AM" src="https://user-images.githubusercontent.com/303226/149207061-299d7bd2-9b78-4bc5-a4b4-4de50ccd92c2.png">

In other modes, adding a new Property would enqueue a Run to update all the Properties, but that doesn't happen in `grouparoo config` mode.  For this use-case, have a new `@afterSave` hook. 

---

To clarify the environment Grouparoo is running in, this PR also swaps the usage of `process.env.GROUPAROO_RUN_MODE` for `config.general.runMode`.  This provides proper typing and validation for this config setting.  As we modify this value often in tests, Actionhero needed to be updated to the latest version which now exports `rebuildConfig()` which can be used to re-create the config object after ENV changes

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
