### PR TITLE
Fix method signature for trackAnonymous in customer.io plugin

### DIFF
--- a/plugins/@grouparoo/customerio/src/lib/client.ts
+++ b/plugins/@grouparoo/customerio/src/lib/client.ts
@@ -18,8 +18,8 @@ class CustomerioClient {
     return this.client.identify(customerId, payload);
   }
 
-  async trackAnonymous(data: object) {
-    return this.client.trackAnonymous(data);
+  async trackAnonymous(anonymousId: string | number, data: object) {
+    return this.client.trackAnonymous(anonymousId, data);
   }
 
   async getCustomer(customerId: string) {

--- a/plugins/@grouparoo/customerio/src/lib/test.ts
+++ b/plugins/@grouparoo/customerio/src/lib/test.ts
@@ -4,7 +4,7 @@ import { connect } from "./connect";
 export const test: TestPluginMethod = async ({ appOptions }) => {
   const client = await connect(appOptions);
 
-  await client.trackAnonymous({
+  await client.trackAnonymous("123", {
     name: "grouparoo_test_connection",
   });
 


### PR DESCRIPTION
## Change description

Customer.IO integration fails at testing connection with the error `Test Failed data.name is required`.

This happens because it's using the `TrackClient` from `customerio-node`, whose method signature for `trackAnonymous` expects 2 parameters: `anonymousId` and `data`. ([Code](https://github.com/customerio/customerio-node/blob/main/lib/track.ts#L74)) Currently, the code is only passing in `data`.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [ ] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
