### PR TITLE
`scheduleIds` param validation for `grouparoo run`

### DIFF
--- a/core/__tests__/bin/run.ts
+++ b/core/__tests__/bin/run.ts
@@ -1,4 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
+import { Run } from "../../src/models/Run";
 import { RunCLI } from "../../src/bin/run";
 
 describe("bin/run", () => {
@@ -30,13 +31,52 @@ describe("bin/run", () => {
     // We can test each method individually
 
     let instance: RunCLI;
-    beforeAll(() => {
+    beforeAll(async () => {
       instance = new RunCLI();
+      await helper.factories.properties();
     });
 
     test("requires workers to be enabled", async () => {
       instance.checkWorkers();
       expect(messages.join(" ")).toContain("❌ No Task Workers are enabled");
+    });
+
+    test("stops running schedules", async () => {
+      const schedule = await helper.factories.schedule();
+      await Run.truncate();
+
+      const run = await Run.create({
+        state: "running",
+        creatorType: "schedule",
+        creatorId: schedule.id,
+      });
+
+      await instance.stopScheduleRuns();
+
+      await run.reload();
+      expect(run.state).toBe("stopped");
+    });
+
+    describe("with scheduleIds", () => {
+      test("will error if param is specified with no schedules", async () => {
+        await instance.checkSchedules(true);
+        expect(messages.join(" ")).toContain(
+          "❌ Please specify which schedule ids to run"
+        );
+      });
+
+      test("will error if non-existent schedule ids are passed", async () => {
+        await instance.checkSchedules(["foo"]);
+        expect(messages.join(" ")).toContain(
+          '❌ Schedule with id "foo" was not found'
+        );
+      });
+
+      test("will not error if valid schedule ids are passed", async () => {
+        const schedule = await helper.factories.schedule();
+        await instance.checkSchedules([schedule.id]);
+        expect(messages.join(" ")).not.toContain("❌");
+      });
     });
   });
 });

--- a/core/__tests__/tasks/schedule/enqueueRuns.ts
+++ b/core/__tests__/tasks/schedule/enqueueRuns.ts
@@ -1,4 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
+import * as actionhero from "actionhero";
 import { api, task, specHelper } from "actionhero";
 import { Schedule, Run } from "../../../src";
 import { Op } from "sequelize";
@@ -202,6 +203,40 @@ describe("tasks/schedules:enqueueRuns", () => {
         expect(runs.length).toBe(1);
         expect(runs[0].creatorType).toBe("schedule");
         expect(runs[0].creatorId).toBe(scheduleToRun.id);
+
+        await scheduleToRun.destroy();
+        await scheduleToIgnore.destroy();
+      });
+    });
+
+    describe("in cli:run mode", () => {
+      let logMsgs: string[] = [];
+      let logSpy: jest.SpyInstance;
+
+      beforeAll(async () => {
+        process.env.GROUPAROO_RUN_MODE = "cli:run";
+      });
+
+      afterAll(() => {
+        delete process.env.GROUPAROO_RUN_MODE;
+      });
+
+      beforeEach(() => {
+        logMsgs = [];
+        logSpy = jest
+          .spyOn(actionhero, "log")
+          .mockImplementation((message) => logMsgs.push(message));
+      });
+
+      afterEach(async () => {
+        logSpy.mockRestore();
+      });
+
+      test("it will log the enqueued schedules", async () => {
+        await specHelper.runTask("schedules:enqueueRuns", {});
+        expect(logMsgs.join(" ")).toContain(
+          `Enqueued runs for Schedules: ${schedule.name} (${schedule.id})`
+        );
       });
     });
   });

--- a/core/__tests__/tasks/schedule/enqueueRuns.ts
+++ b/core/__tests__/tasks/schedule/enqueueRuns.ts
@@ -209,17 +209,9 @@ describe("tasks/schedules:enqueueRuns", () => {
       });
     });
 
