### PR TITLE
fix: use `generateClient` in `getInitialProps`

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/group/new.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/new.tsx
@@ -6,9 +6,9 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { Form } from "react-bootstrap";
 import LoadingButton from "../../../../components/LoadingButton";
-import { errorHandler } from "../../../../eventHandlers";
 import { Actions } from "../../../../utils/apiData";
 import ModelBadge from "../../../../components/badges/ModelBadge";
+import { generateClient } from "../../../../client/client";
 
 export default function NewGroup(props) {
   const {
@@ -77,7 +77,7 @@ export default function NewGroup(props) {
 
 NewGroup.getInitialProps = async (ctx: NextPageContext) => {
   const { modelId } = ctx.query;
-  const { client } = useApi();
+  const client = generateClient(ctx);
   const { model } = await client.request("get", `/model/${modelId}`);
   return { model };
 };

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
@@ -1,4 +1,3 @@
-import { useApi } from "../../../../../contexts/api";
 import { useMemo } from "react";
 import { Row, Col, Table, Badge, Alert, Card } from "react-bootstrap";
 import PageHeader from "../../../../../components/PageHeader";

--- a/ui/ui-components/pages/notification/[id]/edit.tsx
+++ b/ui/ui-components/pages/notification/[id]/edit.tsx
@@ -1,4 +1,3 @@
-import { useApi } from "../../../contexts/api";
 import NotificationTabs from "../../../components/tabs/Notification";
 import Head from "next/head";
 import { Button } from "react-bootstrap";

--- a/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/[plugin].tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/[plugin].tsx
@@ -1,4 +1,3 @@
-import { useApi } from "../../../../../../ui-components/contexts/api";
 import { NextPageContext } from "next";
 import Head from "next/head";
 import GroupTabs from "@grouparoo/ui-components/components/tabs/Group";

--- a/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/records.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/records.tsx
@@ -1,4 +1,3 @@
-import { useApi } from "../../../../../../../../ui-components/contexts/api";
 import Head from "next/head";
 import PropertyTabs from "@grouparoo/ui-components/components/tabs/Property";
 import RecordsList from "@grouparoo/ui-components/components/record/List";


### PR DESCRIPTION
## Change description

Fixes a page crash when going to the new group page due to an incorrect usage of `useApi` from outside a react component.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
