### PR TITLE
Fix edit page to use load preview only if available and serverprops hydration error

### DIFF
--- a/ui/ui-components/pages/_app.tsx
+++ b/ui/ui-components/pages/_app.tsx
@@ -28,7 +28,8 @@ export interface GrouparooNextAppProps {
 export default function GrouparooNextApp(
   props: AppProps & GrouparooNextAppProps & { err: any }
 ) {
-  const { Component, pageProps, err, hydrationError, model } = props;
+  const { Component, pageProps, err, model } = props;
+  const hydrationError = pageProps.hydrationError ?? props.hydrationError;
 
   const combinedProps = {
     ...pageProps,

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -86,8 +86,8 @@ const Page: NextPage<Props> = ({
   }, [preview]);
 
   const mappingColumn = useMemo(
-    () => Object.keys(source.mapping)[0] ?? previewColumns?.[0],
-    [previewColumns, source.mapping]
+    () => Object.keys(source.mapping)[0],
+    [source.mapping]
   );
   const mappingPropertyKey = useMemo(
     () => Object.values(source.mapping)[0],
@@ -700,14 +700,18 @@ export const getServerSideProps: GetServerSideProps<Props> =
         modelId: source?.modelId,
       });
 
-    const { preview = [] } = await client.request<Actions.SourcePreview>(
-      "get",
-      `/source/${sourceId}/preview`,
-      {
-        options: Object.keys(source.options).length > 0 ? source.options : null,
-      },
-      { useCache: false }
-    );
+    let preview: Actions.SourcePreview["preview"] = null;
+    if (source.previewAvailable) {
+      ({ preview } = await client.request<Actions.SourcePreview>(
+        "get",
+        `/source/${sourceId}/preview`,
+        {
+          options:
+            Object.keys(source.options).length > 0 ? source.options : null,
+        },
+        { useCache: false }
+      ));
+    }
 
     return {
       props: {

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -86,8 +86,8 @@ const Page: NextPage<Props> = ({
   }, [preview]);
 
   const mappingColumn = useMemo(
-    () => Object.keys(source.mapping)[0],
-    [source.mapping]
+    () => Object.keys(source.mapping)[0] ?? previewColumns?.[0],
+    [previewColumns, source.mapping]
   );
   const mappingPropertyKey = useMemo(
     () => Object.values(source.mapping)[0],

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -627,40 +627,44 @@ const Page: NextPage<Props> = ({
             </fieldset>
           </Form>
         </Col>
-        <Col xl="7">
-          <ManagedCard title="Example Data">
-            <Card.Body>
-              {previewColumns.length === 0 && !loading ? <>No preview</> : null}
-              {previewColumns.length === 0 && loading ? <Loader /> : null}
-              <div style={{ overflow: "auto" }}>
-                <LoadingTable loading={previewLoading} size="sm">
-                  <thead>
-                    <tr>
-                      {previewColumns.map((col) => (
-                        <th key={`head-${col}`}>{col}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {preview.map((row, i) => (
-                      <tr key={`row-${i}`}>
-                        {previewColumns.map((col, j) => (
-                          <td key={`table-${i}-${j}`}>
-                            {row[col] && typeof row[col] === "object" ? (
-                              <code>{JSON.stringify(row[col])}</code>
-                            ) : (
-                              row[col]?.toString()
-                            )}
-                          </td>
+        {source.previewAvailable && (
+          <Col xl="7">
+            <ManagedCard title="Example Data">
+              <Card.Body>
+                {previewColumns.length === 0 && !loading ? (
+                  <>No preview</>
+                ) : null}
+                {previewColumns.length === 0 && loading ? <Loader /> : null}
+                <div style={{ overflow: "auto" }}>
+                  <LoadingTable loading={previewLoading} size="sm">
+                    <thead>
+                      <tr>
+                        {previewColumns.map((col) => (
+                          <th key={`head-${col}`}>{col}</th>
                         ))}
                       </tr>
-                    ))}
-                  </tbody>
-                </LoadingTable>
-              </div>
-            </Card.Body>
-          </ManagedCard>
-        </Col>
+                    </thead>
+                    <tbody>
+                      {preview.map((row, i) => (
+                        <tr key={`row-${i}`}>
+                          {previewColumns.map((col, j) => (
+                            <td key={`table-${i}-${j}`}>
+                              {row[col] && typeof row[col] === "object" ? (
+                                <code>{JSON.stringify(row[col])}</code>
+                              ) : (
+                                row[col]?.toString()
+                              )}
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </LoadingTable>
+                </div>
+              </Card.Body>
+            </ManagedCard>
+          </Col>
+        )}
       </Row>
     </>
   );


### PR DESCRIPTION
## Change description

This change fixes an issue with the source edit page caused by #2927 where it was loading and using the preview on a source that didn't have a preview available, for example, a postgres query source.

While figuring this out, I fixed an issue where the `hydrationError` from `withServerErrorHandler` was not being used because it gets returned as part of the `pageProps` instead of the nextApp's props (since it doesn't support getServerSideProps).

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
