### PR TITLE
fix: debounce loading destination options on change

### DIFF
--- a/ui/ui-components/hooks/useDebouncedCallback.ts
+++ b/ui/ui-components/hooks/useDebouncedCallback.ts
@@ -1,0 +1,18 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export const useDebouncedCallback = (callback: Function, ms: number) => {
+  const timeout = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeout.current);
+    };
+  }, []);
+
+  return useCallback(() => {
+    clearTimeout(timeout.current);
+    timeout.current = setTimeout(() => {
+      callback();
+    }, ms);
+  }, [callback, ms]);
+};

--- a/ui/ui-components/hooks/useDebouncedCallback.ts
+++ b/ui/ui-components/hooks/useDebouncedCallback.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 
-export const useDebouncedCallback = (callback: Function, ms: number) => {
+export const useDebouncedCallback = (callback: () => void, ms: number) => {
   const timeout = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {

--- a/ui/ui-components/hooks/useDebouncedCallback.ts
+++ b/ui/ui-components/hooks/useDebouncedCallback.ts
@@ -11,8 +11,6 @@ export const useDebouncedCallback = (callback: Function, ms: number) => {
 
   return useCallback(() => {
     clearTimeout(timeout.current);
-    timeout.current = setTimeout(() => {
-      callback();
-    }, ms);
+    timeout.current = setTimeout(callback, ms);
   }, [callback, ms]);
 };

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
@@ -19,6 +19,7 @@ import ModelBadge from "../../../../../components/badges/ModelBadge";
 import { NextPageContext } from "next";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
 import { grouparooUiEdition } from "../../../../../utils/uiEdition";
+import { useDebouncedCallback } from "../../../../../hooks/useDebouncedCallback";
 
 export default function Page(props) {
   const {
@@ -91,7 +92,7 @@ export default function Page(props) {
     }
   };
 
-  async function loadOptions() {
+  const loadOptions = useDebouncedCallback(async () => {
     setLoadingOptions(true);
     const response: Actions.DestinationConnectionOptions = await execApi(
       "get",
@@ -103,7 +104,7 @@ export default function Page(props) {
     );
     if (response?.options) setConnectionOptions(response.options);
     setLoadingOptions(false);
-  }
+  }, 500);
 
   async function handleDelete(force = false) {
     if (window.confirm("are you sure?")) {
@@ -131,14 +132,14 @@ export default function Page(props) {
         ? event.target.checked
         : event.target.value;
     setDestination(_destination);
-    if (event.target.id !== "name") setTimeout(loadOptions, 100);
+    if (event.target.id !== "name") loadOptions();
   };
 
   const updateOption = async (optKey, optValue) => {
     const _destination = Object.assign({}, destination);
     _destination.options[optKey] = optValue;
     setDestination(_destination);
-    setTimeout(loadOptions, 100);
+    loadOptions();
   };
 
   return (


### PR DESCRIPTION
## Change description

When a destination loads options dynamically based on a text input, it would fetch the new options `onChange`, after every keystroke. This PR adds debouncing to the `loadOptions` function in the destination edit page so it only loads after the user has stopped typing. 

Moving to another event like `onBlur` instead of `onChange` was also considered, but the debounce applied on the function level proved to be more appropriate to handle the different types of options that also exhibited similar issues, like the typeahead.

*Before*:
![contacts-predebounce](https://user-images.githubusercontent.com/4368928/149965902-e90a801d-2cfb-40c2-9f83-924adb028f25.gif)

*After*:
![contacts-postdebounce](https://user-images.githubusercontent.com/4368928/149965937-23dc8db6-e53a-4c16-9af8-46f5e9a712a5.gif)


## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
