### PR TITLE
Add `retryExports` CLI command

### DIFF
--- a/cli/src/utils/loadLocalCommands.ts
+++ b/cli/src/utils/loadLocalCommands.ts
@@ -29,6 +29,8 @@ type ActionheroCLIInputStub = {
   flag?: string;
   placeholder?: string;
   variadic?: boolean;
+  formatter?: Function;
+  validator?: Function;
 };
 
 export async function loadLocalCommands(program: Command): Promise<boolean> {
@@ -228,6 +230,16 @@ async function runCommand(
   clearRequireCache();
 
   params["_arguments"] = _arguments;
+
+  for (const [key, inputOpts] of Object.entries(instance.inputs)) {
+    if (typeof inputOpts.formatter === "function") {
+      params[key] = await inputOpts.formatter(params[key]);
+    }
+
+    if (typeof inputOpts.validator === "function") {
+      await inputOpts.validator(params[key]);
+    }
+  }
 
   if (instance.initialize === false && instance.start === false) {
     toStop = await instance.run({ params });

--- a/cli/src/utils/loadLocalCommands.ts
+++ b/cli/src/utils/loadLocalCommands.ts
@@ -25,6 +25,7 @@ type ActionheroCLIInputStub = {
   description?: string;
   default?: boolean;
   required?: boolean;
+  requiredValue?: boolean;
   letter?: string;
   flag?: string;
   placeholder?: string;
@@ -191,7 +192,8 @@ async function convertCLIToCommanderAction(
 
   for (const key in instance.inputs) {
     const input = instance.inputs[key];
-    const separators = input.required ? ["<", ">"] : ["[", "]"];
+    const separators =
+      input.required || input.requiredValue ? ["<", ">"] : ["[", "]"];
     const methodName = input.required ? "requiredOption" : "option";
     const argString = `${input.letter ? `-${input.letter}, ` : ""}--${key} ${
       input.flag

--- a/core/__tests__/bin/retryExports.ts
+++ b/core/__tests__/bin/retryExports.ts
@@ -46,7 +46,9 @@ describe("bin/retryExports", () => {
 
     test("cannot set both --start and --startAgoSeconds", async () => {
       const command = new RetryExportsCLI();
-      await command.run({ params: { start: 1000, startAgoSeconds: "1000" } });
+      await command.run({
+        params: { start: new Date(), startAgoSeconds: 1000 },
+      });
       const output = messages.join(" ");
 
       expect(output).toContain(
@@ -55,44 +57,10 @@ describe("bin/retryExports", () => {
       expect(output).not.toContain("Success!");
     });
 
-    test("--start can be set to 0", async () => {
-      const command = new RetryExportsCLI();
-      await command.run({ params: { start: 0 } });
-      const output = messages.join(" ");
-      expect(output).toContain("Success!");
-    });
-
-    test("it errors on an invalid start date", async () => {
-      const command = new RetryExportsCLI();
-      await command.run({ params: { start: NaN } });
-      const output = messages.join(" ");
-
-      expect(output).toContain("Invalid start date specified");
-      expect(output).not.toContain("Success!");
-    });
-
-    test("it errors on an invalid startAgoSeconds value", async () => {
-      const command = new RetryExportsCLI();
-      await command.run({ params: { startAgoSeconds: "something" } });
-      const output = messages.join(" ");
-
-      expect(output).toContain("--startAgoSeconds must be a number");
-      expect(output).not.toContain("Success!");
-    });
-
-    test("it errors on an invalid end date", async () => {
-      const command = new RetryExportsCLI();
-      await command.run({ params: { startAgoSeconds: "1000", end: NaN } });
-      const output = messages.join(" ");
-
-      expect(output).toContain("Invalid end date specified");
-      expect(output).not.toContain("Success!");
-    });
-
     test("it requires ids to be passed if --destinationIds is set", async () => {
       const command = new RetryExportsCLI();
       await command.run({
-        params: { startAgoSeconds: "1000", destinationIds: true },
+        params: { startAgoSeconds: 1000, destinationIds: true },
       });
       const output = messages.join(" ");
 
@@ -106,7 +74,7 @@ describe("bin/retryExports", () => {
       const command = new RetryExportsCLI();
       await command.run({
         params: {
-          startAgoSeconds: "1000",
+          startAgoSeconds: 1000,
           destinationIds: [destination.id, "foo"],
         },
       });
@@ -138,7 +106,7 @@ describe("bin/retryExports", () => {
 
     test("can preview exports to retry", async () => {
       await instance.run({
-        params: { startAgoSeconds: "3600", preview: true },
+        params: { startAgoSeconds: 3600, preview: true },
       });
       const output = messages.join(" ");
       expect(output).toContain(
@@ -155,7 +123,7 @@ describe("bin/retryExports", () => {
     test("can preview exports to retry for a destination", async () => {
       await instance.run({
         params: {
-          startAgoSeconds: "3600",
+          startAgoSeconds: 3600,
           preview: true,
           destinationIds: [destination.id],
         },
@@ -175,7 +143,7 @@ describe("bin/retryExports", () => {
     test("can retry exports", async () => {
       await instance.run({
         params: {
-          startAgoSeconds: "3600",
+          startAgoSeconds: 3600,
         },
       });
       const output = messages.join(" ");
@@ -193,7 +161,7 @@ describe("bin/retryExports", () => {
     test("can retry exports for a destination", async () => {
       await instance.run({
         params: {
-          startAgoSeconds: "3600",
+          startAgoSeconds: 3600,
           destinationIds: [destination.id],
         },
       });
@@ -214,7 +182,7 @@ describe("bin/retryExports", () => {
 
       await instance.run({
         params: {
-          startAgoSeconds: "3600",
+          startAgoSeconds: 3600,
           destinationIds: [destination2.id],
         },
       });

--- a/core/__tests__/bin/retryExports.ts
+++ b/core/__tests__/bin/retryExports.ts
@@ -57,19 +57,6 @@ describe("bin/retryExports", () => {
       expect(output).not.toContain("Success!");
     });
 
-    test("it requires ids to be passed if --destinationIds is set", async () => {
-      const command = new RetryExportsCLI();
-      await command.run({
-        params: { startAgoSeconds: 1000, destinationIds: true },
-      });
-      const output = messages.join(" ");
-
-      expect(output).toContain(
-        "Please specify which destination ids to check or remove the --destinationIds param to check all Destinations."
-      );
-      expect(output).not.toContain("Success!");
-    });
-
     test("it errors if passed destinations do not exist", async () => {
       const command = new RetryExportsCLI();
       await command.run({

--- a/core/__tests__/bin/retryExports.ts
+++ b/core/__tests__/bin/retryExports.ts
@@ -1,13 +1,18 @@
 import { helper } from "@grouparoo/spec-helper";
+import { Destination, Export } from "../../src";
 import { RetryExportsCLI } from "../../src/bin/retryExports";
 
 describe("bin/retryExports", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
 
-  beforeAll(async () => await helper.factories.properties());
-
+  let destination: Destination;
   let messages: string[] = [];
   const spies: jest.SpyInstance[] = [];
+
+  beforeAll(async () => {
+    await helper.factories.properties();
+    destination = await helper.factories.destination();
+  });
 
   beforeEach(() => {
     messages = [];
@@ -100,11 +105,127 @@ describe("bin/retryExports", () => {
     test("it errors if passed destinations do not exist", async () => {
       const command = new RetryExportsCLI();
       await command.run({
-        params: { startAgoSeconds: "1000", destinationIds: ["foo"] },
+        params: {
+          startAgoSeconds: "1000",
+          destinationIds: [destination.id, "foo"],
+        },
+      });
+
+      const output = messages.join(" ");
+      expect(output).toContain('Destination with id "foo" was not found');
+    });
+  });
+
+  describe("with exports", () => {
+    let failedExport: Export;
+    let otherFailedExport: Export;
+    let instance: RetryExportsCLI;
+
+    beforeEach(async () => {
+      instance = new RetryExportsCLI();
+
+      failedExport = await helper.factories.export(null, destination);
+      await failedExport.update({ state: "failed" });
+
+      otherFailedExport = await helper.factories.export(null);
+      await otherFailedExport.update({ state: "failed" });
+    });
+
+    afterEach(async () => {
+      await failedExport.destroy();
+      await otherFailedExport.destroy();
+    });
+
+    test("can preview exports to retry", async () => {
+      await instance.run({
+        params: { startAgoSeconds: "3600", preview: true },
       });
       const output = messages.join(" ");
+      expect(output).toContain(
+        "ℹ️  (Preview) Found 2 failed Exports to retry."
+      );
 
-      expect(output).toContain('Destination with id "foo" was not found');
+      await failedExport.reload();
+      expect(failedExport.state).toBe("failed");
+
+      await otherFailedExport.reload();
+      expect(otherFailedExport.state).toBe("failed");
+    });
+
+    test("can preview exports to retry for a destination", async () => {
+      await instance.run({
+        params: {
+          startAgoSeconds: "3600",
+          preview: true,
+          destinationIds: [destination.id],
+        },
+      });
+      const output = messages.join(" ");
+      expect(output).toContain(
+        "ℹ️  (Preview) Found 1 failed Exports to retry."
+      );
+
+      await failedExport.reload();
+      expect(failedExport.state).toBe("failed");
+
+      await otherFailedExport.reload();
+      expect(otherFailedExport.state).toBe("failed");
+    });
+
+    test("can retry exports", async () => {
+      await instance.run({
+        params: {
+          startAgoSeconds: "3600",
+        },
+      });
+      const output = messages.join(" ");
+      expect(output).toContain(
+        "✅ Success! 2 failed Exports marked to be retried."
+      );
+
+      await failedExport.reload();
+      expect(failedExport.state).toBe("pending");
+
+      await otherFailedExport.reload();
+      expect(otherFailedExport.state).toBe("pending");
+    });
+
+    test("can retry exports for a destination", async () => {
+      await instance.run({
+        params: {
+          startAgoSeconds: "3600",
+          destinationIds: [destination.id],
+        },
+      });
+      const output = messages.join(" ");
+      expect(output).toContain(
+        "✅ Success! 1 failed Exports marked to be retried."
+      );
+
+      await failedExport.reload();
+      expect(failedExport.state).toBe("pending");
+
+      await otherFailedExport.reload();
+      expect(otherFailedExport.state).toBe("failed");
+    });
+
+    test("returns different messaging if there were no exports to retry", async () => {
+      const destination2 = await helper.factories.destination();
+
+      await instance.run({
+        params: {
+          startAgoSeconds: "3600",
+          destinationIds: [destination2.id],
+        },
+      });
+      const output = messages.join(" ");
+      expect(output).toContain("✨ Success! No failed Exports found to retry.");
+
+      await failedExport.reload();
+      expect(failedExport.state).toBe("failed");
+
+      await otherFailedExport.reload();
+      expect(otherFailedExport.state).toBe("failed");
     });
   });
 });

--- a/core/__tests__/bin/retryExports.ts
+++ b/core/__tests__/bin/retryExports.ts
@@ -167,7 +167,7 @@ describe("bin/retryExports", () => {
       });
       const output = messages.join(" ");
       expect(output).toContain(
-        "✅ Success! 1 failed Exports marked to be retried."
+        "✅ Success! 1 failed Exports marked to be retried. Run `grouparoo run` or `grouparoo start` to retry them."
       );
 
       await failedExport.reload();

--- a/core/__tests__/bin/retryExports.ts
+++ b/core/__tests__/bin/retryExports.ts
@@ -33,26 +33,26 @@ describe("bin/retryExports", () => {
   });
 
   describe("input validation", () => {
-    test("it requires one of --start or --startAgoSeconds", async () => {
+    test("it requires one of --start or --startAgo", async () => {
       const command = new RetryExportsCLI();
       await command.run({ params: {} });
       const output = messages.join(" ");
 
       expect(output).toContain(
-        "One of --start or --startAgoSeconds must be specified"
+        "One of --start or --startAgo must be specified"
       );
       expect(output).not.toContain("Success!");
     });
 
-    test("cannot set both --start and --startAgoSeconds", async () => {
+    test("cannot set both --start and --startAgo", async () => {
       const command = new RetryExportsCLI();
       await command.run({
-        params: { start: new Date(), startAgoSeconds: 1000 },
+        params: { start: new Date(), startAgo: 1000 },
       });
       const output = messages.join(" ");
 
       expect(output).toContain(
-        "One of --start or --startAgoSeconds must be specified"
+        "One of --start or --startAgo must be specified"
       );
       expect(output).not.toContain("Success!");
     });
@@ -61,7 +61,7 @@ describe("bin/retryExports", () => {
       const command = new RetryExportsCLI();
       await command.run({
         params: {
-          startAgoSeconds: 1000,
+          startAgo: 1000,
           destinationIds: [destination.id, "foo"],
         },
       });
@@ -93,7 +93,7 @@ describe("bin/retryExports", () => {
 
     test("can preview exports to retry", async () => {
       await instance.run({
-        params: { startAgoSeconds: 3600, preview: true },
+        params: { startAgo: 3600, preview: true },
       });
       const output = messages.join(" ");
       expect(output).toContain(
@@ -110,7 +110,7 @@ describe("bin/retryExports", () => {
     test("can preview exports to retry for a destination", async () => {
       await instance.run({
         params: {
-          startAgoSeconds: 3600,
+          startAgo: 3600,
           preview: true,
           destinationIds: [destination.id],
         },
@@ -130,7 +130,7 @@ describe("bin/retryExports", () => {
     test("can retry exports", async () => {
       await instance.run({
         params: {
-          startAgoSeconds: 3600,
+          startAgo: 3600,
         },
       });
       const output = messages.join(" ");
@@ -148,7 +148,7 @@ describe("bin/retryExports", () => {
     test("can retry exports for a destination", async () => {
       await instance.run({
         params: {
-          startAgoSeconds: 3600,
+          startAgo: 3600,
           destinationIds: [destination.id],
         },
       });
@@ -169,7 +169,7 @@ describe("bin/retryExports", () => {
 
       await instance.run({
         params: {
-          startAgoSeconds: 3600,
+          startAgo: 3600,
           destinationIds: [destination2.id],
         },
       });

--- a/core/__tests__/bin/retryExports.ts
+++ b/core/__tests__/bin/retryExports.ts
@@ -1,0 +1,110 @@
+import { helper } from "@grouparoo/spec-helper";
+import { RetryExportsCLI } from "../../src/bin/retryExports";
+
+describe("bin/retryExports", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
+  beforeAll(async () => await helper.factories.properties());
+
+  let messages: string[] = [];
+  const spies: jest.SpyInstance[] = [];
+
+  beforeEach(() => {
+    messages = [];
+    spies.push(
+      jest
+        .spyOn(console, "log")
+        .mockImplementation((message) => messages.push(message))
+    );
+    spies.push(
+      jest
+        .spyOn(console, "error")
+        .mockImplementation((message) => messages.push(message))
+    );
+  });
+
+  afterEach(() => {
+    spies.map((s) => s.mockRestore());
+  });
+
+  describe("input validation", () => {
+    test("it requires one of --start or --startAgoSeconds", async () => {
+      const command = new RetryExportsCLI();
+      await command.run({ params: {} });
+      const output = messages.join(" ");
+
+      expect(output).toContain(
+        "One of --start or --startAgoSeconds must be specified"
+      );
+      expect(output).not.toContain("Success!");
+    });
+
+    test("cannot set both --start and --startAgoSeconds", async () => {
+      const command = new RetryExportsCLI();
+      await command.run({ params: { start: 1000, startAgoSeconds: "1000" } });
+      const output = messages.join(" ");
+
+      expect(output).toContain(
+        "One of --start or --startAgoSeconds must be specified"
+      );
+      expect(output).not.toContain("Success!");
+    });
+
+    test("--start can be set to 0", async () => {
+      const command = new RetryExportsCLI();
+      await command.run({ params: { start: 0 } });
+      const output = messages.join(" ");
+      expect(output).toContain("Success!");
+    });
+
+    test("it errors on an invalid start date", async () => {
+      const command = new RetryExportsCLI();
+      await command.run({ params: { start: NaN } });
+      const output = messages.join(" ");
+
+      expect(output).toContain("Invalid start date specified");
+      expect(output).not.toContain("Success!");
+    });
+
+    test("it errors on an invalid startAgoSeconds value", async () => {
+      const command = new RetryExportsCLI();
+      await command.run({ params: { startAgoSeconds: "something" } });
+      const output = messages.join(" ");
+
+      expect(output).toContain("--startAgoSeconds must be a number");
+      expect(output).not.toContain("Success!");
+    });
+
+    test("it errors on an invalid end date", async () => {
+      const command = new RetryExportsCLI();
+      await command.run({ params: { startAgoSeconds: "1000", end: NaN } });
+      const output = messages.join(" ");
+
+      expect(output).toContain("Invalid end date specified");
+      expect(output).not.toContain("Success!");
+    });
+
+    test("it requires ids to be passed if --destinationIds is set", async () => {
+      const command = new RetryExportsCLI();
+      await command.run({
+        params: { startAgoSeconds: "1000", destinationIds: true },
+      });
+      const output = messages.join(" ");
+
+      expect(output).toContain(
+        "Please specify which destination ids to check or remove the --destinationIds param to check all Destinations."
+      );
+      expect(output).not.toContain("Success!");
+    });
+
+    test("it errors if passed destinations do not exist", async () => {
+      const command = new RetryExportsCLI();
+      await command.run({
+        params: { startAgoSeconds: "1000", destinationIds: ["foo"] },
+      });
+      const output = messages.join(" ");
+
+      expect(output).toContain('Destination with id "foo" was not found');
+    });
+  });
+});

--- a/core/__tests__/bin/run.ts
+++ b/core/__tests__/bin/run.ts
@@ -58,13 +58,6 @@ describe("bin/run", () => {
     });
 
     describe("with scheduleIds", () => {
-      test("will error if param is specified with no schedules", async () => {
-        await instance.checkSchedules(true);
-        expect(messages.join(" ")).toContain(
-          "❌ Please specify which schedule ids to run"
-        );
-      });
-
       test("will error if non-existent schedule ids are passed", async () => {
         await instance.checkSchedules(["foo"]);
         expect(messages.join(" ")).toContain(

--- a/core/__tests__/modules/apiData.ts
+++ b/core/__tests__/modules/apiData.ts
@@ -12,6 +12,11 @@ describe("apiDAta", () => {
       expect(APIData.formatDate(time)).toEqual(1577836801000);
     });
 
+    test("it works for numbers as strings", () => {
+      const time = "1577836801000";
+      expect(APIData.formatDate(time)).toEqual(1577836801000);
+    });
+
     test("it works for nulls", () => {
       expect(APIData.formatDate(null)).toEqual(null);
     });

--- a/core/__tests__/modules/apiData.ts
+++ b/core/__tests__/modules/apiData.ts
@@ -22,6 +22,35 @@ describe("apiDAta", () => {
     });
   });
 
+  describe("#ensureDate", () => {
+    test("it works for dates", () => {
+      const time = new Date(1577836801000);
+      expect(APIData.ensureDate(time).getTime()).toEqual(1577836801000);
+    });
+
+    test("it works for strings", () => {
+      const time = "2020-01-01T00:00:01Z";
+      expect(APIData.ensureDate(time).getTime()).toEqual(1577836801000);
+    });
+
+    test("it works for numbers as strings", () => {
+      const time = "1577836801000";
+      expect(APIData.ensureDate(time).getTime()).toEqual(1577836801000);
+    });
+
+    test("it works for numbers", () => {
+      const time = 1577836801000;
+      expect(APIData.ensureDate(time).getTime()).toEqual(1577836801000);
+    });
+
+    test("it throws for everything else", () => {
+      const param = "foo";
+      expect(() => APIData.ensureDate(param)).toThrow(
+        /foo cannot be converted to a date/
+      );
+    });
+  });
+
   describe("#ensureNumber", () => {
     test("it works for numbers", () => {
       const param = 1;

--- a/core/__tests__/modules/status.ts
+++ b/core/__tests__/modules/status.ts
@@ -487,6 +487,7 @@ describe("modules/status", () => {
 
     test("it gathers records", async () => {
       const records = await FinalSummaryReporters.GrouparooRecords.getData();
+      expect(records[0].name).toBeNull();
       expect(records[0].recordsCreated).toEqual(1);
       expect(records[0].recordsUpdated).toEqual(1);
       expect(records[0].allRecords).toEqual(2);

--- a/core/src/bin/retryExports.ts
+++ b/core/src/bin/retryExports.ts
@@ -12,18 +12,21 @@ export class RetryExportsCLI extends CLI {
   inputs = {
     start: {
       required: false,
+      requiredValue: true,
       formatter: APIData.ensureDate,
       description:
         "Search for failed Exports created on or after this timestamp.",
     },
     startAgoSeconds: {
       required: false,
+      requiredValue: true,
       formatter: APIData.ensureNumber,
       description:
         "Search for failed Exports created on or after a certain number of seconds ago.",
     },
     end: {
       required: false,
+      requiredValue: true,
       formatter: APIData.ensureDate,
       description:
         "Search for failed Exports created on or before this timestamp. Defaults to the current time.",
@@ -38,7 +41,8 @@ export class RetryExportsCLI extends CLI {
     },
     destinationIds: {
       required: false,
-      formatter: (val: any) => val as boolean | string[],
+      requiredValue: true,
+      formatter: (val: any) => val as string[],
       description:
         "Only retry Exports for specific Destinations. Defaults to all Destinations.",
       letter: "d",
@@ -68,12 +72,6 @@ export class RetryExportsCLI extends CLI {
     ) {
       return GrouparooCLI.logger.fatal(
         "One of --start or --startAgoSeconds must be specified"
-      );
-    }
-
-    if (typeof params.destinationIds === "boolean") {
-      return GrouparooCLI.logger.fatal(
-        `Please specify which destination ids to check or remove the --destinationIds param to check all Destinations.`
       );
     }
 

--- a/core/src/bin/retryExports.ts
+++ b/core/src/bin/retryExports.ts
@@ -56,13 +56,12 @@ export class RetryExportsCLI extends CLI {
     destinationIds: {
       required: false,
       requiredValue: true,
-      formatter: (val: any) => val as string[],
       description:
         "Only retry Exports for specific Destinations. Defaults to all Destinations.",
       letter: "d",
       variadic: true,
     },
-  };
+  } as const;
 
   constructor() {
     super();

--- a/core/src/bin/retryExports.ts
+++ b/core/src/bin/retryExports.ts
@@ -1,0 +1,126 @@
+import Moment from "moment";
+import { CLI, ParamsFrom } from "actionhero";
+import { GrouparooCLI } from "../modules/cli";
+import { APIData } from "../modules/apiData";
+import { Export } from "../models/Export";
+import { Destination } from "../models/Destination";
+
+export class RetryExportsCLI extends CLI {
+  name = "retryExports";
+  description =
+    "Marks failed Exports that were created in a given time frame to be retried.";
+  inputs = {
+    start: {
+      required: false,
+      formatter: APIData.formatDate,
+      description:
+        "Search for failed Exports created on or after this timestamp. Used in combination with `--end` to specify a time range.",
+    },
+    startAgoSeconds: {
+      required: false,
+      description:
+        "Search for failed Exports created on or after this timestamp. Used in combination with `--end` to specify a time range.",
+    },
+    end: {
+      required: false,
+      formatter: APIData.formatDate,
+      description:
+        "Search for failed Exports created on or before this timestamp. Used in combination with `--start` to specify a time range. Defaults to now.",
+    },
+    preview: {
+      default: false,
+      formatter: APIData.ensureBoolean,
+      description:
+        "When set, will not make any changes and only outputs the number of Exports that would be retried.",
+      flag: true,
+      letter: "p",
+    },
+    destinationId: {
+      description:
+        "Only retry Exports for a specific Destination. Defaults to all Destinations.",
+      letter: "d",
+      required: false,
+    },
+  };
+
+  constructor() {
+    super();
+    GrouparooCLI.timestampOption(this);
+  }
+
+  preInitialize = () => {
+    GrouparooCLI.setGrouparooRunMode(this);
+    GrouparooCLI.setNextDevelopmentMode();
+  };
+
+  parseDate() {}
+
+  async run({ params }: { params: ParamsFrom<RetryExportsCLI> }) {
+    GrouparooCLI.logCLI(this.name, false);
+
+    const hasRelativeStart = params.startAgoSeconds !== undefined;
+    const hasAbsoluteStart = params.start !== null;
+
+    if (
+      (hasRelativeStart && hasAbsoluteStart) ||
+      (!hasRelativeStart && !hasAbsoluteStart)
+    ) {
+      return GrouparooCLI.logger.fatal(
+        "One of --start or --startAgoSeconds must be specified"
+      );
+    }
+
+    const startAgoSeconds = Number(params.startAgoSeconds);
+
+    if (hasAbsoluteStart && Number.isNaN(params.start))
+      return GrouparooCLI.logger.fatal(`Invalid start date specified`);
+    if (Number.isNaN(params.end))
+      return GrouparooCLI.logger.fatal(`Invalid end date specified`);
+    if (hasRelativeStart && Number.isNaN(startAgoSeconds))
+      return GrouparooCLI.logger.fatal(`--startAgoSeconds must be a number`);
+
+    let destination: Destination;
+    if (params.destinationId) {
+      destination = await Destination.findById(params.destinationId);
+    }
+
+    const startDate = hasAbsoluteStart
+      ? new Date(params.start)
+      : Moment().subtract(startAgoSeconds, "seconds").toDate();
+    const endDate = params.end ? new Date(params.end) : new Date();
+
+    GrouparooCLI.logger.log(`Searching for failed Exports:\n`);
+    GrouparooCLI.logger.log(`Start: ${startDate.toLocaleString()}`);
+    GrouparooCLI.logger.log(`End: ${endDate.toLocaleString()}`);
+    if (destination) {
+      GrouparooCLI.logger.log(
+        `Destination: ${destination.name} (${destination.id})`
+      );
+    }
+
+    const count = await Export.retryFailed(
+      startDate,
+      endDate,
+      destination,
+      params.preview
+    );
+
+    GrouparooCLI.logger.log("");
+
+    if (params.preview) {
+      GrouparooCLI.logger.log(
+        `ℹ️  (Preview) Found ${count} failed Exports to retry.`
+      );
+    } else {
+      if (count) {
+        GrouparooCLI.logger.log(
+          `✅ ${count} failed Exports marked to be retried.`
+        );
+      } else {
+        GrouparooCLI.logger.log(`✅ No failed Exports found.`);
+      }
+    }
+
+    return true;
+  }
+}

--- a/core/src/bin/retryExports.ts
+++ b/core/src/bin/retryExports.ts
@@ -27,7 +27,7 @@ export class RetryExportsCLI extends CLI {
     startAgoUnit: {
       required: false,
       requiredValue: true,
-      default: "seconds",
+      default: "second",
       description:
         "Unit for --startAgo (e.g. seconds, minutes, hours, days...)",
       formatter: (val: string) => {

--- a/core/src/bin/retryExports.ts
+++ b/core/src/bin/retryExports.ts
@@ -55,11 +55,13 @@ export class RetryExportsCLI extends CLI {
     GrouparooCLI.setNextDevelopmentMode();
   };
 
-  async run({ params }: { params: ParamsFrom<RetryExportsCLI> }) {
+  async run({ params }: { params: Partial<ParamsFrom<RetryExportsCLI>> }) {
     GrouparooCLI.logCLI(this.name, false);
 
-    const hasRelativeStart = params.startAgoSeconds !== undefined;
-    const hasAbsoluteStart = params.start !== null;
+    const hasRelativeStart =
+      params.startAgoSeconds !== undefined && params.startAgoSeconds !== null;
+    const hasAbsoluteStart =
+      params.start !== undefined && params.start !== null;
 
     if (
       (hasRelativeStart && hasAbsoluteStart) ||
@@ -123,10 +125,12 @@ export class RetryExportsCLI extends CLI {
     } else {
       if (totalCount) {
         GrouparooCLI.logger.log(
-          `✅ ${totalCount} failed Exports marked to be retried.`
+          `✅ Success! ${totalCount} failed Exports marked to be retried.`
         );
       } else {
-        GrouparooCLI.logger.log(`✨ No failed Exports found to retry.`);
+        GrouparooCLI.logger.log(
+          `✨ Success! No failed Exports found to retry.`
+        );
       }
     }
 

--- a/core/src/bin/retryExports.ts
+++ b/core/src/bin/retryExports.ts
@@ -106,7 +106,11 @@ export class RetryExportsCLI extends CLI {
       totalCount += count;
     }
 
-    GrouparooCLI.logger.status("Summary", summaryItems);
+    if (summaryItems.length) {
+      GrouparooCLI.logger.status("Summary", summaryItems);
+    } else {
+      GrouparooCLI.logger.log("\nNo Destinations\n");
+    }
 
     if (params.preview) {
       GrouparooCLI.logger.log(
@@ -115,7 +119,7 @@ export class RetryExportsCLI extends CLI {
     } else {
       if (totalCount) {
         GrouparooCLI.logger.log(
-          `✅ Success! ${totalCount} failed Exports marked to be retried.`
+          `✅ Success! ${totalCount} failed Exports marked to be retried. Run \`grouparoo run\` or \`grouparoo start\` to retry them.`
         );
       } else {
         GrouparooCLI.logger.log(

--- a/core/src/bin/retryExports.ts
+++ b/core/src/bin/retryExports.ts
@@ -102,7 +102,7 @@ export class RetryExportsCLI extends CLI {
       startDate,
       endDate,
       destination,
-      params.preview
+      !params.preview
     );
 
     GrouparooCLI.logger.log("");

--- a/core/src/bin/retryExports.ts
+++ b/core/src/bin/retryExports.ts
@@ -47,7 +47,7 @@ export class RetryExportsCLI extends CLI {
     },
     preview: {
       default: false,
-      formatter: APIData.ensureBoolean,
+      formatter: (val: any) => val as boolean,
       description:
         "When set, will not make any changes and only outputs the number of Exports that would be retried.",
       flag: true,

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -39,10 +39,11 @@ export class RunCLI extends CLI {
     scheduleIds: {
       description: "Only run specific Schedules by id",
       required: false,
+      requiredValue: true,
       variadic: true,
       letter: "s",
       placeholder: "schedule ids",
-      formatter: (v: any) => v as boolean | string[],
+      formatter: (v: any) => v as string[],
     },
   };
 
@@ -99,13 +100,8 @@ export class RunCLI extends CLI {
     }
   }
 
-  async checkSchedules(scheduleIds?: boolean | string[]) {
+  async checkSchedules(scheduleIds?: string[]) {
     if (typeof scheduleIds === "undefined") return;
-    if (typeof scheduleIds === "boolean") {
-      return GrouparooCLI.logger.fatal(
-        `Please specify which schedule ids to run`
-      );
-    }
 
     const schedules = await Schedule.findAll({ where: { id: scheduleIds } });
     const foundScheduleIds = schedules.map((s) => s.id);

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -43,9 +43,8 @@ export class RunCLI extends CLI {
       variadic: true,
       letter: "s",
       placeholder: "schedule ids",
-      formatter: (v: any) => v as string[],
     },
-  };
+  } as const;
 
   constructor() {
     super();

--- a/core/src/modules/apiData.ts
+++ b/core/src/modules/apiData.ts
@@ -73,6 +73,20 @@ export namespace APIData {
     }
   }
 
+  export function ensureDate(param: Date | string | number) {
+    if (param instanceof Date) return param;
+
+    if (typeof param === "string" || typeof param === "number") {
+      const asNumber = Number(param);
+      if (!isNaN(asNumber)) param = asNumber;
+
+      const date = new Date(param);
+      if (!isNaN(date.getTime())) return date;
+    }
+
+    throw new Error(`${param} cannot be converted to a date`);
+  }
+
   export function formatDate(date: Date | string) {
     if (!date || date === "") return null;
     else if (date instanceof Date) return date.getTime();

--- a/core/src/modules/apiData.ts
+++ b/core/src/modules/apiData.ts
@@ -76,7 +76,10 @@ export namespace APIData {
   export function formatDate(date: Date | string) {
     if (!date || date === "") return null;
     else if (date instanceof Date) return date.getTime();
-    else if (typeof date === "string") return new Date(date).getTime();
-    else throw new Error(`${date} is not a date`);
+    else if (typeof date === "string") {
+      const asNumber = Number(date);
+      if (!isNaN(asNumber)) return asNumber;
+      return new Date(date).getTime();
+    } else throw new Error(`${date} is not a date`);
   }
 }

--- a/core/src/modules/statusReporters.ts
+++ b/core/src/modules/statusReporters.ts
@@ -623,17 +623,14 @@ export namespace FinalSummaryReporters {
     export async function getData() {
       const out: DestinationData[] = [];
 
-      // TODO FIXME
-      const exports = await Export.findAll({
-        attributes: [
-          "destinationId",
-          [Sequelize.fn("count", Sequelize.col("id")), "exportsCreated"],
-        ],
-        where: { createdAt: { [Op.gte]: lastRunStart } },
-        group: ["destinationId"],
-      });
-      for (const exp of exports) {
-        const destination = await Destination.findById(exp.destinationId);
+      const destinations = await Destination.scope(null).findAll();
+      for (const destination of destinations) {
+        const exportsCreated = await Export.count({
+          where: {
+            createdAt: { [Op.gte]: lastRunStart },
+            destinationId: destination.id,
+          },
+        });
 
         const exportsFailed = await Export.count({
           where: {
@@ -646,20 +643,21 @@ export namespace FinalSummaryReporters {
         const exportsComplete = await Export.count({
           where: {
             state: "complete",
-            updatedAt: { [Op.gte]: lastRunStart },
+            completedAt: { [Op.gte]: lastRunStart },
             destinationId: destination.id,
           },
         });
 
-        const currentDestination = {
-          name: destination.name,
-          exportsCreated: exp.getDataValue("exportsCreated"),
-          exportsFailed,
-          exportsComplete,
-        };
-
-        out.push(currentDestination);
+        if (exportsCreated > 0 || exportsFailed > 0 || exportsComplete > 0) {
+          out.push({
+            name: destination.name,
+            exportsCreated,
+            exportsFailed,
+            exportsComplete,
+          });
+        }
       }
+
       return out;
     }
   }

--- a/core/src/modules/statusReporters.ts
+++ b/core/src/modules/statusReporters.ts
@@ -601,7 +601,8 @@ export namespace FinalSummaryReporters {
       });
       const allRecords = await GrouparooRecord.count();
 
-      const recordData = {
+      const recordData: RecordData = {
+        name: null,
         recordsUpdated,
         recordsCreated,
         allRecords,
@@ -622,6 +623,7 @@ export namespace FinalSummaryReporters {
     export async function getData() {
       const out: DestinationData[] = [];
 
+      // TODO FIXME
       const exports = await Export.findAll({
         attributes: [
           "destinationId",


### PR DESCRIPTION
## Change description

Adds a new cli command to retry failed exports, following the functionality introduced in #2825 

Example `grouparoo retryExports --startAgo 5000`

```
🦘 Grouparoo: retryExports

Searching for failed Exports:

Start: 1/27/2022, 10:11:21 AM (5000 seconds ago)
End: 1/27/2022, 11:34:41 AM

┌-- Summary @ 2022-01-27T15:34:41.836Z ---
| My Destination (my_destination)
| * Failed Exports: 6
|
| Accounts Destination (accounts_destination)
| * Failed Exports: 0
└-----------------------------------------

✅ Success! 6 failed Exports marked to be retried.
```

Date/times for `--start` and `--end` can be passed in as anything that JS considers valid ("Jan 23, 2022 10:53", "1642949580000", "2022-01-23T14:53:00.000Z")

Also in this PR:
- Brought in `formatter` and `validator` support into CLI following [actionhero/actionhero#2062](https://github.com/actionhero/actionhero/pull/2062)
- Fixed an issue where final status reporter would show `undefined` in the Records section
- Final status reporter now shows destinations that have just failed/completed old exports 

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
