### PR TITLE
Suggest an available key on the multiple props page

### DIFF
--- a/core/__tests__/actions/sources/sources.ts
+++ b/core/__tests__/actions/sources/sources.ts
@@ -17,7 +17,6 @@ import {
 import { PropertyDestroy } from "../../../src/actions/properties";
 import { ConfigWriter } from "../../../src/modules/configWriter";
 
-
 describe("actions/sources", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
   const configSpy = jest.spyOn(ConfigWriter, "run");

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -374,6 +374,7 @@ export class Property extends LoggedModel<Property> {
         id: { [Op.ne]: instance.id },
         key: instance.key,
         state: { [Op.notIn]: ["draft", "deleted"] },
+        // sourceId: instance.sourceId
       },
     });
     if (count > 0) {

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -374,7 +374,6 @@ export class Property extends LoggedModel<Property> {
         id: { [Op.ne]: instance.id },
         key: instance.key,
         state: { [Op.notIn]: ["draft", "deleted"] },
-        // sourceId: instance.sourceId
       },
     });
     if (count > 0) {

--- a/core/src/modules/tableSpeculation.ts
+++ b/core/src/modules/tableSpeculation.ts
@@ -1,6 +1,7 @@
 import { GrouparooModel, Option } from "..";
 import { Property, PropertyTypes } from "../models/Property";
 import { Source } from "../models/Source";
+import { ConfigWriter } from "../modules/configWriter";
 
 export namespace TableSpeculation {
   const uniqueMatchers = [
@@ -67,7 +68,7 @@ export namespace TableSpeculation {
   ): string {
     for (const property of existingProperties) {
       if (property.key === key) {
-        return `${model.name}_${key}`;
+        return `${ConfigWriter.generateId(model.name)}_${key}`;
       }
     }
     return key;

--- a/core/src/modules/tableSpeculation.ts
+++ b/core/src/modules/tableSpeculation.ts
@@ -1,4 +1,6 @@
-import { PropertyTypes } from "../models/Property";
+import { GrouparooModel, Option } from "..";
+import { Property, PropertyTypes } from "../models/Property";
+import { Source } from "../models/Source";
 
 export namespace TableSpeculation {
   const uniqueMatchers = [
@@ -56,5 +58,18 @@ export namespace TableSpeculation {
     }
 
     return databaseType;
+  }
+
+  export function suggestKey(
+    key: string,
+    model: GrouparooModel,
+    existingProperties: Property[]
+  ): string {
+    for (const property of existingProperties) {
+      if (property.key === key) {
+        return `${model.name}_${key}`;
+      }
+    }
+    return key;
   }
 }

--- a/core/src/modules/tableSpeculation.ts
+++ b/core/src/modules/tableSpeculation.ts
@@ -1,6 +1,5 @@
-import { GrouparooModel, Option } from "..";
+import { GrouparooModel } from "../models/GrouparooModel";
 import { Property, PropertyTypes } from "../models/Property";
-import { Source } from "../models/Source";
 import { ConfigWriter } from "../modules/configWriter";
 
 export namespace TableSpeculation {

--- a/core/src/modules/tableSpeculation.ts
+++ b/core/src/modules/tableSpeculation.ts
@@ -64,7 +64,7 @@ export namespace TableSpeculation {
     key: string,
     model: GrouparooModel,
     existingProperties: Property[]
-  ): string {
+  ) {
     const matchingProperty = existingProperties.find((p) => p.key === key);
     return matchingProperty
       ? `${ConfigWriter.generateId(model.name)}_${key}`

--- a/core/src/modules/tableSpeculation.ts
+++ b/core/src/modules/tableSpeculation.ts
@@ -65,11 +65,9 @@ export namespace TableSpeculation {
     model: GrouparooModel,
     existingProperties: Property[]
   ): string {
-    for (const property of existingProperties) {
-      if (property.key === key) {
-        return `${ConfigWriter.generateId(model.name)}_${key}`;
-      }
-    }
-    return key;
+    const matchingProperty = existingProperties.find((p) => p.key === key);
+    return matchingProperty
+      ? `${ConfigWriter.generateId(model.name)}_${key}`
+      : key;
   }
 }

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -197,7 +197,7 @@ export default function Page(props) {
               value={key}
               onChange={(e) => setKey(e.target.value)}
               disabled={disabled}
-            />{!exactProperty && key !== column ? <Alert variant="info">Property with key "{column}" already exists</Alert>: null}
+            />{!exactProperty && key !== column ? <Alert variant="info" className="mt-2">Property with key "{column}" already exists, suggesting "{key}" instead.</Alert>: null}
           </td>
           <td>
             <Form.Control

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -198,10 +198,10 @@ export default function Page(props) {
               disabled={disabled}
             />
             {!exactProperty && key !== column ? (
-              <Alert variant="info" className="mt-2">
-                Property with key "{column}" already exists, suggesting "{key}"
-                instead.
-              </Alert>
+              <Form.Text
+                id="suggestedKeyText"
+                muted
+              >{`Property with key "${column}" already exists, suggesting "${key}" instead.`}</Form.Text>
             ) : null}
           </td>
           <td>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -77,7 +77,6 @@ export default function Page(props) {
     let otherProperties: Models.PropertyType[] = [];
 
     for (const property of properties) {
-      // console.log(property)
       if (property.sourceId !== source.id) continue;
       if (property.options[primaryOptionKey] !== column) continue;
 
@@ -395,7 +394,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
     `/propertyOptions`
   );
 
-  console.log(preview)
 
   return {
     model,

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -111,7 +111,6 @@ export default function Page(props) {
       exactProperty && exactProperty.sourceId === source.id
         ? exactProperty.key
         : columnSpeculation[column].suggestedPropertyKey
-        
     );
     const [type, setType] = useState<typeof exactProperty["type"]>(
       exactProperty && exactProperty.sourceId === source.id
@@ -197,7 +196,13 @@ export default function Page(props) {
               value={key}
               onChange={(e) => setKey(e.target.value)}
               disabled={disabled}
-            />{!exactProperty && key !== column ? <Alert variant="info" className="mt-2">Property with key "{column}" already exists, suggesting "{key}" instead.</Alert>: null}
+            />
+            {!exactProperty && key !== column ? (
+              <Alert variant="info" className="mt-2">
+                Property with key "{column}" already exists, suggesting "{key}"
+                instead.
+              </Alert>
+            ) : null}
           </td>
           <td>
             <Form.Control
@@ -393,7 +398,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
     "get",
     `/propertyOptions`
   );
-
 
   return {
     model,

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -77,6 +77,7 @@ export default function Page(props) {
     let otherProperties: Models.PropertyType[] = [];
 
     for (const property of properties) {
+      // console.log(property)
       if (property.sourceId !== source.id) continue;
       if (property.options[primaryOptionKey] !== column) continue;
 
@@ -110,9 +111,8 @@ export default function Page(props) {
     const [key, setKey] = useState(
       exactProperty && exactProperty.sourceId === source.id
         ? exactProperty.key
-        : exactProperty && exactProperty.sourceId !== source.id
-        ? generateId(`${source.name}-${column}`)
-        : generateId(column)
+        : columnSpeculation[column].suggestedPropertyKey
+        
     );
     const [type, setType] = useState<typeof exactProperty["type"]>(
       exactProperty && exactProperty.sourceId === source.id
@@ -198,7 +198,7 @@ export default function Page(props) {
               value={key}
               onChange={(e) => setKey(e.target.value)}
               disabled={disabled}
-            />
+            />{!exactProperty && key !== column ? <Alert variant="info">Property with key "{column}" already exists</Alert>: null}
           </td>
           <td>
             <Form.Control
@@ -394,6 +394,8 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
     "get",
     `/propertyOptions`
   );
+
+  console.log(preview)
 
   return {
     model,


### PR DESCRIPTION
## Change description

It was possible for the "add multiple properties" page to suggest property keys that are already being used, leading to an unhelpful error message. 

This change will suggest something less likely to conflict with a previous property.

The logic for making a suggested name is now in the `source:preview` action and occurs at the same time as column types and uniqueness are being speculated on.

![Screen Shot 2022-01-13 at 2 42 04 PM](https://user-images.githubusercontent.com/6589528/149420530-1c26f943-2d9f-4537-8731-1e071acd3e6e.png)
![Screen Shot 2022-01-13 at 2 48 25 PM](https://user-images.githubusercontent.com/6589528/149421259-d57a0826-271b-414e-b7c7-c490ea4bf9ea.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
