### PR TITLE
update app header on name change

### DIFF
--- a/ui/ui-components/components/tabs/App.tsx
+++ b/ui/ui-components/components/tabs/App.tsx
@@ -1,7 +1,13 @@
 import Tabs from "../Tabs";
 import { Models } from "../../utils/apiData";
 
-export default function AppTabs({ app }: { app: Models.AppType }) {
+export default function AppTabs({
+  app,
+  name,
+}: {
+  app: Models.AppType;
+  name: string;
+}) {
   const tabs = ["edit"];
 
   if (app.refreshQueryAvailable === true) {
@@ -10,7 +16,7 @@ export default function AppTabs({ app }: { app: Models.AppType }) {
 
   return (
     <div>
-      <Tabs name={app.name} draftType={app.type} tabs={tabs} />
+      <Tabs name={name} draftType={app.type} tabs={tabs} />
     </div>
   );
 }

--- a/ui/ui-components/components/tabs/App.tsx
+++ b/ui/ui-components/components/tabs/App.tsx
@@ -6,7 +6,7 @@ export default function AppTabs({
   name,
 }: {
   app: Models.AppType;
-  name: string;
+  name?: string;
 }) {
   const tabs = ["edit"];
 
@@ -16,7 +16,7 @@ export default function AppTabs({
 
   return (
     <div>
-      <Tabs name={name} draftType={app.type} tabs={tabs} />
+      <Tabs name={name ?? app.name} draftType={app.type} tabs={tabs} />
     </div>
   );
 }

--- a/ui/ui-components/pages/app/[id]/edit.tsx
+++ b/ui/ui-components/pages/app/[id]/edit.tsx
@@ -34,10 +34,11 @@ export default function Page(props) {
   const router = useRouter();
   const { execApi } = UseApi(props, errorHandler);
   const [app, setApp] = useState<Models.AppType>(props.app);
-  const { register, handleSubmit, setValue, getValues, reset, control } =
+  const { register, handleSubmit, setValue, getValues, reset, watch, control } =
     useForm<Models.AppType>({
       defaultValues: props.app,
     });
+  const appName = watch("name");
   const [loading, setLoading] = useState(false);
   const [loadingOAuth, setLoadingOAuth] = useState(false);
   const [oAuthPopup, setOAuthPopup] = useState<Window>(null);
@@ -172,14 +173,14 @@ export default function Page(props) {
   return (
     <>
       <Head>
-        <title>Grouparoo: {app.name || `Draft`}</title>
+        <title>Grouparoo: {appName || `Draft`}</title>
       </Head>
 
-      <AppTabs app={app} />
+      <AppTabs app={app} name={appName} />
 
       <PageHeader
         icon={app.icon}
-        title={app.name}
+        title={appName}
         badges={[
           <SourceBadge object={app} />,
           <DestinationBadge object={app} />,


### PR DESCRIPTION
## Change description

After the switch to `react-hook-form` on the apps edit page in #2789, the header and title stoped updating in response to changing the app name. This watches changes on the name instead of using the initial app for these spots.

The breadcrumb update part of this is addressed in #2835 

Before:
![mc-name-noupdate](https://user-images.githubusercontent.com/4368928/150423210-503287c4-5926-49a7-b8de-299490fe9edc.gif)

After:
![mc-name-updating](https://user-images.githubusercontent.com/4368928/150423221-ed2c653c-9f49-4f90-90a7-f6895d026768.gif)


## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
