### PR TITLE
Render sample record card on server side

### DIFF
--- a/ui/ui-components/components/record/SampleRecordCard.tsx
+++ b/ui/ui-components/components/record/SampleRecordCard.tsx
@@ -61,6 +61,8 @@ const cookies = new Cookies();
 
 const getCachedSampleRecordId = (modelId: string): string => {
   if (isBrowser()) {
+    // Migrate existing localstorage data into cookie
+    // TODO: remove the migration in a later release
     const localStorageRecordId = globalThis.localStorage?.getItem(
       `sampleRecord:${grouparooUiEdition()}:${modelId}`
     );

--- a/ui/ui-components/components/record/SampleRecordCard.tsx
+++ b/ui/ui-components/components/record/SampleRecordCard.tsx
@@ -60,23 +60,9 @@ export const isConfigUI = grouparooUiEdition() === "config";
 const cookies = new Cookies();
 
 const getCachedSampleRecordId = (modelId: string): string => {
-  if (isBrowser()) {
-    // Migrate existing localstorage data into cookie
-    // TODO: remove the migration in a later release
-    const localStorageRecordId = globalThis.localStorage?.getItem(
-      `sampleRecord:${grouparooUiEdition()}:${modelId}`
-    );
-    if (localStorageRecordId) {
-      setCachedSampleRecordId(modelId, localStorageRecordId);
-      globalThis.localStorage?.removeItem(
-        `sampleRecord:${grouparooUiEdition()}:${modelId}`
-      );
-      return localStorageRecordId;
-    } else {
-      return cookies.get(`sampleRecord:${grouparooUiEdition()}`)?.[modelId];
-    }
-  }
-  return undefined;
+  return isBrowser()
+    ? cookies.get(`sampleRecord:${grouparooUiEdition()}`)?.[modelId]
+    : undefined;
 };
 
 const setCachedSampleRecordId = (modelId: string, recordId: string): void => {
@@ -90,7 +76,7 @@ const setCachedSampleRecordId = (modelId: string, recordId: string): void => {
       {
         path: "/",
         sameSite: "strict",
-        maxAge: 60 * 60 * 24 * 14, // two weeks
+        maxAge: 60 * 60 * 24 * 30, // 1 month
       }
     );
   }
@@ -106,6 +92,7 @@ const clearCachedSampleRecordId = (modelId: string): void => {
       cookies.set(`sampleRecord:${grouparooUiEdition()}`, existing, {
         path: "/",
         sameSite: "strict",
+        maxAge: 60 * 60 * 24 * 30, // 1 month
       });
     }
   }

--- a/ui/ui-components/components/record/SampleRecordCard.tsx
+++ b/ui/ui-components/components/record/SampleRecordCard.tsx
@@ -90,6 +90,7 @@ const setCachedSampleRecordId = (modelId: string, recordId: string): void => {
       {
         path: "/",
         sameSite: "strict",
+        maxAge: 60 * 60 * 24 * 14, // two weeks
       }
     );
   }

--- a/ui/ui-components/components/record/SampleRecordCard.tsx
+++ b/ui/ui-components/components/record/SampleRecordCard.tsx
@@ -21,6 +21,8 @@ import RecordImageFromEmail from "../visualizations/RecordImageFromEmail";
 import AddSampleRecordModal from "./AddSampleRecordModal";
 import ArrayRecordPropertyList from "./ArrayRecordPropertyList";
 import { useApi } from "../../contexts/api";
+import Cookies from "universal-cookie";
+import { isBrowser } from "../../utils/isBrowser";
 
 export type RecordType =
   | Models.GrouparooRecordType
@@ -46,30 +48,64 @@ export interface SampleRecordCardProps {
   reloadKey?: string;
   warning?: string;
   groupId?: string;
+
+  record?: RecordType;
+  groups?: Models.GroupType[];
+  destinations?: Models.DestinationType[];
 }
 
 // This is exported so we can manipulate it in tests, but is unused elsewhere.
 export const isConfigUI = grouparooUiEdition() === "config";
 
