### PR TITLE
Choose db=0 when redis database not provided in REDIS_URL

### DIFF
--- a/core/src/config/redis.ts
+++ b/core/src/config/redis.ts
@@ -41,7 +41,7 @@ export const DEFAULT = {
       username:
         username?.length > 1 || process.env.REDIS_USER ? username : undefined,
       password,
-      db: parseInt(db),
+      db: parseInt(db ?? "0"),
       // ssl options
       tls: protocol === "rediss" ? { rejectUnauthorized: false } : undefined,
       // you can learn more about retryStrategy @ https://github.com/luin/ioredis#auto-reconnect


### PR DESCRIPTION
Fixes a bug with the redis database introduced in https://github.com/grouparoo/grouparoo/pull/2930

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
