### PR TITLE
Create an InternalRun when Property Type changes

### DIFF
--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -583,7 +583,6 @@ describe("models/property", () => {
     afterEach(async () => {
       await emailProperty.update({ type: "email" });
       process.env.GROUPAROO_RUN_MODE = undefined;
-      rebuildConfig();
     });
 
     test("updating a property's type will enqueue an internal run in most run modes", async () => {
@@ -598,7 +597,6 @@ describe("models/property", () => {
 
     test("updating a property's type will mark the records and properties pending in cli:config", async () => {
       process.env.GROUPAROO_RUN_MODE = "cli:config";
-      rebuildConfig();
 
       const record = await helper.factories.record();
 

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -551,19 +551,9 @@ export class Property extends LoggedModel<Property> {
   }
 
   @AfterSave
-  static async ensureRecordsMarkedPendingOnTypeChange(instance: Property) {
+  static async updateRecordsOnTypeChange(instance: Property) {
     if (instance.changed("type") && instance.state === "ready") {
-      await RecordProperty.update(
-        { state: "pending", startedAt: null },
-        { where: { propertyId: instance.id } }
-      );
-
-      const source = await instance.$get("source");
-
-      await GrouparooRecord.update(
-        { state: "pending" },
-        { where: { modelId: source.modelId } }
-      );
+      await PropertyOps.enqueueRuns(instance);
     }
   }
 

--- a/core/src/modules/internalRun.ts
+++ b/core/src/modules/internalRun.ts
@@ -13,9 +13,7 @@ export async function internalRun(creatorType: string, creatorId: string) {
     },
   });
 
-  for (const i in previousRuns) {
-    await previousRuns[i].stop();
-  }
+  for (const previousRun of previousRuns) await previousRun.stop();
 
   const run = await Run.create({
     creatorType,


### PR DESCRIPTION
This PR updates the logic added in https://github.com/grouparoo/grouparoo/pull/2766 to use an InternalRun to update Records when a Property's type changes.  While the logic is similar, and execution time is slower, this approach has a few  benefits:

* Shared Code with other Property Updates
* Related models will also be marked pending and updated, e.g. Groups & Group Members
* Imports will be created to track any changes to Record Properties (e.g. data is invalid now)
* For larger datasets, doing this work in a task will spread out the load over time

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
