### PR TITLE
Retry failed exports within a time range

### DIFF
--- a/core/src/actions/exports.ts
+++ b/core/src/actions/exports.ts
@@ -117,7 +117,11 @@ export class ExportsRetryFailed extends AuthenticatedAction {
     destinationId: { required: false },
     startTimestamp: { required: true, formatter: APIData.ensureNumber },
     endTimestamp: { required: true, formatter: APIData.ensureNumber },
-    preview: { required: false, formatter: APIData.ensureBoolean },
+    preview: {
+      required: false,
+      default: false,
+      formatter: APIData.ensureBoolean,
+    },
   };
 
   async runWithinTransaction({

--- a/core/src/config/routes.ts
+++ b/core/src/config/routes.ts
@@ -36,6 +36,7 @@ export const DEFAULT: { [namespace]: () => RoutesConfig } = {
         { path: "/v:apiVersion/exportProcessors", action: "exportProcessors:list" },
         { path: "/v:apiVersion/exports", action: "exports:list" },
         { path: "/v:apiVersion/exports/totals", action: "exports:totals" },
+        { path: "/v:apiVersion/exports/retryFailed", action: "exports:retryFailed" },
         { path: "/v:apiVersion/group/:groupId/records", action: "records:list" },
         { path: "/v:apiVersion/group/:id", action: "group:view" },
         { path: "/v:apiVersion/group/:id/countComponentMembers", action: "group:countComponentMembers" },

--- a/core/src/models/Export.ts
+++ b/core/src/models/Export.ts
@@ -328,6 +328,20 @@ export class Export extends CommonModel<Export> {
     }
   }
 
+  static async retryFailed(
+    startDate: Date,
+    endDate: Date,
+    destination?: Destination,
+    saveExports = true
+  ) {
+    return ExportOps.retryFailedExports(
+      startDate,
+      endDate,
+      destination,
+      saveExports
+    );
+  }
+
   static async sweep(limit: number) {
     const days = 90; // keep all exports for at least 90 days
     const whereDate = Moment()

--- a/ui/ui-community/pages/model/[modelId]/destination/[destinationId]/retry.tsx
+++ b/ui/ui-community/pages/model/[modelId]/destination/[destinationId]/retry.tsx
@@ -1,0 +1,1 @@
+export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/retry";

--- a/ui/ui-components/components/tabs/Destination.tsx
+++ b/ui/ui-components/components/tabs/Destination.tsx
@@ -14,14 +14,14 @@ export default function DestinationTabs({
     case "enterprise":
       tabs.push("edit");
       if (destination.state !== "draft") tabs.push("data");
-      tabs.push("exports");
+      tabs.push("exports", "retry");
       break;
     case "config":
       tabs.push("edit");
       if (destination.state !== "draft") tabs.push("data");
       break;
     default:
-      tabs.push("exports");
+      tabs.push("exports", "retry");
       break;
   }
 

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/retry.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/retry.tsx
@@ -1,0 +1,144 @@
+import Head from "next/head";
+import { NextPageContext } from "next";
+import { useForm } from "react-hook-form";
+import { Badge, Form } from "react-bootstrap";
+import { useState } from "react";
+import { UseApi } from "../../../../../hooks/useApi";
+import DestinationTabs from "../../../../../components/tabs/Destination";
+import PageHeader from "../../../../../components/PageHeader";
+import StateBadge from "../../../../../components/badges/StateBadge";
+import LockedBadge from "../../../../../components/badges/LockedBadge";
+import ModelBadge from "../../../../../components/badges/ModelBadge";
+import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
+import { Actions, Models } from "../../../../../utils/apiData";
+
+import LoadingButton from "../../../../../components/LoadingButton";
+import { ErrorHandler } from "../../../../../utils/errorHandler";
+import { SuccessHandler } from "../../../../../utils/successHandler";
+
+export default function Page(props) {
+  const {
+    destination,
+    model,
+    errorHandler,
+    successHandler,
+  }: {
+    model: Models.GrouparooModelType;
+    destination: Models.DestinationType;
+    errorHandler: ErrorHandler;
+    successHandler: SuccessHandler;
+  } = props;
+  const [loading, setLoading] = useState(false);
+  const [previewCount, setPreviewCount] = useState(0);
+  const { execApi } = UseApi(props, errorHandler);
+
+  const { handleSubmit, register, getValues } = useForm();
+
+  const onSubmit = ({ fromDate, toDate }: { fromDate: Date; toDate: Date }) => {
+    console.log("submit", fromDate, toDate);
+  };
+
+  const updatePreview = async () => {
+    const { fromDate, toDate } = getValues();
+    if (!fromDate || !toDate) return;
+    const response: Actions.ExportsRetryFailed = await execApi(
+      "get",
+      `/exports/retryFailed`,
+      {
+        destinationId: destination.id,
+        startTimestamp: fromDate.getTime(),
+        endTimestamp: toDate.getTime(),
+        preview: true,
+      },
+      null,
+      null,
+      false
+    );
+
+    if (response) {
+      setPreviewCount(response.count);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Grouparoo: {destination.name}</title>
+      </Head>
+
+      <DestinationTabs destination={destination} model={model} />
+
+      <PageHeader
+        icon={destination.app.icon}
+        title={destination.name}
+        badges={[
+          <LockedBadge object={destination} />,
+          <StateBadge state={destination.state} />,
+          <ModelBadge
+            modelName={destination.modelName}
+            modelId={destination.modelId}
+          />,
+        ]}
+      />
+
+      <p>
+        Retry failed exports for <b>{destination.name}</b> that were created in
+        a given time frame.
+      </p>
+      <p>
+        Exports to be retried: &nbsp;
+        <Badge style={{ fontSize: 16 }} variant="info">
+          {previewCount}
+        </Badge>
+      </p>
+
+      <Form id="form" onSubmit={handleSubmit(onSubmit)}>
+        <Form.Group>
+          <Form.Label>From</Form.Label>
+          <Form.Control
+            autoFocus
+            required
+            type="datetime-local"
+            name="fromDate"
+            ref={register({ setValueAs: (v) => v && new Date(v) })}
+            onChange={() => {
+              updatePreview();
+            }}
+            disabled={loading}
+          />
+        </Form.Group>
+        <Form.Group>
+          <Form.Label>To</Form.Label>
+          <Form.Control
+            required
+            type="datetime-local"
+            name="toDate"
+            ref={register({ setValueAs: (v) => v && new Date(v) })}
+            onChange={() => {
+              updatePreview();
+            }}
+            disabled={loading}
+          />
+        </Form.Group>
+
+        <LoadingButton variant="primary" type="submit" loading={loading}>
+          Submit
+        </LoadingButton>
+      </Form>
+    </>
+  );
+}
+
+Page.getInitialProps = async (ctx: NextPageContext) => {
+  const { execApi } = UseApi(ctx);
+  const { destinationId, modelId } = ctx.query;
+  const { destination } = await execApi("get", `/destination/${destinationId}`);
+  ensureMatchingModel("Destination", destination.modelId, modelId.toString());
+
+  const { model } = await execApi<Actions.ModelView>(
+    "get",
+    `/model/${modelId}`
+  );
+
+  return { destination, model };
+};

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/retry.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/retry.tsx
@@ -61,7 +61,7 @@ export default function Page(props) {
       } else {
         if (response.count) {
           successHandler.set({
-            message: `Retrying ${response.count} failed exports`,
+            message: `Retrying ${response.count} failed exports...`,
           });
         } else {
           successHandler.set({

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/retry.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/retry.tsx
@@ -11,22 +11,16 @@ import LockedBadge from "../../../../../components/badges/LockedBadge";
 import ModelBadge from "../../../../../components/badges/ModelBadge";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
 import { Actions, Models } from "../../../../../utils/apiData";
-
+import { errorHandler, successHandler } from "../../../../../eventHandlers";
 import LoadingButton from "../../../../../components/LoadingButton";
-import { ErrorHandler } from "../../../../../utils/errorHandler";
-import { SuccessHandler } from "../../../../../utils/successHandler";
 
 export default function Page(props) {
   const {
     destination,
     model,
-    errorHandler,
-    successHandler,
   }: {
     model: Models.GrouparooModelType;
     destination: Models.DestinationType;
-    errorHandler: ErrorHandler;
-    successHandler: SuccessHandler;
   } = props;
   const [loading, setLoading] = useState(false);
   const [previewCount, setPreviewCount] = useState(0);

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/retry.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/retry.tsx
@@ -56,7 +56,9 @@ export default function Page(props) {
     );
 
     if (response) {
-      if (!preview) {
+      if (preview) {
+        setPreviewCount(response.count);
+      } else {
         if (response.count) {
           successHandler.set({
             message: `Retrying ${response.count} failed exports`,
@@ -66,8 +68,6 @@ export default function Page(props) {
             message: "No failed exports to retry were found in this time range",
           });
         }
-      } else {
-        setPreviewCount(response.count);
       }
     }
 

--- a/ui/ui-components/utils/apiData.ts
+++ b/ui/ui-components/utils/apiData.ts
@@ -164,6 +164,7 @@ import {
   ExportView,
   ExportsTotals,
   ExportsList,
+  ExportsRetryFailed,
 } from "@grouparoo/core/src/actions/exports";
 import {
   ExportProcessorView,
@@ -444,6 +445,9 @@ export namespace Actions {
   >;
   export type ExportsList = AsyncReturnType<
     typeof ExportsList.prototype.runWithinTransaction
+  >;
+  export type ExportsRetryFailed = AsyncReturnType<
+    typeof ExportsRetryFailed.prototype.runWithinTransaction
   >;
 
   export type ExportProcessorView = AsyncReturnType<

--- a/ui/ui-enterprise/pages/model/[modelId]/destination/[destinationId]/retry.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/destination/[destinationId]/retry.tsx
@@ -1,0 +1,1 @@
+export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/retry";


### PR DESCRIPTION
## Change description

Adds the ability to retry failed exports for a destination within a time range via a new "Retry" tab on Destinations.

![image](https://user-images.githubusercontent.com/4368928/150811470-c1182a57-8c31-4d02-8e88-5e53396de273.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
