### PR TITLE
Authentication via `Authorization` header

### DIFF
--- a/core/__tests__/actions/session.ts
+++ b/core/__tests__/actions/session.ts
@@ -778,18 +778,33 @@ describe("session", () => {
             expect(response.id).toMatch(/test-server/);
           });
 
-          test("apiKey can be sent via header", async () => {
+          test("apiKey can be sent via header with bearer scheme", async () => {
             const response = await fetch(`${url}/api/v1/status/private`, {
               method: "GET",
               credentials: "include",
               headers: {
                 "Content-Type": "application/json",
-                Authorization: apiKey.apiKey, // case doesn't matter
+                Authorization: `Bearer ${apiKey.apiKey}`,
               },
             }).then((r) => r.json());
             expect(response.error).toBeUndefined();
             expect(response.id).toMatch(/test-server/);
           });
+        });
+
+        test("apiKey will be rejected with a non-bearer scheme", async () => {
+          const response = await fetch(`${url}/api/v1/status/private`, {
+            method: "GET",
+            credentials: "include",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Secrets ${apiKey.apiKey}`,
+            },
+          }).then((r) => r.json());
+          expect(response.error.message).toBe(
+            "APIKeys should be sent with the `Authorization: Bearer <token>` scheme"
+          );
+          expect(response.id).toBeUndefined();
         });
       });
     });

--- a/core/__tests__/actions/session.ts
+++ b/core/__tests__/actions/session.ts
@@ -784,7 +784,7 @@ describe("session", () => {
               credentials: "include",
               headers: {
                 "Content-Type": "application/json",
-                "X-GROUPAROO-API-KEY": apiKey.apiKey, // case doesn't matter
+                Authorization: apiKey.apiKey, // case doesn't matter
               },
             }).then((r) => r.json());
             expect(response.error).toBeUndefined();

--- a/core/__tests__/actions/session.ts
+++ b/core/__tests__/actions/session.ts
@@ -13,7 +13,12 @@ import { PrivateStatus } from "../../src/actions/status";
 process.env.WEB_SERVER = "true";
 
 describe("session", () => {
+  let url: string;
   helper.grouparooTestServer({ truncate: true });
+
+  beforeAll(() => {
+    url = `http://localhost:${config.web.port}`;
+  });
 
   describe("without team", () => {
     test("authenticated methods called without valid session before a team exists throw a specific error", async () => {
@@ -561,13 +566,8 @@ describe("session", () => {
       });
 
       describe("header, cookie, and csrf authentication", () => {
-        let url: string;
         let csrfToken: string;
         let cookie: string;
-
-        beforeAll(() => {
-          url = `http://localhost:${config.web.port}`;
-        });
 
         async function buildSessionAndCookie() {
           let response = await fetch(`${url}/api/v1/session`, {
@@ -755,6 +755,41 @@ describe("session", () => {
           });
           expect(response.error.code).toBe("AUTHORIZATION_ERROR");
           expect(response["success"]).toBeFalsy();
+        });
+
+        describe("real apiKey requests", () => {
+          beforeAll(async () => {
+            const permissions = await apiKey.$get("permissions");
+            for (const i in permissions) {
+              await permissions[i].update({ read: true, write: false });
+            }
+          });
+
+          test("apiKey can be sent via query param", async () => {
+            const response = await fetch(
+              `${url}/api/v1/status/private?apiKey=${apiKey.apiKey}`,
+              {
+                method: "GET",
+                credentials: "include",
+                headers: { "Content-Type": "application/json" },
+              }
+            ).then((r) => r.json());
+            expect(response.error).toBeUndefined();
+            expect(response.id).toMatch(/test-server/);
+          });
+
+          test("apiKey can be sent via header", async () => {
+            const response = await fetch(`${url}/api/v1/status/private`, {
+              method: "GET",
+              credentials: "include",
+              headers: {
+                "Content-Type": "application/json",
+                "X-GROUPAROO-API-KEY": apiKey.apiKey, // case doesn't matter
+              },
+            }).then((r) => r.json());
+            expect(response.error).toBeUndefined();
+            expect(response.id).toMatch(/test-server/);
+          });
         });
       });
     });

--- a/core/src/modules/middleware/authentication.ts
+++ b/core/src/modules/middleware/authentication.ts
@@ -226,9 +226,16 @@ function parseHeaders(data: ActionProcessor<any>) {
   if (data.connection.type !== "web") return;
 
   if (data.connection.rawConnection.req.headers["authorization"]) {
-    data.params.apiKey =
-      data.connection.rawConnection.req.headers["authorization"];
+    const [scheme, token]: string[] =
+      data.connection.rawConnection.req.headers["authorization"].split(" "); // should resemble `Bearer: abc123`
+    if (scheme.toLowerCase() !== "bearer") {
+      throw new Error(
+        `APIKeys should be sent with the \`Authorization: Bearer <token>\` scheme`
+      );
+    }
+    data.params.apiKey = token;
   }
+
   if (data.connection.rawConnection.req.headers["x-grouparoo-server-token"]) {
     data.params.serverToken =
       data.connection.rawConnection.req.headers["x-grouparoo-server-token"];

--- a/core/src/modules/middleware/authentication.ts
+++ b/core/src/modules/middleware/authentication.ts
@@ -225,9 +225,9 @@ async function authenticateTeamMemberInRoom(
 function parseHeaders(data: ActionProcessor<any>) {
   if (data.connection.type !== "web") return;
 
-  if (data.connection.rawConnection.req.headers["x-grouparoo-api-key"]) {
+  if (data.connection.rawConnection.req.headers["authorization"]) {
     data.params.apiKey =
-      data.connection.rawConnection.req.headers["x-grouparoo-api-key"];
+      data.connection.rawConnection.req.headers["authorization"];
   }
   if (data.connection.rawConnection.req.headers["x-grouparoo-server-token"]) {
     data.params.serverToken =


### PR DESCRIPTION
This PR allows the passing of a Grouparoo API Key via header.   Depending on your infrastructure and logging, it is often more secure to pass the API Key via header than via query param. 

Docs @ https://github.com/grouparoo/www.grouparoo.com/pull/881

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
