### PR TITLE
Navigation Link Styling

### DIFF
--- a/ui/ui-components/components/Navigation.tsx
+++ b/ui/ui-components/components/Navigation.tsx
@@ -389,7 +389,7 @@ export default function Navigation(props) {
                     marginLeft: 15,
                   }}
                 >
-                  <ul>
+                  <ul className="pl-0">
                     {navigation?.bottomMenuItems.map((nav, idx) => {
                       if (nav.type === "link") {
                         return (
@@ -397,19 +397,9 @@ export default function Navigation(props) {
                             <HighlightingNavLink
                               href={nav.href}
                               mainPathSectionIdx={nav.mainPathSectionIdx ?? 1}
-                              text={
-                                <>
-                                  {nav.title}
-                                  {nav.title === "Runs" ? (
-                                    <>
-                                      {" "}
-                                      <RunningRunsBadge />
-                                    </>
-                                  ) : null}
-                                </>
-                              }
+                              text={nav.title}
                               icon={nav.icon}
-                              small={nav.small}
+                              small={true}
                             />
                           </li>
                         );


### PR DESCRIPTION
## Change description
Before: Styling was off on the bottom navigation after a recent update to use `<HighlightingNavLink />`.
<img width="228" alt="Screen Shot 2022-01-19 at 1 19 55 PM" src="https://user-images.githubusercontent.com/63751206/150429677-a7409f68-5296-44e5-bcdd-cdeb4afca251.png">

Now: Better!
![Screen Shot 2022-01-20 at 5 06 42 PM](https://user-images.githubusercontent.com/63751206/150429837-ab05270d-0b50-44a7-af20-3e67cdfe1d83.png)



## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
