### PR TITLE
Display sign in link for older `getInitialProps` pages on auth error

### DIFF
--- a/core/__tests__/actions/session.ts
+++ b/core/__tests__/actions/session.ts
@@ -435,7 +435,7 @@ describe("session", () => {
           );
           expect(secondResponse.error.code).toBe("AUTHENTICATION_ERROR");
           expect(secondResponse.error.message).toBe(
-            "Please log in to continue"
+            "Please sign in to continue"
           );
           expect(secondResponse["success"]).toBeFalsy();
         });
@@ -673,7 +673,7 @@ describe("session", () => {
 
         test("without an apiKey, actions are not authenticated", async () => {
           let response = await specHelper.runAction("appReadAction", {});
-          expect(response.error.message).toBe("Please log in to continue");
+          expect(response.error.message).toBe("Please sign in to continue");
           expect(response.error.code).toBe("AUTHENTICATION_ERROR");
           expect(response["success"]).toBeFalsy();
         });

--- a/core/src/modules/middleware/authentication.ts
+++ b/core/src/modules/middleware/authentication.ts
@@ -72,7 +72,7 @@ async function authenticateTeamMemberFromSession(
             "NO_TEAMS_ERROR"
           );
         } else {
-          throw new Errors.AuthenticationError("Please log in to continue");
+          throw new Errors.AuthenticationError("Please sign in to continue");
         }
       } else if (
         (data.params.csrfToken && data.params.csrfToken !== session.id) ||
@@ -203,7 +203,7 @@ async function authenticateTeamMemberInRoom(
   await CLS.wrap(async () => {
     const session = await api.session.load(connection);
     if (!session || !session.id) {
-      throw new Errors.AuthenticationError("Please log in to continue");
+      throw new Errors.AuthenticationError("Please sign in to continue");
     } else {
       const teamMember = await TeamMember.findOne({
         where: { id: session.teamMemberId },

--- a/ui/ui-components/components/alerts/HydrationError.tsx
+++ b/ui/ui-components/components/alerts/HydrationError.tsx
@@ -1,15 +1,17 @@
 import { Fragment } from "react";
 import { Card } from "react-bootstrap";
 import Link from "next/link";
-import { isBrowser } from "../../utils/isBrowser";
+import { useRouter } from "next/router";
 
 export default function HydrationError({
   hydrationError,
 }: {
   hydrationError: string;
 }) {
+  const router = useRouter();
   let error: Error;
   let errorData: { [key: string]: any };
+
   try {
     const parsed = JSON.parse(hydrationError);
     error = new Error(parsed.message);
@@ -25,12 +27,10 @@ export default function HydrationError({
         <Card.Header>There was an error loading this Page</Card.Header>
         <Card.Body>
           <blockquote className="blockquote mb-0">
-            {error?.message.match(/sign in to continue/) && isBrowser() ? (
+            {error?.message.match(/sign in to continue/) ? (
               <p>
                 Please{" "}
-                <Link
-                  href={`/session/sign-in?nextPage=${window.location.pathname}`}
-                >
+                <Link href={`/session/sign-in?nextPage=${router.asPath}`}>
                   <a>sign in</a>
                 </Link>{" "}
                 to continue

--- a/ui/ui-components/components/alerts/HydrationError.tsx
+++ b/ui/ui-components/components/alerts/HydrationError.tsx
@@ -1,5 +1,7 @@
 import { Fragment } from "react";
 import { Card } from "react-bootstrap";
+import Link from "next/link";
+import { isBrowser } from "../../utils/isBrowser";
 
 export default function HydrationError({
   hydrationError,
@@ -23,7 +25,19 @@ export default function HydrationError({
         <Card.Header>There was an error loading this Page</Card.Header>
         <Card.Body>
           <blockquote className="blockquote mb-0">
-            <p>{error.message}</p>
+            {error?.message.match(/sign in to continue/) && isBrowser() ? (
+              <p>
+                Please{" "}
+                <Link
+                  href={`/session/sign-in?nextPage=${window.location.pathname}`}
+                >
+                  <a>sign in</a>
+                </Link>{" "}
+                to continue
+              </p>
+            ) : (
+              <p>{error.message}</p>
+            )}
           </blockquote>
           {errorData ? (
             <>

--- a/ui/ui-components/hooks/useRealtimeStream.ts
+++ b/ui/ui-components/hooks/useRealtimeStream.ts
@@ -88,7 +88,7 @@ export const useRealtimeStream = (
       return;
     } else if (
       error.error &&
-      error.error.message.includes("Please log in to continue")
+      error.error.message.includes("Please sign in to continue")
     ) {
       return;
     }


### PR DESCRIPTION
Following the work in https://github.com/grouparoo/grouparoo/pull/2872, for our remaining pages that still hydrate via `getInitialProps`, we no longer auto-redirect to the sign in page when there's an auth error.  As we intend to swap `getInitialProps` for `getServerSideProps` on all pages, this PR is a temporary stop-gap. This PR makes the error message show as a link so folks can sign in easily. 

<img width="1504" alt="Screen Shot 2022-01-28 at 8 38 55 AM" src="https://user-images.githubusercontent.com/303226/151586905-e3a20d6a-c065-4d9d-b970-cf9037a09845.png">


## Checklists


### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
