### PR TITLE
Ensure that property keys are unique regardless of case

### DIFF
--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -90,6 +90,31 @@ describe("models/property", () => {
       await property.destroy();
     });
 
+    test("ready properties cannot share the same key regardless of key case", async () => {
+      const ruleOne = await Property.create({
+        sourceId: source.id,
+        key: "CASE",
+        type: "string",
+      });
+      const ruleTwo = await Property.create({
+        sourceId: source.id,
+        key: "case",
+        type: "string",
+      });
+
+      await ruleOne.setOptions({ column: "abc123" });
+      await ruleOne.update({ state: "ready" });
+
+      await ruleTwo.setOptions({ column: "abc123" });
+
+      await expect(ruleTwo.update({ state: "ready" })).rejects.toThrow(
+        /key "case" is already in use/
+      );
+
+      await ruleOne.destroy();
+      await ruleTwo.destroy();
+    });
+
     test("draft property can share the same key, but not with ready rule", async () => {
       const ruleOne = await Property.create({
         sourceId: source.id,

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -372,10 +372,14 @@ export class Property extends LoggedModel<Property> {
     const count = await Property.count({
       where: {
         id: { [Op.ne]: instance.id },
-        key: instance.key,
+        key: Sequelize.where(
+          Sequelize.fn("LOWER", Sequelize.col("key")),
+          instance.key.toLowerCase()
+        ),
         state: { [Op.notIn]: ["draft", "deleted"] },
       },
     });
+
     if (count > 0) {
       throw new Error(`key "${instance.key}" is already in use`);
     }


### PR DESCRIPTION
## Change description

This fixes an issue where a user can create two properties with the same key but with different cases. For example `LTV` and `ltv`. Because ids in config mode are generated out of the key, it would cause the creation of properties with the same ID. This makes it so that the check is case-insensitive.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
