### PR TITLE
Ensure that source edit page is not updated when redirecting to the schedule page

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -208,12 +208,15 @@ const Page: NextPage<Props & InjectedProps> = ({
 
       // this source can have a schedule, and we have no schedules yet
       if (scheduleCount === 0 && response.source.scheduleAvailable) {
-        await createSchedule({
+        const createdScheduleAndRedirected = await createSchedule({
           router,
           execApi,
           source: response.source,
           setLoading: () => {},
         });
+        if (createdScheduleAndRedirected) {
+          return;
+        }
       } else if (
         response.source.state === "ready" &&
         source.state === "draft"


### PR DESCRIPTION
## Change description

This prevents the schedule page from flashing an updated form after setting the primary key and being redirected to the schedule page. It stops the rest of the state of the page from changing.

## Checklists

### Development

- [x] Application changes have been tested appropriately

I went back to the page after I got to the schedule page to ensure it was correctly updated

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
