### PR TITLE
Update ah-sequelize-plugin (fix migraton name bugs)

### DIFF
--- a/core/bin/migrator
+++ b/core/bin/migrator
@@ -63,7 +63,7 @@ modes:
     });
     const sequelizeInstance = new Sequelize(CONFIG);
 
-    const umzugs = Migrations.importMigrationsFromDirectory(
+    const umzugs = await Migrations.importMigrationsFromDirectory(
       CONFIG,
       sequelizeInstance,
       logger,

--- a/core/package.json
+++ b/core/package.json
@@ -37,7 +37,7 @@
     "@types/node": "16.*.*",
     "@types/validator": "*",
     "actionhero": "28.1.4",
-    "ah-sequelize-plugin": "5.1.0",
+    "ah-sequelize-plugin": "5.1.1",
     "bcryptjs": "2.4.3",
     "cls-hooked": "4.2.2",
     "colors": "1.4.0",

--- a/core/package.json
+++ b/core/package.json
@@ -37,7 +37,7 @@
     "@types/node": "16.*.*",
     "@types/validator": "*",
     "actionhero": "28.1.4",
-    "ah-sequelize-plugin": "5.0.2",
+    "ah-sequelize-plugin": "5.1.0",
     "bcryptjs": "2.4.3",
     "cls-hooked": "4.2.2",
     "colors": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,7 +264,7 @@ importers:
       '@types/tar': 6.1.1
       '@types/validator': '*'
       actionhero: 28.1.4
-      ah-sequelize-plugin: 5.1.0
+      ah-sequelize-plugin: 5.1.1
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
       colors: 1.4.0
@@ -312,7 +312,7 @@ importers:
       '@types/node': 16.9.1
       '@types/validator': 13.6.3
       actionhero: 28.1.4
-      ah-sequelize-plugin: 5.1.0_f29751961d501bdbc450ca676b95fe81
+      ah-sequelize-plugin: 5.1.1_f29751961d501bdbc450ca676b95fe81
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
       colors: 1.4.0
@@ -4842,8 +4842,8 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ah-sequelize-plugin/5.1.0_f29751961d501bdbc450ca676b95fe81:
-    resolution: {integrity: sha512-TFDK46Sfis+rSyrNzGutJqtzSRg7hW26acB+Pc+fouP1n9pysyGJUDLeVjDkn8ajA8AspOk9+s5gcCZ77xz8OA==}
+  /ah-sequelize-plugin/5.1.1_f29751961d501bdbc450ca676b95fe81:
+    resolution: {integrity: sha512-p1OrQvYqBG47cTqxOwtM6UYtwpQrkBmnoJaWZpAWkkAJS7m2j69g9okdli0qP75QUlfOTPBLyrNw1MJ9+lPMvQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       actionhero: '>=22.0.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,7 +264,7 @@ importers:
       '@types/tar': 6.1.1
       '@types/validator': '*'
       actionhero: 28.1.4
-      ah-sequelize-plugin: 5.0.2
+      ah-sequelize-plugin: 5.1.0
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
       colors: 1.4.0
@@ -312,7 +312,7 @@ importers:
       '@types/node': 16.9.1
       '@types/validator': 13.6.3
       actionhero: 28.1.4
-      ah-sequelize-plugin: 5.0.2_f29751961d501bdbc450ca676b95fe81
+      ah-sequelize-plugin: 5.1.0_f29751961d501bdbc450ca676b95fe81
       bcryptjs: 2.4.3
       cls-hooked: 4.2.2
       colors: 1.4.0
@@ -4842,8 +4842,8 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ah-sequelize-plugin/5.0.2_f29751961d501bdbc450ca676b95fe81:
-    resolution: {integrity: sha512-VypFqPeJrP3e3MBYGwr9OEGuAQ7uU1ewe+NEsZmPHyhsBYaYyKdwPF6zXE6TVu5McmKM2EpdXfoBbWpLFTRi+w==}
+  /ah-sequelize-plugin/5.1.0_f29751961d501bdbc450ca676b95fe81:
+    resolution: {integrity: sha512-TFDK46Sfis+rSyrNzGutJqtzSRg7hW26acB+Pc+fouP1n9pysyGJUDLeVjDkn8ajA8AspOk9+s5gcCZ77xz8OA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       actionhero: '>=22.0.0'


### PR DESCRIPTION
Upgrade to `ah-seqeulize-plugin@v5.1.1`. 

Older versions of Grouparoo used to keep the file extensions in the names of our migrations.  This is no longer supported. Umzug v3 (which we use to run our migrations) now requires that those older migration names be changed, if any exist in your database.  The new version of `ah-seqeulize-plugin` does this, via https://github.com/actionhero/ah-sequelize-plugin/pull/426 and https://github.com/actionhero/ah-sequelize-plugin/pull/427 realizes that we need to be more careful with try/catch for transactions

<img width="563" alt="Screen Shot 2022-01-14 at 2 17 10 PM" src="https://user-images.githubusercontent.com/303226/149596743-998e15cd-a699-4d70-9a9a-2c11a4e31e58.png">


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
