### PR TITLE
Show loading state for button ins in UI config records page and show better error on add sample record failure

### DIFF
--- a/ui/ui-components/components/layouts/Main.tsx
+++ b/ui/ui-components/components/layouts/Main.tsx
@@ -116,7 +116,7 @@ export default function Main(props) {
               bottom: 0,
               right: 0,
               padding: 20,
-              zIndex: 99,
+              zIndex: 2000,
             }}
           >
             <Toast variant="success" handler={successHandler} />

--- a/ui/ui-components/components/record/AddSampleRecordForm.tsx
+++ b/ui/ui-components/components/record/AddSampleRecordForm.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
+import { errorHandler } from "../../eventHandlers";
 import { ApiHook } from "../../hooks/useApi";
 import { Actions, Models } from "../../utils/apiData";
 import LoadingButton from "../LoadingButton";
@@ -60,6 +61,12 @@ const AddSampleRecordForm: React.FC<Props> = ({
         properties: { [data.uniqueProperty]: data.value },
       });
       setSubmitting(false);
+      if (!response.record) {
+        errorHandler.set({
+          message: `Could not add Sample Record.
+          Record with ${data.uniqueProperty} = ${data.value} may not exist or may be already added.`,
+        });
+      }
       onSubmitComplete(response?.record);
     },
     [modelId]

--- a/ui/ui-components/components/record/AddSampleRecordForm.tsx
+++ b/ui/ui-components/components/record/AddSampleRecordForm.tsx
@@ -19,7 +19,7 @@ const getInputType = (type?: Models.PropertyType["type"]): string => {
 interface Props {
   modelId: string;
   properties: Models.PropertyType[];
-  onSubmitComplete: (record?: Models.GrouparooRecordType) => void;
+  onSubmitComplete: (record: Models.GrouparooRecordType) => void;
   execApi: ApiHook["execApi"];
 }
 
@@ -61,13 +61,15 @@ const AddSampleRecordForm: React.FC<Props> = ({
         properties: { [data.uniqueProperty]: data.value },
       });
       setSubmitting(false);
-      if (!response.record) {
+
+      if (response?.record) {
+        onSubmitComplete(response.record);
+      } else {
         errorHandler.set({
           message: `Could not add Sample Record.
           Record with ${data.uniqueProperty} = ${data.value} may not exist or may be already added.`,
         });
       }
-      onSubmitComplete(response?.record);
     },
     [modelId]
   );

--- a/ui/ui-components/components/record/AddSampleRecordModal.tsx
+++ b/ui/ui-components/components/record/AddSampleRecordModal.tsx
@@ -31,10 +31,8 @@ const AddSampleRecordModal: React.FC<Props> = ({
           properties={properties}
           execApi={execApi}
           onSubmitComplete={(record) => {
-            if (record) {
-              onRecordCreated(record);
-              onHide();
-            }
+            onRecordCreated(record);
+            onHide();
           }}
         />
       </Modal.Body>

--- a/ui/ui-config/pages/model/[modelId]/records.tsx
+++ b/ui/ui-config/pages/model/[modelId]/records.tsx
@@ -23,12 +23,13 @@ export default function Page(props) {
   const router = useRouter();
   const { execApi } = UseApi(props, errorHandler);
 
-  const [loading, setLoading] = useState(false);
+  const [importing, setImporting] = useState(false);
   const [addingRecord, setAddingRecord] = useState(false);
+  const [reloading, setReloading] = useState(false);
 
   async function importAllRecords() {
-    setLoading(true);
-    successHandler.set({ message: "enqueued for import..." });
+    setImporting(true);
+    successHandler.set({ message: "Importing Records..." });
     const response: Actions.RecordsImport = await execApi(
       "post",
       `/records/${modelId}/import`
@@ -39,16 +40,17 @@ export default function Page(props) {
           return { id: r.recordId };
         })
       );
-      successHandler.set({ message: "Import Complete!" });
+      successHandler.set({ message: "Import complete!" });
     }
-    setLoading(false);
+    setImporting(false);
   }
 
   return (
     <>
       <RecordsPage {...props} />
       <LoadingButton
-        disabled={addingRecord || loading}
+        disabled={addingRecord || importing}
+        loading={reloading}
         variant="primary"
         onClick={() => setAddingRecord(true)}
       >
@@ -58,7 +60,8 @@ export default function Page(props) {
       <LoadingButton
         variant="primary"
         onClick={() => importAllRecords()}
-        disabled={loading}
+        disabled={addingRecord || reloading}
+        loading={importing}
       >
         Import All Records
       </LoadingButton>
@@ -68,6 +71,7 @@ export default function Page(props) {
         execApi={execApi}
         show={addingRecord}
         onRecordCreated={() => {
+          setReloading(true);
           router.reload();
         }}
         onHide={() => {


### PR DESCRIPTION
## Change description

These changes are related to the UI config records page:

- Ensures that the 'add sample record' shows a loading state while the record is being added and the page hasn't reloaded (currently the only way to refresh the page)
- Ensures that the 'import all records' shows a loading state while importing records

While working on this, I noticed there was a bad error when adding a dupe sample record or one without a valid number and added an error there. It also ensures that the toasts appear in front on the bootstrap modal by changing the z-index.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
