### PR TITLE
fix: generate unique ids when creating properties

### DIFF
--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -880,6 +880,37 @@ describe("models/source", () => {
       await property.destroy();
     });
 
+    test("bootstrapUniqueProperty will generate an available primary key if conflicting id exists", async () => {
+      // Create a conflicting property
+      const mappedColumn = "id";
+      const existingPropertyKey = `${model.name.toLowerCase()}_${mappedColumn}`;
+
+      await Property.create(
+        {
+          sourceId: source.id,
+          id: existingPropertyKey,
+          key: existingPropertyKey,
+          type: "string",
+          unique: false,
+          isArray: false,
+          state: "ready",
+        },
+        { hooks: false }
+      );
+
+      const property = await source.bootstrapUniqueProperty({
+        mappedColumn,
+        sourceOptions: await source.getOptions(),
+      });
+
+      expect(property.id).toMatch(/prp_/);
+      expect(property.key).toBe(
+        `${model.name.toLowerCase()}_${mappedColumn}_1`
+      );
+
+      await property.destroy();
+    });
+
     test("bootstrapUniqueProperty without with conflicting generated key will resolve with indexed key", async () => {
       const mappedColumn = "id";
       const key = `${model.name.toLowerCase()}_${mappedColumn}`;

--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -850,12 +850,31 @@ describe("models/source", () => {
 
     test("bootstrapUniqueProperty will create a new unique property", async () => {
       const property = await source.bootstrapUniqueProperty({
-        key: "uniqueId",
+        key: "uniqueKey",
         type: "integer",
         mappedColumn: "id",
       });
 
-      expect(property.key).toBe("uniqueId");
+      expect(property.id).toMatch(/prp_/);
+      expect(property.key).toBe("uniqueKey");
+      expect(property.type).toBe("integer");
+      expect(property.isArray).toBe(false);
+      expect(property.state).toBe("ready");
+      expect(property.unique).toBe(true);
+
+      await property.destroy();
+    });
+
+    test("bootstrapUniqueProperty will create a new unique property with a given ID", async () => {
+      const property = await source.bootstrapUniqueProperty({
+        id: "uniqueId",
+        key: "uniqueKey",
+        type: "integer",
+        mappedColumn: "id",
+      });
+
+      expect(property.id).toBe("uniqueId");
+      expect(property.key).toBe("uniqueKey");
       expect(property.type).toBe("integer");
       expect(property.isArray).toBe(false);
       expect(property.state).toBe("ready");

--- a/core/__tests__/tasks/system/destroy.ts
+++ b/core/__tests__/tasks/system/destroy.ts
@@ -226,7 +226,7 @@ describe("tasks/destroy", () => {
                 type: "integer",
                 mappedColumn: "id",
               });
-              await userIdProperty.update({ isPrimaryKey: true });
+              await source.setMapping({ id: "userId" });
             });
 
             test("it will enqueue destroy task by model for records when there is no primary key property", async () => {

--- a/core/src/modules/ops/source.ts
+++ b/core/src/modules/ops/source.ts
@@ -554,7 +554,7 @@ export namespace SourceOps {
       retry = false;
 
       const property = Property.build({
-        id: id ?? ConfigWriter.generateId(key),
+        id,
         key,
         type,
         state: "ready",

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -130,7 +130,6 @@ export default function Page(props) {
         `/property`,
         {
           sourceId: source.id,
-          id: key, // reuse the key as ID
           key,
           type,
           unique,


### PR DESCRIPTION
## Change description

When creating properties via the multiple properties page and `bootstrapUniqueProperty` after #2086 , we were explicitly setting the ID of the new property to be the same as the key, instead of letting grouparoo generate an ID for it as it used to and still does for the regular "Create a property" page. 

This was causing conflicts with the auto key generation logic within `bootstrapUniqueProperty`, because while it would keep iterating to find a valid key if a property with the same _key_ already existed, it would fail if a property with the same _id_ already existed. 

To make things more consistent and also prevent this issue, the changes in this PR lets Grouparoo generate UUIDs like it usually does for properties created through this way. Creating properties in config mode still generates the pretty IDs as expected, since it still switches the IDs when generating the config objects.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
