### PR TITLE
fix: disconnect app after options changed

### DIFF
--- a/core/__tests__/models/app/app.ts
+++ b/core/__tests__/models/app/app.ts
@@ -505,6 +505,24 @@ describe("models/app", () => {
       );
     });
 
+    test("it will disconnect app after changing options", async () => {
+      const spy = jest.spyOn(App, "disconnect");
+
+      // options haven't changed, keep connection
+      await app.setOptions({ password: "SECRET", test_key: "something" });
+      expect(App.disconnect).toHaveBeenCalledTimes(0);
+
+      // options changed, disconnect
+      await app.setOptions({
+        password: "SECRET",
+        test_key: "some other thing",
+      });
+      expect(App.disconnect).toHaveBeenCalledTimes(1);
+      expect(App.disconnect).toHaveBeenCalledWith(app.id);
+
+      spy.mockRestore();
+    });
+
     test("it will filter empty app options for the plugin's test method", async () => {
       const plugin = api.plugins.plugins.find(
         (plugin) => plugin.name === "test-plugin"

--- a/core/__tests__/models/app/app.ts
+++ b/core/__tests__/models/app/app.ts
@@ -508,6 +508,8 @@ describe("models/app", () => {
     test("it will disconnect app after changing options", async () => {
       const spy = jest.spyOn(App, "disconnect");
 
+      await app.update({ state: "ready" });
+
       // options haven't changed, keep connection
       await app.setOptions({ password: "SECRET", test_key: "something" });
       expect(App.disconnect).toHaveBeenCalledTimes(0);

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -114,7 +114,7 @@ export class App extends LoggedModel<App> {
   }
 
   async afterSetOptions(hasChanges: boolean) {
-    if (hasChanges) {
+    if (hasChanges && this.state === "ready") {
       await redis.doCluster(
         "api.rpc.app.disconnect",
         [this.id],

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -114,7 +114,7 @@ export class App extends LoggedModel<App> {
   }
 
   async afterSetOptions(hasChanges: boolean) {
-    if (hasChanges && !this.isSoftDeleted) {
+    if (hasChanges) {
       await redis.doCluster(
         "api.rpc.app.disconnect",
         [this.id],

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -114,7 +114,7 @@ export class App extends LoggedModel<App> {
   }
 
   async afterSetOptions(hasChanges: boolean) {
-    if (hasChanges && this.state === "ready") {
+    if (hasChanges && this.state !== "draft" && !this.isNewRecord) {
       await redis.doCluster(
         "api.rpc.app.disconnect",
         [this.id],

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -130,7 +130,7 @@ export namespace OptionHelper {
     await instance.touch();
     await LoggedModel.logUpdate(instance);
 
-    // if there's an afterSetMapping hook and we want to commit our changes
+    // if there's an afterSetOptions hook and we want to commit our changes
     if (typeof instance["afterSetOptions"] === "function") {
       await instance["afterSetOptions"](hasChanges);
     }


### PR DESCRIPTION
## Change description

Apps were not properly being disconnected after options had changed, which meant old options were still being used after connecting.

The issue comes down to using `!this.isSoftDeleted` in the hook that would disconnect the app. `isSoftDeleted` is a function that's always defined on the model, so this would always resolve to false. I did not call the function because I don't think it's appropriate in this case - `isSoftDeleted` only applies to "paranoid" models, which we're not using and would cause an error to be thrown.

See `isSoftDeleted` reference here https://sequelize.org/master/class/lib/model.js~Model.html#instance-method-isSoftDeleted

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
