### PR TITLE
Ensure that Property model is unique when it's also primary key

### DIFF
--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -944,7 +944,7 @@ describe("models/property", () => {
         await source.setMapping({ id: "userId" });
         await loadUserIdProperty();
         await expect(userIdProperty.update({ unique: false })).rejects.toThrow(
-          /must be unique because it‘s a Primary Key/
+          /must be unique because it‘s the model‘s Primary Key/
         );
       });
     });

--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -742,6 +742,7 @@ describe("models/property", () => {
   describe("with plugin", () => {
     let app: App;
     let source: Source;
+    let secondarySource: Source;
     let queryCounter = 0;
 
     const propertiesToMoveKeys = Object.freeze([
@@ -857,6 +858,15 @@ describe("models/property", () => {
         propertyToMove.sourceId = source.id;
         await propertyToMove.save();
       }
+
+      secondarySource = await Source.create({
+        name: "secondary source",
+        type: "import-from-test-app",
+        appId: app.id,
+        modelId: model.id,
+      });
+
+      await secondarySource.update({ state: "ready" });
     });
 
     beforeEach(() => {
@@ -874,15 +884,74 @@ describe("models/property", () => {
       }
     });
 
-    describe("mapped though a non-unique property", () => {
-      let property: Property;
+    describe("primary key", () => {
+      let userIdProperty: Property;
+      let emailProperty: Property;
 
-      const updateUserIdPropertyUnique = async (unique: boolean) => {
-        const userIdProperty = await Property.scope(null).findOne({
+      const loadUserIdProperty = async () => {
+        userIdProperty = await Property.findOne({
           where: { key: "userId" },
         });
-        await userIdProperty.update({ unique });
       };
+
+      const loadEmailProperty = async () => {
+        emailProperty = await Property.findOne({
+          where: { key: "myEmail" },
+        });
+      };
+
+      beforeAll(async () => {
+        await loadUserIdProperty();
+        await userIdProperty.update({ unique: true });
+
+        emailProperty = await helper.factories.property(
+          source,
+          {
+            key: "myEmail",
+            unique: true,
+          },
+          { column: "email" }
+        );
+      });
+
+      afterEach(async () => {
+        await source.setMapping({});
+      });
+
+      afterAll(async () => {
+        await emailProperty.destroy();
+      });
+
+      test("primary key is set to true when primary source is mapped to property", async () => {
+        await source.setMapping({ id: "userId" });
+        expect(userIdProperty.isPrimaryKey).toBe(true);
+      });
+
+      test("primary key is updated when updating mapping", async () => {
+        await source.setMapping({ id: "userId" });
+        expect(userIdProperty.isPrimaryKey).toBe(true);
+
+        await source.setMapping({ email: "myEmail" });
+
+        await loadEmailProperty();
+        expect(emailProperty.isPrimaryKey).toBe(true);
+
+        await loadUserIdProperty();
+        expect(userIdProperty.isPrimaryKey).toBe(false);
+      });
+
+      test("property must be unique when primary key is true", async () => {
+        await source.setMapping({ id: "userId" });
+        await loadUserIdProperty();
+        await expect(userIdProperty.update({ unique: false })).rejects.toThrow(
+          /must be unique because it‘s a Primary Key/
+        );
+      });
+    });
+
+    describe("mapped though a non-unique property", () => {
+      let property: Property;
+      let secondaryProperty: Property;
 
       beforeAll(async () => {
         property = await helper.factories.property(
@@ -890,19 +959,27 @@ describe("models/property", () => {
           { key: "wordInSpanish" },
           { column: "spanishWord" }
         );
+
+        secondaryProperty = await helper.factories.property(
+          secondarySource,
+          { key: "company" },
+          { column: "company_name" }
+        );
       });
 
       beforeEach(async () => {
         await property.update({ unique: false, isArray: false });
+        await secondaryProperty.update({ unique: false, isArray: false });
       });
 
       afterEach(async () => {
         await source.setMapping({});
-        await updateUserIdPropertyUnique(true);
+        await secondarySource.setMapping({});
       });
 
       afterAll(async () => {
         await property.destroy();
+        await secondaryProperty.destroy();
       });
 
       test("properties mapped through unique properties can be unique", async () => {
@@ -918,17 +995,19 @@ describe("models/property", () => {
       });
 
       test("properties mapped through non-unique properties cannot be unique", async () => {
-        await updateUserIdPropertyUnique(false);
-        await source.setMapping({ last_name: "lastName" });
-        await expect(property.update({ unique: true })).rejects.toThrow(
+        await secondarySource.setMapping({ last_name: "lastName" });
+        await expect(
+          secondaryProperty.update({ unique: true })
+        ).rejects.toThrow(
           /Unique Property .+ cannot be mapped through a non-unique Property/
         );
       });
 
       test("properties mapped through non-unique properties cannot be arrays", async () => {
-        await updateUserIdPropertyUnique(false);
-        await source.setMapping({ last_name: "lastName" });
-        await expect(property.update({ isArray: true })).rejects.toThrow(
+        await secondarySource.setMapping({ last_name: "lastName" });
+        await expect(
+          secondaryProperty.update({ isArray: true })
+        ).rejects.toThrow(
           /Array Property .+ cannot be mapped through a non-unique Property/
         );
       });

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -389,6 +389,15 @@ export class Property extends LoggedModel<Property> {
   }
 
   @BeforeSave
+  static async ensureUniquePrimaryKey(instance: Property) {
+    if (instance.isPrimaryKey && !instance.unique) {
+      throw new Error(
+        `Property "${instance.key}" must be unique because it‘s a Primary Key.`
+      );
+    }
+  }
+
+  @BeforeSave
   static async ensureOptions(instance: Property) {
     const source = await Source.findById(instance.sourceId);
     await source.validateOptions(null);

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -392,7 +392,7 @@ export class Property extends LoggedModel<Property> {
   static async ensureUniquePrimaryKey(instance: Property) {
     if (instance.isPrimaryKey && !instance.unique) {
       throw new Error(
-        `Property "${instance.key}" must be unique because it‘s a Primary Key.`
+        `Property "${instance.key}" must be unique because it‘s the model‘s Primary Key.`
       );
     }
   }


### PR DESCRIPTION
## Change description

This change ensures that a Property model is unique when `isPrimaryKey` is set to true. Otherwise, it will throw an error.

UI changes already made in #2865

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
