### PR TITLE
fix: apply group rules match type at the right level

### DIFF
--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -455,8 +455,6 @@ export class Group extends LoggedModel<Group> {
     const wheres: WhereAttributeHash[] = [];
     const localNumbers = [].concat(numbers);
 
-    if (recordState) wheres.push({ state: recordState });
-
     for (const i in rules) {
       const rule = rules[i];
       const number = localNumbers.pop();
@@ -648,6 +646,7 @@ export class Group extends LoggedModel<Group> {
 
     const joinType = matchType === "all" ? Op.and : Op.or;
     const whereContainer: WhereAttributeHash = {};
+    if (recordState) whereContainer.state = recordState;
     // @ts-ignore
     whereContainer[joinType] = wheres;
 


### PR DESCRIPTION
## Change description

When using groups with the `any` match type, imports were being created for every record that was `ready` due to applying the `or` at the wrong level.

Before: (notice the `OR` applied to `state=ready`)
```
SELECT "RecordMultipleAssociationShim"."id", "RecordMultipleAssociationShim"."createdAt" FROM "records" AS "RecordMultipleAssociationShim" INNER JOIN "recordProperties" AS "RecordProperties_10" ON "RecordMultipleAssociationShim"."id" = "RecordProperties_10"."recordId" AND "RecordProperties_10"."propertyId" = 'user_id' INNER JOIN "recordProperties" AS "RecordProperties_9" ON "RecordMultipleAssociationShim"."id" = "RecordProperties_9"."recordId" AND "RecordProperties_9"."propertyId" = 'user_id' 
    WHERE (
        "RecordMultipleAssociationShim"."state" = 'ready' 
        OR (
            CAST("RecordProperties_10"."rawValue" AS BIGINT) = '432'
        ) OR (
            CAST("RecordProperties_9"."rawValue" AS BIGINT) = '33'
        )
    ) AND (
            "RecordMultipleAssociationShim"."createdAt" < '2022-01-24 22:48:41.245 +00:00'
    ) ORDER BY "RecordMultipleAssociationShim"."createdAt" ASC LIMIT 1000 OFFSET 0; 
```

After:
```
SELECT "RecordMultipleAssociationShim"."id", "RecordMultipleAssociationShim"."createdAt" FROM "records" AS "RecordMultipleAssociationShim" INNER JOIN "recordProperties" AS "RecordProperties_10" ON "RecordMultipleAssociationShim"."id" = "RecordProperties_10"."recordId" AND "RecordProperties_10"."propertyId" = 'user_id' INNER JOIN "recordProperties" AS "RecordProperties_9" ON "RecordMultipleAssociationShim"."id" = "RecordProperties_9"."recordId" AND "RecordProperties_9"."propertyId" = 'user_id' 
    WHERE 
        ((CAST("RecordProperties_10"."rawValue" AS BIGINT) = '432') OR (CAST("RecordProperties_9"."rawValue" AS BIGINT) = '33')) 
        AND "RecordMultipleAssociationShim"."state" = 'ready' 
        AND ("RecordMultipleAssociationShim"."createdAt" < '2022-01-24 22:50:54.237 +00:00') 
    ORDER BY "RecordMultipleAssociationShim"."createdAt" ASC LIMIT 1000 OFFSET 0;
```

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
