### PR TITLE
Upgrade to node-resque@9.1.4

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     "libphonenumber-js": "1.9.44",
     "moment": "2.29.1",
     "mustache": "4.2.0",
-    "node-resque": "9.1.3",
+    "node-resque": "9.1.4",
     "nodemon": "2.0.15",
     "pacote": "12.0.2",
     "pg": "8.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,7 +285,7 @@ importers:
       moment: 2.29.1
       mustache: 4.2.0
       nock: 13.2.1
-      node-resque: 9.1.3
+      node-resque: 9.1.4
       nodemon: 2.0.15
       pacote: 12.0.2
       pg: 8.7.1
@@ -329,7 +329,7 @@ importers:
       libphonenumber-js: 1.9.44
       moment: 2.29.1
       mustache: 4.2.0
-      node-resque: 9.1.3
+      node-resque: 9.1.4
       nodemon: 2.0.15
       pacote: 12.0.2
       pg: 8.7.1
@@ -4800,7 +4800,7 @@ packages:
       glob: 7.2.0
       ioredis: 4.28.2
       mime: 3.0.0
-      node-resque: 9.1.3
+      node-resque: 9.1.4
       primus: 8.0.5
       qs: 6.10.1
       uuid: 8.3.2
@@ -11586,8 +11586,8 @@ packages:
   /node-releases/1.1.75:
     resolution: {integrity: sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==}
 
-  /node-resque/9.1.3:
-    resolution: {integrity: sha512-9bX/DsMV/hbWygV1HeuY5C8FuQsBayLiB7REbsVWvAsgPFwYw2hyi9mSGYgI4LfNQczZm19QtEHQmaUVIubO9g==}
+  /node-resque/9.1.4:
+    resolution: {integrity: sha512-tpvY5SKjpNbMPu/f77dQ/cYg8SZhrdtJWrxePKgbimcn/uqv0E04ExokhDXM75ZISE0R0TRGUgsfrSlG+m90NQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
       ioredis: 4.28.2


### PR DESCRIPTION
This newest version of `node-resque` will help prevent problems when the Grouparoo server crashes and redis data is left in a messy state.

Implementation: https://github.com/actionhero/node-resque/pull/750
Release notes: https://github.com/actionhero/node-resque/releases/tag/v9.1.4

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
