### PR TITLE
add button on model overview page schedules to "Run Now"

### DIFF
--- a/ui/ui-components/components/model/overview/ModelOverviewSchedules.tsx
+++ b/ui/ui-components/components/model/overview/ModelOverviewSchedules.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import EnterpriseLink from "../../GrouparooLink";
-import { Models } from "../../../utils/apiData";
+import { Actions, Models } from "../../../utils/apiData";
 import { formatName } from "../../../utils/formatName";
 import { formatSchedule } from "../../../utils/formatSchedule";
 import SectionContainer from "../../lib/SectionContainer";
@@ -8,13 +8,34 @@ import EntityInfoContainer from "../../lib/entity/EntityInfoContainer";
 import EntityInfoHeader from "../../lib/entity/EntityInfoHeader";
 import RunAllSchedulesButton from "../../schedule/RunAllSchedulesButton";
 import { ApiHook } from "../../../hooks/useApi";
+import { successHandler } from "../../../utils/eventHandlers";
 import { useGrouparooModelContext } from "../../../contexts/grouparooModel";
 import EntityList from "../../lib/entity/EntityList";
+import LoadingButton from "../../LoadingButton";
+import { grouparooUiEdition } from "../../../utils/uiEdition";
 
 const ScheduleInfo: React.FC<{
   schedule: Models.ScheduleType;
   source?: Models.SourceType;
-}> = ({ schedule, source }) => {
+  execApi: ApiHook["execApi"];
+}> = ({ schedule, source, execApi }) => {
+  const [loading, setLoading] = useState(false);
+
+  async function enqueueScheduleRun() {
+    setLoading(true);
+    try {
+      const response: Actions.ScheduleRun = await execApi(
+        "post",
+        `/schedule/${schedule.id}/run`
+      );
+      if (response.run) {
+        successHandler.set({ message: `run ${response.run.id} enqueued` });
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
     <EntityInfoContainer app={source.app}>
       <EntityInfoHeader
@@ -24,6 +45,19 @@ const ScheduleInfo: React.FC<{
       />
       <div>Source: {formatName(source)}</div>
       <div>Schedule: {formatSchedule(schedule)}</div>
+      {grouparooUiEdition() !== "config" && (
+        <LoadingButton
+          className="mt-1"
+          variant="outline-primary"
+          size="sm"
+          loading={loading}
+          onClick={() => {
+            enqueueScheduleRun();
+          }}
+        >
+          Run Now
+        </LoadingButton>
+      )}
     </EntityInfoContainer>
   );
 };
@@ -76,6 +110,7 @@ const ModelOverviewSchedules: React.FC<Props> = ({
           <ScheduleInfo
             schedule={schedule}
             source={sourcesById[schedule.sourceId]}
+            execApi={execApi}
           />
         )}
       />


### PR DESCRIPTION
## Change description

After removing the source list page, Community edition had no way of running a specific schedule. This adds the `run now` button back to the model overview page.

![image](https://user-images.githubusercontent.com/4368928/149373535-71cc1151-f86c-444b-863b-920a4f21184d.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
