### PR TITLE
update to `commander@9.0.0`, remove negated cli param defaults

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "chalk": "4.1.2",
-    "commander": "8.3.0",
+    "commander": "9.0.0",
     "fs-extra": "10.0.0",
     "glob": "7.2.0",
     "isomorphic-fetch": "3.0.0",

--- a/core/src/bin/run.ts
+++ b/core/src/bin/run.ts
@@ -25,7 +25,6 @@ export class RunCLI extends CLI {
       flag: true,
     },
     "no-export": {
-      default: false,
       description: "Skip exporting the records",
       letter: "n",
       flag: true,

--- a/core/src/bin/sync.ts
+++ b/core/src/bin/sync.ts
@@ -14,7 +14,6 @@ export class SyncCLI extends CLI {
       letter: "p",
     },
     "no-export": {
-      default: false,
       description: "Skip exporting the record",
       letter: "n",
       flag: true,


### PR DESCRIPTION
## Change description

Supersedes #2911 

In the latest version of commander, the behavior of default values for boolean options has changed (see https://github.com/tj/commander.js/pull/1652). This affects our use of negated options with a default value.

*With a param `no-exports` with `default: false`...*

**Previously (8.3.0)**:
```
$ roo run
params.export = true 

$ roo run --no-exports
params.export = false
```

**Now (9.0.0)**:
```
$ roo run
params.export = false 

$ roo run --no-exports
params.export = false
```

This meant that `roo run` by default was no longer exporting records after the commander upgrade. Removing the default value from these negated boolean options returns the expected behavior.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
