### PR TITLE
Add `GROUPAROO_RECORDS_BATCH_SIZE` separate from `GROUPAROO_INTERNAL_BATCH_SIZE`

### DIFF
--- a/core/src/config/batchSize.ts
+++ b/core/src/config/batchSize.ts
@@ -12,10 +12,12 @@ export const DEFAULT = {
     return {
       // How many Imports and should a Run enqueue in each batch before deferring to associate those Imports already enqueued?
       imports: parseInt(process.env.GROUPAROO_IMPORTS_BATCH_SIZE ?? "1000"),
-      // How many Record Properties needing import should we process at once?
-      recordProperties: parseInt(process.env.GROUPAROO_INTERNAL_BATCH_SIZE ?? "500"),
+      // How many Records needing import should we process at once? Affects the query size to sources.
+      recordProperties: parseInt(process.env.GROUPAROO_RECORDS_BATCH_SIZE ?? "500"),
       // How many Records should a Run try to send at once to Destinations which support batch exporting?
       exports: parseInt(process.env.GROUPAROO_EXPORTS_BATCH_SIZE ?? "100"),
+      // How many rows can we update in the Grouparoo database at a time. Affects db performance.
+      internalWrite: parseInt(process.env.GROUPAROO_INTERNAL_BATCH_SIZE ?? "1000"),
     };
   },
 };


### PR DESCRIPTION
Adds even more tuning ability when importing lots of data.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [ ] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
