### PR TITLE
Improve how queries get built in SQLite plugin

### DIFF
--- a/plugins/@grouparoo/sqlite/__tests__/data/records.csv
+++ b/plugins/@grouparoo/sqlite/__tests__/data/records.csv
@@ -3,8 +3,8 @@ id,first_name,last_name,email,gender,ip_address,ios_app,android_app,vip,ltv,date
 2,Cacilie,Eate,ceate1@example.com,Female,253.146.41.201,false,true,false,94.36,2020/02/02,2020/02/02 12:13:14
 3,Gretel,Groucock,ggroucock2@example.com,Female,211.89.110.134,true,false,true,668.30,2020/02/03,2020/02/03 12:13:14
 4,Amata,Cotesford,acotesford3@example.com,Female,193.9.240.246,true,true,true,489.00,2020/02/04,2020/02/04 12:13:14
-5,Lira,Johnston,ljohnston4@example.com,Female,53.161.58.99,false,true,false,823.16,2020/02/05,2020/02/05 12:13:14
-6,Deni,Scalia,dscalia5@example.com,Female,138.131.148.74,true,false,true,273.98,2020/02/06,2020/02/06 12:13:14
+5,Lira,"""Airquotes"" Johnston",ljohnston4@example.com,Female,53.161.58.99,false,true,false,823.16,2020/02/05,2020/02/05 12:13:14
+6,Deni,O‘Hara,dscalia5@example.com,Female,138.131.148.74,true,false,true,273.98,2020/02/06,2020/02/06 12:13:14
 7,Helga,Kleis,hkleis6@example.com,Female,85.248.8.158,true,true,true,407.05,2020/02/07,2020/02/07 12:13:14
 8,Gertie,Cubitt,gcubitt7@example.com,Female,123.255.130.24,false,false,true,841.45,2020/02/08,2020/02/08 12:13:14
 9,Lurleen,Browell,lbrowell8@example.com,Female,231.159.55.43,true,false,false,623.34,2020/02/09,2020/02/09 12:13:14

--- a/plugins/@grouparoo/sqlite/__tests__/data/records.csv
+++ b/plugins/@grouparoo/sqlite/__tests__/data/records.csv
@@ -1,10 +1,10 @@
 id,first_name,last_name,email,gender,ip_address,ios_app,android_app,vip,ltv,date,stamp
-1,Erie,Jervois,ejervois0@example.com,Male,15.247.38.72,true,false,true,259.12,2020/02/01,2020/02/01 12:13:14
-2,Cacilie,Eate,ceate1@example.com,Female,253.146.41.201,false,true,false,94.36,2020/02/02,2020/02/02 12:13:14
+1,Erie,O‘Hara,eohara0@example.com,Male,15.247.38.72,true,false,true,259.12,2020/02/01,2020/02/01 12:13:14
+2,"Cacilie ""Cici""",Eate,ceate1@example.com,Female,253.146.41.201,false,true,false,94.36,2020/02/02,2020/02/02 12:13:14
 3,Gretel,Groucock,ggroucock2@example.com,Female,211.89.110.134,true,false,true,668.30,2020/02/03,2020/02/03 12:13:14
 4,Amata,Cotesford,acotesford3@example.com,Female,193.9.240.246,true,true,true,489.00,2020/02/04,2020/02/04 12:13:14
