### PR TITLE
fix: only do one redirect after schedule creation

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -73,10 +73,17 @@ export default function Page(props) {
 
     if (response?.schedule) {
       if (response.schedule.state === "ready" && schedule.state === "draft") {
-        router.push(
-          "/model/[modelId]/source/[sourceId]/overview",
-          `/model/${source.modelId}/source/${source.id}/overview`
-        );
+        if (totalSources === 1 && totalProperties === 1) {
+          router.push(
+            "/model/[modelId]/source/[sourceId]/multipleProperties",
+            `/model/${source.modelId}/source/${source.id}/multipleProperties`
+          );
+        } else {
+          router.push(
+            "/model/[modelId]/source/[sourceId]/overview",
+            `/model/${source.modelId}/source/${source.id}/overview`
+          );
+        }
       } else {
         setRecurringFrequencyMinutes(
           response.schedule.recurringFrequency / (60 * 1000)
@@ -84,13 +91,6 @@ export default function Page(props) {
         setSchedule(response.schedule);
         setLoading(false);
         successHandler.set({ message: "Schedule Updated" });
-      }
-
-      if (totalSources === 1 && totalProperties === 1) {
-        router.push(
-          "/model/[modelId]/source/[sourceId]/multipleProperties",
-          `/model/${source.modelId}/source/${source.id}/multipleProperties`
-        );
       }
     } else {
       setLoading(false);

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -73,17 +73,11 @@ export default function Page(props) {
 
     if (response?.schedule) {
       if (response.schedule.state === "ready" && schedule.state === "draft") {
-        if (totalSources === 1 && totalProperties === 1) {
-          router.push(
-            "/model/[modelId]/source/[sourceId]/multipleProperties",
-            `/model/${source.modelId}/source/${source.id}/multipleProperties`
-          );
-        } else {
-          router.push(
-            "/model/[modelId]/source/[sourceId]/overview",
-            `/model/${source.modelId}/source/${source.id}/overview`
-          );
-        }
+        const nextPath =
+          totalSources === 1 && totalProperties === 1
+            ? `/model/${source.modelId}/source/${source.id}/multipleProperties`
+            : `/model/${source.modelId}/source/${source.id}/overview`;
+        router.push(nextPath);
       } else {
         setRecurringFrequencyMinutes(
           response.schedule.recurringFrequency / (60 * 1000)

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -73,11 +73,12 @@ export default function Page(props) {
 
     if (response?.schedule) {
       if (response.schedule.state === "ready" && schedule.state === "draft") {
-        const nextPath =
+        const nextPage =
           totalSources === 1 && totalProperties === 1
-            ? `/model/${source.modelId}/source/${source.id}/multipleProperties`
-            : `/model/${source.modelId}/source/${source.id}/overview`;
-        router.push(nextPath);
+            ? "multipleProperties"
+            : "overview";
+
+        router.push(`/model/${source.modelId}/source/${source.id}/${nextPage}`);
       } else {
         setRecurringFrequencyMinutes(
           response.schedule.recurringFrequency / (60 * 1000)


### PR DESCRIPTION
## Change description

There were multiple `router.push` firing on the case where you were setting up your first source/schedule, which would cause an infinite spinner after taking you to one of the two. This makes sure we're only doing the right one.

The redirect to add multiple properties was also being performed even if you were just editing the schedule. This changes the behavior so it only happens upon first creation.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
