### PR TITLE
table sources provide table options as sorted typeahead

### DIFF
--- a/plugins/@grouparoo/app-templates/src/source/table/sourceOptions.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/sourceOptions.ts
@@ -25,17 +25,17 @@ export const getSourceOptions: GetSourceOptionsMethod = ({
     appOptions,
     appId,
   }) => {
-    const response: SourceOptionsMethodResponse = {
-      [tableNameKey]: { type: "list", options: [] },
-    };
     const map: TableDefinitionMap = await getTables({
       connection,
       appOptions,
       appId,
     });
-    for (const tableName in map) {
-      response[tableNameKey].options.push(tableName);
-    }
+
+    const tableNames = Object.keys(map).sort();
+    const response: SourceOptionsMethodResponse = {
+      [tableNameKey]: { type: "typeahead", options: tableNames },
+    };
+
     // TODO later: const getMore = extraSourceOptions?.method
     const extra = extraSourceOptions?.options || [];
     for (const option of extra) {

--- a/ui/ui-components/__tests__/components/__snapshots__/typeahead.tsx.snap
+++ b/ui/ui-components/__tests__/components/__snapshots__/typeahead.tsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormTypeahead should render: basic 1`] = `
+<div>
+  <div
+    class="rbt"
+    style="outline: none; position: relative;"
+    tabindex="-1"
+  >
+    <div
+      style="display: flex; flex: 1; height: 100%; position: relative;"
+    >
+      <input
+        aria-autocomplete="both"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="off"
+        class="rbt-input-main form-control rbt-input"
+        role="combobox"
+        type="text"
+        value=""
+      />
+      <input
+        aria-hidden="true"
+        class="rbt-input-hint"
+        readonly=""
+        style="background-color: transparent; border-color: transparent; box-shadow: none; color: rgba(0, 0, 0, 0.54); left: 0px; pointer-events: none; position: absolute; top: 0px; width: 100%;"
+        tabindex="-1"
+        value=""
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/ui/ui-components/__tests__/components/__snapshots__/typeahead.tsx.snap
+++ b/ui/ui-components/__tests__/components/__snapshots__/typeahead.tsx.snap
@@ -1,5 +1,200 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FormTypeahead should render with options 1`] = `
+<div>
+  <div
+    class="rbt"
+    style="outline: none; position: relative;"
+    tabindex="-1"
+  >
+    <div
+      style="display: flex; flex: 1; height: 100%; position: relative;"
+    >
+      <input
+        aria-autocomplete="both"
+        aria-expanded="true"
+        aria-haspopup="listbox"
+        aria-owns="typeahead"
+        autocomplete="off"
+        class="rbt-input-main form-control rbt-input  focus"
+        role="combobox"
+        type="text"
+        value=""
+      />
+      <input
+        aria-hidden="true"
+        class="rbt-input-hint"
+        readonly=""
+        style="background-color: transparent; border-color: transparent; box-shadow: none; color: rgba(0, 0, 0, 0.54); left: 0px; pointer-events: none; position: absolute; top: 0px; width: 100%; border-style: inset inset inset inset; border-width: 2px 2px 2px 2px; line-height: normal; padding: 1px 1px 1px 1px;"
+        tabindex="-1"
+        value=""
+      />
+    </div>
+    <div
+      aria-label="menu-options"
+      class="rbt-menu dropdown-menu show"
+      id="typeahead"
+      role="listbox"
+      style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none; display: block; max-height: 300px; overflow: auto;"
+    >
+      <a
+        aria-label="Austin"
+        aria-selected="false"
+        class="dropdown-item"
+        href="#"
+        id="typeahead-item-0"
+        role="option"
+      >
+        <span>
+          Austin
+          <br />
+        </span>
+        <small
+          class="text-small"
+        />
+      </a>
+      <a
+        aria-label="London"
+        aria-selected="false"
+        class="dropdown-item"
+        href="#"
+        id="typeahead-item-1"
+        role="option"
+      >
+        <span>
+          London
+          <br />
+        </span>
+        <small
+          class="text-small"
+        />
+      </a>
+      <a
+        aria-label="Santo Domingo"
+        aria-selected="false"
+        class="dropdown-item"
+        href="#"
+        id="typeahead-item-2"
+        role="option"
+      >
+        <span>
+          Santo Domingo
+          <br />
+        </span>
+        <small
+          class="text-small"
+        />
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FormTypeahead should render with options and descriptions 1`] = `
+<div>
+  <div
+    class="rbt"
+    style="outline: none; position: relative;"
+    tabindex="-1"
+  >
+    <div
+      style="display: flex; flex: 1; height: 100%; position: relative;"
+    >
+      <input
+        aria-autocomplete="both"
+        aria-expanded="true"
+        aria-haspopup="listbox"
+        aria-owns="typeahead"
+        autocomplete="off"
+        class="rbt-input-main form-control rbt-input  focus"
+        role="combobox"
+        type="text"
+        value=""
+      />
+      <input
+        aria-hidden="true"
+        class="rbt-input-hint"
+        readonly=""
+        style="background-color: transparent; border-color: transparent; box-shadow: none; color: rgba(0, 0, 0, 0.54); left: 0px; pointer-events: none; position: absolute; top: 0px; width: 100%; border-style: inset inset inset inset; border-width: 2px 2px 2px 2px; line-height: normal; padding: 1px 1px 1px 1px;"
+        tabindex="-1"
+        value=""
+      />
+    </div>
+    <div
+      aria-label="menu-options"
+      class="rbt-menu dropdown-menu show"
+      id="typeahead"
+      role="listbox"
+      style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none; display: block; max-height: 300px; overflow: auto;"
+    >
+      <a
+        aria-label="Austin"
+        aria-selected="false"
+        class="dropdown-item"
+        href="#"
+        id="typeahead-item-0"
+        role="option"
+      >
+        <span>
+          Austin
+          <br />
+        </span>
+        <small
+          class="text-small"
+        >
+          <em>
+            Description: 
+            One
+          </em>
+        </small>
+      </a>
+      <a
+        aria-label="London"
+        aria-selected="false"
+        class="dropdown-item"
+        href="#"
+        id="typeahead-item-1"
+        role="option"
+      >
+        <span>
+          London
+          <br />
+        </span>
+        <small
+          class="text-small"
+        >
+          <em>
+            Description: 
+            Two
+          </em>
+        </small>
+      </a>
+      <a
+        aria-label="Santo Domingo"
+        aria-selected="false"
+        class="dropdown-item"
+        href="#"
+        id="typeahead-item-2"
+        role="option"
+      >
+        <span>
+          Santo Domingo
+          <br />
+        </span>
+        <small
+          class="text-small"
+        >
+          <em>
+            Description: 
+            Three
+          </em>
+        </small>
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`FormTypeahead should render: basic 1`] = `
 <div>
   <div

--- a/ui/ui-components/__tests__/components/typeahead.tsx
+++ b/ui/ui-components/__tests__/components/typeahead.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import { FormTypeahead } from "../../components/Typeahead";
+
+describe("FormTypeahead", () => {
+  it("should render", async () => {
+    const Component = () => {
+      const { control } = useForm();
+      return (
+        <FormTypeahead
+          control={control}
+          name="city"
+          option={{
+            type: "typeahead",
+            options: ["Austin", "London", "Santo Domingo"],
+          }}
+        />
+      );
+    };
+
+    const { container } = render(<Component />);
+    expect(container).toMatchSnapshot("basic");
+  });
+
+  it("can have a default value", async () => {
+    const Component = () => {
+      const { control } = useForm();
+      return (
+        <FormTypeahead
+          control={control}
+          name="city"
+          defaultSelected={["Santo Domingo"]}
+          option={{
+            type: "typeahead",
+            options: ["Austin", "Arlington", "London", "Santo Domingo"],
+          }}
+        />
+      );
+    };
+
+    const { getByRole } = render(<Component />);
+    const input = getByRole("combobox");
+    expect(input).toHaveValue("Santo Domingo");
+  });
+
+  it("can be marked as required", async () => {
+    const Component = () => {
+      const { control } = useForm();
+      return (
+        <FormTypeahead
+          control={control}
+          name="city"
+          required
+          option={{
+            type: "typeahead",
+            options: ["Austin", "Arlington", "London", "Santo Domingo"],
+          }}
+        />
+      );
+    };
+
+    const { getByRole } = render(<Component />);
+    const input = getByRole("combobox");
+    expect(input).toBeRequired();
+  });
+
+  it("should trigger custom onChange", async () => {
+    const handleChange = jest.fn();
+    const Component = () => {
+      const { control } = useForm();
+      return (
+        <FormTypeahead
+          control={control}
+          name="city"
+          onChange={handleChange}
+          option={{
+            type: "typeahead",
+            options: ["Austin", "Arlington", "London", "Santo Domingo"],
+          }}
+        />
+      );
+    };
+
+    const { getByRole, getByLabelText } = render(<Component />);
+
+    const input = getByRole("combobox");
+    fireEvent.change(input, { target: { value: "A" } });
+
+    const option = getByLabelText("Arlington");
+    fireEvent.click(option);
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith([{ key: "Arlington" }]);
+  });
+});

--- a/ui/ui-components/__tests__/components/typeahead.tsx
+++ b/ui/ui-components/__tests__/components/typeahead.tsx
@@ -22,6 +22,53 @@ describe("FormTypeahead", () => {
     expect(container).toMatchSnapshot("basic");
   });
 
+  it("should render with options", async () => {
+    const Component = () => {
+      const { control } = useForm();
+      return (
+        <FormTypeahead
+          control={control}
+          name="city"
+          option={{
+            type: "typeahead",
+            options: ["Austin", "London", "Santo Domingo"],
+          }}
+        />
+      );
+    };
+
+    const { container, getByRole } = render(<Component />);
+
+    const input = getByRole("combobox");
+    fireEvent.click(input);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should render with options and descriptions", async () => {
+    const Component = () => {
+      const { control } = useForm();
+      return (
+        <FormTypeahead
+          control={control}
+          name="city"
+          option={{
+            type: "typeahead",
+            options: ["Austin", "London", "Santo Domingo"],
+            descriptions: ["One", "Two", "Three"],
+          }}
+        />
+      );
+    };
+
+    const { container, getByRole } = render(<Component />);
+
+    const input = getByRole("combobox");
+    fireEvent.click(input);
+
+    expect(container).toMatchSnapshot();
+  });
+
   it("can have a default value", async () => {
     const Component = () => {
       const { control } = useForm();

--- a/ui/ui-components/components/Typeahead.tsx
+++ b/ui/ui-components/components/Typeahead.tsx
@@ -1,3 +1,4 @@
+import { string } from "prop-types";
 import { Typeahead as BootstrapTypeahead } from "react-bootstrap-typeahead";
 import { Controller, Control, Path } from "react-hook-form";
 import { Actions } from "../utils/apiData";
@@ -22,7 +23,12 @@ interface Props<T> {
   placeholder?: string;
   disabled?: boolean;
   required?: boolean;
-  onChange?: (selected?: { key: string }[]) => void;
+  onChange?: (selected: TypeaheadOption[]) => void;
+}
+
+interface TypeaheadOption {
+  key: string;
+  description?: string;
 }
 
 export const FormTypeahead = <T,>({
@@ -49,25 +55,29 @@ export const FormTypeahead = <T,>({
             options={option?.options.map((k, idx) => {
               return {
                 key: k,
-                descriptions: option?.descriptions?.[idx],
-              };
+                description: option?.descriptions?.[idx],
+              } as TypeaheadOption;
             })}
             placeholder={placeholder}
-            renderMenuItemChildren={(opt, _props, idx) => {
+            renderMenuItemChildren={(
+              opt: TypeaheadOption,
+              _props,
+              idx: number
+            ) => {
               return [
                 <span key={`opt-${idx}-key`}>
                   {opt.key}
                   <br />
                 </span>,
-                <small key={`opt-${idx}-descriptions`} className="text-small">
-                  {opt.descriptions ? (
-                    <em>Descriptions: {opt.descriptions.join(", ")}</em>
+                <small key={`opt-${idx}-description`} className="text-small">
+                  {opt.description ? (
+                    <em>Description: {opt.description}</em>
                   ) : null}
                 </small>,
               ];
             }}
             defaultSelected={defaultSelected}
-            onChange={(selected) => {
+            onChange={(selected: TypeaheadOption[]) => {
               reactHookFormOnChange(selected[0]?.key);
               onChange?.(selected);
             }}

--- a/ui/ui-components/components/Typeahead.tsx
+++ b/ui/ui-components/components/Typeahead.tsx
@@ -1,0 +1,79 @@
+import { Typeahead as BootstrapTypeahead } from "react-bootstrap-typeahead";
+import { Controller, Control, Path } from "react-hook-form";
+import { Actions } from "../utils/apiData";
+
+type PluginOption = (
+  | Actions.SourceConnectionOptions
+  | Actions.DestinationConnectionOptions
+  | Actions.AppOptions
+)["options"][string];
+
+type PluginOptionValue = (
+  | Actions.SourceView["source"]
+  | Actions.DestinationView["destination"]
+  | Actions.AppView["app"]
+)["options"][string];
+
+interface Props<T> {
+  control: Control<T>;
+  name: Path<T>;
+  option: PluginOption;
+  defaultSelected?: PluginOptionValue[];
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  onChange?: (selected?: { key: string }[]) => void;
+}
+
+export const FormTypeahead = <T,>({
+  control,
+  name,
+  disabled,
+  required,
+  option,
+  placeholder,
+  defaultSelected,
+  onChange,
+}: Props<T>) => {
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field: { onChange: reactHookFormOnChange } }) => {
+        return (
+          <BootstrapTypeahead
+            id="typeahead"
+            labelKey="key"
+            disabled={disabled}
+            inputProps={{ required }}
+            options={option?.options.map((k, idx) => {
+              return {
+                key: k,
+                descriptions: option?.descriptions?.[idx],
+              };
+            })}
+            placeholder={placeholder}
+            renderMenuItemChildren={(opt, _props, idx) => {
+              return [
+                <span key={`opt-${idx}-key`}>
+                  {opt.key}
+                  <br />
+                </span>,
+                <small key={`opt-${idx}-descriptions`} className="text-small">
+                  {opt.descriptions ? (
+                    <em>Descriptions: {opt.descriptions.join(", ")}</em>
+                  ) : null}
+                </small>,
+              ];
+            }}
+            defaultSelected={defaultSelected}
+            onChange={(selected) => {
+              reactHookFormOnChange(selected[0]?.key);
+              onChange?.(selected);
+            }}
+          />
+        );
+      }}
+    />
+  );
+};

--- a/ui/ui-components/pages/app/[id]/edit.tsx
+++ b/ui/ui-components/pages/app/[id]/edit.tsx
@@ -2,9 +2,8 @@ import { useApi } from "../../../contexts/api";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useState, useEffect, Fragment, useCallback, useMemo } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { Row, Col, Form, Badge, Alert } from "react-bootstrap";
-import { Typeahead } from "react-bootstrap-typeahead";
 import { appHandler, successHandler } from "../../../eventHandlers";
 import PageHeader from "../../../components/PageHeader";
 import StateBadge from "../../../components/badges/StateBadge";
@@ -18,6 +17,7 @@ import { Actions, Models } from "../../../utils/apiData";
 import { grouparooUiEdition } from "../../../utils/uiEdition";
 import { NextPageContext } from "next";
 import { generateClient } from "../../../client/client";
+import { FormTypeahead } from "../../../components/Typeahead";
 
 export default function Page(
   props: Awaited<ReturnType<typeof Page.getInitialProps>>
@@ -269,66 +269,19 @@ export default function Page(
                             if (options[opt.key]?.type === "typeahead") {
                               return (
                                 <>
-                                  <Controller
+                                  <FormTypeahead
                                     control={control}
                                     name={`options.${opt.key}`}
-                                    render={({ field: { onChange } }) => {
-                                      return (
-                                        <Typeahead
-                                          id="typeahead"
-                                          labelKey="key"
-                                          disabled={loading}
-                                          onChange={(selected) => {
-                                            onChange(selected[0]?.key);
-                                          }}
-                                          options={options[
-                                            opt.key
-                                          ]?.options.map((k, idx) => {
-                                            return {
-                                              key: k,
-                                              descriptions:
-                                                options[k]?.descriptions[idx],
-                                            };
-                                          })}
-                                          placeholder={
-                                            opt.placeholder ||
-                                            `Select ${opt.key}`
-                                          }
-                                          renderMenuItemChildren={(
-                                            opt,
-                                            props,
-                                            idx
-                                          ) => {
-                                            return [
-                                              <span key={`opt-${idx}-key`}>
-                                                {opt.key}
-                                                <br />
-                                              </span>,
-                                              <small
-                                                key={`opt-${idx}-descriptions`}
-                                                className="text-small"
-                                              >
-                                                <em>
-                                                  Descriptions:{" "}
-                                                  {opt.descriptions
-                                                    ? opt.descriptions.join(
-                                                        ", "
-                                                      )
-                                                    : "None"}
-                                                </em>
-                                              </small>,
-                                            ];
-                                          }}
-                                          defaultSelected={
-                                            app.options[opt.key]
-                                              ? [app.options[opt.key]]
-                                              : undefined
-                                          }
-                                        />
-                                      );
-                                    }}
+                                    option={options[opt.key]}
+                                    placeholder={
+                                      opt.placeholder || `Select ${opt.key}`
+                                    }
+                                    defaultSelected={
+                                      app.options[opt.key]
+                                        ? [app.options[opt.key]]
+                                        : undefined
+                                    }
                                   />
-
                                   <Form.Text className="text-muted">
                                     {opt.description}
                                   </Form.Text>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -338,7 +338,6 @@ const Page: NextPage<Props> = ({
   };
 
   const updateOption = async (optKey, optValue) => {
-    console.log("update option", optKey, optValue);
     const _source = { ...source };
     _source.options[optKey] = optValue;
     _source.mapping = {};
@@ -424,6 +423,7 @@ const Page: NextPage<Props> = ({
                                     id="typeahead"
                                     labelKey="key"
                                     disabled={loading || loadingOptions}
+                                    inputProps={{ required: opt.required }}
                                     options={connectionOptions[
                                       opt.key
                                     ]?.options.map((k, idx) => {
@@ -551,6 +551,7 @@ const Page: NextPage<Props> = ({
                               placeholder={opt.placeholder}
                               name={`source.options.${opt.key}`}
                               {...register(`source.options.${opt.key}`, {
+                                shouldUnregister: true,
                                 onChange: (e) =>
                                   updateOption(
                                     e.target.id.replace("_opt~", ""),

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -4,8 +4,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { Row, Col, Form, Badge, Alert, Card } from "react-bootstrap";
-import { Typeahead } from "react-bootstrap-typeahead";
-import { Controller, SubmitHandler, useForm } from "react-hook-form";
+import { SubmitHandler, useForm } from "react-hook-form";
 import SourceTabs from "../../../../../components/tabs/Source";
 import PageHeader from "../../../../../components/PageHeader";
 import StateBadge from "../../../../../components/badges/StateBadge";
@@ -30,6 +29,7 @@ import { useApi } from "../../../../../contexts/api";
 import { generateClient } from "../../../../../client/client";
 import { withServerErrorHandler } from "../../../../../utils/withServerErrorHandler";
 import { SourcePreviewMethodResponseRow } from "@grouparoo/core/src/classes/plugin";
+import { FormTypeahead } from "../../../../../components/Typeahead";
 
 export interface FormData {
   mapping?: {
@@ -414,64 +414,21 @@ const Page: NextPage<Props> = ({
                       if (connectionOptions[opt.key]?.type === "typeahead") {
                         return (
                           <>
-                            <Controller
+                            <FormTypeahead
                               control={control}
                               name={`source.options.${opt.key}`}
-                              render={({ field: { onChange } }) => {
-                                return (
-                                  <Typeahead
-                                    id="typeahead"
-                                    labelKey="key"
-                                    disabled={loading || loadingOptions}
-                                    inputProps={{ required: opt.required }}
-                                    options={connectionOptions[
-                                      opt.key
-                                    ]?.options.map((k, idx) => {
-                                      return {
-                                        key: k,
-                                        descriptions:
-                                          connectionOptions[k]?.descriptions[
-                                            idx
-                                          ],
-                                      };
-                                    })}
-                                    placeholder={
-                                      opt.placeholder || `Select ${opt.key}`
-                                    }
-                                    renderMenuItemChildren={(
-                                      opt,
-                                      props,
-                                      idx
-                                    ) => {
-                                      return [
-                                        <span key={`opt-${idx}-key`}>
-                                          {opt.key}
-                                          <br />
-                                        </span>,
-                                        <small
-                                          key={`opt-${idx}-descriptions`}
-                                          className="text-small"
-                                        >
-                                          {opt.descriptions ? (
-                                            <em>
-                                              Descriptions:{" "}
-                                              {opt.descriptions.join(", ")}
-                                            </em>
-                                          ) : null}
-                                        </small>,
-                                      ];
-                                    }}
-                                    defaultSelected={
-                                      source.options[opt.key]
-                                        ? [source.options[opt.key]]
-                                        : undefined
-                                    }
-                                    onChange={(selected) => {
-                                      onChange(selected[0]?.key);
-                                      updateOption(opt.key, selected[0]?.key);
-                                    }}
-                                  />
-                                );
+                              option={connectionOptions[opt.key]}
+                              disabled={loading || loadingOptions}
+                              placeholder={
+                                opt.placeholder || `Select ${opt.key}`
+                              }
+                              defaultSelected={
+                                source.options[opt.key]
+                                  ? [source.options[opt.key]]
+                                  : undefined
+                              }
+                              onChange={(selected) => {
+                                updateOption(opt.key, selected[0]?.key);
                               }}
                             />
                             <Form.Text className="text-muted">


### PR DESCRIPTION
## Change description

Provides better experience for configuring the source when users have lots of tables in their database.
Also fixes typeaheads on the source edit page to play nicely alongside react-hook-form.

![image](https://user-images.githubusercontent.com/4368928/152561590-216a2adb-8b5a-455b-a050-2d441fb58df2.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
