### PR TITLE
default secondary source mapping to nothing

### DIFF
--- a/ui/ui-components/components/source/FormMappingSelector.tsx
+++ b/ui/ui-components/components/source/FormMappingSelector.tsx
@@ -152,6 +152,7 @@ const FormMappingSelector: React.FC<Props> = ({
                 as="select"
                 required
                 disabled={disabled}
+                defaultValue={""}
                 value={selectedProperty?.key}
                 onChange={(e) => {
                   setSelectedProperty(


### PR DESCRIPTION
## Change description

Set form default for the mapping in a Secondary Source as empty. 

![Screen Shot 2022-01-31 at 12 27 32 PM](https://user-images.githubusercontent.com/63751206/151842968-3ddfb0b2-fd9a-4537-be27-c35ee6ea3c2f.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