-    describe("in cli:run mode", () => {
+    describe("logging", () => {
       let logMsgs: string[] = [];
       let logSpy: jest.SpyInstance;
-
-      beforeAll(async () => {
-        process.env.GROUPAROO_RUN_MODE = "cli:run";
-      });
-
-      afterAll(() => {
-        delete process.env.GROUPAROO_RUN_MODE;
-      });
 
       beforeEach(() => {
         logMsgs = [];
@@ -235,7 +227,7 @@ describe("tasks/schedules:enqueueRuns", () => {
       test("it will log the enqueued schedules", async () => {
         await specHelper.runTask("schedules:enqueueRuns", {});
         expect(logMsgs.join(" ")).toContain(
-          `Enqueued runs for Schedules: ${schedule.name} (${schedule.id})`
+          `Enqueued Runs for Schedules: ${schedule.name} (${schedule.id})`
         );
       });
     });

--- a/core/src/tasks/schedule/enqueueRuns.ts
+++ b/core/src/tasks/schedule/enqueueRuns.ts
@@ -1,4 +1,4 @@
-import { ParamsFrom } from "actionhero";
+import { ParamsFrom, log } from "actionhero";
 import { WhereOptions } from "sequelize/types";
 import { Schedule } from "../../models/Schedule";
 import { CLSTask } from "../../classes/tasks/clsTask";
@@ -38,12 +38,26 @@ export class ScheduleEnqueueRuns extends CLSTask {
 
     const schedules = await Schedule.findAll({ where });
 
+    const enqueuedSchedules: Schedule[] = [];
     for (const schedule of schedules) {
       const shouldRun = await schedule.shouldRun({
         ignoreDeltas,
         runIfNotRecurring,
       });
-      if (shouldRun) await schedule.enqueueRun();
+
+      if (shouldRun) {
+        await schedule.enqueueRun();
+        enqueuedSchedules.push(schedule);
+      }
+    }
+
+    if (getGrouparooRunMode() === "cli:run" && enqueuedSchedules.length > 0) {
+      log(
+        `Enqueued runs for Schedules: ${enqueuedSchedules
+          .map((s) => `${s.name} (${s.id})`)
+          .join(", ")}`,
+        "notice"
+      );
     }
   }
 }

--- a/core/src/tasks/schedule/enqueueRuns.ts
+++ b/core/src/tasks/schedule/enqueueRuns.ts
@@ -53,7 +53,7 @@ export class ScheduleEnqueueRuns extends CLSTask {
 
     if (enqueuedSchedules.length) {
       log(
-        `Enqueued runs for Schedules: ${enqueuedSchedules
+        `Enqueued Runs for Schedules: ${enqueuedSchedules
           .map((s) => `${s.name} (${s.id})`)
           .join(", ")}`,
         getGrouparooRunMode() === "cli:run" ? "notice" : "info"

--- a/core/src/tasks/schedule/enqueueRuns.ts
+++ b/core/src/tasks/schedule/enqueueRuns.ts
@@ -51,12 +51,12 @@ export class ScheduleEnqueueRuns extends CLSTask {
       }
     }
 
-    if (getGrouparooRunMode() === "cli:run" && enqueuedSchedules.length > 0) {
+    if (enqueuedSchedules.length) {
       log(
         `Enqueued runs for Schedules: ${enqueuedSchedules
           .map((s) => `${s.name} (${s.id})`)
           .join(", ")}`,
-        "notice"
+        getGrouparooRunMode() === "cli:run" ? "notice" : "info"
       );
     }
   }


### PR DESCRIPTION
## Change description

Checks if the passed schedules are valid and adds some more output.

The `grouparoo run` command now also stops currently running schedule runs at the start. We are assuming that if you are using `grouparoo run` you only expect things to run when you tell them to, and the previous behavior of continuing old schedules that may have been in a weird state was unexpected. Initial runs enqueued by the creation of schedules through config files will be stopped, but new runs will be enqueued for them anyway as part of the manually triggered `schedules:enqueueRuns` so the behavior remains as expected.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
