### PR TITLE
fix: use new handler syntax on group edit page

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
@@ -32,12 +32,12 @@ export default function Page(props) {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    props.groupHandler.subscribe("group-edit", (_group) => {
+    groupHandler.subscribe("group-edit", (_group) => {
       setGroup(_group);
     });
 
     return () => {
-      props.groupHandler.unsubscribe("group-edit");
+      groupHandler.unsubscribe("group-edit");
     };
   }, []);
 

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Row, Col, Form } from "react-bootstrap";
-import { NextPageContext } from "next";
+import { NextPage, NextPageContext } from "next";
 import { useRouter } from "next/router";
 import Head from "next/head";
 import StateBadge from "../../../../../components/badges/StateBadge";
@@ -20,15 +20,15 @@ import { UseApi } from "../../../../../hooks/useApi";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
 import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 
-export default function Page(props) {
-  const {
-    model,
-  }: {
-    model: Models.GrouparooModelType;
-  } = props;
+interface Props {
+  model: Models.GrouparooModelType;
+  group: Models.GroupType;
+}
+
+const Page: NextPage<Props> = (props) => {
   const router = useRouter();
   const [group, setGroup] = useState<Models.GroupType>(props.group);
-  const { execApi } = UseApi(props, errorHandler);
+  const { execApi } = UseApi(undefined, errorHandler);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -92,7 +92,7 @@ export default function Page(props) {
         <title>Grouparoo: {group.name}</title>
       </Head>
 
-      <GroupTabs group={group} model={model} />
+      <GroupTabs group={group} model={props.model} />
 
       <PageHeader
         title={group.name}
@@ -203,7 +203,7 @@ export default function Page(props) {
       </Row>
     </>
   );
-}
+};
 
 Page.getInitialProps = async (ctx: NextPageContext) => {
   const { groupId, modelId } = ctx.query;
@@ -218,3 +218,5 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
 
   return { group, model };
 };
+
+export default Page;


### PR DESCRIPTION
## Change description

After the changes in #2821, it looks like we missed updating the usage of `groupHandler` in the group edit page to use the new global handler, which was causing a crash on page load.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
