### PR TITLE
Loads record count on page load or model switch

### DIFF
--- a/ui/ui-components/__tests__/components/record/__snapshots__/SampleRecordCard.tsx.snap
+++ b/ui/ui-components/__tests__/components/record/__snapshots__/SampleRecordCard.tsx.snap
@@ -232,7 +232,7 @@ exports[`SampleRecordCard should render with 1 record in config mode 1`] = `
               type="button"
             >
               View All 
-              0
+              1
                Records
             </button>
           </a>

--- a/ui/ui-components/components/record/SampleRecordCard.tsx
+++ b/ui/ui-components/components/record/SampleRecordCard.tsx
@@ -120,6 +120,18 @@ const SampleRecordCard: React.FC<SampleRecordCardProps> = ({
     [modelId]
   );
 
+  useEffect(() => {
+    if (modelId) {
+      execApi<Actions.RecordsList>("get", "/records", {
+        limit: 1,
+        offset: 0,
+        modelId,
+      }).then(({ total }) => {
+        setTotalRecords(total);
+      });
+    }
+  }, [execApi, modelId]);
+
   const loadRecord = useCallback(async () => {
     setLoading(true);
 
@@ -281,7 +293,7 @@ const SampleRecordCard: React.FC<SampleRecordCardProps> = ({
       );
     }
     return result;
-  }, [record, hideViewAllRecords, hasRecords, totalRecords, modelId, disabled]);
+  }, [record, hideViewAllRecords, totalRecords, modelId, disabled]);
 
   if (!sortedPropertyKeys?.length && !properties.length) {
     return (


### PR DESCRIPTION
## Change description

The record count was only updating when the sample record was loaded or changed. Now it always loads on page load, in addition to the sample record changing.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
