### PR TITLE
Fix key input on multiple properties page

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -191,7 +191,8 @@ export default function Page(props) {
               onChange={(e) => setKey(e.target.value)}
               disabled={disabled}
             />
-            {!exactProperty && columnSpeculation[column].suggestedPropertyKey !== column ? (
+            {!exactProperty &&
+            columnSpeculation[column].suggestedPropertyKey !== column ? (
               <Form.Text
                 id="suggestedKeyText"
                 muted

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -102,10 +102,12 @@ export default function Page(props) {
       ? exactProperty.sourceId === source.id
       : false;
 
+    const suggestedKey = columnSpeculation[column].suggestedPropertyKey;
+
     const [key, setKey] = useState(
       exactProperty && exactProperty.sourceId === source.id
         ? exactProperty.key
-        : columnSpeculation[column].suggestedPropertyKey
+        : suggestedKey
     );
     const [type, setType] = useState<typeof exactProperty["type"]>(
       exactProperty && exactProperty.sourceId === source.id
@@ -191,12 +193,11 @@ export default function Page(props) {
               onChange={(e) => setKey(e.target.value)}
               disabled={disabled}
             />
-            {!exactProperty &&
-            columnSpeculation[column].suggestedPropertyKey !== column ? (
+            {!exactProperty && suggestedKey !== column ? (
               <Form.Text
                 id="suggestedKeyText"
                 muted
-              >{`Property with key "${column}" already exists, suggesting "${columnSpeculation[column].suggestedPropertyKey}" instead.`}</Form.Text>
+              >{`Property with key "${column}" already exists, suggesting "${suggestedKey}" instead.`}</Form.Text>
             ) : null}
           </td>
           <td>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -191,11 +191,11 @@ export default function Page(props) {
               onChange={(e) => setKey(e.target.value)}
               disabled={disabled}
             />
-            {!exactProperty && key !== column ? (
+            {!exactProperty && columnSpeculation[column].suggestedPropertyKey !== column ? (
               <Form.Text
                 id="suggestedKeyText"
                 muted
-              >{`Property with key "${column}" already exists, suggesting "${key}" instead.`}</Form.Text>
+              >{`Property with key "${column}" already exists, suggesting "${columnSpeculation[column].suggestedPropertyKey}" instead.`}</Form.Text>
             ) : null}
           </td>
           <td>


### PR DESCRIPTION
## Change description

The new help text below the input didn't behave as I expected once someone else got their hands on it. I was using the state variable where I shouldn't have.

This fix makes the text more static, and prevents the text from showing up when a user makes edits to already acceptable keys.

Check Brian's recording to see the problems this fixes: https://share.getcloudapp.com/5zunBQAm

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
