### PR TITLE
Fix disabled state for Unique checkbox in property editor

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit.tsx
@@ -290,18 +290,22 @@ export default function Page(props) {
                       label={"Unique"}
                       checked={property.unique}
                       onChange={(e) => update(e)}
-                      disabled={property.unique || loading}
+                      disabled={property.isPrimaryKey || loading}
                     />
                     {property.isPrimaryKey && (
                       <Form.Text className="text-muted">
                         <code>Unique</code> cannot be updated while this
-                        Property is the Primary Key for the Model.{" "}
+                        Property is the Primary Key for the Model.
                         {grouparooUiEdition() !== "community" && (
-                          <EnterpriseLink
-                            href={`/model/${source.modelId}/source/${source.id}/edit`}
-                          >
-                            <a>Edit mapping</a>
-                          </EnterpriseLink>
+                          <>
+                            {" "}
+                            <EnterpriseLink
+                              href={`/model/${source.modelId}/source/${source.id}/edit`}
+                            >
+                              <a>Edit mapping</a>
+                            </EnterpriseLink>{" "}
+                            first.
+                          </>
                         )}
                       </Form.Text>
                     )}


### PR DESCRIPTION
## Change description

This features a trivial check missed in #2864 to ensure that the "Unique" checkbox is disabled only when the property is the primary key.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
