### PR TITLE
Don't allow update Property `unique` value when it's primary key 

### DIFF
--- a/ui/ui-components/components/badges/PrimaryKeyBadge.tsx
+++ b/ui/ui-components/components/badges/PrimaryKeyBadge.tsx
@@ -1,5 +1,11 @@
 import { Badge } from "react-bootstrap";
 
-const PrimaryKeyBadge = () => <Badge variant="info">primary</Badge>;
+interface Props {
+  isSource?: boolean;
+}
+
+const PrimaryKeyBadge: React.FC<Props> = ({ isSource }) => (
+  <Badge variant="info">primary{isSource ? " source" : ""}</Badge>
+);
 
 export default PrimaryKeyBadge;

--- a/ui/ui-components/components/badges/PrimaryKeyBadge.tsx
+++ b/ui/ui-components/components/badges/PrimaryKeyBadge.tsx
@@ -1,0 +1,5 @@
+import { Badge } from "react-bootstrap";
+
+const PrimaryKeyBadge = () => <Badge variant="info">primary</Badge>;
+
+export default PrimaryKeyBadge;

--- a/ui/ui-components/components/source/FormMappingSelector.tsx
+++ b/ui/ui-components/components/source/FormMappingSelector.tsx
@@ -90,11 +90,11 @@ const FormMappingSelector: React.FC<Props> = ({
       ).length > 0;
 
     // Properties rules:
-    // Include properties in own source if it has the primary key or the primary key has not been defined
-    // Otherwise, show properties from other sources
+    // Include unique properties in own source if it has the primary key or the primary key has not been defined
+    // Otherwise, it's not the primary source and show all properties from other sources
     return properties.filter((property) =>
       isPrimaryKeyInSource || !hasPrimaryKeyProperty
-        ? property.sourceId === source.id
+        ? property.sourceId === source.id && property.unique
         : property.sourceId !== source.id
     );
   }, [source, properties, hasPrimaryKeyProperty]);

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -25,6 +25,7 @@ import FormMappingSelector from "../../../../../components/source/FormMappingSel
 import { createSchedule } from "../../../../../components/schedule/Add";
 import ManagedCard from "../../../../../components/lib/ManagedCard";
 import { grouparooUiEdition } from "../../../../../utils/uiEdition";
+import PrimaryKeyBadge from "../../../../../components/badges/PrimaryKeyBadge";
 
 interface FormData {
   mapping?: {
@@ -93,7 +94,7 @@ const Page: NextPage<Props> = ({
       <ModelBadge modelName={source.modelName} modelId={source.modelId} />,
     ];
     if (isPrimarySource) {
-      badges.unshift(<Badge variant="info">primary source</Badge>);
+      badges.unshift(<PrimaryKeyBadge isSource />);
     }
     return badges;
   }, [source, isPrimarySource]);

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
@@ -18,6 +18,7 @@ import { NextPageContext } from "next";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
 import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 import ManagedCard from "../../../../../components/lib/ManagedCard";
+import PrimaryKeyBadge from "../../../../../components/badges/PrimaryKeyBadge";
 
 export default function Page({
   model,
@@ -50,7 +51,7 @@ export default function Page({
       <ModelBadge modelName={source.modelName} modelId={source.modelId} />,
     ];
     if (isPrimarySource) {
-      badges.unshift(<Badge variant="info">primary source</Badge>);
+      badges.unshift(<PrimaryKeyBadge isSource />);
     }
     return badges;
   }, [source, isPrimarySource]);
@@ -157,7 +158,7 @@ export default function Page({
                           {rule.isPrimaryKey && (
                             <>
                               {" "}
-                              <Badge variant="info">primary</Badge>
+                              <PrimaryKeyBadge />
                             </>
                           )}
                         </td>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit.tsx
@@ -26,6 +26,9 @@ import {
   propertiesHandler,
   successHandler,
 } from "../../../../../../../eventHandlers";
+import PrimaryKeyBadge from "../../../../../../../components/badges/PrimaryKeyBadge";
+import EnterpriseLink from "../../../../../../../components/GrouparooLink";
+import { grouparooUiEdition } from "../../../../../../../utils/uiEdition";
 
 export default function Page(props) {
   const {
@@ -213,6 +216,16 @@ export default function Page(props) {
     return <Loader />;
   }
 
+  const badges = [
+    <LockedBadge object={property} />,
+    <StateBadge state={property.state} />,
+    <ModelBadge modelName={source.modelName} modelId={source.modelId} />,
+  ];
+
+  if (property.isPrimaryKey) {
+    badges.push(<PrimaryKeyBadge />);
+  }
+
   let rowChanges = false;
   return (
     <>
@@ -222,15 +235,7 @@ export default function Page(props) {
 
       <PropertyTabs property={property} source={source} model={model} />
 
-      <PageHeader
-        icon={source.app.icon}
-        title={property.key}
-        badges={[
-          <LockedBadge object={property} />,
-          <StateBadge state={property.state} />,
-          <ModelBadge modelName={source.modelName} modelId={source.modelId} />,
-        ]}
-      />
+      <PageHeader icon={source.app.icon} title={property.key} badges={badges} />
       <Row>
         <Col>
           <Form id="form" onSubmit={onSubmit} autoComplete="off">
@@ -281,11 +286,24 @@ export default function Page(props) {
                   <Form.Group controlId="unique">
                     <Form.Check
                       type="checkbox"
-                      label="Unique"
+                      label={"Unique"}
                       checked={property.unique}
                       onChange={(e) => update(e)}
-                      disabled={loading}
+                      disabled={property.unique || loading}
                     />
+                    {property.isPrimaryKey && (
+                      <Form.Text className="text-muted">
+                        <code>Unique</code> cannot be updated while this
+                        Property is the Primary Key for the Model.{" "}
+                        {grouparooUiEdition() !== "community" && (
+                          <EnterpriseLink
+                            href={`/model/${source.modelId}/source/${source.id}/edit`}
+                          >
+                            <a>Edit mapping</a>
+                          </EnterpriseLink>
+                        )}
+                      </Form.Text>
+                    )}
                   </Form.Group>
                   <Form.Group controlId="isArray">
                     <Form.Check


### PR DESCRIPTION
## Change description

This change prevents the "unique" value in a Property model from being updated when the Property is also the primary key (`isPrimaryKey`). It also fixes up the primary badge and adds it to the property edit page when the property is the primary.

This change only impacts UI. A model-level change will be done in a separate PR.

UI Changes:

![image](https://user-images.githubusercontent.com/168664/151068720-dc9e5ef0-6a63-4e1f-b5ae-6ec39ff66996.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
