### PR TITLE
Select from multiple apps after installing plugin from config UI

### DIFF
--- a/ui/ui-config/pages/app/new/index.tsx
+++ b/ui/ui-config/pages/app/new/index.tsx
@@ -154,10 +154,10 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
       setShowSpinner(false);
       setInstallingMessage(
         <Alert variant="warning">
-          There was a problem restarting the Grouparoo config app.
+          There was a problem restarting.
           <br />
           <br />
-          Please restart config app via the command line.
+          Please restart the Grouparoo config app via the CLI.
         </Alert>
       );
       return;


### PR DESCRIPTION
## Change description

This change ensures when adding a new app that needs to be installed first, if there are multiple apps in the plugin, it goes to the app selection page instead of creating the first app it finds.

Additionally, it cleans up the page code and fixes some issues with checking on restarting the app.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
