### PR TITLE
Add missing style to navigation link

### DIFF
--- a/ui/ui-components/components/Navigation.tsx
+++ b/ui/ui-components/components/Navigation.tsx
@@ -191,7 +191,7 @@ export default function Navigation(props) {
               {navigation?.navigationItems.map((nav, idx) => {
                 if (nav.type === "link") {
                   return (
-                    <li key={nav.href}>
+                    <li key={nav.href} style={navLiStyle}>
                       <HighlightingNavLink
                         href={nav.href}
                         mainPathSectionIdx={nav.mainPathSectionIdx ?? 1}

--- a/ui/ui-components/components/navigation/HighlightingNavLink.tsx
+++ b/ui/ui-components/components/navigation/HighlightingNavLink.tsx
@@ -36,7 +36,7 @@ export default function HighlightingNavLink({
   }, [globalThis?.location?.href, router, href]);
 
   return (
-    <div>
+    <>
       <Link href={href}>
         <a role="tab" aria-selected={active} style={navIconStyle}>
           {icon && (
@@ -67,6 +67,6 @@ export default function HighlightingNavLink({
           </span>
         </a>
       </Link>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Change description

This just adds a missing style missing from #2815 that restores the vertical spacing.

Before:
![image](https://user-images.githubusercontent.com/168664/151031950-c82628a1-e6bc-4b96-8ef8-34fe2c48437d.png)


After:

![image](https://user-images.githubusercontent.com/168664/151031697-e5459c4f-99f5-4b42-a661-6e0749a7bb89.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
