### PR TITLE
`@grouparoo/core` should not be a dependency of airtable

### DIFF
--- a/plugins/@grouparoo/airtable/package.json
+++ b/plugins/@grouparoo/airtable/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "@grouparoo/app-templates": "0.8.0-alpha.8",
-    "@grouparoo/core": "0.8.0-alpha.8",
     "airtable": "0.11.1",
     "axios": "0.24.0"
   },

--- a/plugins/@grouparoo/airtable/package.json
+++ b/plugins/@grouparoo/airtable/package.json
@@ -34,7 +34,7 @@
     "axios": "0.24.0"
   },
   "devDependencies": {
-    "@grouparoo/core": "0.8.0-alpha.7",
+    "@grouparoo/core": "0.8.0-alpha.8",
     "@grouparoo/spec-helper": "0.8.0-alpha.8",
     "@types/jest": "*",
     "@types/node": "16.*.*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,10 +389,10 @@ importers:
       typescript: 4.5.4
     dependencies:
       '@grouparoo/app-templates': link:../app-templates
-      '@grouparoo/core': link:../../../core
       airtable: 0.11.1
       axios: 0.24.0
     devDependencies:
+      '@grouparoo/core': link:../../../core
       '@grouparoo/spec-helper': link:../spec-helper
       '@types/jest': 27.0.1
       '@types/node': 16.9.1
@@ -15195,7 +15195,7 @@ packages:
       '@types/jest': 27.0.1
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.4.5_ts-node@10.4.0
+      jest: 27.4.5
       jest-util: 27.4.2
       json5: 2.2.0
       lodash.memoize: 4.1.2


### PR DESCRIPTION
This will fix the version bumping problems as well with the Airtable plugin

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