+const cookies = new Cookies();
+
 const getCachedSampleRecordId = (modelId: string): string => {
-  return globalThis.localStorage?.getItem(
-    `sampleRecord:${grouparooUiEdition()}:${modelId}`
-  );
+  if (isBrowser()) {
+    const localStorageRecordId = globalThis.localStorage?.getItem(
+      `sampleRecord:${grouparooUiEdition()}:${modelId}`
+    );
+    if (localStorageRecordId) {
+      setCachedSampleRecordId(modelId, localStorageRecordId);
+      globalThis.localStorage?.removeItem(
+        `sampleRecord:${grouparooUiEdition()}:${modelId}`
+      );
+      return localStorageRecordId;
+    } else {
+      return cookies.get(`sampleRecord:${grouparooUiEdition()}`)?.[modelId];
+    }
+  }
+  return undefined;
 };
 
 const setCachedSampleRecordId = (modelId: string, recordId: string): void => {
-  if (recordId) {
-    globalThis.localStorage?.setItem(
-      `sampleRecord:${grouparooUiEdition()}:${modelId}`,
-      recordId
+  if (isBrowser() && recordId) {
+    const existing = cookies.get<Record<string, string>>(
+      `sampleRecord:${grouparooUiEdition()}`
+    );
+    cookies.set(
+      `sampleRecord:${grouparooUiEdition()}`,
+      { ...existing, [modelId]: recordId },
+      {
+        path: "/",
+        sameSite: "strict",
+      }
     );
   }
 };
 
 const clearCachedSampleRecordId = (modelId: string): void => {
-  globalThis.localStorage?.removeItem(
-    `sampleRecord:${grouparooUiEdition()}:${modelId}`
-  );
+  if (isBrowser()) {
+    const existing = cookies.get<Record<string, string>>(
+      `sampleRecord:${grouparooUiEdition()}`
+    );
+    if (existing) {
+      delete existing[modelId];
+      cookies.set(`sampleRecord:${grouparooUiEdition()}`, existing, {
+        path: "/",
+        sameSite: "strict",
+      });
+    }
+  }
 };
 
 const SampleRecordCard: React.FC<SampleRecordCardProps> = ({
@@ -88,8 +124,9 @@ const SampleRecordCard: React.FC<SampleRecordCardProps> = ({
   warning,
   reloadKey,
   groupId,
+  ...props
 }) => {
-  const prevModelId = usePrevious(modelId);
+  const previousRecord = usePrevious(props.record);
   const prevReloadKey = usePrevious(reloadKey);
   const { client } = useApi();
 
@@ -98,11 +135,13 @@ const SampleRecordCard: React.FC<SampleRecordCardProps> = ({
   const [addingRecord, setAddingRecord] = useState(false);
   const [hasRecords, setHasRecords] = useState(true);
   const [totalRecords, setTotalRecords] = useState(0);
-  const [record, setRecord] = useState<RecordType>();
-  const [groups, setGroups] = useState<Models.GroupType[]>();
-  const [destinations, setDestinations] = useState<Models.DestinationType[]>();
-  const [recordId, setRecordId] = useState(() =>
-    getCachedSampleRecordId(modelId)
+  const [record, setRecord] = useState<RecordType>(props.record);
+  const [groups, setGroups] = useState<Models.GroupType[]>(props.groups);
+  const [destinations, setDestinations] = useState<Models.DestinationType[]>(
+    props.destinations
+  );
+  const [recordId, setRecordId] = useState(
+    () => props.record?.id || getCachedSampleRecordId(modelId)
   );
 
   const saveRecord = useCallback(
@@ -221,16 +260,16 @@ const SampleRecordCard: React.FC<SampleRecordCardProps> = ({
 
   useEffect(() => {
     // Switched to another model
-    if (prevModelId && prevModelId !== modelId) {
+    if ((previousRecord || props.record) && previousRecord !== props.record) {
       setLoading(true);
-      setRecordId(getCachedSampleRecordId(modelId));
-      setRecord(undefined);
-      setGroups(undefined);
-      setDestinations(undefined);
+      setRecordId(props.record?.id || getCachedSampleRecordId(modelId));
+      setRecord(props.record);
+      setGroups(props.groups);
+      setDestinations(props.destinations);
       setHasRecords(true);
       setLoading(false);
     }
-  }, [record, modelId, prevModelId]);
+  }, [props.record, props.groups, props.destinations, modelId, previousRecord]);
 
   useEffect(() => {
     if (

--- a/ui/ui-components/pages/model/[modelId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/overview.tsx
@@ -2,6 +2,7 @@ import { GetServerSideProps, NextPage } from "next";
 import Head from "next/head";
 import { useMemo } from "react";
 import { Col, ListGroup, ListGroupItem, Row } from "react-bootstrap";
+import Cookies from "universal-cookie/es6";
 import { generateClient } from "../../../client/client";
 import ManagedCard from "../../../components/lib/ManagedCard";
 import ModelOverviewDestinations from "../../../components/model/overview/ModelOverviewDestinations";
@@ -14,6 +15,7 @@ import PageHeader from "../../../components/PageHeader";
 import ModelTabs from "../../../components/tabs/Model";
 import { useGrouparooModel } from "../../../contexts/grouparooModel";
 import { Actions, Models } from "../../../utils/apiData";
+import { grouparooUiEdition } from "../../../utils/uiEdition";
 import { withServerErrorHandler } from "../../../utils/withServerErrorHandler";
 
 interface Props {
@@ -24,6 +26,7 @@ interface Props {
   groups: Models.GroupType[];
   schedules: Models.ScheduleType[];
   destinations?: Models.DestinationType[];
+  sampleRecord?: Actions.RecordView;
 }
 
 const Page: NextPage<Props> = ({
@@ -34,6 +37,7 @@ const Page: NextPage<Props> = ({
   groups,
   schedules,
   destinations,
+  sampleRecord,
 }) => {
   const { model } = useGrouparooModel();
   const sources = useMemo(() => {
@@ -108,6 +112,9 @@ const Page: NextPage<Props> = ({
             modelId={model.id}
             properties={properties}
             disabled={!sources.length}
+            record={sampleRecord?.record}
+            groups={sampleRecord?.groups}
+            destinations={sampleRecord?.destinations}
           />
         </Col>
       </Row>
@@ -125,6 +132,8 @@ const Page: NextPage<Props> = ({
 
 export const getServerSideProps: GetServerSideProps<Props> =
   withServerErrorHandler(async (context) => {
+    const cookies = new Cookies(context.req.headers.cookie);
+
     const { modelId, limit, offset } = context.query;
     const client = generateClient(context);
 
@@ -159,6 +168,17 @@ export const getServerSideProps: GetServerSideProps<Props> =
       ? sources.filter(({ id }) => id !== primarySource.id)
       : sources;
 
+    const sampleRecordId = cookies.get<Record<string, string>>(
+      `sampleRecord:${grouparooUiEdition()}`
+    )?.[modelId as string];
+
+    const sampleRecord = sampleRecordId
+      ? await client.request<Actions.RecordView>(
+          "get",
+          `/record/${sampleRecordId}`
+        )
+      : null;
+
     return {
       props: {
         primarySource,
@@ -168,6 +188,7 @@ export const getServerSideProps: GetServerSideProps<Props> =
         groups,
         schedules,
         destinations,
+        sampleRecord,
       },
     };
   });

--- a/ui/ui-components/pages/model/[modelId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/overview.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps, NextPage } from "next";
 import Head from "next/head";
 import { useMemo } from "react";
 import { Col, ListGroup, ListGroupItem, Row } from "react-bootstrap";
-import Cookies from "universal-cookie/es6";
+import Cookies from "universal-cookie";
 import { generateClient } from "../../../client/client";
 import ManagedCard from "../../../components/lib/ManagedCard";
 import ModelOverviewDestinations from "../../../components/model/overview/ModelOverviewDestinations";


### PR DESCRIPTION
## Change description

In order to have the correct scroll position when a user navigates to `#destinations`, we're moving the sample record into server side rendering (when possible).

This includes moving some small amount of user state from localstorage to a cookie based solution (accessible in both client and server code)

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
