### PR TITLE
validate compatible app and connection types

### DIFF
--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -636,6 +636,20 @@ export class Destination extends LoggedModel<Destination> {
   }
 
   @BeforeCreate
+  static async ensureSupportedAppType(instance: Destination) {
+    const app = await App.findById(instance.appId);
+    const { pluginConnection } = await instance.getPlugin();
+    if (!pluginConnection.apps.includes(app.type))
+      throw new Error(
+        `Destination of type "${instance.type}" does not support the App \`${
+          app.name
+        }\` (${app.id}) of type "${
+          app.type
+        }". Supported App types: ${pluginConnection.apps.join(", ")}.`
+      );
+  }
+
+  @BeforeCreate
   static async ensureExportRecordsMethod(instance: Destination) {
     const { pluginConnection } = await instance.getPlugin();
     if (!pluginConnection) {

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -397,6 +397,20 @@ export class Source extends LoggedModel<Source> {
     if (app.state !== "ready") throw new Error(`app ${app.id} is not ready`);
   }
 
+  @BeforeCreate
+  static async ensureSupportedAppType(instance: Source) {
+    const app = await App.findById(instance.appId);
+    const { pluginConnection } = await instance.getPlugin();
+    if (!pluginConnection.apps.includes(app.type))
+      throw new Error(
+        `Source of type "${instance.type}" does not support the App \`${
+          app.name
+        }\` (${app.id}) of type "${
+          app.type
+        }". Supported App types: ${pluginConnection.apps.join(", ")}.`
+      );
+  }
+
   @BeforeSave
   static async ensureUniqueName(instance: Source) {
     const count = await Source.count({

--- a/plugins/@grouparoo/salesforce/__tests__/export-account/destination-mapping-options-enrich.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-account/destination-mapping-options-enrich.ts
@@ -36,7 +36,10 @@ describe("salesforce/sales-cloud/destinationMappingOptions", () => {
 
   beforeAll(async () => {
     ({ model } = await helper.factories.properties());
-    app = await helper.factories.app();
+    app = await helper.factories.app({
+      type: "salesforce",
+      options: appOptions,
+    });
     destination = await Destination.create({
       name: "Salesforce Test Destination",
       type: "salesforce-export-accounts",

--- a/plugins/@grouparoo/salesforce/__tests__/export-account/destination-mapping-options.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-account/destination-mapping-options.ts
@@ -36,7 +36,10 @@ describe("salesforce/sales-cloud/destinationMappingOptions", () => {
 
   beforeAll(async () => {
     ({ model } = await helper.factories.properties());
-    app = await helper.factories.app();
+    app = await helper.factories.app({
+      type: "salesforce",
+      options: appOptions,
+    });
     destination = await Destination.create({
       name: "Salesforce Test Destination",
       type: "salesforce-export-accounts",

--- a/plugins/@grouparoo/salesforce/__tests__/export-contacts/destination-mapping-options-enrich.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-contacts/destination-mapping-options-enrich.ts
@@ -33,7 +33,10 @@ describe("salesforce/sales-cloud/destinationMappingOptions", () => {
 
   beforeAll(async () => {
     ({ model } = await helper.factories.properties());
-    app = await helper.factories.app();
+    app = await helper.factories.app({
+      type: "salesforce",
+      options: appOptions,
+    });
     destination = await Destination.create({
       name: "Salesforce Test Destination",
       type: "salesforce-export-contacts",

--- a/plugins/@grouparoo/salesforce/__tests__/export-contacts/destination-mapping-options.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-contacts/destination-mapping-options.ts
@@ -32,7 +32,10 @@ describe("salesforce/sales-cloud/destinationMappingOptions", () => {
 
   beforeAll(async () => {
     ({ model } = await helper.factories.properties());
-    app = await helper.factories.app();
+    app = await helper.factories.app({
+      type: "salesforce",
+      options: appOptions,
+    });
     destination = await Destination.create({
       name: "Salesforce Test Destination",
       type: "salesforce-export-accounts",

--- a/plugins/@grouparoo/salesforce/__tests__/export-objects/destination-mapping-options-enrich.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-objects/destination-mapping-options-enrich.ts
@@ -33,7 +33,10 @@ describe("salesforce/sales-cloud/destinationMappingOptions", () => {
 
   beforeAll(async () => {
     ({ model } = await helper.factories.properties());
-    app = await helper.factories.app();
+    app = await helper.factories.app({
+      type: "salesforce",
+      options: appOptions,
+    });
     destination = await Destination.create({
       name: "Salesforce Test Destination",
       type: "salesforce-export-accounts",

--- a/plugins/@grouparoo/salesforce/__tests__/export-objects/destination-mapping-options.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-objects/destination-mapping-options.ts
@@ -33,7 +33,10 @@ describe("salesforce/sales-cloud/destinationMappingOptions", () => {
 
   beforeAll(async () => {
     ({ model } = await helper.factories.properties());
-    app = await helper.factories.app();
+    app = await helper.factories.app({
+      type: "salesforce",
+      options: appOptions,
+    });
     destination = await Destination.create({
       name: "Salesforce Test Destination",
       type: "salesforce-export-accounts",


### PR DESCRIPTION
## Change description

Adds validation to ensure destination/source's app is of a compatible type.

```
Validating 39 objects...
info: [ config ] validated App `Demo Calculated Property App` (demo_calculated_property_app) 
info: [ config ] validated App `Demo Database` (demo_db) 
info: [ config ] validated App `mailchimp` (mailchimp) 
info: [ config ] validated GrouparooModel `Users` (users) 
info: [ config ] validated Source `Product Users` (demo_users) 
info: [ config ] validated Property `userId` (user_id) 
info: [ config ] validated Property `email` (email) 
warning: [ config ] error with Destination `Mailchimp` (mailchimp): Destination of type "mailchimp-export-contacts" does not support the App `Demo Database` (demo_db) of type "postgres". Supported App types: mailchimp, mailchimp-oauth. 
```

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
