### PR TITLE
feat: `grouparoo run` can target specific schedules

### DIFF
--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -34,6 +34,14 @@ export class RunCLI extends CLI {
       letter: "w",
       flag: true,
     },
+    scheduleIds: {
+      description: "Only run specific Schedules by id",
+      required: false,
+      variadic: true,
+      letter: "s",
+      placeholder: "schedule ids",
+      formatter: (v: any) => v as boolean | string[],
+    },
   };
 
   constructor() {
@@ -69,7 +77,10 @@ export class RunCLI extends CLI {
     const { main } = await import("../grouparoo");
     await main();
 
-    await this.runTasks();
+    const scheduleIds = Array.isArray(params.scheduleIds)
+      ? params.scheduleIds
+      : undefined;
+    await this.runTasks(scheduleIds);
 
     return false;
   }
@@ -82,12 +93,13 @@ export class RunCLI extends CLI {
     }
   }
 
-  async runTasks() {
+  async runTasks(scheduleIds?: string[]) {
     const tasks = {
       "appRefreshQueries:check": {},
       "schedules:enqueueRuns": {
         ignoreDeltas: true,
         runIfNotRecurring: true,
+        scheduleIds,
       },
       "run:recurringInternalRun": {},
       "group:updateCalculatedGroups": {},

--- a/core/src/tasks/schedule/enqueueRuns.ts
+++ b/core/src/tasks/schedule/enqueueRuns.ts
@@ -1,4 +1,5 @@
 import { ParamsFrom } from "actionhero";
+import { WhereOptions } from "sequelize/types";
 import { Schedule } from "../../models/Schedule";
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { APIData } from "../../modules/apiData";
@@ -20,6 +21,10 @@ export class ScheduleEnqueueRuns extends CLSTask {
       default: false,
       formatter: APIData.ensureBoolean,
     },
+    scheduleIds: {
+      required: false,
+      formatter: APIData.ensureArray,
+    },
   };
 
   async runWithinTransaction(params: ParamsFrom<ScheduleEnqueueRuns>) {
@@ -28,9 +33,10 @@ export class ScheduleEnqueueRuns extends CLSTask {
     const runIfNotRecurring =
       params.runIfNotRecurring === undefined ? false : params.runIfNotRecurring;
 
-    const schedules = await Schedule.scope(null).findAll({
-      where: { state: "ready" },
-    });
+    const where: WhereOptions<Schedule> = { state: "ready" };
+    if (params.scheduleIds) where.id = params.scheduleIds;
+
+    const schedules = await Schedule.scope(null).findAll({ where });
 
     for (const schedule of schedules) {
       const shouldRun = await schedule.shouldRun({

--- a/core/src/tasks/schedule/enqueueRuns.ts
+++ b/core/src/tasks/schedule/enqueueRuns.ts
@@ -33,10 +33,10 @@ export class ScheduleEnqueueRuns extends CLSTask {
     const runIfNotRecurring =
       params.runIfNotRecurring === undefined ? false : params.runIfNotRecurring;
 
-    const where: WhereOptions<Schedule> = { state: "ready" };
+    const where: WhereOptions<Schedule> = {};
     if (params.scheduleIds) where.id = params.scheduleIds;
 
-    const schedules = await Schedule.scope(null).findAll({ where });
+    const schedules = await Schedule.findAll({ where });
 
     for (const schedule of schedules) {
       const shouldRun = await schedule.shouldRun({


### PR DESCRIPTION
## Change description

Adds the ability to pass specific schedule Ids to `grouparoo run`, as requested by #2788.

Usage:
```
grouparoo run --scheduleIds schedule_one_id schedule_two_id
grouparoo run -s schedule_id
```

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
