### PR TITLE
Fix missing await and imports

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -17,7 +17,7 @@ export {
 export { DestinationGroupMembership } from "./models/DestinationGroupMembership";
 export { Export } from "./models/Export";
 export { ExportProcessor } from "./models/ExportProcessor";
-export { Group } from "./models/Group";
+export { Group, GroupRuleWithKey } from "./models/Group";
 export { GroupMember } from "./models/GroupMember";
 export { GroupRule } from "./models/GroupRule";
 export { Import } from "./models/Import";

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -312,14 +312,6 @@ export class Schedule extends LoggedModel<Schedule> {
   }
 
   @BeforeSave
-  static async ensureSourceMapping(instance: Schedule) {
-    const source = await Source.findById(instance.sourceId);
-    if (!(await source.scheduleAvailable())) {
-      throw new Error(`a ${source.type} source cannot have a schedule`);
-    }
-  }
-
-  @BeforeSave
   static async noUpdateIfLocked(instance: Schedule) {
     await LockableHelper.beforeSave(instance, ["state"]);
   }

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -314,7 +314,7 @@ export class Schedule extends LoggedModel<Schedule> {
   @BeforeSave
   static async ensureSourceMapping(instance: Schedule) {
     const source = await Source.findById(instance.sourceId);
-    if (!source.scheduleAvailable()) {
+    if (!(await source.scheduleAvailable())) {
       throw new Error(`a ${source.type} source cannot have a schedule`);
     }
   }

--- a/core/src/modules/configLoaders/apiKey.ts
+++ b/core/src/modules/configLoaders/apiKey.ts
@@ -5,8 +5,7 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { ApiKey } from "../../models/ApiKey";
-import { Permission } from "../../models/Permission";
+import { ApiKey, Permission } from "../.."; // configLoader imports need to be from root
 import { Op } from "sequelize";
 
 export async function loadApiKey(

--- a/core/src/modules/configLoaders/apiKey.ts
+++ b/core/src/modules/configLoaders/apiKey.ts
@@ -5,7 +5,8 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { ApiKey, Permission } from "../..";
+import { ApiKey } from "../../models/ApiKey";
+import { Permission } from "../../models/Permission";
 import { Op } from "sequelize";
 
 export async function loadApiKey(

--- a/core/src/modules/configLoaders/app.ts
+++ b/core/src/modules/configLoaders/app.ts
@@ -6,7 +6,7 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { App } from "../../models/App";
+import { App } from "../.."; // configLoader imports need to be from root
 import { Op } from "sequelize";
 
 import { ConfigWriter } from "../configWriter";

--- a/core/src/modules/configLoaders/app.ts
+++ b/core/src/modules/configLoaders/app.ts
@@ -6,7 +6,7 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { App } from "../..";
+import { App } from "../../models/App";
 import { Op } from "sequelize";
 
 import { ConfigWriter } from "../configWriter";

--- a/core/src/modules/configLoaders/destination.ts
+++ b/core/src/modules/configLoaders/destination.ts
@@ -7,7 +7,10 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { App, Destination, Group, Property } from "../..";
+import { App } from "../../models/App";
+import { Destination } from "../../models/Destination";
+import { Group } from "../../models/Group";
+import { Property } from "../../models/Property";
 import { Op } from "sequelize";
 
 import { ConfigWriter } from "../configWriter";

--- a/core/src/modules/configLoaders/destination.ts
+++ b/core/src/modules/configLoaders/destination.ts
@@ -7,10 +7,7 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { App } from "../../models/App";
-import { Destination } from "../../models/Destination";
-import { Group } from "../../models/Group";
-import { Property } from "../../models/Property";
+import { App, Destination, Group, Property } from "../.."; // configLoader imports need to be from root
 import { Op } from "sequelize";
 
 import { ConfigWriter } from "../configWriter";

--- a/core/src/modules/configLoaders/group.ts
+++ b/core/src/modules/configLoaders/group.ts
@@ -7,9 +7,8 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { Group, GroupRuleWithKey } from "../../models/Group";
+import { Group, Property, GroupRuleWithKey } from "../.."; // configLoader imports need to be from root
 import { TopLevelGroupRules } from "../../modules/topLevelGroupRules";
-import { Property } from "../../models/Property";
 import { ConfigWriter } from "../configWriter";
 import { Deprecation } from "../deprecation";
 

--- a/core/src/modules/configLoaders/index.ts
+++ b/core/src/modules/configLoaders/index.ts
@@ -219,8 +219,7 @@ export async function processConfigObjects(
   // Delete unseen config objects ahead of time
   const deletedIds = await deleteLockedObjects(getSeenIds(configObjects));
 
-  for (const i in configObjects) {
-    const configObject = configObjects[i];
+  for (const configObject of configObjects) {
     if (Object.keys(configObject).length === 0) continue;
     let klass = configObject?.class?.toLowerCase();
     let ids: IdsByClass;

--- a/core/src/modules/configLoaders/model.ts
+++ b/core/src/modules/configLoaders/model.ts
@@ -5,7 +5,7 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { GrouparooModel } from "../../models/GrouparooModel";
+import { GrouparooModel } from "../.."; // configLoader imports need to be from root
 import { Op } from "sequelize";
 
 import { ConfigWriter } from "../configWriter";

--- a/core/src/modules/configLoaders/model.ts
+++ b/core/src/modules/configLoaders/model.ts
@@ -5,7 +5,7 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { GrouparooModel } from "../..";
+import { GrouparooModel } from "../../models/GrouparooModel";
 import { Op } from "sequelize";
 
 import { ConfigWriter } from "../configWriter";

--- a/core/src/modules/configLoaders/property.ts
+++ b/core/src/modules/configLoaders/property.ts
@@ -7,8 +7,7 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { Source } from "../../models/Source";
-import { Property } from "../../models/Property";
+import { Source, Property } from "../.."; // configLoader imports need to be from root
 import { FilterHelper } from "../filterHelper";
 import { Op } from "sequelize";
 import { Deprecation } from "../deprecation";

--- a/core/src/modules/configLoaders/property.ts
+++ b/core/src/modules/configLoaders/property.ts
@@ -7,7 +7,8 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { Property, Source } from "../..";
+import { Source } from "../../models/Source";
+import { Property } from "../../models/Property";
 import { FilterHelper } from "../filterHelper";
 import { Op } from "sequelize";
 import { Deprecation } from "../deprecation";

--- a/core/src/modules/configLoaders/record.ts
+++ b/core/src/modules/configLoaders/record.ts
@@ -4,8 +4,7 @@ import {
   extractNonNullParts,
   logModel,
 } from "../../classes/codeConfig";
-import { GrouparooRecord } from "../../models/GrouparooRecord";
-import { Property } from "../../models/Property";
+import { GrouparooRecord, Property } from "../.."; // configLoader imports need to be from root
 import { getGrouparooRunMode } from "../runMode";
 
 export async function loadRecord(

--- a/core/src/modules/configLoaders/schedule.ts
+++ b/core/src/modules/configLoaders/schedule.ts
@@ -9,8 +9,7 @@ import {
 } from "../../classes/codeConfig";
 import { FilterHelper } from "../filterHelper";
 import { Op } from "sequelize";
-import { Source } from "../../models/Source";
-import { Schedule } from "../../models/Schedule";
+import { Source, Schedule } from "../.."; // configLoader imports need to be from root
 import { Deprecation } from "../deprecation";
 import { ConfigWriter } from "../configWriter";
 

--- a/core/src/modules/configLoaders/schedule.ts
+++ b/core/src/modules/configLoaders/schedule.ts
@@ -8,8 +8,9 @@ import {
   IdsByClass,
 } from "../../classes/codeConfig";
 import { FilterHelper } from "../filterHelper";
-import { Schedule, Source } from "../..";
 import { Op } from "sequelize";
+import { Source } from "../../models/Source";
+import { Schedule } from "../../models/Schedule";
 import { Deprecation } from "../deprecation";
 import { ConfigWriter } from "../configWriter";
 

--- a/core/src/modules/configLoaders/setting.ts
+++ b/core/src/modules/configLoaders/setting.ts
@@ -5,7 +5,7 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { plugin } from "../..";
+import { plugin } from "../../modules/plugin";
 import { Setting } from "../../models/Setting";
 
 export async function loadSetting(

--- a/core/src/modules/configLoaders/setting.ts
+++ b/core/src/modules/configLoaders/setting.ts
@@ -5,8 +5,7 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { plugin } from "../../modules/plugin";
-import { Setting } from "../../models/Setting";
+import { plugin, Setting } from "../.."; // configLoader imports need to be from root
 
 export async function loadSetting(
   configObject: SettingConfigurationObject,

--- a/core/src/modules/configLoaders/source.ts
+++ b/core/src/modules/configLoaders/source.ts
@@ -9,9 +9,7 @@ import {
   getAutoBootstrappedProperty,
   AnyConfigurationObject,
 } from "../../classes/codeConfig";
-import { App } from "../../models/App";
-import { Property, PropertyTypes } from "../../models/Property";
-import { Source } from "../../models/Source";
+import { App, Property, PropertyTypes, Source } from "../.."; // configLoader imports need to be from root
 import { Op } from "sequelize";
 
 import { ConfigWriter } from "../configWriter";

--- a/core/src/modules/configLoaders/source.ts
+++ b/core/src/modules/configLoaders/source.ts
@@ -9,9 +9,10 @@ import {
   getAutoBootstrappedProperty,
   AnyConfigurationObject,
 } from "../../classes/codeConfig";
-import { App, Source, Property, PropertyTypes } from "../..";
+import { App } from "../../models/App";
+import { Property, PropertyTypes } from "../../models/Property";
+import { Source } from "../../models/Source";
 import { Op } from "sequelize";
-import { log } from "actionhero";
 
 import { ConfigWriter } from "../configWriter";
 

--- a/core/src/modules/configLoaders/team.ts
+++ b/core/src/modules/configLoaders/team.ts
@@ -5,7 +5,8 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { Team, Permission } from "../..";
+import { Team } from "../../models/Team";
+import { Permission } from "../../models/Permission";
 import { Op } from "sequelize";
 
 export async function loadTeam(

--- a/core/src/modules/configLoaders/team.ts
+++ b/core/src/modules/configLoaders/team.ts
@@ -5,8 +5,7 @@ import {
   validateConfigObjectKeys,
   IdsByClass,
 } from "../../classes/codeConfig";
-import { Team } from "../../models/Team";
-import { Permission } from "../../models/Permission";
+import { Team, Permission } from "../.."; // configLoader imports need to be from root
 import { Op } from "sequelize";
 
 export async function loadTeam(

--- a/core/src/modules/configLoaders/teamMember.ts
+++ b/core/src/modules/configLoaders/teamMember.ts
@@ -6,8 +6,7 @@ import {
   logModel,
   validateConfigObjectKeys,
 } from "../../classes/codeConfig";
-import { Team } from "../../models/Team";
-import { TeamMember } from "../../models/TeamMember";
+import { Team, TeamMember } from "../.."; // configLoader imports need to be from root
 import { Op } from "sequelize";
 
 export async function loadTeamMember(

--- a/core/src/modules/configLoaders/teamMember.ts
+++ b/core/src/modules/configLoaders/teamMember.ts
@@ -6,7 +6,8 @@ import {
   logModel,
   validateConfigObjectKeys,
 } from "../../classes/codeConfig";
-import { Team, TeamMember } from "../..";
+import { Team } from "../../models/Team";
+import { TeamMember } from "../../models/TeamMember";
 import { Op } from "sequelize";
 
 export async function loadTeamMember(


### PR DESCRIPTION
Fixes a missing `await` in a Schedule hook by removing the method entirely :D  This problem looked like a crash when loading a schedule via config.

Also uses direct imports for config loaders.


The old method (`Schedule.ensureSourceMapping()`) :

https://github.com/grouparoo/grouparoo/blob/d1947cd4e96993a3a37b9c2e54890d980ab32787/core/src/models/Schedule.ts#L314-L320

Is functionally equivalent to `Schedule.ensureSourceCanUseSchedule()`

https://github.com/grouparoo/grouparoo/blob/d1947cd4e96993a3a37b9c2e54890d980ab32787/core/src/models/Schedule.ts#L363-L374

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
