### PR TITLE
SQLite Sample Rows no longer `ORDER BY RANDOM()`

### DIFF
--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getSampleRows.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getSampleRows.ts
@@ -7,7 +7,7 @@ export const getSampleRows: GetSampleRowsMethod = async ({
   connection,
   tableName,
 }) => {
-  const query = `SELECT * FROM "${tableName}" ORDER BY RANDOM() LIMIT 10;`;
+  const query = `SELECT * FROM "${tableName}" LIMIT 10;`;
   const out: DataResponseRow[] = await connection.asyncQuery(query);
 
   return out;


### PR DESCRIPTION
This PR removes an `ORDER BY RANDOM()` from the SQLite sourcePreview method.  This was the reason that sometimes tests were failing... randomly (🥁)

The other table sources do not order by random to avoid performance problems.  This also has the side-effect of producing deterministic sample rows from a SQLite source.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
