### PR TITLE
Use `GROUPAROO_INTERNAL_BATCH_SIZE` to configure `config.batchSize.recordProperties`

### DIFF
--- a/core/__tests__/tasks/recordProperty/enqueue/smallerBatchSize.ts
+++ b/core/__tests__/tasks/recordProperty/enqueue/smallerBatchSize.ts
@@ -1,4 +1,4 @@
-process.env.GROUPAROO_IMPORTS_BATCH_SIZE = "1";
+process.env.GROUPAROO_INTERNAL_BATCH_SIZE = "1";
 
 import { helper } from "@grouparoo/spec-helper";
 import { api, specHelper } from "actionhero";

--- a/core/src/config/batchSize.ts
+++ b/core/src/config/batchSize.ts
@@ -13,7 +13,7 @@ export const DEFAULT = {
       // How many Imports and should a Run enqueue in each batch before deferring to associate those Imports already enqueued?
       imports: parseInt(process.env.GROUPAROO_IMPORTS_BATCH_SIZE ?? "1000"),
       // How many Record Properties needing import should we process at once?
-      recordProperties: parseInt(process.env.GROUPAROO_IMPORTS_BATCH_SIZE ?? "500"),
+      recordProperties: parseInt(process.env.GROUPAROO_INTERNAL_BATCH_SIZE ?? "500"),
       // How many Records should a Run try to send at once to Destinations which support batch exporting?
       exports: parseInt(process.env.GROUPAROO_EXPORTS_BATCH_SIZE ?? "100"),
     };

--- a/documents/environment-variables.md
+++ b/documents/environment-variables.md
@@ -19,8 +19,9 @@ This document is an exhaustive list of all of the Environment Variables that can
 - `GROUPAROO_CONFIG_DIR` - Set the config directory path. Default is `${process.cwd()}/config`
 - `GROUPAROO_CONFIG_ARCHIVE` - The URL of a config Tarball which will be downloaded at boot and used to create `GROUPAROO_CONFIG_DIR`
 - `GROUPAROO_RUN_MODE` - What CLI command are we running? Usually set by the CLI
-- `GROUPAROO_IMPORTS_BATCH_SIZE` - How many to records to import at once? (default 500)
-- `GROUPAROO_EXPORTS_BATCH_SIZE` - How many to records to export at once? (default 1000)
+- `GROUPAROO_IMPORTS_BATCH_SIZE` - How many to records to import at once? (default 1000)
+- `GROUPAROO_INTERNAL_BATCH_SIZE` - How many to records/recordProperties to process at once? (default 500)
+- `GROUPAROO_EXPORTS_BATCH_SIZE` - How many to records to export at once? (default 100)
 - `GROUPAROO_DISABLE_EXPORTS` - Should we really send exports (normally configured via `grouparoo run` args)
 - `GROUPAROO_EXPORT_LOG` - The path to a log file which will contain all the data exported from Grouparoo
 


### PR DESCRIPTION
Prior to this PR, the environment variable `GROUPAROO_INTERNAL_BATCH_SIZE` was doing double-duty, controlling how many Records/Properties were being read from Sources at once, and how many Records/Properties we were processing at a time internally.  This was bad because you may want a large batch of records from your source, but internally, the Grouparoo Postgres database should still continue to work on ~500 Records at a time. This PR separates the environment variables:

- `GROUPAROO_IMPORTS_BATCH_SIZE` - How many to records to import at once? (default 1000)
-  (new!)`GROUPAROO_INTERNAL_BATCH_SIZE` - How many to records/recordProperties to process at once? (default 500)
- `GROUPAROO_EXPORTS_BATCH_SIZE` - How many to records to export at once? (default 100) 

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
