### PR TITLE
Add Grouparoo model global context

### DIFF
--- a/ui/ui-components/__tests__/components/tabs.tsx
+++ b/ui/ui-components/__tests__/components/tabs.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import PropertyTab from "../../components/tabs/Property";
 import AppTab from "../../components/tabs/App";
+import { GrouparooModelContextProvider } from "../../contexts/grouparooModel";
 
 describe("<PropertyTab />", () => {
   const useRouter = jest.spyOn(require("next/router"), "useRouter");
@@ -16,7 +17,11 @@ describe("<PropertyTab />", () => {
       asPath: `/model/${model.id}/source/${source.id}/property/${propertyId}/edit`,
     }));
 
-    render(<PropertyTab property={property} source={source} model={model} />);
+    render(
+      <GrouparooModelContextProvider value={model}>
+        <PropertyTab property={property} source={source} />
+      </GrouparooModelContextProvider>
+    );
   });
 
   it("renders the model link properly", async () => {

--- a/ui/ui-components/__tests__/components/tabs.tsx
+++ b/ui/ui-components/__tests__/components/tabs.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import PropertyTab from "../../components/tabs/Property";
 import AppTab from "../../components/tabs/App";
-import { GrouparooModelContextProvider } from "../../contexts/grouparooModel";
+import { GrouparooModelContext } from "../../contexts/grouparooModel";
 
 describe("<PropertyTab />", () => {
   const useRouter = jest.spyOn(require("next/router"), "useRouter");
@@ -18,9 +18,9 @@ describe("<PropertyTab />", () => {
     }));
 
     render(
-      <GrouparooModelContextProvider value={model}>
+      <GrouparooModelContext.Provider value={{ model }}>
         <PropertyTab property={property} source={source} />
-      </GrouparooModelContextProvider>
+      </GrouparooModelContext.Provider>
     );
   });
 

--- a/ui/ui-components/components/lib/entity/EntityList.tsx
+++ b/ui/ui-components/components/lib/entity/EntityList.tsx
@@ -11,7 +11,7 @@ import {
   Row,
 } from "react-bootstrap";
 import EnterpriseLink from "../../GrouparooLink";
-import { useGrouparooModelContext } from "../../../contexts/grouparooModel";
+import { useGrouparooModel } from "../../../contexts/grouparooModel";
 import { Models } from "../../../utils/apiData";
 import { formatName } from "../../../utils/formatName";
 import { grouparooUiEdition } from "../../../utils/uiEdition";
@@ -80,7 +80,7 @@ const EntityList = function <T extends Models.EntityTypes>({
   itemType,
   renderItem,
 }: React.PropsWithChildren<Props<T>>): JSX.Element {
-  const model = useGrouparooModelContext();
+  const { model } = useGrouparooModel();
   const [expanded, setExpanded] = useState(false);
 
   if (!items?.length) return null;

--- a/ui/ui-components/components/model/overview/ModelOverviewDestinations.tsx
+++ b/ui/ui-components/components/model/overview/ModelOverviewDestinations.tsx
@@ -6,7 +6,7 @@ import EntityInfoContainer from "../../lib/entity/EntityInfoContainer";
 import EntityInfoHeader from "../../lib/entity/EntityInfoHeader";
 import Link from "next/link";
 import EnterpriseLink from "../../../components/GrouparooLink";
-import { useGrouparooModelContext } from "../../../contexts/grouparooModel";
+import { useGrouparooModel } from "../../../contexts/grouparooModel";
 import LinkButton from "../../LinkButton";
 import ManagedCard from "../../lib/ManagedCard";
 import SectionContainer from "../../lib/SectionContainer";
@@ -47,7 +47,7 @@ const ModelOverviewDestinations: React.FC<Props> = ({
   destinations,
   disabled,
 }) => {
-  const model = useGrouparooModelContext();
+  const { model } = useGrouparooModel();
 
   return (
     <ManagedCard

--- a/ui/ui-components/components/model/overview/ModelOverviewGroups.tsx
+++ b/ui/ui-components/components/model/overview/ModelOverviewGroups.tsx
@@ -3,7 +3,7 @@ import SectionContainer from "../../lib/SectionContainer";
 import EntityInfoContainer from "../../lib/entity/EntityInfoContainer";
 import EntityInfoHeader from "../../lib/entity/EntityInfoHeader";
 import LinkButton from "../../LinkButton";
-import { useGrouparooModelContext } from "../../../contexts/grouparooModel";
+import { useGrouparooModel } from "../../../contexts/grouparooModel";
 import EntityList from "../../lib/entity/EntityList";
 import { grouparooUiEdition } from "../../../utils/uiEdition";
 
@@ -29,7 +29,7 @@ interface Props {
 }
 
 const ModelOverviewGroups: React.FC<Props> = ({ groups, disabled }) => {
-  const model = useGrouparooModelContext();
+  const { model } = useGrouparooModel();
 
   return (
     <SectionContainer

--- a/ui/ui-components/components/model/overview/ModelOverviewPrimarySource.tsx
+++ b/ui/ui-components/components/model/overview/ModelOverviewPrimarySource.tsx
@@ -1,4 +1,4 @@
-import { useGrouparooModelContext } from "../../../contexts/grouparooModel";
+import { useGrouparooModel } from "../../../contexts/grouparooModel";
 import { Models } from "../../../utils/apiData";
 import LinkButton from "../../LinkButton";
 import EntityList from "../../lib/entity/EntityList";
@@ -8,7 +8,7 @@ import SourceInfo from "./SourceInfo";
 const ModelOverviewPrimarySource: React.FC<{ source?: Models.SourceType }> = ({
   source,
 }) => {
-  const model = useGrouparooModelContext();
+  const { model } = useGrouparooModel();
 
   return (
     <SectionContainer

--- a/ui/ui-components/components/model/overview/ModelOverviewSchedules.tsx
+++ b/ui/ui-components/components/model/overview/ModelOverviewSchedules.tsx
@@ -8,7 +8,7 @@ import EntityInfoContainer from "../../lib/entity/EntityInfoContainer";
 import EntityInfoHeader from "../../lib/entity/EntityInfoHeader";
 import RunAllSchedulesButton from "../../schedule/RunAllSchedulesButton";
 import { successHandler } from "../../../eventHandlers";
-import { useGrouparooModelContext } from "../../../contexts/grouparooModel";
+import { useGrouparooModel } from "../../../contexts/grouparooModel";
 import EntityList from "../../lib/entity/EntityList";
 import LoadingButton from "../../LoadingButton";
 import { grouparooUiEdition } from "../../../utils/uiEdition";
@@ -68,7 +68,7 @@ interface Props {
 }
 
 const ModelOverviewSchedules: React.FC<Props> = ({ schedules, sources }) => {
-  const model = useGrouparooModelContext();
+  const { model } = useGrouparooModel();
 
   const sourcesById = useMemo<Record<string, Models.SourceType>>(() => {
     const result: Record<string, Models.SourceType> = {};

--- a/ui/ui-components/components/model/overview/ModelOverviewSecondarySources.tsx
+++ b/ui/ui-components/components/model/overview/ModelOverviewSecondarySources.tsx
@@ -1,4 +1,4 @@
-import { useGrouparooModelContext } from "../../../contexts/grouparooModel";
+import { useGrouparooModel } from "../../../contexts/grouparooModel";
 import { Models } from "../../../utils/apiData";
 import LinkButton from "../../LinkButton";
 import EntityList from "../../lib/entity/EntityList";
@@ -14,7 +14,7 @@ const ModelOverviewSecondarySources: React.FC<Props> = ({
   sources,
   disabled,
 }) => {
-  const model = useGrouparooModelContext();
+  const { model } = useGrouparooModel();
 
   return (
     <SectionContainer

--- a/ui/ui-components/components/record/List.tsx
+++ b/ui/ui-components/components/record/List.tsx
@@ -16,16 +16,18 @@ import LoadingButton from "../LoadingButton";
 import LoadingTable from "../LoadingTable";
 import Pagination from "../Pagination";
 import ArrayRecordPropertyList from "./ArrayRecordPropertyList";
+import { useGrouparooModel } from "../../contexts/grouparooModel";
 
 export default function RecordsList(props) {
   const {
     properties,
-    modelName,
   }: {
     properties: Models.PropertyType[];
-    modelName?: string;
   } = props;
   const { client } = useApi();
+  const {
+    model: { name: modelName },
+  } = useGrouparooModel();
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [searchLoading, setSearchLoading] = useState(false);
@@ -428,14 +430,5 @@ RecordsList.hydrate = async (
     modelId,
   });
 
-  let modelName: string;
-  if (modelId) {
-    modelName = records.length > 0 ? records[0].modelName : null;
-    if (!modelName) {
-      const { model } = await client.request("get", `/model/${modelId}`);
-      modelName = model.name;
-    }
-  }
-
-  return { records, total, properties, modelName, modelId };
+  return { records, total, properties };
 };

--- a/ui/ui-components/components/tabs/Destination.tsx
+++ b/ui/ui-components/components/tabs/Destination.tsx
@@ -1,14 +1,15 @@
 import Tabs from "../Tabs";
 import { Models } from "../../utils/apiData";
+import { useGrouparooModel } from "../../contexts/grouparooModel";
 import { grouparooUiEdition } from "../../utils/uiEdition";
 
 export default function DestinationTabs({
   destination,
-  model,
 }: {
   destination: Models.DestinationType;
-  model: Models.GrouparooModelType;
 }) {
+  const { model } = useGrouparooModel();
+
   let tabs = [];
   switch (grouparooUiEdition()) {
     case "enterprise":

--- a/ui/ui-components/components/tabs/Group.tsx
+++ b/ui/ui-components/components/tabs/Group.tsx
@@ -1,14 +1,11 @@
 import Tabs from "../Tabs";
 import { Models } from "../../utils/apiData";
 import { grouparooUiEdition } from "../../utils/uiEdition";
+import { useGrouparooModel } from "../../contexts/grouparooModel";
 
-export default function GroupTabs({
-  group,
-  model,
-}: {
-  group: Models.GroupType;
-  model: Models.GrouparooModelType;
-}) {
+export default function GroupTabs({ group }: { group: Models.GroupType }) {
+  const { model } = useGrouparooModel();
+
   let tabs = [];
   let defaultTab = "rules";
 

--- a/ui/ui-components/components/tabs/Property.tsx
+++ b/ui/ui-components/components/tabs/Property.tsx
@@ -1,14 +1,16 @@
 import Tabs from "../Tabs";
 import { Models } from "../../utils/apiData";
 import { grouparooUiEdition } from "../../utils/uiEdition";
+import { useGrouparooModel } from "../../contexts/grouparooModel";
 
 interface Props {
-  model: Models.GrouparooModelType;
   property: Models.PropertyType;
   source: Models.SourceType;
 }
 
-const PropertyTabs: React.FC<Props> = ({ model, property, source }) => {
+const PropertyTabs: React.FC<Props> = ({ property, source }) => {
+  const { model } = useGrouparooModel();
+
   let tabs = ["edit"];
 
   if (grouparooUiEdition() === "enterprise") {

--- a/ui/ui-components/components/tabs/Record.tsx
+++ b/ui/ui-components/components/tabs/Record.tsx
@@ -2,14 +2,14 @@ import Tabs from "../Tabs";
 import { Models } from "../../utils/apiData";
 import { getRecordDisplayName } from "../record/GetRecordDisplayName";
 import { grouparooUiEdition } from "../../utils/uiEdition";
+import { useGrouparooModel } from "../../contexts/grouparooModel";
 
 export default function RecordTabs({
   record,
-  model,
 }: {
   record: Models.GrouparooRecordType;
-  model: Models.GrouparooModelType;
 }) {
+  const { model } = useGrouparooModel();
   const tabs = ["edit", "imports", "exports", "logs"];
 
   if (grouparooUiEdition() === "config") {

--- a/ui/ui-components/components/tabs/Source.tsx
+++ b/ui/ui-components/components/tabs/Source.tsx
@@ -2,13 +2,15 @@ import { useMemo } from "react";
 import Tabs from "../Tabs";
 import { Models } from "../../utils/apiData";
 import { grouparooUiEdition } from "../../utils/uiEdition";
+import { useGrouparooModel } from "../../contexts/grouparooModel";
 
 interface Props {
   source: Models.SourceType;
-  model: Models.GrouparooModelType;
 }
 
-export default function SourceTabs({ source, model }: Props) {
+export default function SourceTabs({ source }: Props) {
+  const { model } = useGrouparooModel();
+
   const tabs = useMemo<string[]>(() => {
     const tabs = ["overview", "edit"];
 

--- a/ui/ui-components/contexts/grouparooModel.tsx
+++ b/ui/ui-components/contexts/grouparooModel.tsx
@@ -1,4 +1,4 @@
-import { createContext, Dispatch, SetStateAction, useContext } from "react";
+import { createContext, useContext } from "react";
 import { Models } from "../utils/apiData";
 
 interface GrouparooModelContext {

--- a/ui/ui-components/contexts/grouparooModel.tsx
+++ b/ui/ui-components/contexts/grouparooModel.tsx
@@ -21,7 +21,7 @@ export const useGrouparooModel = () => useContext(GrouparooModelContext);
 export const GrouparooModelContextProvider: React.FC<{
   value: Models.GrouparooModelType;
 }> = ({ value: modelProp, children }) => {
-  const [updatedModel, setModel] = useState(modelProp);
+  const [model, setModel] = useState(modelProp);
 
   useEffect(() => {
     setModel(modelProp);
@@ -29,7 +29,7 @@ export const GrouparooModelContextProvider: React.FC<{
 
   return (
     <GrouparooModelContext.Provider
-      value={{ model: updatedModel || modelProp, setModel }}
+      value={{ model: model ?? modelProp, setModel }}
     >
       {children}
     </GrouparooModelContext.Provider>

--- a/ui/ui-components/contexts/grouparooModel.tsx
+++ b/ui/ui-components/contexts/grouparooModel.tsx
@@ -21,14 +21,16 @@ export const useGrouparooModel = () => useContext(GrouparooModelContext);
 export const GrouparooModelContextProvider: React.FC<{
   value: Models.GrouparooModelType;
 }> = ({ value: modelProp, children }) => {
-  const [model, setModel] = useState(modelProp);
+  const [updatedModel, setModel] = useState(modelProp);
 
   useEffect(() => {
     setModel(modelProp);
   }, [modelProp]);
 
   return (
-    <GrouparooModelContext.Provider value={{ model, setModel }}>
+    <GrouparooModelContext.Provider
+      value={{ model: updatedModel || modelProp, setModel }}
+    >
       {children}
     </GrouparooModelContext.Provider>
   );

--- a/ui/ui-components/contexts/grouparooModel.tsx
+++ b/ui/ui-components/contexts/grouparooModel.tsx
@@ -1,37 +1,11 @@
-import {
-  createContext,
-  Dispatch,
-  SetStateAction,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
+import { createContext, Dispatch, SetStateAction, useContext } from "react";
 import { Models } from "../utils/apiData";
 
 interface GrouparooModelContext {
   model: Models.GrouparooModelType;
-  setModel: Dispatch<SetStateAction<Models.GrouparooModelType>>;
 }
 
 export const GrouparooModelContext =
   createContext<GrouparooModelContext>(undefined);
 
 export const useGrouparooModel = () => useContext(GrouparooModelContext);
-
-export const GrouparooModelContextProvider: React.FC<{
-  value: Models.GrouparooModelType;
-}> = ({ value: modelProp, children }) => {
-  const [model, setModel] = useState(modelProp);
-
-  useEffect(() => {
-    setModel(modelProp);
-  }, [modelProp]);
-
-  return (
-    <GrouparooModelContext.Provider
-      value={{ model: model ?? modelProp, setModel }}
-    >
-      {children}
-    </GrouparooModelContext.Provider>
-  );
-};

--- a/ui/ui-components/contexts/grouparooModel.tsx
+++ b/ui/ui-components/contexts/grouparooModel.tsx
@@ -1,15 +1,35 @@
-import { createContext, useContext } from "react";
+import {
+  createContext,
+  Dispatch,
+  SetStateAction,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import { Models } from "../utils/apiData";
 
-export const GrouparooModelContext =
-  createContext<Models.GrouparooModelType>(undefined);
+interface GrouparooModelContext {
+  model: Models.GrouparooModelType;
+  setModel: Dispatch<SetStateAction<Models.GrouparooModelType>>;
+}
 
-export const useGrouparooModelContext = () => useContext(GrouparooModelContext);
+export const GrouparooModelContext =
+  createContext<GrouparooModelContext>(undefined);
+
+export const useGrouparooModel = () => useContext(GrouparooModelContext);
 
 export const GrouparooModelContextProvider: React.FC<{
-  model: Models.GrouparooModelType;
-}> = ({ model, children }) => (
-  <GrouparooModelContext.Provider value={model}>
-    {children}
-  </GrouparooModelContext.Provider>
-);
+  value: Models.GrouparooModelType;
+}> = ({ value: modelProp, children }) => {
+  const [model, setModel] = useState(modelProp);
+
+  useEffect(() => {
+    setModel(modelProp);
+  }, [modelProp]);
+
+  return (
+    <GrouparooModelContext.Provider value={{ model, setModel }}>
+      {children}
+    </GrouparooModelContext.Provider>
+  );
+};

--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -81,16 +81,6 @@ GrouparooNextApp.getInitialProps = async (appContext: AppContext) => {
   try {
     let model: Models.GrouparooModelType | null = null;
 
-    const promises: Promise<any>[] = [
-      client.request<Actions.NavigationList>("get", `/navigation`),
-    ];
-
-    if (modelId) {
-      promises.push(
-        client.request<Actions.ModelView>("get", `/model/${modelId}`)
-      );
-    }
-
     const [navigationResponse, modelResponse] = await Promise.all([
       client.request<Actions.NavigationList>("get", `/navigation`),
       modelId

--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -3,17 +3,20 @@ import type { AppContext, AppProps } from "next/app";
 import App from "next/app";
 import { useMemo } from "react";
 import { Client, generateClient } from "../client/client";
-import "../components/Icons";
 import Layout from "../components/layouts/Main";
 import PageTransition from "../components/PageTransition";
 import StatusSubscription from "../components/StatusSubscription";
 import { ApiContext } from "../contexts/api";
+import { GrouparooModelContextProvider } from "../contexts/grouparooModel";
 import { WebAppContext } from "../contexts/webApp";
-import "../eventHandlers";
-import { Actions } from "../utils/apiData";
+import { Actions, Models } from "../utils/apiData";
 import { renderNestedContextProviders } from "../utils/contextHelper";
 
+import "../components/Icons";
+import "../eventHandlers";
+
 export interface GrouparooNextAppProps {
+  model?: Models.GrouparooModelType;
   clusterName: Actions.NavigationList["clusterName"];
   currentTeamMember: Partial<Actions.NavigationList["teamMember"]>;
   hydrationError?: string;
@@ -25,7 +28,7 @@ export interface GrouparooNextAppProps {
 export default function GrouparooNextApp(
   props: AppProps & GrouparooNextAppProps & { err: any }
 ) {
-  const { Component, pageProps, err, hydrationError } = props;
+  const { Component, pageProps, err, hydrationError, model } = props;
 
   const combinedProps = {
     ...pageProps,
@@ -48,8 +51,9 @@ export default function GrouparooNextApp(
   const client = props.client instanceof Client ? props.client : new Client();
   return renderNestedContextProviders(
     [
-      [WebAppContext, pageContext],
-      [ApiContext, { client }],
+      [WebAppContext.Provider, pageContext],
+      [ApiContext.Provider, { client }],
+      [GrouparooModelContextProvider, model],
     ],
     <>
       <PageTransition />
@@ -66,6 +70,7 @@ export default function GrouparooNextApp(
 }
 
 GrouparooNextApp.getInitialProps = async (appContext: AppContext) => {
+  const { modelId } = appContext.ctx.query;
   const client = generateClient(appContext);
 
   let currentTeamMember: Partial<Actions.SessionView["teamMember"]> = {
@@ -74,13 +79,28 @@ GrouparooNextApp.getInitialProps = async (appContext: AppContext) => {
   };
 
   try {
-    const navigationResponse: Actions.NavigationList = await client.request(
-      "get",
-      `/navigation`
-    );
+    let model: Models.GrouparooModelType | null = null;
+    let modelResponse: Actions.ModelView;
+    let navigationResponse: Actions.NavigationList;
+
+    const promises: Promise<any>[] = [
+      client.request<Actions.NavigationList>("get", `/navigation`),
+    ];
+
+    if (modelId) {
+      promises.push(
+        client.request<Actions.ModelView>("get", `/model/${modelId}`)
+      );
+    }
+
+    [navigationResponse, modelResponse] = await Promise.all(promises);
 
     if (navigationResponse.teamMember) {
       currentTeamMember = navigationResponse.teamMember;
+    }
+
+    if (modelResponse) {
+      model = modelResponse.model;
     }
 
     // render page-specific getInitialProps
@@ -106,6 +126,7 @@ GrouparooNextApp.getInitialProps = async (appContext: AppContext) => {
 
     return {
       ...appProps,
+      model: model || null,
       currentTeamMember,
       navigationMode: navigationResponse.navigationMode,
       navigation: navigationResponse.navigation,

--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -7,7 +7,7 @@ import Layout from "../components/layouts/Main";
 import PageTransition from "../components/PageTransition";
 import StatusSubscription from "../components/StatusSubscription";
 import { ApiContext } from "../contexts/api";
-import { GrouparooModelContextProvider } from "../contexts/grouparooModel";
+import { GrouparooModelContext } from "../contexts/grouparooModel";
 import { WebAppContext } from "../contexts/webApp";
 import { Actions, Models } from "../utils/apiData";
 import { renderNestedContextProviders } from "../utils/contextHelper";
@@ -53,7 +53,7 @@ export default function GrouparooNextApp(
     [
       [WebAppContext.Provider, pageContext],
       [ApiContext.Provider, { client }],
-      [GrouparooModelContextProvider, model],
+      [GrouparooModelContext.Provider, { model }],
     ],
     <>
       <PageTransition />

--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -80,8 +80,6 @@ GrouparooNextApp.getInitialProps = async (appContext: AppContext) => {
 
   try {
     let model: Models.GrouparooModelType | null = null;
-    let modelResponse: Actions.ModelView;
-    let navigationResponse: Actions.NavigationList;
 
     const promises: Promise<any>[] = [
       client.request<Actions.NavigationList>("get", `/navigation`),
@@ -93,7 +91,12 @@ GrouparooNextApp.getInitialProps = async (appContext: AppContext) => {
       );
     }
 
-    [navigationResponse, modelResponse] = await Promise.all(promises);
+    const [navigationResponse, modelResponse] = await Promise.all([
+      client.request<Actions.NavigationList>("get", `/navigation`),
+      modelId
+        ? client.request<Actions.ModelView>("get", `/model/${modelId}`)
+        : Promise.resolve(),
+    ]);
 
     if (navigationResponse.teamMember) {
       currentTeamMember = navigationResponse.teamMember;

--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -129,7 +129,7 @@ GrouparooNextApp.getInitialProps = async (appContext: AppContext) => {
 
     return {
       ...appProps,
-      model: model || null,
+      model,
       currentTeamMember,
       navigationMode: navigationResponse.navigationMode,
       navigation: navigationResponse.navigation,

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -21,7 +21,6 @@ import { generateClient } from "../../../../../client/client";
 
 export default function Page(props) {
   const {
-    model,
     properties,
     mappingOptions,
     destinationTypeConversions,
@@ -29,7 +28,6 @@ export default function Page(props) {
     exportArrayProperties,
     hydrationError,
   }: {
-    model: Models.GrouparooModelType;
     hydrationError: Error;
     properties: Models.PropertyType[];
     groups: Models.GroupType[];
@@ -270,7 +268,7 @@ export default function Page(props) {
         <title>Grouparoo: {destination.name}</title>
       </Head>
 
-      <DestinationTabs destination={destination} model={model} />
+      <DestinationTabs destination={destination} />
 
       <PageHeader
         icon={destination.app.icon}
@@ -872,10 +870,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
     state: "ready",
     modelId: destination?.modelId,
   });
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
 
   let mappingOptions = {};
   let destinationTypeConversions = {};
@@ -903,7 +897,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   return {
     destination,
     properties,
-    model,
     mappingOptions,
     destinationTypeConversions,
     exportArrayProperties,

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
@@ -25,10 +25,8 @@ import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 
 export default function Page(props) {
   const {
-    model,
     environmentVariableOptions,
   }: {
-    model: Models.GrouparooModelType;
     environmentVariableOptions: Actions.AppOptions["environmentVariableOptions"];
   } = props;
   const router = useRouter();
@@ -142,7 +140,7 @@ export default function Page(props) {
         <title>Grouparoo: {destination.name}</title>
       </Head>
 
-      <DestinationTabs destination={destination} model={model} />
+      <DestinationTabs destination={destination} />
 
       <PageHeader
         icon={destination.app.icon}
@@ -446,10 +444,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   );
   ensureMatchingModel("Destination", destination.modelId, modelId.toString());
 
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
   const { environmentVariableOptions } = await client.request(
     "get",
     "/destinations/connectionApps"
@@ -458,6 +452,5 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   return {
     destination,
     environmentVariableOptions,
-    model,
   };
 };

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/exports.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/exports.tsx
@@ -11,7 +11,7 @@ import { Actions } from "../../../../../utils/apiData";
 import { generateClient } from "../../../../../client/client";
 
 export default function Page(props) {
-  const { destination, model } = props;
+  const { destination } = props;
 
   return (
     <>
@@ -19,7 +19,7 @@ export default function Page(props) {
         <title>Grouparoo: {destination.name}</title>
       </Head>
 
-      <DestinationTabs destination={destination} model={model} />
+      <DestinationTabs destination={destination} />
 
       <ExportsList
         header={
@@ -51,11 +51,7 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   );
   ensureMatchingModel("Destination", destination.modelId, modelId.toString());
 
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
   const exportListInitialProps = await ExportsList.hydrate(ctx);
 
-  return { destination, model, ...exportListInitialProps };
+  return { destination, ...exportListInitialProps };
 };

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/retry.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/retry.tsx
@@ -89,7 +89,7 @@ export default function Page(props) {
         <title>Grouparoo: {destination.name}</title>
       </Head>
 
-      <DestinationTabs destination={destination} model={model} />
+      <DestinationTabs destination={destination} />
 
       <PageHeader
         icon={destination.app.icon}

--- a/ui/ui-components/pages/model/[modelId]/destination/new/[appId].tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/new/[appId].tsx
@@ -11,15 +11,15 @@ import { Actions } from "../../../../../utils/apiData";
 import ModelBadge from "../../../../../components/badges/ModelBadge";
 import AppBadge from "../../../../../components/badges/AppBadge";
 import { generateClient } from "../../../../../client/client";
+import { useGrouparooModel } from "../../../../../contexts/grouparooModel";
 
 export default function Page(props) {
   const {
     connectionApps,
-    model,
   }: {
     connectionApps: Actions.SourceConnectionApps["connectionApps"];
-    model: Actions.ModelView["model"];
   } = props;
+  const { model } = useGrouparooModel();
   const router = useRouter();
   const { client } = useApi();
   const [loading, setLoading] = useState(false);
@@ -100,11 +100,10 @@ export default function Page(props) {
 
 Page.getInitialProps = async (ctx: NextPageContext) => {
   const client = generateClient(ctx);
-  const { modelId } = ctx.query;
   const { connectionApps } = await client.request(
     "get",
     `/destinations/connectionApps`
   );
-  const { model } = await client.request("get", `/model/${modelId}`);
-  return { connectionApps, model };
+
+  return { connectionApps };
 };

--- a/ui/ui-components/pages/model/[modelId]/destination/new/index.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/new/index.tsx
@@ -1,25 +1,24 @@
-import { useApi } from "../../../../../contexts/api";
+import { NextPageContext } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { Form, Alert } from "react-bootstrap";
-import { errorHandler } from "../../../../../eventHandlers";
-import AppSelectorList from "../../../../../components/AppSelectorList";
-import { Actions } from "../../../../../utils/apiData";
-import LinkButton from "../../../../../components/LinkButton";
 import { generateClient } from "../../../../../client/client";
-import { NextPageContext } from "next";
+import AppSelectorList from "../../../../../components/AppSelectorList";
+import LinkButton from "../../../../../components/LinkButton";
+import { useApi } from "../../../../../contexts/api";
+import { useGrouparooModel } from "../../../../../contexts/grouparooModel";
+import { Actions } from "../../../../../utils/apiData";
 
 export default function Page(props) {
   const {
     connectionApps,
-    model,
   }: {
     connectionApps: Actions.DestinationConnectionApps["connectionApps"];
-    model: Actions.ModelView["model"];
   } = props;
   const router = useRouter();
   const { client } = useApi();
+  const { model } = useGrouparooModel();
   const [loading, setLoading] = useState(false);
   const [app, setApp] = useState({ id: null });
 
@@ -100,11 +99,9 @@ export default function Page(props) {
 
 Page.getInitialProps = async (ctx: NextPageContext) => {
   const client = generateClient(ctx);
-  const { modelId } = ctx.query;
-  const { model } = await client.request("get", `/model/${modelId}`);
   const { connectionApps } = await client.request(
     "get",
     `/destinations/connectionApps`
   );
-  return { connectionApps, model };
+  return { connectionApps };
 };

--- a/ui/ui-components/pages/model/[modelId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/edit.tsx
@@ -1,15 +1,16 @@
 import { useApi } from "../../../contexts/api";
 import Head from "next/head";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Row, Col, Form } from "react-bootstrap";
 import { useRouter } from "next/router";
 import { successHandler } from "../../../eventHandlers";
 import PageHeader from "../../../components/PageHeader";
 import ModelTabs from "../../../components/tabs/Model";
 import LoadingButton from "../../../components/LoadingButton";
-import { Actions, Models } from "../../../utils/apiData";
+import { Actions } from "../../../utils/apiData";
 import { generateClient } from "../../../client/client";
 import { NextPageContext } from "next";
+import { useGrouparooModel } from "../../../contexts/grouparooModel";
 
 export default function Page(props) {
   const {
@@ -19,13 +20,9 @@ export default function Page(props) {
   } = props;
   const router = useRouter();
   const { client } = useApi();
-  const [model, setModel] = useState<Models.GrouparooModelType>(props.model);
+  const { model, setModel } = useGrouparooModel();
   const [loading, setLoading] = useState(false);
   const { modelId } = router.query;
-
-  useEffect(() => {
-    setModel(props.model);
-  }, [modelId]);
 
   async function edit(event) {
     event.preventDefault();
@@ -141,9 +138,8 @@ export default function Page(props) {
 }
 
 Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { modelId } = ctx.query;
   const client = generateClient(ctx);
-  const { model } = await client.request("get", `/model/${modelId}`);
   const { types } = await client.request("get", `/modelOptions`);
-  return { model, types };
+
+  return { types };
 };

--- a/ui/ui-components/pages/model/[modelId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/edit.tsx
@@ -20,9 +20,9 @@ export default function Page(props) {
   } = props;
   const router = useRouter();
   const { client } = useApi();
-  const { model, setModel } = useGrouparooModel();
+  const { model } = useGrouparooModel();
+  const [modelToUpdate, setModelToUpdate] = useState(model);
   const [loading, setLoading] = useState(false);
-  const { modelId } = router.query;
 
   async function edit(event) {
     event.preventDefault();
@@ -30,14 +30,12 @@ export default function Page(props) {
 
     const response: Actions.ModelEdit = await client.request(
       "put",
-      `/model/${modelId}`,
-      Object.assign({}, model)
+      `/model/${modelToUpdate.id}`,
+      Object.assign({}, modelToUpdate)
     );
     if (response?.model) {
       setLoading(false);
       successHandler.set({ message: "Model Updated" });
-      setModel(response.model);
-
       router.replace(router.asPath);
     } else {
       setLoading(false);
@@ -49,7 +47,7 @@ export default function Page(props) {
       setLoading(true);
       const response: Actions.ModelDestroy = await client.request(
         "delete",
-        `/model/${modelId}`
+        `/model/${model.id}`
       );
       if (response?.success) {
         successHandler.set({ message: "Model Deleted" });
@@ -63,7 +61,7 @@ export default function Page(props) {
   const update = async (event) => {
     const _model = Object.assign({}, model);
     _model[event.target.id] = event.target.value;
-    setModel(_model);
+    setModelToUpdate(_model);
   };
 
   return (
@@ -90,7 +88,7 @@ export default function Page(props) {
                   required
                   type="text"
                   placeholder="Name"
-                  value={model.name}
+                  value={modelToUpdate.name}
                   disabled={loading}
                   onChange={(e) => update(e)}
                 />

--- a/ui/ui-components/pages/model/[modelId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/edit.tsx
@@ -20,8 +20,8 @@ export default function Page(props) {
   } = props;
   const router = useRouter();
   const { client } = useApi();
-  const { model } = useGrouparooModel();
-  const [modelToUpdate, setModelToUpdate] = useState(model);
+  const { model: currentModel } = useGrouparooModel();
+  const [model, setModel] = useState(currentModel);
   const [loading, setLoading] = useState(false);
 
   async function edit(event) {
@@ -30,8 +30,8 @@ export default function Page(props) {
 
     const response: Actions.ModelEdit = await client.request(
       "put",
-      `/model/${modelToUpdate.id}`,
-      Object.assign({}, modelToUpdate)
+      `/model/${model.id}`,
+      Object.assign({}, model)
     );
     if (response?.model) {
       setLoading(false);
@@ -61,7 +61,7 @@ export default function Page(props) {
   const update = async (event) => {
     const _model = Object.assign({}, model);
     _model[event.target.id] = event.target.value;
-    setModelToUpdate(_model);
+    setModel(_model);
   };
 
   return (
@@ -88,7 +88,7 @@ export default function Page(props) {
                   required
                   type="text"
                   placeholder="Name"
-                  value={modelToUpdate.name}
+                  value={model.name}
                   disabled={loading}
                   onChange={(e) => update(e)}
                 />

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/edit.tsx
@@ -18,7 +18,6 @@ import { useApi } from "../../../../../contexts/api";
 import { generateClient } from "../../../../../client/client";
 
 interface Props {
-  model: Models.GrouparooModelType;
   group: Models.GroupType;
 }
 
@@ -89,7 +88,7 @@ const Page: NextPage<Props> = (props) => {
         <title>Grouparoo: {group.name}</title>
       </Head>
 
-      <GroupTabs group={group} model={props.model} />
+      <GroupTabs group={group} />
 
       <PageHeader
         title={group.name}
@@ -208,12 +207,7 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   const { group } = await client.request("get", `/group/${groupId}`);
   ensureMatchingModel("Group", group.modelId, modelId.toString());
 
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
-
-  return { group, model };
+  return { group };
 };
 
 export default Page;

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/members.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/members.tsx
@@ -15,10 +15,8 @@ import { generateClient } from "../../../../../client/client";
 
 export default function Page(props) {
   const {
-    model,
     group,
   }: {
-    model: Models.GrouparooModelType;
     group: Models.GroupType;
   } = props;
 
@@ -43,7 +41,7 @@ export default function Page(props) {
         <title>Grouparoo: {group.name}</title>
       </Head>
 
-      <GroupTabs group={group} model={model} />
+      <GroupTabs group={group} />
 
       <RecordsList
         {...props}
@@ -82,14 +80,10 @@ export default function Page(props) {
 }
 
 Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { groupId, modelId } = ctx.query;
+  const { groupId } = ctx.query;
   const client = generateClient(ctx);
   const { group } = await client.request("get", `/group/${groupId}`);
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
   const recordListInitialProps = await RecordsList.hydrate(ctx);
 
-  return { group, model, ...recordListInitialProps };
+  return { group, ...recordListInitialProps };
 };

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -20,13 +20,11 @@ import { generateClient } from "../../../../../client/client";
 
 export default function Page(props) {
   const {
-    model,
     properties,
     ruleLimit,
     ops,
     topLevelGroupRules,
   }: {
-    model: Models.GrouparooModelType;
     properties: Models.PropertyType[];
     ruleLimit: Actions.GroupsRuleOptions["ruleLimit"];
     ops: Actions.GroupsRuleOptions["ops"];
@@ -151,7 +149,7 @@ export default function Page(props) {
       <Head>
         <title>Grouparoo: {group.name}</title>
       </Head>
-      <GroupTabs group={group} model={model} />
+      <GroupTabs group={group} />
 
       <PageHeader
         title={`${group.name} - Rules`}
@@ -514,10 +512,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   const { group } = await client.request("get", `/group/${groupId}`);
   ensureMatchingModel("Group", group.modelId, modelId.toString());
 
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
   const { properties } = await client.request("get", `/properties`, {
     state: "ready",
     modelId: group?.modelId,
@@ -526,7 +520,7 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
     "get",
     `/groups/ruleOptions`
   );
-  return { group, model, properties, ruleLimit, ops, topLevelGroupRules };
+  return { group, properties, ruleLimit, ops, topLevelGroupRules };
 };
 
 function rulesAreEqual(a, b) {

--- a/ui/ui-components/pages/model/[modelId]/group/new.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/new.tsx
@@ -1,5 +1,4 @@
 import { useApi } from "../../../../contexts/api";
-import { NextPageContext } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useState } from "react";
@@ -8,16 +7,12 @@ import { Form } from "react-bootstrap";
 import LoadingButton from "../../../../components/LoadingButton";
 import { Actions } from "../../../../utils/apiData";
 import ModelBadge from "../../../../components/badges/ModelBadge";
-import { generateClient } from "../../../../client/client";
+import { useGrouparooModel } from "../../../../contexts/grouparooModel";
 
 export default function NewGroup(props) {
-  const {
-    model,
-  }: {
-    model: Actions.ModelView["model"];
-  } = props;
   const router = useRouter();
   const { client } = useApi();
+  const { model } = useGrouparooModel();
   const { handleSubmit, register } = useForm();
   const [loading, setLoading] = useState(false);
 
@@ -74,10 +69,3 @@ export default function NewGroup(props) {
     </>
   );
 }
-
-NewGroup.getInitialProps = async (ctx: NextPageContext) => {
-  const { modelId } = ctx.query;
-  const client = generateClient(ctx);
-  const { model } = await client.request("get", `/model/${modelId}`);
-  return { model };
-};

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/edit.tsx
@@ -27,11 +27,9 @@ import { generateClient } from "../../../../../client/client";
 
 export default function Page(props) {
   const {
-    model,
     properties,
     allGroups,
   }: {
-    model: Models.GrouparooModelType;
     properties: Models.PropertyType[];
     allGroups: Models.GroupType[];
     apps: Models.AppType[];
@@ -171,7 +169,7 @@ export default function Page(props) {
         <title>Grouparoo: {getRecordDisplayName(record)}</title>
       </Head>
 
-      <RecordTabs record={record} model={model} />
+      <RecordTabs record={record} />
 
       <PageHeader
         title={uniqueRecordProperties
@@ -376,10 +374,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   );
   ensureMatchingModel("Record", record?.modelId, modelId.toString());
 
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
   const { properties } = await client.request("get", `/properties`, {
     modelId: record?.modelId,
   });
@@ -390,7 +384,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   return {
     record,
     properties,
-    model,
     groups,
     allGroups,
     destinations,

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/exports.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/exports.tsx
@@ -13,11 +13,9 @@ import { generateClient } from "../../../../../client/client";
 export default function Page(props) {
   const {
     record,
-    model,
     properties,
   }: {
     record: Models.GrouparooRecordType;
-    model: Models.GrouparooModelType;
     properties: Models.PropertyType[];
   } = props;
 
@@ -39,7 +37,7 @@ export default function Page(props) {
         <title>Grouparoo: {getRecordDisplayName(record)}</title>
       </Head>
 
-      <RecordTabs record={record} model={model} />
+      <RecordTabs record={record} />
 
       <ExportsList
         header={
@@ -67,13 +65,9 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   const { recordId, modelId } = ctx.query;
   const { record } = await client.request("get", `/record/${recordId}`);
   ensureMatchingModel("Record", record?.modelId, modelId.toString());
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
   const { properties } = await client.request("get", `/properties`, {
     modelId,
   });
   const exportListInitialProps = await ExportsList.hydrate(ctx);
-  return { record, model, properties, ...exportListInitialProps };
+  return { record, properties, ...exportListInitialProps };
 };

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/imports.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/imports.tsx
@@ -13,11 +13,9 @@ import { generateClient } from "../../../../../client/client";
 export default function Page(props) {
   const {
     record,
-    model,
     properties,
   }: {
     record: Models.GrouparooRecordType;
-    model: Models.GrouparooModelType;
     properties: Models.PropertyType[];
   } = props;
 
@@ -39,7 +37,7 @@ export default function Page(props) {
         <title>Grouparoo: {getRecordDisplayName(record)}</title>
       </Head>
 
-      <RecordTabs record={record} model={model} />
+      <RecordTabs record={record} />
 
       <ImportList
         header={
@@ -67,13 +65,9 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   const { recordId, modelId } = ctx.query;
   const { record } = await client.request("get", `/record/${recordId}`);
   ensureMatchingModel("Record", record?.modelId, modelId.toString());
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
   const { properties } = await client.request("get", `/properties`, {
     modelId,
   });
   const importListInitialProps = await ImportList.hydrate(ctx);
-  return { record, model, properties, ...importListInitialProps };
+  return { record, properties, ...importListInitialProps };
 };

--- a/ui/ui-components/pages/model/[modelId]/record/[recordId]/logs.tsx
+++ b/ui/ui-components/pages/model/[modelId]/record/[recordId]/logs.tsx
@@ -13,11 +13,9 @@ import { generateClient } from "../../../../../client/client";
 export default function Page(props) {
   const {
     record,
-    model,
     properties,
   }: {
     record: Models.GrouparooRecordType;
-    model: Models.GrouparooModelType;
     properties: Models.PropertyType[];
   } = props;
 
@@ -39,7 +37,7 @@ export default function Page(props) {
         <title>Grouparoo: {getRecordDisplayName(record)}</title>
       </Head>
 
-      <RecordTabs record={record} model={model} />
+      <RecordTabs record={record} />
 
       <LogsList
         header={
@@ -65,15 +63,18 @@ export default function Page(props) {
 Page.getInitialProps = async (ctx: NextPageContext) => {
   const { recordId, modelId } = ctx.query;
   const client = generateClient(ctx);
-  const { record } = await client.request("get", `/record/${recordId}`);
-  ensureMatchingModel("Record", record?.modelId, modelId.toString());
-  const { model } = await client.request<Actions.ModelView>(
+  const { record } = await client.request<Actions.RecordView>(
     "get",
-    `/model/${modelId}`
+    `/record/${recordId}`
   );
-  const { properties } = await client.request("get", `/properties`, {
-    modelId,
-  });
+  ensureMatchingModel("Record", record?.modelId, modelId.toString());
+  const { properties } = await client.request<Actions.PropertiesList>(
+    "get",
+    `/properties`,
+    {
+      modelId,
+    }
+  );
   const logListInitialProps = await LogsList.hydrate(ctx);
-  return { record, model, properties, ...logListInitialProps };
+  return { record, properties, ...logListInitialProps };
 };

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -38,7 +38,6 @@ interface FormData {
 }
 
 interface Props {
-  model: Models.GrouparooModelType;
   environmentVariableOptions: Actions.AppOptions["environmentVariableOptions"];
   properties: Models.PropertyType[];
   propertyExamples: Record<string, string[]>;
@@ -48,7 +47,6 @@ interface Props {
 }
 
 const Page: NextPage<Props> = ({
-  model,
   environmentVariableOptions,
   scheduleCount,
   totalSources,
@@ -305,7 +303,7 @@ const Page: NextPage<Props> = ({
         <title>Grouparoo: {source.name}</title>
       </Head>
 
-      <SourceTabs source={source} model={model} />
+      <SourceTabs source={source} />
 
       <PageHeader
         icon={source.app.icon}
@@ -629,11 +627,6 @@ export const getServerSideProps: GetServerSideProps<Props> =
     const { source } = await client.request("get", `/source/${sourceId}`);
     ensureMatchingModel("Source", source.modelId, modelId.toString());
 
-    const { model } = await client.request<Actions.ModelView>(
-      "get",
-      `/model/${modelId}`
-    );
-
     const { total: totalSources } = await client.request("get", `/sources`, {
       modelId,
       limit: 1,
@@ -659,7 +652,6 @@ export const getServerSideProps: GetServerSideProps<Props> =
     return {
       props: {
         environmentVariableOptions,
-        model,
         properties,
         propertyExamples,
         source,

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -11,7 +11,6 @@ import SourceTabs from "../../../../../components/tabs/Source";
 import Head from "next/head";
 import { errorHandler, successHandler } from "../../../../../eventHandlers";
 import { Models, Actions } from "../../../../../utils/apiData";
-import { generateId } from "../../../../../utils/generateId";
 import PropertyAddButton from "../../../../../components/property/Add";
 import ModelBadge from "../../../../../components/badges/ModelBadge";
 import { NextPageContext } from "next";
@@ -20,14 +19,12 @@ import { generateClient } from "../../../../../client/client";
 
 export default function Page(props) {
   const {
-    model,
     source,
     preview,
     columnSpeculation,
     types,
     defaultPropertyOptions,
   }: {
-    model: Models.GrouparooModelType;
     source: Models.SourceType;
     preview: Actions.SourcePreview["preview"];
     columnSpeculation: Actions.SourcePreview["columnSpeculation"];
@@ -274,7 +271,7 @@ export default function Page(props) {
           <title>Grouparoo: {source.name}</title>
         </Head>
 
-        <SourceTabs source={source} model={model} />
+        <SourceTabs source={source} />
 
         <PageHeader
           icon={source.app.icon}
@@ -304,7 +301,7 @@ export default function Page(props) {
         <title>Grouparoo: {source.name}</title>
       </Head>
 
-      <SourceTabs source={source} model={model} />
+      <SourceTabs source={source} />
 
       <PageHeader
         icon={source.app.icon}
@@ -373,10 +370,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   );
   ensureMatchingModel("Source", source.modelId, modelId.toString());
 
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
   const { preview, columnSpeculation } =
     await client.request<Actions.SourcePreview>(
       "get",
@@ -398,7 +391,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   );
 
   return {
-    model,
     source,
     properties,
     columnSpeculation,

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
@@ -21,13 +21,11 @@ import PrimaryKeyBadge from "../../../../../components/badges/PrimaryKeyBadge";
 import { generateClient } from "../../../../../client/client";
 
 export default function Page({
-  model,
   source,
   totalSources,
   run,
   properties,
 }: {
-  model: Models.GrouparooModelType;
   source: Models.SourceType;
   totalSources: number;
   run: Models.RunType;
@@ -67,7 +65,7 @@ export default function Page({
         <title>Grouparoo: {source.name}</title>
       </Head>
 
-      <SourceTabs source={source} model={model} />
+      <SourceTabs source={source} />
 
       <PageHeader
         icon={source.app.icon}
@@ -327,11 +325,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   const { source } = await client.request("get", `/source/${sourceId}`);
   ensureMatchingModel("Source", source.modelId, modelId.toString());
 
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
-
   const { total: totalSources } = await client.request("get", `/sources`, {
     modelId,
     limit: 1,
@@ -349,5 +342,5 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
     run = runs[0];
   }
 
-  return { model, source, totalSources, run, properties };
+  return { source, totalSources, run, properties };
 };

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit.tsx
@@ -33,7 +33,6 @@ import { generateClient } from "../../../../../../../client/client";
 
 export default function Page(props) {
   const {
-    model,
     sources,
     types,
     filterOptions,
@@ -41,7 +40,6 @@ export default function Page(props) {
     properties,
     hydrationError,
   }: {
-    model: Models.GrouparooModelType;
     sources: Models.SourceType[];
     types: Actions.PropertiesOptions["types"];
     filterOptions: Actions.PropertyFilterOptions["options"];
@@ -234,7 +232,7 @@ export default function Page(props) {
         <title>Grouparoo: {property.key}</title>
       </Head>
 
-      <PropertyTabs property={property} source={source} model={model} />
+      <PropertyTabs property={property} source={source} />
 
       <PageHeader icon={source.app.icon} title={property.key} badges={badges} />
       <Row>
@@ -795,10 +793,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
 
   const { sources } = await client.request("get", "/sources");
   const { types } = await client.request("get", `/propertyOptions`);
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
 
   let property: Models.PropertyType = {};
   let properties = [];
@@ -839,7 +833,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   }
 
   return {
-    model,
     property,
     properties,
     sources,

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -11,7 +11,7 @@ import PageHeader from "../../../../../components/PageHeader";
 import StateBadge from "../../../../../components/badges/StateBadge";
 import LockedBadge from "../../../../../components/badges/LockedBadge";
 import DatePicker from "../../../../../components/DatePicker";
-import { errorHandler, successHandler } from "../../../../../eventHandlers";
+import { successHandler } from "../../../../../eventHandlers";
 import { Models, Actions } from "../../../../../utils/apiData";
 import { formatTimestamp } from "../../../../../utils/formatTimestamp";
 import { filtersAreEqual } from "../../../../../utils/filtersAreEqual";
@@ -34,7 +34,6 @@ const renderCheckboxLabel = (
 export default function Page(props) {
   const {
     source,
-    model,
     run,
     pluginOptions,
     filterOptions,
@@ -43,7 +42,6 @@ export default function Page(props) {
     totalSources,
   }: {
     source: Models.SourceType;
-    model: Models.GrouparooModelType;
     run: Models.RunType;
     pluginOptions: Actions.ScheduleView["pluginOptions"];
     filterOptions: Actions.ScheduleFilterOptions["options"];
@@ -162,7 +160,7 @@ export default function Page(props) {
       <Head>
         <title>Grouparoo: {source.name}</title>
       </Head>
-      <SourceTabs source={source} model={model} />
+      <SourceTabs source={source} />
       <PageHeader
         icon={source.app.icon}
         title={`${source.name} - Schedule`}
@@ -649,11 +647,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   let filterOptionDescriptions = {};
   ensureMatchingModel("Source", source.modelId, modelId.toString());
 
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
-
   const { schedule, pluginOptions } = await client.request(
     "get",
     `/schedule/${source.schedule.id}`
@@ -684,7 +677,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
 
   return {
     source,
-    model,
     schedule,
     pluginOptions,
     filterOptions,

--- a/ui/ui-components/pages/model/[modelId]/source/new/[appId].tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/new/[appId].tsx
@@ -1,4 +1,3 @@
-import { useApi } from "../../../../../contexts/api";
 import { NextPageContext } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
@@ -6,24 +5,25 @@ import { useState, Fragment, useEffect } from "react";
 import { Row, Col, Card } from "react-bootstrap";
 import LoadingButton from "../../../../../components/LoadingButton";
 import AppIcon from "../../../../../components/AppIcon";
-import { humanizePluginName } from "../../../../../utils/languageHelper";
-import { Actions } from "../../../../../utils/apiData";
 import ModelBadge from "../../../../../components/badges/ModelBadge";
 import AppBadge from "../../../../../components/badges/AppBadge";
 import { generateClient } from "../../../../../client/client";
+import { useApi } from "../../../../../contexts/api";
+import { useGrouparooModel } from "../../../../../contexts/grouparooModel";
+import { humanizePluginName } from "../../../../../utils/languageHelper";
+import { Actions } from "../../../../../utils/apiData";
 
 export default function Page(props) {
   const {
     connectionApps,
-    model,
     isPrimarySourceNotReady,
   }: {
     connectionApps: Actions.SourceConnectionApps["connectionApps"];
-    model: Actions.ModelView["model"];
     isPrimarySourceNotReady: boolean;
   } = props;
   const router = useRouter();
   const { client } = useApi();
+  const { model } = useGrouparooModel();
   const [loading, setLoading] = useState(false);
   const { appId } = router.query;
 
@@ -117,7 +117,6 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
     "get",
     `/sources/connectionApps`
   );
-  const { model } = await client.request("get", `/model/${modelId}`);
   const { sources, total: totalSources } =
     await client.request<Actions.SourcesList>("get", "/sources", {
       modelId,
@@ -126,5 +125,5 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   const isPrimarySourceNotReady =
     totalSources === 1 && sources[0].state !== "ready";
 
-  return { connectionApps, model, isPrimarySourceNotReady };
+  return { connectionApps, isPrimarySourceNotReady };
 };

--- a/ui/ui-components/pages/model/[modelId]/source/new/index.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/new/index.tsx
@@ -3,27 +3,26 @@ import Head from "next/head";
 import { useEffect, useMemo, useState } from "react";
 import { Form, Alert } from "react-bootstrap";
 import { useRouter } from "next/router";
-import { errorHandler } from "../../../../../eventHandlers";
 import AppSelectorList from "../../../../../components/AppSelectorList";
 import { Actions, Models } from "../../../../../utils/apiData";
 import LinkButton from "../../../../../components/LinkButton";
 import { generateClient } from "../../../../../client/client";
+import { useGrouparooModel } from "../../../../../contexts/grouparooModel";
 
 export default function Page(props) {
   const {
     connectionApps,
-    model,
     isCreatingPrimarySource,
     isPrimarySourceNotReady,
   }: {
     connectionApps: Actions.SourceConnectionApps["connectionApps"];
-    model: Actions.ModelView["model"];
     primarySource: Models.SourceType;
     isCreatingPrimarySource: boolean;
     isPrimarySourceNotReady: boolean;
   } = props;
   const router = useRouter();
   const { client } = useApi();
+  const { model } = useGrouparooModel();
   const [loading, setLoading] = useState(false);
   const [app, setApp] = useState({ id: null });
 
@@ -161,14 +160,9 @@ Page.getInitialProps = async (ctx) => {
     "get",
     `/sources/connectionApps`
   );
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
 
   return {
     connectionApps,
-    model,
     isCreatingPrimarySource,
     isPrimarySourceNotReady,
   };

--- a/ui/ui-components/utils/contextHelper.tsx
+++ b/ui/ui-components/utils/contextHelper.tsx
@@ -1,11 +1,12 @@
-export type ContextValue<T = unknown> = [Context: React.Context<T>, value: T];
+import React from "react";
 
-// Note: Once strict mode is on, we can more strongly type this
-export const renderContextProvider = <T extends any>(
-  Context: React.Context<T>,
+export type ContextValue<T> = [Provider: React.FC<{ value: T }>, value: T];
+
+export const renderContextProvider = <T extends object>(
+  Provider: React.FC<{ value: T }>,
   value: T,
   children: React.ReactNode
-) => <Context.Provider value={value}>{children}</Context.Provider>;
+) => <Provider value={value}>{children}</Provider>;
 
 export const renderNestedContextProviders = <
   TContextValues extends ContextValue<T>[],
@@ -13,17 +14,12 @@ export const renderNestedContextProviders = <
 >(
   contextValues: TContextValues,
   children: React.ReactNode
-): JSX.Element => {
-  {
-    if (contextValues.length) {
-      const [[Context, value]] = contextValues;
-      return renderContextProvider(
-        Context,
-        value,
-        renderNestedContextProviders(contextValues.slice(1), children)
-      );
-    }
-
-    return <>{children}</>;
-  }
-};
+): JSX.Element =>
+  contextValues?.length > 0 ? (
+    renderContextProvider(
+      ...contextValues[0],
+      renderNestedContextProviders(contextValues.slice(1), children)
+    )
+  ) : (
+    <>{children}</>
+  );

--- a/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/destinations.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/destinations.tsx
@@ -18,10 +18,8 @@ import { generateClient } from "@grouparoo/ui-components/client/client";
 
 export default function Page(props) {
   const {
-    model,
     group,
   }: {
-    model: Models.GrouparooModelType;
     group: Models.GroupType;
   } = props;
   const { client } = useApi();
@@ -63,7 +61,7 @@ export default function Page(props) {
         <title>Grouparoo: {group.name}</title>
       </Head>
 
-      <GroupTabs group={group} model={model} />
+      <GroupTabs group={group} />
 
       <PageHeader
         title={`${group.name} - Destinations`}
@@ -124,20 +122,18 @@ export default function Page(props) {
 }
 
 Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { groupId, limit, offset, modelId } = ctx.query;
+  const { groupId, limit, offset } = ctx.query;
   const client = generateClient(ctx);
   const { group } = await client.request("get", `/group/${groupId}`);
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
-  const { destinations, total } = await client.request(
-    "get",
-    `/group/${group.id}/destinations`,
-    {
-      limit,
-      offset,
-    }
-  );
-  return { model, group, destinations, total };
+  const { destinations, total } =
+    await client.request<Actions.GroupListDestinations>(
+      "get",
+      `/group/${group.id}/destinations`,
+      {
+        limit,
+        offset,
+      }
+    );
+
+  return { group, destinations, total };
 };

--- a/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/logs.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/logs.tsx
@@ -10,7 +10,7 @@ import { Actions } from "@grouparoo/ui-components/utils/apiData";
 import { generateClient } from "@grouparoo/ui-components/client/client";
 
 export default function Page(props) {
-  const { group, model } = props;
+  const { group } = props;
 
   return (
     <>
@@ -18,7 +18,7 @@ export default function Page(props) {
         <title>Grouparoo: Logs</title>
       </Head>
 
-      <GroupTabs group={group} model={model} />
+      <GroupTabs group={group} />
 
       <LogsList
         header={
@@ -43,13 +43,12 @@ export default function Page(props) {
 }
 
 Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { groupId, modelId } = ctx.query;
+  const { groupId } = ctx.query;
   const client = generateClient(ctx);
-  const { group } = await client.request("get", `/group/${groupId}`);
-  const { model } = await client.request<Actions.ModelView>(
+  const { group } = await client.request<Actions.GroupView>(
     "get",
-    `/model/${modelId}`
+    `/group/${groupId}`
   );
   const logListInitialProps = await LogsList.hydrate(ctx);
-  return { group, model, ...logListInitialProps };
+  return { group, ...logListInitialProps };
 };

--- a/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/runs.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/runs.tsx
@@ -10,7 +10,7 @@ import { Actions } from "@grouparoo/ui-components/utils/apiData";
 import { generateClient } from "@grouparoo/ui-components/client/client";
 
 export default function Page(props) {
-  const { group, model } = props;
+  const { group } = props;
 
   return (
     <>
@@ -18,7 +18,7 @@ export default function Page(props) {
         <title>Grouparoo: {group.name}</title>
       </Head>
 
-      <GroupTabs group={group} model={model} />
+      <GroupTabs group={group} />
 
       <RunsList
         header={
@@ -43,13 +43,12 @@ export default function Page(props) {
 }
 
 Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { groupId, modelId } = ctx.query;
+  const { groupId } = ctx.query;
   const client = generateClient(ctx);
-  const { group } = await client.request("get", `/group/${groupId}`);
-  const { model } = await client.request<Actions.ModelView>(
+  const { group } = await client.request<Actions.GroupView>(
     "get",
-    `/model/${modelId}`
+    `/group/${groupId}`
   );
   const runsListInitialProps = await RunsList.hydrate(ctx, { topic: "group" });
-  return { group, model, ...runsListInitialProps };
+  return { group, ...runsListInitialProps };
 };

--- a/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/groups.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/groups.tsx
@@ -11,12 +11,10 @@ import { NextPageContext } from "next";
 import { generateClient } from "@grouparoo/ui-components/client/client";
 
 export default function Page({
-  model,
   property,
   groups,
   source,
 }: {
-  model: Models.GrouparooModelType;
   property: Models.PropertyType;
   groups: Models.GroupType[];
   source: Models.SourceType;
@@ -27,7 +25,7 @@ export default function Page({
         <title>Grouparoo: {property.key}</title>
       </Head>
 
-      <PropertyTabs property={property} source={source} model={model} />
+      <PropertyTabs property={property} source={source} />
 
       <PageHeader
         icon={source.app.icon}
@@ -86,21 +84,20 @@ export default function Page({
 }
 
 Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { propertyId, modelId } = ctx.query;
+  const { propertyId } = ctx.query;
   const client = generateClient(ctx);
-  const { model } = await client.request<Actions.ModelView>(
+  const { property } = await client.request<Actions.PropertyView>(
     "get",
-    `/model/${modelId}`
+    `/property/${propertyId}`
   );
-  const { property } = await client.request("get", `/property/${propertyId}`);
-  const { source } = await client.request(
+  const { source } = await client.request<Actions.SourceView>(
     "get",
     `/source/${property.sourceId}`
   );
-  const { groups } = await client.request(
+  const { groups } = await client.request<Actions.PropertyGroups>(
     "get",
     `/property/${propertyId}/groups`
   );
 
-  return { model, property, source, groups };
+  return { property, source, groups };
 };

--- a/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/logs.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/logs.tsx
@@ -11,11 +11,9 @@ import { generateClient } from "@grouparoo/ui-components/client/client";
 
 export default function Page(props) {
   const {
-    model,
     property,
     source,
   }: {
-    model: Models.GrouparooModelType;
     property: Models.PropertyType;
     source: Models.SourceType;
   } = props;
@@ -26,7 +24,7 @@ export default function Page(props) {
         <title>Grouparoo: Logs</title>
       </Head>
 
-      <PropertyTabs property={property} source={source} model={model} />
+      <PropertyTabs property={property} source={source} />
 
       <LogsList
         header={
@@ -51,17 +49,16 @@ export default function Page(props) {
 }
 
 Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { propertyId, modelId } = ctx.query;
+  const { propertyId } = ctx.query;
   const client = generateClient(ctx);
-  const { model } = await client.request<Actions.ModelView>(
+  const { property } = await client.request<Actions.PropertyView>(
     "get",
-    `/model/${modelId}`
+    `/property/${propertyId}`
   );
-  const { property } = await client.request("get", `/property/${propertyId}`);
-  const { source } = await client.request(
+  const { source } = await client.request<Actions.SourceView>(
     "get",
     `/source/${property.sourceId}`
   );
   const logListInitialProps = await LogsList.hydrate(ctx);
-  return { model, property, source, ...logListInitialProps };
+  return { property, source, ...logListInitialProps };
 };

--- a/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/records.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/records.tsx
@@ -11,7 +11,6 @@ import { generateClient } from "@grouparoo/ui-components/client/client";
 
 export default function Page(props) {
   const {
-    model,
     property,
     source,
   }: {
@@ -26,7 +25,7 @@ export default function Page(props) {
         <title>Grouparoo: {property.key} Records</title>
       </Head>
 
-      <PropertyTabs property={property} source={source} model={model} />
+      <PropertyTabs property={property} source={source} />
 
       <RecordsList
         {...props}
@@ -53,16 +52,15 @@ export default function Page(props) {
 }
 
 Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { propertyId, modelId } = ctx.query;
+  const { propertyId } = ctx.query;
   const client = generateClient(ctx);
-  const { property } = await client.request("get", `/property/${propertyId}`);
-  const { source } = await client.request(
+  const { property } = await client.request<Actions.PropertyView>(
+    "get",
+    `/property/${propertyId}`
+  );
+  const { source } = await client.request<Actions.SourceView>(
     "get",
     `/source/${property.sourceId}`
-  );
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
   );
   const recordListInitialProps = await RecordsList.hydrate(
     ctx,
@@ -70,5 +68,5 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
     "%"
   );
 
-  return { model, property, source, ...recordListInitialProps };
+  return { property, source, ...recordListInitialProps };
 };

--- a/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/runs.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/runs.tsx
@@ -26,7 +26,7 @@ export default function Page(props) {
         <title>Grouparoo: {property.key} Runs</title>
       </Head>
 
-      <PropertyTabs property={property} source={source} model={model} />
+      <PropertyTabs property={property} source={source} />
 
       <RunsList
         header={
@@ -51,19 +51,18 @@ export default function Page(props) {
 }
 
 Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { propertyId, modelId } = ctx.query;
+  const { propertyId } = ctx.query;
   const client = generateClient(ctx);
-  const { model } = await client.request<Actions.ModelView>(
+  const { property } = await client.request<Actions.PropertyView>(
     "get",
-    `/model/${modelId}`
+    `/property/${propertyId}`
   );
-  const { property } = await client.request("get", `/property/${propertyId}`);
-  const { source } = await client.request(
+  const { source } = await client.request<Actions.SourceView>(
     "get",
     `/source/${property.sourceId}`
   );
   const runsListInitialProps = await RunsList.hydrate(ctx, {
     topic: "property",
   });
-  return { model, property, source, ...runsListInitialProps };
+  return { property, source, ...runsListInitialProps };
 };

--- a/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/runs.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/runs.tsx
@@ -9,7 +9,6 @@ import StateBadge from "@grouparoo/ui-components/components/badges/StateBadge";
 import LockedBadge from "@grouparoo/ui-components/components/badges/LockedBadge";
 import ModelBadge from "@grouparoo/ui-components/components/badges/ModelBadge";
 import {
-  errorHandler,
   runsHandler,
   successHandler,
 } from "@grouparoo/ui-components/eventHandlers";
@@ -22,10 +21,8 @@ import { generateClient } from "@grouparoo/ui-components/client/client";
 export default function Page(props) {
   const {
     source,
-    model,
   }: {
     source: Models.SourceType;
-    model: Models.GrouparooModelType;
   } = props;
   const { client } = useApi();
   const [loading, setLoading] = useState(false);
@@ -52,7 +49,7 @@ export default function Page(props) {
         <title>Grouparoo: {source.name}</title>
       </Head>
 
-      <SourceTabs source={source} model={model} />
+      <SourceTabs source={source} />
 
       <RunsList
         header={
@@ -101,11 +98,7 @@ Page.getInitialProps = async (ctx: NextPageContext) => {
   const { source } = await client.request("get", `/source/${sourceId}`);
   ensureMatchingModel("Source", source.modelId, modelId.toString());
 
-  const { model } = await client.request<Actions.ModelView>(
-    "get",
-    `/model/${modelId}`
-  );
   const runsListInitialProps = await RunsList.hydrate(ctx, { topic: "source" });
 
-  return { source, model, ...runsListInitialProps };
+  return { source, ...runsListInitialProps };
 };


### PR DESCRIPTION
## Change description

This moves the grouparooModel context to be global so that any page can get the model without having to fetch it individually. All pages have been migrated to get the model from the global context.

Usage:

```ts
import { useGrouparooModel } from '../contexts/grouparooModel'

const PageOrComponent = (props) => {
   const { model } = useGrouparooModel()
}
```

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
