### PR TITLE
Fix recurring and refreshEnabled schedule update

### DIFF
--- a/core/__tests__/actions/schedules.ts
+++ b/core/__tests__/actions/schedules.ts
@@ -245,6 +245,53 @@ describe("actions/schedules", () => {
         expect(schedule.recurringFrequency).toBe(0);
       });
 
+      test("an administrator can edit refresh enabled", async () => {
+        connection.params = {
+          csrfToken,
+          id,
+          refreshEnabled: true,
+        };
+
+        const { schedule: firstSchedule, error: firstError } =
+          await specHelper.runAction<ScheduleEdit>("schedule:edit", connection);
+        expect(firstError).toBeUndefined();
+        expect(firstSchedule.refreshEnabled).toBe(true);
+
+        connection.params.refreshEnabled = false;
+
+        const { error, schedule } = await specHelper.runAction<ScheduleEdit>(
+          "schedule:edit",
+          connection
+        );
+
+        expect(error).toBeUndefined();
+        expect(schedule.refreshEnabled).toBe(false);
+      });
+
+      test("an administrator can skip editing refresh enabled", async () => {
+        connection.params = {
+          csrfToken,
+          id,
+          refreshEnabled: true,
+        };
+
+        const { error: firstError } = await specHelper.runAction<ScheduleEdit>(
+          "schedule:edit",
+          connection
+        );
+        expect(firstError).toBeUndefined();
+
+        delete connection.params["refreshEnabled"];
+
+        const { error, schedule } = await specHelper.runAction<ScheduleEdit>(
+          "schedule:edit",
+          connection
+        );
+
+        expect(error).toBeUndefined();
+        expect(schedule.refreshEnabled).toBe(true);
+      });
+
       test("an administrator can view a schedule", async () => {
         connection.params = {
           csrfToken,

--- a/core/src/actions/schedules.ts
+++ b/core/src/actions/schedules.ts
@@ -211,21 +211,25 @@ export class ScheduleEdit extends AuthenticatedAction {
   async runWithinTransaction({ params }: { params: ParamsFrom<ScheduleEdit> }) {
     const schedule = await Schedule.findById(params.id);
 
-    const recurringFrequency =
-      params.recurring && params.recurringFrequency
-        ? params.recurringFrequency
-        : 0;
+    if (typeof params.recurring === "boolean") {
+      const recurringFrequency =
+        params.recurring && params.recurringFrequency
+          ? params.recurringFrequency
+          : 0;
 
-    // these timing options are validated separately, and should be set first
-    await schedule.update({
-      recurring: !!params.recurring,
-      recurringFrequency,
-    });
+      // these timing options are validated separately, and should be set first
+      await schedule.update({
+        recurring: params.recurring,
+        recurringFrequency,
+      });
+    }
 
     if (params.options) await schedule.setOptions(params.options);
     if (params.filters) await schedule.setFilters(params.filters);
-    if (params.refreshEnabled)
+
+    if (typeof params.refreshEnabled === "boolean") {
       await schedule.update({ refreshEnabled: params.refreshEnabled });
+    }
 
     await schedule.update({
       state: params.state,


### PR DESCRIPTION
## Change description

This ensures that `recurring` and `refreshEnabled` can be updated in the schedule regardless of true or false value. Like before, it allows the user to skip those values (and they will not get updated instead.)

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