-5,Lira,"""Airquotes"" Johnston",ljohnston4@example.com,Female,53.161.58.99,false,true,false,823.16,2020/02/05,2020/02/05 12:13:14
-6,Deni,O‘Hara,dscalia5@example.com,Female,138.131.148.74,true,false,true,273.98,2020/02/06,2020/02/06 12:13:14
+5,Lira,Johnston,ljohnston4@example.com,Female,53.161.58.99,false,true,false,823.16,2020/02/05,2020/02/05 12:13:14
+6,Deni,Scalia,dscalia5@example.com,Female,138.131.148.74,true,false,true,273.98,2020/02/06,2020/02/06 12:13:14
 7,Helga,Kleis,hkleis6@example.com,Female,85.248.8.158,true,true,true,407.05,2020/02/07,2020/02/07 12:13:14
 8,Gertie,Cubitt,gcubitt7@example.com,Female,123.255.130.24,false,false,true,841.45,2020/02/08,2020/02/08 12:13:14
 9,Lurleen,Browell,lbrowell8@example.com,Female,231.159.55.43,true,false,false,623.34,2020/02/09,2020/02/09 12:13:14

--- a/plugins/@grouparoo/sqlite/__tests__/integration/logChecking.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/integration/logChecking.ts
@@ -52,7 +52,7 @@ describe("sqlite/integration/log-checking", () => {
     record = await helper.factories.record();
     await record.addOrUpdateProperties({
       userId: [1],
-      email: ["ejervois0@example.com"],
+      email: ["eohara0@example.com"],
     });
     expect(record.id).toBeTruthy();
   });

--- a/plugins/@grouparoo/sqlite/__tests__/integration/sqliteTableImport.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/integration/sqliteTableImport.ts
@@ -493,7 +493,7 @@ describe("integration/runs/sqlite", () => {
         `SELECT * FROM "${recordsDestinationTableName}" ORDER BY id ASC`
       );
       expect(userRows.length).toBe(10);
-      expect(userRows[0].customer_email).toBe("ejervois0@example.com");
+      expect(userRows[0].customer_email).toBe("eohara0@example.com");
 
       const groupRows = await client.asyncQuery(
         `SELECT * FROM "${groupsDestinationTableName}"`
@@ -513,7 +513,7 @@ describe("integration/runs/sqlite", () => {
     const record = await GrouparooRecord.findOne({ where: { id: recordId } });
     const properties = await record.getProperties();
     expect(properties.userId.values).toEqual([1]);
-    expect(properties.email.values).toEqual(["ejervois0@example.com"]);
+    expect(properties.email.values).toEqual(["eohara0@example.com"]);
   });
 
   test(
@@ -615,7 +615,7 @@ describe("integration/runs/sqlite", () => {
         `SELECT * FROM "${recordsDestinationTableName}" ORDER BY id ASC`
       );
       expect(userRows.length).toBe(10);
-      expect(userRows[0].customer_email).toBe("ejervois0@example.com");
+      expect(userRows[0].customer_email).toBe("eohara0@example.com");
 
       const groupRows = await client.asyncQuery(
         `SELECT * FROM "${groupsDestinationTableName}"`

--- a/plugins/@grouparoo/sqlite/__tests__/query-import/importProperty.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/query-import/importProperty.ts
@@ -50,7 +50,7 @@ describe("sqlite/query/recordProperty", () => {
     record = await helper.factories.record();
     await record.addOrUpdateProperties({
       userId: [1],
-      email: ["ejervois0@example.com"],
+      email: ["eohara0@example.com"],
     });
     expect(record.id).toBeTruthy();
   });

--- a/plugins/@grouparoo/sqlite/__tests__/table-import/importProperties.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/table-import/importProperties.ts
@@ -122,7 +122,7 @@ describe("sqlite/table/recordProperties", () => {
     record = await helper.factories.record();
     await record.addOrUpdateProperties({
       userId: [1],
-      email: ["ejervois0@example.com"],
+      email: ["eohara0@example.com"],
       lastName: null,
     });
     expect(record.id).toBeTruthy();
@@ -172,7 +172,9 @@ describe("sqlite/table/recordProperties", () => {
             aggregationMethod,
           });
           expect(values[record.id][properties[0].id]).toEqual(["Erie"]);
-          expect(values[otherRecord.id][properties[0].id]).toEqual(["Cacilie"]);
+          expect(values[otherRecord.id][properties[0].id]).toEqual([
+            `Cacilie "Cici"`,
+          ]);
         });
 
         test("to get multiple values with a string", async () => {
@@ -183,8 +185,10 @@ describe("sqlite/table/recordProperties", () => {
             aggregationMethod,
           });
           expect(values[record.id][properties[0].id]).toEqual(["Erie"]);
-          expect(values[otherRecord.id][properties[0].id]).toEqual(["Cacilie"]);
-          expect(values[record.id][properties[1].id]).toEqual(["Jervois"]);
+          expect(values[otherRecord.id][properties[0].id]).toEqual([
+            `Cacilie "Cici"`,
+          ]);
+          expect(values[record.id][properties[1].id]).toEqual(["O‘Hara"]);
           expect(values[otherRecord.id][properties[1].id]).toEqual(["Eate"]);
         });
 
@@ -196,9 +200,13 @@ describe("sqlite/table/recordProperties", () => {
             aggregationMethod,
           });
           expect(values[record.id][properties[0].id]).toEqual(["Erie"]);
-          expect(values[otherRecord.id][properties[0].id]).toEqual(["Cacilie"]);
+          expect(values[otherRecord.id][properties[0].id]).toEqual([
+            `Cacilie "Cici"`,
+          ]);
           expect(values[record.id][properties[1].id]).toEqual(["Erie"]);
-          expect(values[otherRecord.id][properties[1].id]).toEqual(["Cacilie"]);
+          expect(values[otherRecord.id][properties[1].id]).toEqual([
+            `Cacilie "Cici"`,
+          ]);
         });
 
         test("to get a float", async () => {
@@ -221,7 +229,7 @@ describe("sqlite/table/recordProperties", () => {
           });
           expect(values[record.id][properties[0].id]).toEqual([259.12]);
           expect(values[otherRecord.id][properties[0].id]).toEqual([94.36]);
-          expect(values[record.id][properties[1].id]).toEqual(["Jervois"]);
+          expect(values[record.id][properties[1].id]).toEqual(["O‘Hara"]);
           expect(values[otherRecord.id][properties[1].id]).toEqual(["Eate"]);
         });
 
@@ -245,7 +253,7 @@ describe("sqlite/table/recordProperties", () => {
           });
           expect(values[record.id][properties[0].id]).toEqual(["true"]);
           expect(values[otherRecord.id][properties[0].id]).toEqual(["false"]);
-          expect(values[record.id][properties[1].id]).toEqual(["Jervois"]);
+          expect(values[record.id][properties[1].id]).toEqual(["O‘Hara"]);
           expect(values[otherRecord.id][properties[1].id]).toEqual(["Eate"]);
         });
 
@@ -273,7 +281,7 @@ describe("sqlite/table/recordProperties", () => {
           expect(values[otherRecord.id][properties[0].id]).toEqual([
             "2020/02/02",
           ]);
-          expect(values[record.id][properties[1].id]).toEqual(["Jervois"]);
+          expect(values[record.id][properties[1].id]).toEqual(["O‘Hara"]);
           expect(values[otherRecord.id][properties[1].id]).toEqual(["Eate"]);
         });
 
@@ -305,7 +313,7 @@ describe("sqlite/table/recordProperties", () => {
           expect(
             (<string[]>values[otherRecord.id][properties[0].id])[0]
           ).toEqual("2020/02/02 12:13:14");
-          expect(values[record.id][properties[1].id]).toEqual(["Jervois"]);
+          expect(values[record.id][properties[1].id]).toEqual(["O‘Hara"]);
           expect(values[otherRecord.id][properties[1].id]).toEqual(["Eate"]);
         });
       });

--- a/plugins/@grouparoo/sqlite/__tests__/table-import/importProperty.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/table-import/importProperty.ts
@@ -81,7 +81,7 @@ describe("sqlite/table/recordProperty", () => {
     record = await helper.factories.record();
     await record.addOrUpdateProperties({
       userId: [1],
-      email: ["ejervois0@example.com"],
+      email: ["eohara0@example.com"],
       lastName: null,
     });
     expect(record.id).toBeTruthy();

--- a/plugins/@grouparoo/sqlite/__tests__/utils/data.ts
+++ b/plugins/@grouparoo/sqlite/__tests__/utils/data.ts
@@ -8,6 +8,7 @@ import { ConfigWriter } from "@grouparoo/core/dist/modules/configWriter";
 
 const workerId = process.env.JEST_WORKER_ID || 1;
 export const usersTableName = `USERS - '${workerId}'`;
+export const usersByEmailTableName = `USERS BY EMAIL - '${workerId}'`;
 export const usersTableSlug = ConfigWriter.generateId(usersTableName);
 export const purchasesTableName = `Purchases - '${workerId}'`;
 export const recordsDestinationTableName = `OUTPUT_USERS - '${workerId}'`;
@@ -28,6 +29,13 @@ CREATE TABLE "${usersTableName}" (
   "ltv" float,
   "date" date,
   "stamp" datetime
+)
+`,
+  [usersByEmailTableName]: `
+CREATE TABLE "${usersByEmailTableName}" (
+  "email" text PRIMARY KEY,
+  "first_name" text,
+  "last_name" text
 )
 `,
   [purchasesTableName]: `

--- a/plugins/@grouparoo/sqlite/src/lib/connect.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/connect.ts
@@ -4,7 +4,9 @@ import fs from "fs";
 import path from "path";
 import { SQLite } from "./sqlite";
 
-export const connect: ConnectPluginAppMethod = async ({ appOptions }) => {
+export const connect: ConnectPluginAppMethod<SQLite> = async ({
+  appOptions,
+}) => {
   const formattedOptions: any = Object.assign({}, appOptions);
 
   let dbPath = formattedOptions.file;

--- a/plugins/@grouparoo/sqlite/src/lib/connect.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/connect.ts
@@ -2,9 +2,9 @@ import { ConnectPluginAppMethod } from "@grouparoo/core";
 import { getParentPath } from "@grouparoo/core/dist/modules/pluginDetails";
 import fs from "fs";
 import path from "path";
-import { SQLite } from "./sqlite";
+import { SQLiteConnection } from "./sqlite";
 
-export const connect: ConnectPluginAppMethod<SQLite> = async ({
+export const connect: ConnectPluginAppMethod<SQLiteConnection> = async ({
   appOptions,
 }) => {
   const formattedOptions: any = Object.assign({}, appOptions);
@@ -24,7 +24,7 @@ export const connect: ConnectPluginAppMethod<SQLite> = async ({
     throw new Error(`Could not find SQLite database: ${dbPath}`);
   }
 
-  const connection = new SQLite({ database: dbPath });
+  const connection = new SQLiteConnection({ database: dbPath });
   await connection.asyncConnect();
 
   return connection;

--- a/plugins/@grouparoo/sqlite/src/lib/export/exportRecord.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/export/exportRecord.ts
@@ -128,9 +128,9 @@ export const exportRecord: ExportRecordPluginMethod<SQLiteConnection> = async ({
 
         await connection.asyncQuery(
           ...SQLiteQueryBuilder.build(
-            `INSERT INTO "${groupsTable}" (${keys}) VALUES (${values.map(
-              () => "?"
-            )}) ON CONFLICT DO NOTHING`,
+            `INSERT INTO "${groupsTable}" (${keys}) VALUES ${toValuePlaceholders(
+              values
+            )} ON CONFLICT DO NOTHING`,
             values
           )
         );

--- a/plugins/@grouparoo/sqlite/src/lib/queryBuilder.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/queryBuilder.ts
@@ -1,0 +1,44 @@
+import { SQLiteQueryParamValue } from "./sqlite";
+import { validateQuery } from "./validateQuery";
+
+export default class SQLiteQueryBuilder {
+  private statements: string[] = [];
+  private params: SQLiteQueryParamValue[];
+
+  constructor(statement?: string, params?: SQLiteQueryParamValue[]) {
+    if (statement) {
+      this.push(statement, params);
+    }
+  }
+
+  push(
+    statement: string,
+    params?: SQLiteQueryParamValue[]
+  ): SQLiteQueryBuilder {
+    this.statements.push(statement);
+    if (params) {
+      this.pushParams(params);
+    }
+    return this;
+  }
+
+  pushParams(params: SQLiteQueryParamValue[]): SQLiteQueryBuilder {
+    if (!this.params) {
+      this.params = [];
+    }
+
+    this.params.push(...params);
+    return this;
+  }
+
+  build(): [query: string, params: SQLiteQueryParamValue[]] {
+    const query = validateQuery(this.statements.join(" "));
+    const params = [...this.params];
+
+    return [query, params];
+  }
+
+  static build(statement: string, params?: SQLiteQueryParamValue[]) {
+    return new SQLiteQueryBuilder(statement, params).build();
+  }
+}

--- a/plugins/@grouparoo/sqlite/src/lib/queryBuilder.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/queryBuilder.ts
@@ -3,7 +3,7 @@ import { validateQuery } from "./validateQuery";
 
 export default class SQLiteQueryBuilder {
   private statements: string[] = [];
-  private params: SQLiteQueryParamValue[];
+  private params: SQLiteQueryParamValue[] = [];
 
   constructor(statement?: string, params?: SQLiteQueryParamValue[]) {
     if (statement) {
@@ -13,21 +13,27 @@ export default class SQLiteQueryBuilder {
 
   push(
     statement: string,
-    params?: SQLiteQueryParamValue[]
+    params?: SQLiteQueryParamValue[],
+    options?: {
+      prependComma?: boolean;
+    }
   ): SQLiteQueryBuilder {
+    if (options?.prependComma && this.statements.length > 0) {
+      this.statements[this.statements.length - 1] += ",";
+    }
+
     this.statements.push(statement);
+
     if (params) {
       this.pushParams(params);
     }
+
     return this;
   }
 
   pushParams(params: SQLiteQueryParamValue[]): SQLiteQueryBuilder {
-    if (!this.params) {
-      this.params = [];
-    }
-
     this.params.push(...params);
+
     return this;
   }
 

--- a/plugins/@grouparoo/sqlite/src/lib/sqlite.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/sqlite.ts
@@ -1,14 +1,15 @@
 import { log } from "actionhero";
 import { Database } from "sqlite3";
 
-export class SQLite extends Database {
-  database: string;
-  connection: Database;
+export type SQLiteQueryParamValue = string | number | boolean | null;
 
-  constructor({ database }) {
+export class SQLite extends Database {
+  private database: string;
+  private connection: Database;
+
+  constructor({ database }: { database: string }) {
     super(database);
     this.database = database;
-    this.connection = undefined;
   }
 
   async asyncConnect(): Promise<string> {
@@ -28,15 +29,22 @@ export class SQLite extends Database {
     });
   }
 
-  async asyncQuery(query: string): Promise<any[]> {
+  async asyncQuery(
+    query: string,
+    params?: SQLiteQueryParamValue[] | Record<string, SQLiteQueryParamValue>
+  ): Promise<Record<string, any>[]> {
     log(`[ sqlite ] ${query}`, "debug");
     return new Promise((resolve, reject) => {
-      this.connection.all(query, (err: Error, res: any[]) => {
-        if (err) {
-          return reject(new Error(`${err.message}\nQuery: ${query}`));
+      this.connection.all(
+        query,
+        params,
+        (err: Error, res: Record<string, any>[]) => {
+          if (err) {
+            return reject(new Error(`${err.message}\nQuery: ${query}`));
+          }
+          return resolve(res);
         }
-        return resolve(res);
-      });
+      );
     });
   }
 

--- a/plugins/@grouparoo/sqlite/src/lib/sqlite.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/sqlite.ts
@@ -1,9 +1,9 @@
 import { log } from "actionhero";
 import { Database } from "sqlite3";
 
-export type SQLiteQueryParamValue = string | number | boolean | null;
+export type SQLiteQueryParamValue = string | number | boolean | null | Date;
 
-export class SQLite extends Database {
+export class SQLiteConnection extends Database {
   private database: string;
   private connection: Database;
 
@@ -33,7 +33,7 @@ export class SQLite extends Database {
     query: string,
     params?: SQLiteQueryParamValue[] | Record<string, SQLiteQueryParamValue>
   ): Promise<Record<string, any>[]> {
-    log(`[ sqlite ] ${query} ${params}`, "debug");
+    log(`[ sqlite ] ${query}${params ? `[${params}]` : ""}`, "debug");
     return new Promise((resolve, reject) => {
       this.connection.all(
         query,

--- a/plugins/@grouparoo/sqlite/src/lib/sqlite.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/sqlite.ts
@@ -33,7 +33,7 @@ export class SQLite extends Database {
     query: string,
     params?: SQLiteQueryParamValue[] | Record<string, SQLiteQueryParamValue>
   ): Promise<Record<string, any>[]> {
-    log(`[ sqlite ] ${query}`, "debug");
+    log(`[ sqlite ] ${query} ${params}`, "debug");
     return new Promise((resolve, reject) => {
       this.connection.all(
         query,

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getPropertyValues.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getPropertyValues.ts
@@ -73,7 +73,7 @@ export const getPropertyValues: GetPropertyValuesMethod<
     queryBuilder.push(aggFunc, undefined, { prependComma: true });
     groupByColumns.push(tablePrimaryKeyCol);
   } else {
-    queryBuilder.push(`, ${columnList}`);
+    queryBuilder.push(`${columnList}`, undefined, { prependComma: true });
     if (!isArray && orderBys.length > 0) {
       // Note: windowing (ROW_NUMBER) only in SQLite >= 3.25.0 released 2018-09-15
       const order = `ORDER BY ${orderBys.join(", ")}`;

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getPropertyValues.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getPropertyValues.ts
@@ -8,6 +8,7 @@ import {
 } from "@grouparoo/app-templates/dist/source/table";
 import SQLiteQueryBuilder from "../queryBuilder";
 import { SQLiteConnection } from "../sqlite";
+import { buildKeyList } from "../util";
 
 export const getPropertyValues: GetPropertyValuesMethod<
   SQLiteConnection
@@ -76,7 +77,7 @@ export const getPropertyValues: GetPropertyValuesMethod<
     queryBuilder.push(`${columnList}`, undefined, { prependComma: true });
     if (!isArray && orderBys.length > 0) {
       // Note: windowing (ROW_NUMBER) only in SQLite >= 3.25.0 released 2018-09-15
-      const order = `ORDER BY ${orderBys.join(", ")}`;
+      const order = `ORDER BY ${orderBys}`;
       queryBuilder.push(
         `ROW_NUMBER() OVER (PARTITION BY "${tablePrimaryKeyCol}" ${order}) AS __rownum`,
         undefined,
@@ -109,10 +110,10 @@ export const getPropertyValues: GetPropertyValuesMethod<
   addAnd = true;
 
   if (groupByColumns.length > 0) {
-    queryBuilder.push(`GROUP BY ${groupByColumns}`);
+    queryBuilder.push(`GROUP BY ${buildKeyList(groupByColumns)}`);
   }
   if (!ranked && orderBys.length > 0) {
-    queryBuilder.push(`ORDER BY ${orderBys.join(", ")}`);
+    queryBuilder.push(`ORDER BY ${orderBys}}`);
   }
 
   let [query, params] = queryBuilder.build();

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getRowCount.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getRowCount.ts
@@ -1,29 +1,30 @@
 import { GetRowCountMethod } from "@grouparoo/app-templates/dist/source/table";
 import { makeWhereClause } from "./util";
-import { validateQuery } from "../validateQuery";
+import SQLiteQueryBuilder from "../queryBuilder";
+import { SQLiteConnection } from "../sqlite";
 
-export const getRowCount: GetRowCountMethod = async ({
+export const getRowCount: GetRowCountMethod<SQLiteConnection> = async ({
   connection,
   tableName,
   matchConditions,
   highWaterMarkCondition,
   incremental,
 }) => {
-  let query = `SELECT COUNT(*) AS __count FROM "${tableName}"`;
+  const queryBuilder = new SQLiteQueryBuilder(
+    `SELECT COUNT(*) AS __count FROM "${tableName}"`
+  );
 
   if (incremental && highWaterMarkCondition) {
-    query += ` WHERE ${makeWhereClause(highWaterMarkCondition)}`;
+    queryBuilder.push("WHERE");
+    makeWhereClause(highWaterMarkCondition, queryBuilder);
   }
 
   for (const [idx, condition] of matchConditions.entries()) {
-    const filterClause = makeWhereClause(condition);
-    query += ` ${
-      highWaterMarkCondition || idx > 0 ? "AND" : "WHERE"
-    } ${filterClause}`;
+    queryBuilder.push(highWaterMarkCondition || idx > 0 ? "AND" : "WHERE");
+    makeWhereClause(condition, queryBuilder);
   }
 
-  validateQuery(query);
-  const rows = await connection.asyncQuery(query);
+  const rows = await connection.asyncQuery(...queryBuilder.build());
   const total = parseInt(rows[0]["__count"]);
 
   return total;

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getRows.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getRows.ts
@@ -1,12 +1,9 @@
 import { makeWhereClause } from "./util";
-import { validateQuery } from "../validateQuery";
-import {
-  GetRowsMethod,
-  DataResponseRow,
-  MatchCondition,
-} from "@grouparoo/app-templates/dist/source/table";
+import { GetRowsMethod } from "@grouparoo/app-templates/dist/source/table";
+import SQLiteQueryBuilder from "../queryBuilder";
+import { SQLiteConnection } from "../sqlite";
 
-export const getRows: GetRowsMethod = async ({
+export const getRows: GetRowsMethod<SQLiteConnection> = async ({
   connection,
   tableName,
   highWaterMarkCondition,
@@ -17,33 +14,29 @@ export const getRows: GetRowsMethod = async ({
   matchConditions,
   highWaterMarkKey,
   incremental,
-}: {
-  highWaterMarkCondition: MatchCondition;
-  [key: string]: any;
 }) => {
   // Begin with SELECT statement.
-  let query = `SELECT *, ${highWaterMarkAndSortColumnASC} AS ${highWaterMarkKey} FROM "${tableName}"`;
+  const queryBuilder = new SQLiteQueryBuilder(
+    `SELECT *, ${highWaterMarkAndSortColumnASC} AS ${highWaterMarkKey} FROM "${tableName}"`
+  );
 
   // Add WHERE clause, if there is a condition for the HWM.
   if (incremental && highWaterMarkCondition) {
-    query += ` WHERE ${makeWhereClause(highWaterMarkCondition)}`;
+    queryBuilder.push(`WHERE`);
+    makeWhereClause(highWaterMarkCondition, queryBuilder);
   }
 
   // Add additional WHERE clauses for Filters on the schedule
   for (const [idx, condition] of matchConditions.entries()) {
-    const filterClause = makeWhereClause(condition);
-    query += ` ${
-      highWaterMarkCondition || idx > 0 ? "AND" : "WHERE"
-    } ${filterClause}`;
+    queryBuilder.push(highWaterMarkCondition || idx > 0 ? "AND" : "WHERE");
+    makeWhereClause(condition, queryBuilder);
   }
 
   // Add ORDER, LIMIT, and OFFSET clauses.
-  query += ` ORDER BY ${highWaterMarkAndSortColumnASC} ASC, ${secondarySortColumnASC} ASC LIMIT ${limit} OFFSET ${sourceOffset}`;
-
-  // Ensure we don't have any extraneous characters, multiple queries, etc.
-  validateQuery(query);
+  queryBuilder.push(
+    `ORDER BY ${highWaterMarkAndSortColumnASC} ASC, ${secondarySortColumnASC} ASC LIMIT ${limit} OFFSET ${sourceOffset}`
+  );
 
   // Run the query and return the result.
-  const out: DataResponseRow[] = await connection.asyncQuery(query);
-  return out;
+  return await connection.asyncQuery(...queryBuilder.build());
 };

--- a/plugins/@grouparoo/sqlite/src/lib/table-import/getRows.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/table-import/getRows.ts
@@ -17,7 +17,7 @@ export const getRows: GetRowsMethod<SQLiteConnection> = async ({
 }) => {
   // Begin with SELECT statement.
   const queryBuilder = new SQLiteQueryBuilder(
-    `SELECT *, ${highWaterMarkAndSortColumnASC} AS ${highWaterMarkKey} FROM "${tableName}"`
+    `SELECT *, "${highWaterMarkAndSortColumnASC}" AS "${highWaterMarkKey}" FROM "${tableName}"`
   );
 
   // Add WHERE clause, if there is a condition for the HWM.
@@ -34,7 +34,7 @@ export const getRows: GetRowsMethod<SQLiteConnection> = async ({
 
   // Add ORDER, LIMIT, and OFFSET clauses.
   queryBuilder.push(
-    `ORDER BY ${highWaterMarkAndSortColumnASC} ASC, ${secondarySortColumnASC} ASC LIMIT ${limit} OFFSET ${sourceOffset}`
+    `ORDER BY "${highWaterMarkAndSortColumnASC}" ASC, "${secondarySortColumnASC}" ASC LIMIT ${limit} OFFSET ${sourceOffset}`
   );
 
   // Run the query and return the result.

--- a/plugins/@grouparoo/sqlite/src/lib/util.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/util.ts
@@ -1,0 +1,20 @@
+import { SQLiteQueryParamValue } from "./sqlite";
+
+type DataParam =
+  | SQLiteQueryParamValue[]
+  | Record<string, SQLiteQueryParamValue>;
+
+export const buildKeyList = (data: DataParam): string[] => {
+  const keys = Array.isArray(data) ? data : Object.keys(data);
+  return keys.map((v) => `"${v}"`);
+};
+
+export const toValuesArray = (data: DataParam): SQLiteQueryParamValue[] =>
+  Array.isArray(data) ? data : Object.values(data);
+
+export const toValuePlaceholders = (
+  values: SQLiteQueryParamValue[]
+): string => {
+  const placeholders = values.map(() => "?");
+  return placeholders.length > 1 ? `(${placeholders})` : placeholders.join(",");
+};

--- a/plugins/@grouparoo/sqlite/src/lib/util.ts
+++ b/plugins/@grouparoo/sqlite/src/lib/util.ts
@@ -16,5 +16,5 @@ export const toValuePlaceholders = (
   values: SQLiteQueryParamValue[]
 ): string => {
   const placeholders = values.map(() => "?");
-  return placeholders.length > 1 ? `(${placeholders})` : placeholders.join(",");
+  return placeholders.length > 0 ? `(${placeholders})` : "";
 };


### PR DESCRIPTION
## Change description

This change fixes an issue with the SQLite plugin where clauses don't often format strings correctly. It improves the way that SQLite queries are prepared in the plugin so that the values are formatted correctly by taking advantage of the formatter available in the SQLite module:

https://github.com/mapbox/node-sqlite3/wiki/API#databaserunsql-param--callback

It introduces a `SQLLiteQueryBuilder` that assists with putting parts of a query together. Its really simple usage allows pushing different parts of a query and parameters to eventually build a full list.

TODO:
- [x] Migrate table-import

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
