### PR TITLE
Fix issues with updating recurring schedule

### DIFF
--- a/core/__tests__/actions/schedules.ts
+++ b/core/__tests__/actions/schedules.ts
@@ -174,6 +174,77 @@ describe("actions/schedules", () => {
         expect(configSpy).toBeCalledTimes(1);
       });
 
+      test("an administrator can edit recurring frequency", async () => {
+        connection.params = {
+          csrfToken,
+          id,
+          recurring: true,
+          recurringFrequency: 60000,
+        };
+
+        const { error: firstError } = await specHelper.runAction<ScheduleEdit>(
+          "schedule:edit",
+          connection
+        );
+        expect(firstError).toBeUndefined();
+
+        connection.params.recurringFrequency = 120000;
+
+        const { error, schedule } = await specHelper.runAction<ScheduleEdit>(
+          "schedule:edit",
+          connection
+        );
+
+        expect(error).toBeUndefined();
+        expect(schedule.recurring).toBe(true);
+        expect(schedule.recurringFrequency).toBe(120000);
+      });
+
+      test("an administrator cannot edit recurring frequency when schedule is not recurring", async () => {
+        connection.params = {
+          csrfToken,
+          id,
+          recurring: false,
+          recurringFrequency: 60000,
+        };
+
+        const { error, schedule } = await specHelper.runAction<ScheduleEdit>(
+          "schedule:edit",
+          connection
+        );
+
+        expect(error).toBeUndefined();
+        expect(schedule.recurring).toBe(false);
+        expect(schedule.recurringFrequency).toBe(0);
+      });
+
+      test("an administrator can update recurring to false", async () => {
+        connection.params = {
+          csrfToken,
+          id,
+          recurring: true,
+          recurringFrequency: 60000,
+        };
+
+        const { error: firstError } = await specHelper.runAction<ScheduleEdit>(
+          "schedule:edit",
+          connection
+        );
+        expect(firstError).toBeUndefined();
+
+        connection.params.recurring = false;
+        delete connection.params["recurringFrequency"];
+
+        const { error, schedule } = await specHelper.runAction<ScheduleEdit>(
+          "schedule:edit",
+          connection
+        );
+
+        expect(error).toBeUndefined();
+        expect(schedule.recurring).toBe(false);
+        expect(schedule.recurringFrequency).toBe(0);
+      });
+
       test("an administrator can view a schedule", async () => {
         connection.params = {
           csrfToken,

--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -210,13 +210,17 @@ export class ScheduleEdit extends AuthenticatedAction {
 
   async runWithinTransaction({ params }: { params: ParamsFrom<ScheduleEdit> }) {
     const schedule = await Schedule.findById(params.id);
+
+    const recurringFrequency =
+      params.recurring && params.recurringFrequency
+        ? params.recurringFrequency
+        : 0;
+
     // these timing options are validated separately, and should be set first
-    if (params.recurringFrequency || params.recurring) {
-      await schedule.update({
-        recurringFrequency: params.recurringFrequency,
-        recurring: params.recurring,
-      });
-    }
+    await schedule.update({
+      recurring: params.recurring,
+      recurringFrequency,
+    });
 
     if (params.options) await schedule.setOptions(params.options);
     if (params.filters) await schedule.setFilters(params.filters);

--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -218,7 +218,7 @@ export class ScheduleEdit extends AuthenticatedAction {
 
     // these timing options are validated separately, and should be set first
     await schedule.update({
-      recurring: params.recurring,
+      recurring: !!params.recurring,
       recurringFrequency,
     });
 

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -65,8 +65,6 @@ export default function Page(props) {
         : 0,
     };
 
-    console.log(scheduleToSave);
-
     const response = await execApi<Actions.ScheduleEdit>(
       "put",
       `/schedule/${schedule.id}`,

--- a/ui/ui-components/utils/makeLocal.ts
+++ b/ui/ui-components/utils/makeLocal.ts
@@ -2,6 +2,6 @@
  * Sometimes you *really* need to decouple a child object form a parent in a react useState method
  * TODO: Why is this require to break the object chain to rules?
  */
-export function makeLocal(obj: any) {
+export function makeLocal<T>(obj: T): T {
   return JSON.parse(JSON.stringify(obj));
 }


### PR DESCRIPTION
## Change description

This fixes some issues related to updating a recurring schedule to not updating. It would cause some validation failures because setting a recurring schedule to false will not necessarily update if the recurring frequency was also reset to 0. Now the `recurring` flag is always updated and the `recurring frequency` will be reset to 0 when updating recurring to `false` to avoid confusion.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
