### PR TITLE
Mailchimp OAuth works in config mode

### DIFF
--- a/plugins/@grouparoo/mailchimp/src/lib/connect.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/connect.ts
@@ -3,9 +3,7 @@ import Mailchimp from "mailchimp-api-v3";
 import axios from "axios";
 
 export async function connect(appOptions: SimpleAppOptions) {
-  if (appOptions.apiKey) {
-    return new Mailchimp(appOptions.apiKey?.toString());
-  } else if (appOptions.oAuthToken) {
+  if (appOptions.oAuthToken) {
     const oAuthToken = appOptions.oAuthToken.toString();
 
     const metaResponse = await axios.get(
@@ -30,4 +28,6 @@ export async function connect(appOptions: SimpleAppOptions) {
     //@ts-ignore Mailchimp client typings have not been updated for OAuth support (with dc param)
     return new Mailchimp(oAuthToken, datacenter);
   }
+
+  return new Mailchimp(appOptions.apiKey?.toString());
 }

--- a/ui/ui-components/pages/app/[id]/edit.tsx
+++ b/ui/ui-components/pages/app/[id]/edit.tsx
@@ -387,7 +387,9 @@ export default function Page(props) {
                                   <br />
                                   <LoadingButton
                                     size="sm"
-                                    disabled={app.locked || loadingOAuth}
+                                    disabled={
+                                      Boolean(app.locked) || loadingOAuth
+                                    }
                                     loading={loadingOAuth}
                                     variant="outline-primary"
                                     onClick={() => startOAuthLogin(opt.key)}

--- a/ui/ui-components/pages/app/[id]/edit.tsx
+++ b/ui/ui-components/pages/app/[id]/edit.tsx
@@ -387,7 +387,7 @@ export default function Page(props) {
                                   <br />
                                   <LoadingButton
                                     size="sm"
-                                    disabled={loadingOAuth}
+                                    disabled={app.locked || loadingOAuth}
                                     loading={loadingOAuth}
                                     variant="outline-primary"
                                     onClick={() => startOAuthLogin(opt.key)}

--- a/ui/ui-components/pages/oauth/callback.tsx
+++ b/ui/ui-components/pages/oauth/callback.tsx
@@ -4,6 +4,7 @@ import Loader from "../../components/Loader";
 import { UseApi } from "../../hooks/useApi";
 import { Actions } from "../../utils/apiData";
 import { ErrorHandler } from "../../utils/errorHandler";
+import { grouparooUiEdition } from "../../utils/uiEdition";
 
 export default function OauthCallbackPage(props) {
   const router = useRouter();
@@ -21,7 +22,10 @@ export default function OauthCallbackPage(props) {
       `/oauth/client/request/${requestId}/edit`
     );
     if (response.oAuthRequest) {
-      if (response.oAuthRequest.type === "user") {
+      if (
+        response.oAuthRequest.type === "user" &&
+        grouparooUiEdition() !== "config"
+      ) {
         router.replace(`/session/sign-in?requestId=${requestId}`);
       } else if (response.oAuthRequest.type === "app" && window.opener) {
         window.opener?.postMessage({ requestId });

--- a/ui/ui-config/pages/oauth/callback.tsx
+++ b/ui/ui-config/pages/oauth/callback.tsx
@@ -1,0 +1,1 @@
+export { default } from "@grouparoo/ui-components/pages/oauth/callback";


### PR DESCRIPTION
## Change description

This PR contains a couple fixes for app oauth:

1. Add the callback page to `ui-config` so that `grouparoo config` can configure oauth apps properly.
2. Disable the "sign in with oauth" button if the app is locked due to being code-configured
3. Small fix to the mailchimp connect method so it always returns a client 

Because of the way we were checking the options after #2789, we could end up without a client if the options were both falsy, leading to ambiguous errors down the line:

![image](https://user-images.githubusercontent.com/4368928/149582019-6b21e271-5df7-49a9-aa06-ab18836708ae.png)

After this change we're always returning a client again so we get better errors:

![image](https://user-images.githubusercontent.com/4368928/149582266-34cc44bd-d663-47cf-8258-bb6203cefe3e.png)




## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
