### PR TITLE
generate unique key in configWriter test

### DIFF
--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -806,8 +806,7 @@ describe("modules/configWriter", () => {
     test("properties should only humanize their ID if it matches default pattern", async () => {
       let property: Property = await helper.factories.property(
         source,
-        // @ts-expect-error can be removed once faker.unique types are fixed (https://github.com/faker-js/faker/pull/333)
-        { key: faker.unique(faker.lorem.word) },
+        { key: uuid.v4() },
         { column: faker.database.column() }
       );
       expect(property.getConfigId()).toEqual(
@@ -818,8 +817,7 @@ describe("modules/configWriter", () => {
         source,
         {
           id: "hello-world",
-          // @ts-expect-error can be removed once faker.unique types are fixed (https://github.com/faker-js/faker/pull/333)
-          key: faker.unique(faker.lorem.word),
+          key: uuid.v4(),
         },
         { column: faker.database.column() }
       );

--- a/core/__tests__/modules/configWriter.ts
+++ b/core/__tests__/modules/configWriter.ts
@@ -806,7 +806,8 @@ describe("modules/configWriter", () => {
     test("properties should only humanize their ID if it matches default pattern", async () => {
       let property: Property = await helper.factories.property(
         source,
-        { key: faker.lorem.word() },
+        // @ts-expect-error can be removed once faker.unique types are fixed (https://github.com/faker-js/faker/pull/333)
+        { key: faker.unique(faker.lorem.word) },
         { column: faker.database.column() }
       );
       expect(property.getConfigId()).toEqual(
@@ -817,7 +818,8 @@ describe("modules/configWriter", () => {
         source,
         {
           id: "hello-world",
-          key: faker.lorem.word(),
+          // @ts-expect-error can be removed once faker.unique types are fixed (https://github.com/faker-js/faker/pull/333)
+          key: faker.unique(faker.lorem.word),
         },
         { column: faker.database.column() }
       );


### PR DESCRIPTION
## Change description

This test was failing sometimes due to not generating a unique key:

```
FAIL  __tests__/modules/configWriter.ts (40.59 s)
  ● modules/configWriter › Model Config Providers › properties should only humanize their ID if it matches default pattern

    key "qui" is already in use

      385 |
      386 |     if (count > 0) {
    > 387 |       throw new Error(`key "${instance.key}" is already in use`);
          |             ^
      388 |     }
      389 |   }
      390 |

      at Function.ensureUniqueKey (src/models/Property.ts:387:13)
          at runMicrotasks (<anonymous>)
      at Function.runHooks (../node_modules/.pnpm/sequelize@6.15.0_98f032adade92d92d5295670c0365597/node_modules/sequelize/lib/hooks.js:129:7)
      at Property.save (../node_modules/.pnpm/sequelize@6.15.0_98f032adade92d92d5295670c0365597/node_modules/sequelize/lib/model.js:3982:7)
      at Object.<anonymous>.exports.default [as property] (../plugins/@grouparoo/spec-helper/dist/lib/factories/property.js:45:5)
      at Object.<anonymous> (__tests__/modules/configWriter.ts:816:18)


Test Suites: 1 failed, 24 passed, 25 total
Tests:       1 failed, 363 passed, 364 total
```

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
