### PR TITLE
Migrate pages from `Page.getInitialProps` to `getServerSideProps`

### DIFF
--- a/core/src/models/Group.ts
+++ b/core/src/models/Group.ts
@@ -56,11 +56,16 @@ import { PropertiesCache } from "../modules/caches/propertiesCache";
 export const GROUP_RULE_LIMIT = 10;
 const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
+export interface GroupRuleOperation {
+  op: GroupRuleOpType;
+  description?: string;
+}
+
 export interface GroupRuleWithKey {
   key?: string;
   type?: Property["type"];
   topLevel?: boolean;
-  operation: { op: GroupRuleOpType; description?: string };
+  operation: GroupRuleOperation;
   match?: string | number | boolean;
   relativeMatchNumber?: number;
   relativeMatchUnit?: RelativeMatchUnitType;

--- a/ui/ui-community/pages/about.tsx
+++ b/ui/ui-community/pages/about.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/about";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/about";

--- a/ui/ui-community/pages/apiKeys.tsx
+++ b/ui/ui-community/pages/apiKeys.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/apiKeys";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/apiKeys";

--- a/ui/ui-community/pages/export/[id]/edit.tsx
+++ b/ui/ui-community/pages/export/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/export/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/export/[id]/edit";

--- a/ui/ui-community/pages/exportProcessor/[id]/edit.tsx
+++ b/ui/ui-community/pages/exportProcessor/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/exportProcessor/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/exportProcessor/[id]/edit";

--- a/ui/ui-community/pages/exportProcessor/[id]/exports.tsx
+++ b/ui/ui-community/pages/exportProcessor/[id]/exports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/exportProcessor/[id]/exports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/exportProcessor/[id]/exports";

--- a/ui/ui-community/pages/exportProcessors.tsx
+++ b/ui/ui-community/pages/exportProcessors.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/exportProcessors";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/exportProcessors";

--- a/ui/ui-community/pages/exports.tsx
+++ b/ui/ui-community/pages/exports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/exports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/exports";

--- a/ui/ui-community/pages/import/[id]/edit.tsx
+++ b/ui/ui-community/pages/import/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/import/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/import/[id]/edit";

--- a/ui/ui-community/pages/imports.tsx
+++ b/ui/ui-community/pages/imports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/imports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/imports";

--- a/ui/ui-community/pages/imports/[creatorId].tsx
+++ b/ui/ui-community/pages/imports/[creatorId].tsx
@@ -1,8 +1,14 @@
 import Head from "next/head";
 import ImportList from "@grouparoo/ui-components/components/import/List";
 import { useRouter } from "next/router";
+import { withServerErrorHandler } from "@grouparoo/ui-components/utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "@grouparoo/ui-components/utils/pageHelper";
 
-export default function Page(props) {
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  return { props: await ImportList.hydrate(ctx) };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
   const router = useRouter();
   const { query } = router;
 
@@ -15,8 +21,6 @@ export default function Page(props) {
       <ImportList {...props} />
     </>
   );
-}
-
-Page.getInitialProps = async (ctx) => {
-  return ImportList.hydrate(ctx);
 };
+
+export default Page;

--- a/ui/ui-community/pages/model/[modelId]/destination/[destinationId]/exports.tsx
+++ b/ui/ui-community/pages/model/[modelId]/destination/[destinationId]/exports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/exports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/exports";

--- a/ui/ui-community/pages/model/[modelId]/destination/[destinationId]/retry.tsx
+++ b/ui/ui-community/pages/model/[modelId]/destination/[destinationId]/retry.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/retry";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/retry";

--- a/ui/ui-community/pages/model/[modelId]/group/[groupId]/members.tsx
+++ b/ui/ui-community/pages/model/[modelId]/group/[groupId]/members.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/group/[groupId]/members";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/group/[groupId]/members";

--- a/ui/ui-community/pages/model/[modelId]/record/[recordId]/edit.tsx
+++ b/ui/ui-community/pages/model/[modelId]/record/[recordId]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/edit";

--- a/ui/ui-community/pages/model/[modelId]/record/[recordId]/exports.tsx
+++ b/ui/ui-community/pages/model/[modelId]/record/[recordId]/exports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/exports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/exports";

--- a/ui/ui-community/pages/model/[modelId]/record/[recordId]/imports.tsx
+++ b/ui/ui-community/pages/model/[modelId]/record/[recordId]/imports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/imports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/imports";

--- a/ui/ui-community/pages/model/[modelId]/records.tsx
+++ b/ui/ui-community/pages/model/[modelId]/records.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/records";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/records";

--- a/ui/ui-community/pages/notification/[id]/edit.tsx
+++ b/ui/ui-community/pages/notification/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/notification/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/notification/[id]/edit";

--- a/ui/ui-community/pages/notifications.tsx
+++ b/ui/ui-community/pages/notifications.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/notifications";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/notifications";

--- a/ui/ui-community/pages/resque/overview.tsx
+++ b/ui/ui-community/pages/resque/overview.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/resque/overview";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/resque/overview";

--- a/ui/ui-community/pages/run/[id]/edit.tsx
+++ b/ui/ui-community/pages/run/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/run/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/run/[id]/edit";

--- a/ui/ui-community/pages/runs.tsx
+++ b/ui/ui-community/pages/runs.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/runs";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/runs";

--- a/ui/ui-community/pages/settings/[tab].tsx
+++ b/ui/ui-community/pages/settings/[tab].tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/settings/[tab]";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/settings/[tab]";

--- a/ui/ui-community/pages/team/initialize.tsx
+++ b/ui/ui-community/pages/team/initialize.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/team/initialize";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/team/initialize";

--- a/ui/ui-community/pages/teamMember/[id]/edit.tsx
+++ b/ui/ui-community/pages/teamMember/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/teamMember/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/teamMember/[id]/edit";

--- a/ui/ui-community/pages/teamMember/new.tsx
+++ b/ui/ui-community/pages/teamMember/new.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/teamMember/new";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/teamMember/new";

--- a/ui/ui-community/pages/teams.tsx
+++ b/ui/ui-community/pages/teams.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/teams";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/teams";

--- a/ui/ui-components/components/record/List.tsx
+++ b/ui/ui-components/components/record/List.tsx
@@ -1,4 +1,4 @@
-import type { NextPageContext } from "next";
+import type { GetServerSidePropsContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { FormEvent, useCallback, useEffect, useState } from "react";
@@ -18,11 +18,11 @@ import Pagination from "../Pagination";
 import ArrayRecordPropertyList from "./ArrayRecordPropertyList";
 import { useGrouparooModel } from "../../contexts/grouparooModel";
 
-type Props = Awaited<ReturnType<typeof RecordsList.hydrate>> & {
+interface Props extends Awaited<ReturnType<typeof RecordsList.hydrate>> {
   header?: React.ReactNode;
   searchKey?: string;
   searchValue?: string;
-};
+}
 
 export default function RecordsList(props: Props) {
   const { properties } = props;
@@ -411,7 +411,7 @@ export default function RecordsList(props: Props) {
 }
 
 RecordsList.hydrate = async (
-  ctx: NextPageContext,
+  ctx: GetServerSidePropsContext,
   _searchKey?: string,
   _searchValue?: string
 ) => {
@@ -428,7 +428,7 @@ RecordsList.hydrate = async (
     caseSensitive,
   } = ctx.query;
 
-  const { records, total }: Actions.RecordsList = await client.request(
+  const { records, total } = await client.request<Actions.RecordsList>(
     "get",
     `/records`,
     {
@@ -442,9 +442,14 @@ RecordsList.hydrate = async (
       caseSensitive,
     }
   );
-  const { properties } = await client.request("get", `/properties`, {
-    modelId,
-  });
+
+  const { properties } = await client.request<Actions.PropertiesList>(
+    "get",
+    `/properties`,
+    {
+      modelId,
+    }
+  );
 
   return { records, total, properties };
 };

--- a/ui/ui-components/components/runs/List.tsx
+++ b/ui/ui-components/components/runs/List.tsx
@@ -1,4 +1,4 @@
-import { NextPageContext } from "next";
+import { GetServerSidePropsContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { Fragment, useEffect, useState } from "react";
@@ -301,19 +301,23 @@ export default function RunsList(props) {
 }
 
 RunsList.hydrate = async (
-  ctx: NextPageContext,
+  ctx: GetServerSidePropsContext,
   options: { topic?: string } = {}
 ) => {
   const { sourceId, groupId, propertyId, limit, offset, stateFilter, error } =
     ctx.query;
   const client = generateClient(ctx);
-  const { runs, total } = await client.request("get", `/runs`, {
-    creatorId: sourceId ?? groupId ?? propertyId,
-    topic: options.topic,
-    limit,
-    offset,
-    state: stateFilter,
-    hasError: error,
-  });
+  const { runs, total } = await client.request<Actions.RunsList>(
+    "get",
+    `/runs`,
+    {
+      creatorId: sourceId ?? groupId ?? propertyId,
+      topic: options.topic,
+      limit,
+      offset,
+      state: stateFilter,
+      hasError: error,
+    }
+  );
   return { runs, total, topic: options.topic };
 };

--- a/ui/ui-components/components/runs/List.tsx
+++ b/ui/ui-components/components/runs/List.tsx
@@ -302,8 +302,9 @@ export default function RunsList(props) {
 
 RunsList.hydrate = async (
   ctx: GetServerSidePropsContext,
-  options: { topic?: string } = {}
+  options?: { topic?: string }
 ) => {
+  const { topic = null } = options ?? {};
   const { sourceId, groupId, propertyId, limit, offset, stateFilter, error } =
     ctx.query;
   const client = generateClient(ctx);
@@ -312,12 +313,12 @@ RunsList.hydrate = async (
     `/runs`,
     {
       creatorId: sourceId ?? groupId ?? propertyId,
-      topic: options.topic,
+      topic,
       limit,
       offset,
       state: stateFilter,
       hasError: error,
     }
   );
-  return { runs, total, topic: options.topic };
+  return { runs, total, topic };
 };

--- a/ui/ui-components/pages/exportProcessor/[id]/edit.tsx
+++ b/ui/ui-components/pages/exportProcessor/[id]/edit.tsx
@@ -2,18 +2,27 @@ import { Table, Alert, Card } from "react-bootstrap";
 import EnterpriseLink from "../../../components/GrouparooLink";
 import Head from "next/head";
 import ExportProcessorTabs from "../../../components/tabs/ExportProcessor";
-import { Models } from "../../../utils/apiData";
 import StateBadge from "../../../components/badges/StateBadge";
 import { DurationTime } from "../../../components/DurationTime";
 import { formatTimestamp } from "../../../utils/formatTimestamp";
-import { NextPageContext } from "next";
 import { generateClient } from "../../../client/client";
+import { withServerErrorHandler } from "../../../utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "../../../utils/pageHelper";
+import { Actions } from "../../../utils/apiData";
 
-export default function Page({
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const { id } = ctx.query;
+  const client = generateClient(ctx);
+  const { exportProcessor } = await client.request<Actions.ExportProcessorView>(
+    "get",
+    `/exportProcessor/${id}`
+  );
+  return { props: { exportProcessor } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
   exportProcessor,
-}: {
-  exportProcessor: Models.ExportProcessorType;
-}) {
+}) => {
   return (
     <>
       <Head>
@@ -128,14 +137,6 @@ export default function Page({
       </Card>
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { id } = ctx.query;
-  const client = generateClient(ctx);
-  const { exportProcessor } = await client.request(
-    "get",
-    `/exportProcessor/${id}`
-  );
-  return { exportProcessor };
 };
+
+export default Page;

--- a/ui/ui-components/pages/exportProcessor/[id]/exports.tsx
+++ b/ui/ui-components/pages/exportProcessor/[id]/exports.tsx
@@ -1,19 +1,29 @@
 import Head from "next/head";
 import ExportsList from "../../../components/export/List";
 import ExportProcessorTabs from "../../../components/tabs/ExportProcessor";
-import PageHeader from "../../../components/PageHeader";
-import StateBadge from "../../../components/badges/StateBadge";
-import LockedBadge from "../../../components/badges/LockedBadge";
-import { NextPageContext } from "next";
 import { generateClient } from "../../../client/client";
+import { withServerErrorHandler } from "../../../utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "../../../utils/pageHelper";
+import { Actions } from "../../../utils/apiData";
 
-export default function Page(props) {
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const client = generateClient(ctx);
+  const { id } = ctx.query;
+  const { exportProcessor } = await client.request<Actions.ExportProcessorView>(
+    "get",
+    `/exportProcessor/${id}`
+  );
+  const exportListInitialProps = await ExportsList.hydrate(ctx);
+  return { props: { exportProcessor, ...exportListInitialProps } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
   const { exportProcessor } = props;
 
   return (
     <>
       <Head>
-        <title>Grouparoo: {exportProcessor.name}</title>
+        <title>Grouparoo: {exportProcessor.id}</title>
       </Head>
 
       <ExportProcessorTabs exportProcessor={exportProcessor} />
@@ -24,15 +34,6 @@ export default function Page(props) {
       />
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const client = generateClient(ctx);
-  const { id } = ctx.query;
-  const { exportProcessor } = await client.request(
-    "get",
-    `/exportProcessor/${id}`
-  );
-  const exportListInitialProps = await ExportsList.hydrate(ctx);
-  return { exportProcessor, ...exportListInitialProps };
 };
+
+export default Page;

--- a/ui/ui-components/pages/exportProcessors.tsx
+++ b/ui/ui-components/pages/exportProcessors.tsx
@@ -24,15 +24,16 @@ export const getServerSideProps = withServerErrorHandler(async (ctx) => {
   const client = generateClient(ctx);
   const { limit, offset, state } = ctx.query;
 
-  const { exportProcessors, total } = await client.request(
-    "get",
-    `/exportProcessors`,
-    {
-      limit,
-      offset,
-      state: state === "all" ? undefined : state,
-    }
-  );
+  const { exportProcessors, total } =
+    await client.request<Actions.ExportProcessorsList>(
+      "get",
+      `/exportProcessors`,
+      {
+        limit,
+        offset,
+        state: state === "all" ? undefined : state,
+      }
+    );
 
   return { props: { exportProcessors, total } };
 });

--- a/ui/ui-components/pages/exportProcessors.tsx
+++ b/ui/ui-components/pages/exportProcessors.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { Fragment, useState } from "react";
 import { Alert, Button, ButtonGroup, Col, Row } from "react-bootstrap";
-import { errorHandler } from "../eventHandlers";
 import StateBadge from "../components/badges/StateBadge";
 import LoadingTable from "../components/LoadingTable";
 import Pagination from "../components/Pagination";
@@ -16,11 +15,29 @@ import { capitalize } from "../utils/languageHelper";
 import { formatTimestamp } from "../utils/formatTimestamp";
 import { DurationTime } from "../components/DurationTime";
 import { generateClient } from "../client/client";
-import { NextPageContext } from "next";
+import { withServerErrorHandler } from "../utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "../utils/pageHelper";
 
 const states = ["all", "pending", "failed", "complete"];
 
-export default function Page(props) {
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const client = generateClient(ctx);
+  const { limit, offset, state } = ctx.query;
+
+  const { exportProcessors, total } = await client.request(
+    "get",
+    `/exportProcessors`,
+    {
+      limit,
+      offset,
+      state: state === "all" ? undefined : state,
+    }
+  );
+
+  return { props: { exportProcessors, total } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
   const router = useRouter();
   const { client } = useApi();
   const [loading, setLoading] = useState(false);
@@ -200,21 +217,6 @@ export default function Page(props) {
       />
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const client = generateClient(ctx);
-  const { limit, offset, state } = ctx.query;
-
-  const { exportProcessors, total } = await client.request(
-    "get",
-    `/exportProcessors`,
-    {
-      limit,
-      offset,
-      state: state === "all" ? undefined : state,
-    }
-  );
-
-  return { exportProcessors, total };
 };
+
+export default Page;

--- a/ui/ui-components/pages/exports.tsx
+++ b/ui/ui-components/pages/exports.tsx
@@ -1,7 +1,13 @@
 import Head from "next/head";
 import ExportsList from "../components/export/List";
+import { NextPageWithInferredProps } from "../utils/pageHelper";
+import { withServerErrorHandler } from "../utils/withServerErrorHandler";
 
-export default function Page(props) {
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  return { props: await ExportsList.hydrate(ctx) };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
   return (
     <>
       <Head>
@@ -11,8 +17,6 @@ export default function Page(props) {
       <ExportsList {...props} />
     </>
   );
-}
-
-Page.getInitialProps = async (ctx) => {
-  return ExportsList.hydrate(ctx);
 };
+
+export default Page;

--- a/ui/ui-components/pages/imports.tsx
+++ b/ui/ui-components/pages/imports.tsx
@@ -1,7 +1,13 @@
 import Head from "next/head";
 import ImportList from "../components/import/List";
+import { NextPageWithInferredProps } from "../utils/pageHelper";
+import { withServerErrorHandler } from "../utils/withServerErrorHandler";
 
-export default function Page(props) {
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  return { props: await ImportList.hydrate(ctx) };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
   return (
     <>
       <Head>
@@ -11,8 +17,6 @@ export default function Page(props) {
       <ImportList {...props} />
     </>
   );
-}
-
-Page.getInitialProps = async (ctx) => {
-  return ImportList.hydrate(ctx);
 };
+
+export default Page;

--- a/ui/ui-components/pages/model/[modelId]/destination/new/[appId].tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/new/[appId].tsx
@@ -1,5 +1,4 @@
 import { useApi } from "../../../../../contexts/api";
-import { NextPageContext } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useState, Fragment } from "react";
@@ -12,13 +11,23 @@ import ModelBadge from "../../../../../components/badges/ModelBadge";
 import AppBadge from "../../../../../components/badges/AppBadge";
 import { generateClient } from "../../../../../client/client";
 import { useGrouparooModel } from "../../../../../contexts/grouparooModel";
+import { withServerErrorHandler } from "../../../../../utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "../../../../../utils/pageHelper";
 
-export default function Page(props) {
-  const {
-    connectionApps,
-  }: {
-    connectionApps: Actions.SourceConnectionApps["connectionApps"];
-  } = props;
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const client = generateClient(ctx);
+  const { connectionApps } =
+    await client.request<Actions.DestinationConnectionApps>(
+      "get",
+      `/destinations/connectionApps`
+    );
+
+  return { props: { connectionApps } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
+  connectionApps,
+}) => {
   const { model } = useGrouparooModel();
   const router = useRouter();
   const { client } = useApi();
@@ -96,14 +105,6 @@ export default function Page(props) {
       ))}
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const client = generateClient(ctx);
-  const { connectionApps } = await client.request(
-    "get",
-    `/destinations/connectionApps`
-  );
-
-  return { connectionApps };
 };
+
+export default Page;

--- a/ui/ui-components/pages/model/[modelId]/destination/new/index.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/new/index.tsx
@@ -1,4 +1,3 @@
-import { NextPageContext } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useState } from "react";
@@ -9,13 +8,22 @@ import LinkButton from "../../../../../components/LinkButton";
 import { useApi } from "../../../../../contexts/api";
 import { useGrouparooModel } from "../../../../../contexts/grouparooModel";
 import { Actions } from "../../../../../utils/apiData";
+import { NextPageWithInferredProps } from "../../../../../utils/pageHelper";
+import { withServerErrorHandler } from "../../../../../utils/withServerErrorHandler";
 
-export default function Page(props) {
-  const {
-    connectionApps,
-  }: {
-    connectionApps: Actions.DestinationConnectionApps["connectionApps"];
-  } = props;
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const client = generateClient(ctx);
+  const { connectionApps } =
+    await client.request<Actions.DestinationConnectionApps>(
+      "get",
+      `/destinations/connectionApps`
+    );
+  return { props: { connectionApps } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
+  connectionApps,
+}) => {
   const router = useRouter();
   const { client } = useApi();
   const { model } = useGrouparooModel();
@@ -95,13 +103,6 @@ export default function Page(props) {
       </Form>
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const client = generateClient(ctx);
-  const { connectionApps } = await client.request(
-    "get",
-    `/destinations/connectionApps`
-  );
-  return { connectionApps };
 };
+
+export default Page;

--- a/ui/ui-components/pages/model/[modelId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/edit.tsx
@@ -9,15 +9,23 @@ import ModelTabs from "../../../components/tabs/Model";
 import LoadingButton from "../../../components/LoadingButton";
 import { Actions } from "../../../utils/apiData";
 import { generateClient } from "../../../client/client";
-import { NextPageContext } from "next";
 import { useGrouparooModel } from "../../../contexts/grouparooModel";
+import { withServerErrorHandler } from "../../../utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "../../../utils/pageHelper";
 
-export default function Page(props) {
-  const {
-    types,
-  }: {
-    types: Actions.ModelOptions["types"];
-  } = props;
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const client = generateClient(ctx);
+  const { types } = await client.request<Actions.ModelOptions>(
+    "get",
+    `/modelOptions`
+  );
+
+  return { props: { types } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
+  types,
+}) => {
   const router = useRouter();
   const { client } = useApi();
   const { model: currentModel } = useGrouparooModel();
@@ -133,11 +141,6 @@ export default function Page(props) {
       </Row>
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const client = generateClient(ctx);
-  const { types } = await client.request("get", `/modelOptions`);
-
-  return { types };
 };
+
+export default Page;

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/members.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/members.tsx
@@ -17,7 +17,10 @@ import { withServerErrorHandler } from "../../../../../utils/withServerErrorHand
 export const getServerSideProps = withServerErrorHandler(async (ctx) => {
   const { groupId } = ctx.query;
   const client = generateClient(ctx);
-  const { group } = await client.request("get", `/group/${groupId}`);
+  const { group } = await client.request<Actions.GroupView>(
+    "get",
+    `/group/${groupId}`
+  );
   const recordListInitialProps = await RecordsList.hydrate(ctx);
 
   return { props: { group, ...recordListInitialProps } };

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/members.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/members.tsx
@@ -1,27 +1,32 @@
 import { useApi } from "../../../../../contexts/api";
 import Head from "next/head";
-import { NextPageContext } from "next";
 import { useState } from "react";
 import { Button } from "react-bootstrap";
 import { successHandler } from "../../../../../eventHandlers";
 import StateBadge from "../../../../../components/badges/StateBadge";
 import GroupTabs from "../../../../../components/tabs/Group";
 import RecordsList from "../../../../../components/record/List";
-import { Models, Actions } from "../../../../../utils/apiData";
+import { Actions } from "../../../../../utils/apiData";
 import PageHeader from "../../../../../components/PageHeader";
 import LockedBadge from "../../../../../components/badges/LockedBadge";
 import ModelBadge from "../../../../../components/badges/ModelBadge";
 import { generateClient } from "../../../../../client/client";
+import { NextPageWithInferredProps } from "../../../../../utils/pageHelper";
+import { withServerErrorHandler } from "../../../../../utils/withServerErrorHandler";
 
-export default function Page(
-  props: Awaited<ReturnType<typeof Page.getInitialProps>>
-) {
-  const {
-    group,
-  }: {
-    group: Models.GroupType;
-  } = props;
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const { groupId } = ctx.query;
+  const client = generateClient(ctx);
+  const { group } = await client.request("get", `/group/${groupId}`);
+  const recordListInitialProps = await RecordsList.hydrate(ctx);
 
+  return { props: { group, ...recordListInitialProps } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
+  group,
+  ...props
+}) => {
   const { client } = useApi();
   const [loading, setLoading] = useState(false);
 
@@ -79,13 +84,6 @@ export default function Page(
       />
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { groupId } = ctx.query;
-  const client = generateClient(ctx);
-  const { group } = await client.request("get", `/group/${groupId}`);
-  const recordListInitialProps = await RecordsList.hydrate(ctx);
-
-  return { group, ...recordListInitialProps };
 };
+
+export default Page;

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -105,7 +105,9 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
     props.group.rules.map((rule) => {
       _autocompleteResults[rule.key] = [rule.match];
     });
+
     setAutoCompleteResults(_autocompleteResults);
+
     didLoad.current = true;
   }, [autocompleteResults, getCounts, props.group.rules]);
 
@@ -227,25 +229,15 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
 
             <tbody>
               {localRules.map((rule, idx) => {
-                let type: string;
-                propertiesAndTopLevelGroupRules.forEach((r) => {
-                  if (rule.key === r.key) {
-                    type = r.type;
-                  }
-                });
+                const type: string = propertiesAndTopLevelGroupRules.find(
+                  (r) => rule.key === r.key
+                )?.type;
 
-                if (
+                const opValue =
                   rule.operation.op &&
-                  ops[type]?.indexOf(rule.operation.op) < 0
-                ) {
-                  rule = {
-                    ...rule,
-                    operation: {
-                      ...rule.operation,
-                      op: ops[type][0],
-                    },
-                  };
-                }
+                  !ops[type]?.find(({ op }) => op === rule.operation.op)
+                    ? ops[type]?.[0].op
+                    : rule.operation.op;
 
                 let rowChanged = false;
                 if (!rulesAreEqual(group.rules[idx], localRules[idx])) {
@@ -312,7 +304,7 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
                       <Form.Group controlId={`${rule.key}-op-${idx}`}>
                         <Form.Control
                           as="select"
-                          value={rule.operation.op}
+                          value={opValue}
                           disabled={loading}
                           onChange={(e) => {
                             const op = e.target

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -64,7 +64,6 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
   const [componentCounts, setComponentCounts] = useState({});
   const [autocompleteResults, setAutoCompleteResults] = useState({});
   const didLoad = useRef(false);
-  // const [funnelCounts, setFunnelCounts] = useState([]);
 
   const getCounts = useCallback(
     async (useCache = true) => {
@@ -79,7 +78,6 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
 
       if (componentMembersResponse?.componentCounts) {
         setComponentCounts(componentMembersResponse.componentCounts);
-        // setFunnelCounts(response.funnelCounts);
       }
 
       const potentialMembersResponse: Actions.GroupCountPotentialMembers =

--- a/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-components/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -1,11 +1,5 @@
 import Head from "next/head";
-import {
-  ChangeEventHandler,
-  Fragment,
-  useCallback,
-  useEffect,
-  useState,
-} from "react";
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 import { Form, Table, Badge, Button } from "react-bootstrap";
 import { AsyncTypeahead } from "react-bootstrap-typeahead";
 import { successHandler } from "../../../../../eventHandlers";
@@ -59,11 +53,14 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
 }) => {
   const [group, setGroup] = useState<Models.GroupType>(props.group);
   const { client } = useApi();
-  const [loading, setLoading] = useState(false);
-  const [localRules, setLocalRules] = useState(makeLocal(props.group.rules));
+  const [loading, setLoading] = useState(true);
+  const [localRules, setLocalRules] = useState(() =>
+    makeLocal(props.group.rules)
+  );
   const [countPotentialMembers, setCountPotentialMembers] = useState(0);
   const [componentCounts, setComponentCounts] = useState({});
   const [autocompleteResults, setAutoCompleteResults] = useState({});
+  const didLoad = useRef(false);
   // const [funnelCounts, setFunnelCounts] = useState([]);
 
   const getCounts = useCallback(
@@ -99,6 +96,8 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
   );
 
   useEffect(() => {
+    if (didLoad.current) return;
+
     getCounts();
 
     // seed typeahead responses
@@ -107,6 +106,7 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
       _autocompleteResults[rule.key] = [rule.match];
     });
     setAutoCompleteResults(_autocompleteResults);
+    didLoad.current = true;
   }, [autocompleteResults, getCounts, props.group.rules]);
 
   function addRule() {

--- a/ui/ui-components/pages/model/[modelId]/records.tsx
+++ b/ui/ui-components/pages/model/[modelId]/records.tsx
@@ -1,10 +1,13 @@
-import { NextPageContext } from "next";
 import Head from "next/head";
 import RecordsList from "../../../components/record/List";
+import { NextPageWithInferredProps } from "../../../utils/pageHelper";
+import { withServerErrorHandler } from "../../../utils/withServerErrorHandler";
 
-export default function Page(
-  props: Awaited<ReturnType<typeof Page.getInitialProps>>
-) {
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  return { props: await RecordsList.hydrate(ctx) };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
   return (
     <>
       <Head>
@@ -14,8 +17,6 @@ export default function Page(
       <RecordsList {...props} />
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  return await RecordsList.hydrate(ctx);
 };
+
+export default Page;

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
@@ -46,7 +46,7 @@ export const getServerSideProps = withServerErrorHandler(async (ctx) => {
     }
   );
 
-  let run: Models.RunType;
+  let run: Models.RunType = null;
   if (source?.schedule?.id) {
     const { runs } = await client.request<Actions.RunsList>("get", `/runs`, {
       id: source.schedule.id,

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
@@ -13,24 +13,57 @@ import Head from "next/head";
 import { Actions, Models } from "../../../../../utils/apiData";
 import { formatTimestamp } from "../../../../../utils/formatTimestamp";
 import ModelBadge from "../../../../../components/badges/ModelBadge";
-import { NextPageContext } from "next";
 import { ensureMatchingModel } from "../../../../../utils/ensureMatchingModel";
 import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 import ManagedCard from "../../../../../components/lib/ManagedCard";
 import PrimaryKeyBadge from "../../../../../components/badges/PrimaryKeyBadge";
 import { generateClient } from "../../../../../client/client";
+import { NextPageWithInferredProps } from "../../../../../utils/pageHelper";
+import { withServerErrorHandler } from "../../../../../utils/withServerErrorHandler";
 
-export default function Page({
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const { sourceId, modelId } = ctx.query;
+  const client = generateClient(ctx);
+  const { source } = await client.request<Actions.SourceView>(
+    "get",
+    `/source/${sourceId}`
+  );
+  ensureMatchingModel("Source", source.modelId, modelId.toString());
+
+  const { total: totalSources } = await client.request<Actions.SourcesList>(
+    "get",
+    `/sources`,
+    {
+      modelId,
+      limit: 1,
+    }
+  );
+  const { properties } = await client.request<Actions.PropertiesList>(
+    "get",
+    `/properties`,
+    {
+      sourceId,
+    }
+  );
+
+  let run: Models.RunType;
+  if (source?.schedule?.id) {
+    const { runs } = await client.request<Actions.RunsList>("get", `/runs`, {
+      id: source.schedule.id,
+      limit: 1,
+    });
+    run = runs[0];
+  }
+
+  return { props: { source, totalSources, run, properties } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
   source,
   totalSources,
   run,
   properties,
-}: {
-  source: Models.SourceType;
-  totalSources: number;
-  run: Models.RunType;
-  properties: Models.PropertyType[];
-}) {
+}) => {
   const recurringFrequencyMinutes = source?.schedule?.recurringFrequency
     ? Math.round(source.schedule.recurringFrequency / 1000 / 60)
     : null;
@@ -39,7 +72,7 @@ export default function Page({
     () =>
       (totalSources === 1 && source.state !== "ready") ||
       !!properties.find((property) => property.isPrimaryKey),
-    [properties]
+    [properties, totalSources, source.state]
   );
 
   const sourceBadges = useMemo(() => {
@@ -317,30 +350,6 @@ export default function Page({
       </Row>
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { sourceId, modelId } = ctx.query;
-  const client = generateClient(ctx);
-  const { source } = await client.request("get", `/source/${sourceId}`);
-  ensureMatchingModel("Source", source.modelId, modelId.toString());
-
-  const { total: totalSources } = await client.request("get", `/sources`, {
-    modelId,
-    limit: 1,
-  });
-  const { properties } = await client.request("get", `/properties`, {
-    sourceId,
-  });
-
-  let run;
-  if (source?.schedule?.id) {
-    const { runs } = await client.request("get", `/runs`, {
-      id: source.schedule.id,
-      limit: 1,
-    });
-    run = runs[0];
-  }
-
-  return { source, totalSources, run, properties };
 };
+
+export default Page;

--- a/ui/ui-components/pages/model/new.tsx
+++ b/ui/ui-components/pages/model/new.tsx
@@ -3,19 +3,23 @@ import { useState } from "react";
 import { Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useRouter } from "next/router";
-import { errorHandler } from "../../eventHandlers";
 import { Actions, Models } from "../../utils/apiData";
 import LoadingButton from "../../components/LoadingButton";
 import { generateClient } from "../../client/client";
-import { NextPageContext } from "next";
 import { useApi } from "../../contexts/api";
+import { withServerErrorHandler } from "../../utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "../../utils/pageHelper";
 
-export default function Page(props) {
-  const {
-    types,
-  }: {
-    types: Actions.ModelOptions["types"];
-  } = props;
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const client = generateClient(ctx);
+  const { types }: Actions.ModelOptions =
+    await client.request<Actions.ModelOptions>("get", `/modelOptions`);
+  return { props: { types } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
+  types,
+}) => {
   const router = useRouter();
   const { client } = useApi();
   const { handleSubmit, register } = useForm();
@@ -84,13 +88,6 @@ export default function Page(props) {
       </Form>
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const client = generateClient(ctx);
-  const { types }: Actions.ModelOptions = await client.request(
-    "get",
-    `/modelOptions`
-  );
-  return { types };
 };
+
+export default Page;

--- a/ui/ui-components/pages/notification/[id]/edit.tsx
+++ b/ui/ui-components/pages/notification/[id]/edit.tsx
@@ -1,15 +1,26 @@
 import NotificationTabs from "../../../components/tabs/Notification";
 import Head from "next/head";
 import { Button } from "react-bootstrap";
-import { Models } from "../../../utils/apiData";
+import { Actions } from "../../../utils/apiData";
 import Markdown from "react-markdown";
 import { formatTimestamp } from "../../../utils/formatTimestamp";
 import { generateClient } from "../../../client/client";
-import { NextPageContext } from "next";
+import { withServerErrorHandler } from "../../../utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "../../../utils/pageHelper";
 
-export default function Page(props) {
-  const { notification }: { notification: Models.NotificationType } = props;
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const { id } = ctx.query;
+  const client = generateClient(ctx);
+  const { notification } = await client.request<Actions.NotificationView>(
+    "get",
+    `/notification/${id}`
+  );
+  return { props: { notification } };
+});
 
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
+  notification,
+}) => {
   return (
     <>
       <Head>
@@ -39,11 +50,6 @@ export default function Page(props) {
       ) : null}
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { id } = ctx.query;
-  const client = generateClient(ctx);
-  const { notification } = await client.request("get", `/notification/${id}`);
-  return { notification };
 };
+
+export default Page;

--- a/ui/ui-components/pages/oauth/callback.tsx
+++ b/ui/ui-components/pages/oauth/callback.tsx
@@ -10,32 +10,31 @@ export default function OauthCallbackPage() {
   const { client } = useApi();
   const requestId = String(router.query?.requestId ?? "");
 
-  const updateOAuthRequest = async () => {
-    const response: Actions.OAuthClientEdit = await client.request(
-      "put",
-      `/oauth/client/request/${requestId}/edit`
-    );
-    if (response.oAuthRequest) {
-      if (
-        response.oAuthRequest.type === "user" &&
-        grouparooUiEdition() !== "config"
-      ) {
-        router.replace(`/session/sign-in?requestId=${requestId}`);
-      } else if (
-        response.oAuthRequest.type === "app" &&
-        typeof window?.opener !== "undefined"
-      ) {
-        window.opener?.postMessage({ requestId });
-        window.close();
-      } else {
-        throw new Error("OAuth Request could not be handled.");
-      }
-    }
-  };
-
   useEffect(() => {
+    const updateOAuthRequest = async () => {
+      const response: Actions.OAuthClientEdit = await client.request(
+        "put",
+        `/oauth/client/request/${requestId}/edit`
+      );
+      if (response.oAuthRequest) {
+        if (
+          response.oAuthRequest.type === "user" &&
+          grouparooUiEdition() !== "config"
+        ) {
+          router.replace(`/session/sign-in?requestId=${requestId}`);
+        } else if (
+          response.oAuthRequest.type === "app" &&
+          typeof window?.opener !== "undefined"
+        ) {
+          window.opener?.postMessage({ requestId });
+          window.close();
+        } else {
+          throw new Error("OAuth Request could not be handled.");
+        }
+      }
+    };
     updateOAuthRequest();
-  }, []);
+  }, [client, requestId, router]);
 
   return <Loader />;
 }

--- a/ui/ui-components/pages/resque/overview.tsx
+++ b/ui/ui-components/pages/resque/overview.tsx
@@ -10,20 +10,28 @@ import {
 import Head from "next/head";
 import ResqueTabs from "../../components/tabs/Resque";
 import { generateClient } from "../../client/client";
-import { NextPageContext } from "next";
+import { withServerErrorHandler } from "../../utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "../../utils/pageHelper";
 
 const maxSampleLength = 30;
 const DELAY = 1000 * 3;
 
-export default function ResqueOverview(props) {
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const client = generateClient(ctx);
+  const { resqueDetails, failedCount } =
+    await client.request<Actions.ResqueResqueDetails>(
+      "get",
+      "/resque/resqueDetails"
+    );
+
+  return { props: { resqueDetails, failedCount } };
+});
+
+export const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
+  resqueDetails,
+  failedCount: _failedCount,
+}) => {
   const { client } = useApi();
-  const {
-    resqueDetails,
-    failedCount: _failedCount,
-  }: {
-    resqueDetails: Actions.ResqueResqueDetails["resqueDetails"];
-    failedCount: Actions.ResqueResqueDetails["failedCount"];
-  } = props;
   const [queues, setQueues] = useState(resqueDetails.queues);
   const [workers, setWorkers] = useState(
     formatWorkersForDisplay(resqueDetails.workers)
@@ -252,15 +260,9 @@ export default function ResqueOverview(props) {
       </Row>
     </>
   );
-}
-
-ResqueOverview.getInitialProps = async function (ctx: NextPageContext) {
-  const client = generateClient(ctx);
-  const { resqueDetails, failedCount }: Actions.ResqueResqueDetails =
-    await client.request("get", "/resque/resqueDetails");
-
-  return { resqueDetails, failedCount };
 };
+
+export default Page;
 
 function formatWorkersForDisplay(
   _workers: Actions.ResqueResqueDetails["resqueDetails"]["workers"]

--- a/ui/ui-components/pages/runs.tsx
+++ b/ui/ui-components/pages/runs.tsx
@@ -4,7 +4,7 @@ import { NextPageWithInferredProps } from "../utils/pageHelper";
 import { withServerErrorHandler } from "../utils/withServerErrorHandler";
 
 export const getServerSideProps = withServerErrorHandler(async (ctx) => {
-  return { props: RunsList.hydrate(ctx) };
+  return { props: await RunsList.hydrate(ctx) };
 });
 
 const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {

--- a/ui/ui-components/pages/runs.tsx
+++ b/ui/ui-components/pages/runs.tsx
@@ -1,7 +1,13 @@
 import Head from "next/head";
 import RunsList from "../components/runs/List";
+import { NextPageWithInferredProps } from "../utils/pageHelper";
+import { withServerErrorHandler } from "../utils/withServerErrorHandler";
 
-export default function Page(props) {
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  return { props: RunsList.hydrate(ctx) };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
   return (
     <>
       <Head>
@@ -11,8 +17,6 @@ export default function Page(props) {
       <RunsList {...props} />
     </>
   );
-}
-
-Page.getInitialProps = async (ctx) => {
-  return RunsList.hydrate(ctx);
 };
+
+export default Page;

--- a/ui/ui-components/pages/team/[id]/edit.tsx
+++ b/ui/ui-components/pages/team/[id]/edit.tsx
@@ -9,9 +9,17 @@ import TeamTabs from "../../../components/tabs/Team";
 import LockedBadge from "../../../components/badges/LockedBadge";
 import { successHandler, teamHandler } from "../../../eventHandlers";
 import { generateClient } from "../../../client/client";
-import { NextPageContext } from "next";
+import { withServerErrorHandler } from "../../../utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "../../../utils/pageHelper";
 
-export default function Page(props) {
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const client = generateClient(ctx);
+  const { id } = ctx.query;
+  const { team } = await client.request<Actions.TeamView>("get", `/team/${id}`);
+  return { props: { team } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
   const router = useRouter();
   const { client } = useApi();
   const [loading, setLoading] = useState(false);
@@ -146,11 +154,6 @@ export default function Page(props) {
       </Form>
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const client = generateClient(ctx);
-  const { id } = ctx.query;
-  const { team } = await client.request("get", `/team/${id}`);
-  return { team };
 };
+
+export default Page;

--- a/ui/ui-components/pages/team/[id]/teamMember/new.tsx
+++ b/ui/ui-components/pages/team/[id]/teamMember/new.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../../teamMember/new";
+export { default, getServerSideProps } from "../../../teamMember/new";

--- a/ui/ui-components/pages/team/initialize.tsx
+++ b/ui/ui-components/pages/team/initialize.tsx
@@ -8,14 +8,25 @@ import LoadingButton from "../../components/LoadingButton";
 import { Actions } from "../../utils/apiData";
 import { sessionHandler, successHandler } from "../../eventHandlers";
 import { generateClient } from "../../client/client";
-import { NextPageContext } from "next";
+import { withServerErrorHandler } from "../../utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "../../utils/pageHelper";
 
-export default function TeamInitializePage(props) {
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const client = generateClient(ctx);
+  const { setting } = await client.request<Actions.SettingCoreClusterName>(
+    "get",
+    `/setting/core/cluster-name`
+  );
+  return { props: { setting } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
+  setting,
+}) => {
   const router = useRouter();
   const { client } = useApi();
   const { handleSubmit, register } = useForm();
   const [loading, setLoading] = useState(false);
-  const setting: Actions.SettingCoreClusterName["setting"] = props.setting;
 
   async function onSubmit(data) {
     setLoading(true);
@@ -173,10 +184,6 @@ export default function TeamInitializePage(props) {
       </Form>
     </>
   );
-}
-
-TeamInitializePage.getInitialProps = async (ctx: NextPageContext) => {
-  const client = generateClient(ctx);
-  const { setting } = await client.request("get", `/setting/core/cluster-name`);
-  return { setting };
 };
+
+export default Page;

--- a/ui/ui-components/pages/teamMember/new.tsx
+++ b/ui/ui-components/pages/teamMember/new.tsx
@@ -5,22 +5,22 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { Form } from "react-bootstrap";
 import LoadingButton from "../../components/LoadingButton";
-import {
-  errorHandler,
-  successHandler,
-  teamMemberHandler,
-} from "../../eventHandlers";
-import { Actions, Models } from "../../utils/apiData";
+import { successHandler, teamMemberHandler } from "../../eventHandlers";
+import { Actions } from "../../utils/apiData";
 import { grouparooUiEdition } from "../../utils/uiEdition";
 import { generateClient } from "../../client/client";
-import { NextPageContext } from "next";
+import { NextPageWithInferredProps } from "../../utils/pageHelper";
+import { withServerErrorHandler } from "../../utils/withServerErrorHandler";
 
-export default function Page(props) {
-  const {
-    teams,
-  }: {
-    teams: Models.TeamType[];
-  } = props;
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const client = generateClient(ctx);
+  const { teams } = await client.request<Actions.TeamsList>("get", `/teams`);
+  return { props: { teams } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
+  teams,
+}) => {
   const router = useRouter();
   const { client } = useApi();
   const { handleSubmit, register } = useForm();
@@ -164,10 +164,6 @@ export default function Page(props) {
       </Form>
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const client = generateClient(ctx);
-  const { teams } = await client.request("get", `/teams`);
-  return { teams };
 };
+
+export default Page;

--- a/ui/ui-components/pages/teams.tsx
+++ b/ui/ui-components/pages/teams.tsx
@@ -6,19 +6,28 @@ import EnterpriseLink from "../components/GrouparooLink";
 import { Form } from "react-bootstrap";
 import LoadingTable from "../components/LoadingTable";
 import RecordImageFromEmail from "../components/visualizations/RecordImageFromEmail";
-import { Models } from "../utils/apiData";
+import { Actions, Models } from "../utils/apiData";
 import { formatTimestamp } from "../utils/formatTimestamp";
 import LinkButton from "../components/LinkButton";
 import { grouparooUiEdition } from "../utils/uiEdition";
 import { generateClient } from "../client/client";
+import { NextPageWithInferredProps } from "../utils/pageHelper";
+import { withServerErrorHandler } from "../utils/withServerErrorHandler";
 
-export default function Page({
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const client = generateClient(ctx);
+  const { teams } = await client.request<Actions.TeamsList>("get", `/teams`);
+  const { teamMembers } = await client.request<Actions.TeamMembersList>(
+    "get",
+    `/teamMembers`
+  );
+  return { props: { teams, teamMembers } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
   teams,
   teamMembers,
-}: {
-  teams: Models.TeamType[];
-  teamMembers: Models.TeamMemberType[];
-}) {
+}) => {
   const router = useRouter();
 
   return (
@@ -71,7 +80,11 @@ export default function Page({
         <Alert variant="primary" style={{ textAlign: "center" }}>
           Does your organization need additional Teams with finer-grained
           permissions?{" "}
-          <a target="_blank" href="https://www.grouparoo.com/meet">
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://www.grouparoo.com/meet"
+          >
             Contact us
           </a>
           .
@@ -132,11 +145,6 @@ export default function Page({
       </LinkButton>
     </>
   );
-}
-
-Page.getInitialProps = async (ctx) => {
-  const client = generateClient(ctx);
-  const { teams } = await client.request("get", `/teams`);
-  const { teamMembers } = await client.request("get", `/teamMembers`);
-  return { teams, teamMembers };
 };
+
+export default Page;

--- a/ui/ui-config/pages/app/[id]/edit.tsx
+++ b/ui/ui-config/pages/app/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/app/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/app/[id]/edit";

--- a/ui/ui-config/pages/app/[id]/refresh.tsx
+++ b/ui/ui-config/pages/app/[id]/refresh.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/app/[id]/refresh";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/app/[id]/refresh";

--- a/ui/ui-config/pages/app/new/[...plugin].tsx
+++ b/ui/ui-config/pages/app/new/[...plugin].tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/app/new/[...plugin]";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/app/new/[...plugin]";

--- a/ui/ui-config/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-config/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/data";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/data";

--- a/ui/ui-config/pages/model/[modelId]/destination/[destinationId]/edit.tsx
+++ b/ui/ui-config/pages/model/[modelId]/destination/[destinationId]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/edit";

--- a/ui/ui-config/pages/model/[modelId]/destination/new/[appId].tsx
+++ b/ui/ui-config/pages/model/[modelId]/destination/new/[appId].tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/new/[appId]";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/destination/new/[appId]";

--- a/ui/ui-config/pages/model/[modelId]/destination/new/index.tsx
+++ b/ui/ui-config/pages/model/[modelId]/destination/new/index.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/new";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/destination/new";

--- a/ui/ui-config/pages/model/[modelId]/edit.tsx
+++ b/ui/ui-config/pages/model/[modelId]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/edit";

--- a/ui/ui-config/pages/model/[modelId]/group/[groupId]/edit.tsx
+++ b/ui/ui-config/pages/model/[modelId]/group/[groupId]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/group/[groupId]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/group/[groupId]/edit";

--- a/ui/ui-config/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-config/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/group/[groupId]/rules";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/group/[groupId]/rules";

--- a/ui/ui-config/pages/model/[modelId]/record/[recordId]/edit.tsx
+++ b/ui/ui-config/pages/model/[modelId]/record/[recordId]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/edit";

--- a/ui/ui-config/pages/model/[modelId]/record/[recordId]/exports.tsx
+++ b/ui/ui-config/pages/model/[modelId]/record/[recordId]/exports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/exports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/exports";

--- a/ui/ui-config/pages/model/[modelId]/records.tsx
+++ b/ui/ui-config/pages/model/[modelId]/records.tsx
@@ -10,12 +10,13 @@ import { Actions, Models } from "@grouparoo/ui-components/utils/apiData";
 import LoadingButton from "@grouparoo/ui-components/components/LoadingButton";
 import AddSampleRecordModal from "@grouparoo/ui-components/components/record/AddSampleRecordModal";
 import { useApi } from "@grouparoo/ui-components/contexts/api";
-import { NextPageContext } from "next";
 import { useGrouparooModel } from "@grouparoo/ui-components/contexts/grouparooModel";
+import { NextPageWithInferredProps } from "@grouparoo/ui-components/utils/pageHelper";
+import { getServerSideProps } from "@grouparoo/ui-components/pages/model/[modelId]/records";
 
-export default function Page(
-  props: Awaited<ReturnType<typeof Page.getInitialProps>>
-) {
+export { getServerSideProps };
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
   const { model } = useGrouparooModel();
   const router = useRouter();
   const { client } = useApi();
@@ -75,8 +76,6 @@ export default function Page(
       />
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  return await RecordsPage.getInitialProps(ctx);
 };
+
+export default Page;

--- a/ui/ui-config/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-config/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties";

--- a/ui/ui-config/pages/model/[modelId]/source/[sourceId]/overview.tsx
+++ b/ui/ui-config/pages/model/[modelId]/source/[sourceId]/overview.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/overview";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/overview";

--- a/ui/ui-config/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-config/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit";

--- a/ui/ui-config/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-config/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/schedule";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/schedule";

--- a/ui/ui-config/pages/model/[modelId]/source/new/[appId].tsx
+++ b/ui/ui-config/pages/model/[modelId]/source/new/[appId].tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/source/new/[appId]";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/source/new/[appId]";

--- a/ui/ui-config/pages/model/[modelId]/source/new/index.tsx
+++ b/ui/ui-config/pages/model/[modelId]/source/new/index.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/source/new";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/source/new";

--- a/ui/ui-config/pages/model/new.tsx
+++ b/ui/ui-config/pages/model/new.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/new";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/new";

--- a/ui/ui-enterprise/pages/about.tsx
+++ b/ui/ui-enterprise/pages/about.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/about";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/about";

--- a/ui/ui-enterprise/pages/apiKey/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/apiKey/[id]/edit.tsx
@@ -10,9 +10,20 @@ import LockedBadge from "@grouparoo/ui-components/components/badges/LockedBadge"
 import { successHandler } from "@grouparoo/ui-components/eventHandlers";
 import { Models, Actions } from "@grouparoo/ui-components/utils/apiData";
 import { generateClient } from "@grouparoo/ui-components/client/client";
-import { NextPageContext } from "next";
+import { withServerErrorHandler } from "@grouparoo/ui-components/utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "@grouparoo/ui-components/utils/pageHelper";
 
-export default function Page(props) {
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const client = generateClient(ctx);
+  const { id } = ctx.query;
+  const { apiKey } = await client.request<Actions.ApiKeyView>(
+    "get",
+    `/apiKey/${id}`
+  );
+  return { props: { apiKey } };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
   const router = useRouter();
   const { client } = useApi();
   const [loading, setLoading] = useState(false);
@@ -155,14 +166,6 @@ export default function Page(props) {
       </Form>
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const client = generateClient(ctx);
-  const { id } = ctx.query;
-  const { apiKey }: Actions.ApiKeyView = await client.request(
-    "get",
-    `/apiKey/${id}`
-  );
-  return { apiKey };
 };
+
+export default Page;

--- a/ui/ui-enterprise/pages/apiKeys.tsx
+++ b/ui/ui-enterprise/pages/apiKeys.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/apiKeys";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/apiKeys";

--- a/ui/ui-enterprise/pages/app/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/app/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/app/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/app/[id]/edit";

--- a/ui/ui-enterprise/pages/app/[id]/refresh.tsx
+++ b/ui/ui-enterprise/pages/app/[id]/refresh.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/app/[id]/refresh";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/app/[id]/refresh";

--- a/ui/ui-enterprise/pages/app/new/[...plugin].tsx
+++ b/ui/ui-enterprise/pages/app/new/[...plugin].tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/app/new/[...plugin]";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/app/new/[...plugin]";

--- a/ui/ui-enterprise/pages/app/new/index.tsx
+++ b/ui/ui-enterprise/pages/app/new/index.tsx
@@ -23,7 +23,7 @@ export const getServerSideProps = withServerErrorHandler(async (ctx) => {
 
   plugins = plugins
     .filter((p) => p.apps?.length > 0)
-    .sort((a, b) => (a.name > b.name ? 1 : -1));
+    .sort((a, b) => (a.name > b.name ? 1 : a.name < b.name ? -1 : 0));
 
   return {
     props: {

--- a/ui/ui-enterprise/pages/export/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/export/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/export/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/export/[id]/edit";

--- a/ui/ui-enterprise/pages/exportProcessor/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/exportProcessor/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/exportProcessor/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/exportProcessor/[id]/edit";

--- a/ui/ui-enterprise/pages/exportProcessor/[id]/exports.tsx
+++ b/ui/ui-enterprise/pages/exportProcessor/[id]/exports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/exportProcessor/[id]/exports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/exportProcessor/[id]/exports";

--- a/ui/ui-enterprise/pages/exportProcessors.tsx
+++ b/ui/ui-enterprise/pages/exportProcessors.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/exportProcessors";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/exportProcessors";

--- a/ui/ui-enterprise/pages/exports.tsx
+++ b/ui/ui-enterprise/pages/exports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/exports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/exports";

--- a/ui/ui-enterprise/pages/import/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/import/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/import/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/import/[id]/edit";

--- a/ui/ui-enterprise/pages/imports.tsx
+++ b/ui/ui-enterprise/pages/imports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/imports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/imports";

--- a/ui/ui-enterprise/pages/imports/[creatorId].tsx
+++ b/ui/ui-enterprise/pages/imports/[creatorId].tsx
@@ -1,8 +1,14 @@
 import Head from "next/head";
 import ImportList from "@grouparoo/ui-components/components/import/List";
 import { useRouter } from "next/router";
+import { NextPageWithInferredProps } from "@grouparoo/ui-components/utils/pageHelper";
+import { withServerErrorHandler } from "@grouparoo/ui-components/utils/withServerErrorHandler";
 
-export default function Page(props) {
+export const getServerSideProps = withServerErrorHandler(async (ctx) => ({
+  props: await ImportList.hydrate(ctx),
+}));
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
   const router = useRouter();
   const { query } = router;
 
@@ -15,8 +21,6 @@ export default function Page(props) {
       <ImportList {...props} />
     </>
   );
-}
-
-Page.getInitialProps = async (ctx) => {
-  return ImportList.hydrate(ctx);
 };
+
+export default Page;

--- a/ui/ui-enterprise/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/data";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/data";

--- a/ui/ui-enterprise/pages/model/[modelId]/destination/[destinationId]/edit.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/destination/[destinationId]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/edit";

--- a/ui/ui-enterprise/pages/model/[modelId]/destination/[destinationId]/exports.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/destination/[destinationId]/exports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/exports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/exports";

--- a/ui/ui-enterprise/pages/model/[modelId]/destination/[destinationId]/retry.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/destination/[destinationId]/retry.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/retry";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/destination/[destinationId]/retry";

--- a/ui/ui-enterprise/pages/model/[modelId]/destination/new/[appId].tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/destination/new/[appId].tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/new/[appId]";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/destination/new/[appId]";

--- a/ui/ui-enterprise/pages/model/[modelId]/destination/new/index.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/destination/new/index.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/destination/new";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/destination/new";

--- a/ui/ui-enterprise/pages/model/[modelId]/edit.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/edit";

--- a/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/edit.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/group/[groupId]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/group/[groupId]/edit";

--- a/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/members.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/members.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/group/[groupId]/members";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/group/[groupId]/members";

--- a/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/rules.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/group/[groupId]/rules.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/group/[groupId]/rules";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/group/[groupId]/rules";

--- a/ui/ui-enterprise/pages/model/[modelId]/record/[recordId]/edit.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/record/[recordId]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/edit";

--- a/ui/ui-enterprise/pages/model/[modelId]/record/[recordId]/exports.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/record/[recordId]/exports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/exports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/exports";

--- a/ui/ui-enterprise/pages/model/[modelId]/record/[recordId]/imports.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/record/[recordId]/imports.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/imports";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/record/[recordId]/imports";

--- a/ui/ui-enterprise/pages/model/[modelId]/records.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/records.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/records";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/records";

--- a/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties";

--- a/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/overview.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/overview.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/overview";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/overview";

--- a/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/edit";

--- a/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/records.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/property/[propertyId]/records.tsx
@@ -4,20 +4,40 @@ import RecordsList from "@grouparoo/ui-components/components/record/List";
 import PageHeader from "@grouparoo/ui-components/components/PageHeader";
 import StateBadge from "@grouparoo/ui-components/components/badges/StateBadge";
 import LockedBadge from "@grouparoo/ui-components/components/badges/LockedBadge";
-import { Actions, Models } from "@grouparoo/ui-components/utils/apiData";
+import { Actions } from "@grouparoo/ui-components/utils/apiData";
 import ModelBadge from "@grouparoo/ui-components/components/badges/ModelBadge";
-import { NextPageContext } from "next";
 import { generateClient } from "@grouparoo/ui-components/client/client";
+import { withServerErrorHandler } from "@grouparoo/ui-components/utils/withServerErrorHandler";
+import { NextPageWithInferredProps } from "@grouparoo/ui-components/utils/pageHelper";
 
-export default function Page(props) {
-  const {
-    property,
-    source,
-  }: {
-    model: Models.GrouparooModelType;
-    property: Models.PropertyType;
-    source: Models.SourceType;
-  } = props;
+export const getServerSideProps = withServerErrorHandler(async (ctx) => {
+  const { propertyId } = ctx.query;
+  const client = generateClient(ctx);
+  const { property } = await client.request<Actions.PropertyView>(
+    "get",
+    `/property/${propertyId}`
+  );
+  const { source } = await client.request<Actions.SourceView>(
+    "get",
+    `/source/${property.sourceId}`
+  );
+  const recordListInitialProps = await RecordsList.hydrate(
+    ctx,
+    property.key,
+    "%"
+  );
+
+  return {
+    props: {
+      property,
+      source,
+      ...recordListInitialProps,
+    },
+  };
+});
+
+const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
+  const { property, source } = props;
 
   return (
     <>
@@ -49,24 +69,6 @@ export default function Page(props) {
       />
     </>
   );
-}
-
-Page.getInitialProps = async (ctx: NextPageContext) => {
-  const { propertyId } = ctx.query;
-  const client = generateClient(ctx);
-  const { property } = await client.request<Actions.PropertyView>(
-    "get",
-    `/property/${propertyId}`
-  );
-  const { source } = await client.request<Actions.SourceView>(
-    "get",
-    `/source/${property.sourceId}`
-  );
-  const recordListInitialProps = await RecordsList.hydrate(
-    ctx,
-    property.key,
-    "%"
-  );
-
-  return { property, source, ...recordListInitialProps };
 };
+
+export default Page;

--- a/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/schedule";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/source/[sourceId]/schedule";

--- a/ui/ui-enterprise/pages/model/[modelId]/source/new/[appId].tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/new/[appId].tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/source/new/[appId]";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/source/new/[appId]";

--- a/ui/ui-enterprise/pages/model/[modelId]/source/new/index.tsx
+++ b/ui/ui-enterprise/pages/model/[modelId]/source/new/index.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/[modelId]/source/new";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/[modelId]/source/new";

--- a/ui/ui-enterprise/pages/model/new.tsx
+++ b/ui/ui-enterprise/pages/model/new.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/model/new";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/model/new";

--- a/ui/ui-enterprise/pages/notification/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/notification/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/notification/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/notification/[id]/edit";

--- a/ui/ui-enterprise/pages/notifications.tsx
+++ b/ui/ui-enterprise/pages/notifications.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/notifications";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/notifications";

--- a/ui/ui-enterprise/pages/resque/overview.tsx
+++ b/ui/ui-enterprise/pages/resque/overview.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/resque/overview";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/resque/overview";

--- a/ui/ui-enterprise/pages/run/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/run/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/run/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/run/[id]/edit";

--- a/ui/ui-enterprise/pages/runs.tsx
+++ b/ui/ui-enterprise/pages/runs.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/runs";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/runs";

--- a/ui/ui-enterprise/pages/settings/[tab].tsx
+++ b/ui/ui-enterprise/pages/settings/[tab].tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/settings/[tab]";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/settings/[tab]";

--- a/ui/ui-enterprise/pages/team/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/team/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/team/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/team/[id]/edit";

--- a/ui/ui-enterprise/pages/team/[id]/members.tsx
+++ b/ui/ui-enterprise/pages/team/[id]/members.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/team/[id]/members";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/team/[id]/members";

--- a/ui/ui-enterprise/pages/team/[id]/teamMember/new.tsx
+++ b/ui/ui-enterprise/pages/team/[id]/teamMember/new.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/team/[id]/teamMember/new";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/team/[id]/teamMember/new";

--- a/ui/ui-enterprise/pages/team/initialize.tsx
+++ b/ui/ui-enterprise/pages/team/initialize.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/team/initialize";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/team/initialize";

--- a/ui/ui-enterprise/pages/teamMember/[id]/edit.tsx
+++ b/ui/ui-enterprise/pages/teamMember/[id]/edit.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/teamMember/[id]/edit";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/teamMember/[id]/edit";

--- a/ui/ui-enterprise/pages/teamMember/new.tsx
+++ b/ui/ui-enterprise/pages/teamMember/new.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/teamMember/new";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/teamMember/new";

--- a/ui/ui-enterprise/pages/teams.tsx
+++ b/ui/ui-enterprise/pages/teams.tsx
@@ -1,1 +1,4 @@
-export { default } from "@grouparoo/ui-components/pages/teams";
+export {
+  default,
+  getServerSideProps,
+} from "@grouparoo/ui-components/pages/teams";


### PR DESCRIPTION
## Change description

This updates all UI pages to use `getServerSideProps` over `getInitialProps` as it's the newest recommended way to use Next: https://nextjs.org/docs/api-reference/data-fetching/get-initial-props

```ts
// Before:

export default function Page (props) {
  return { ... }
}

Page.getInitialProps = (ctx: NextPageContext) => {
}


// Now:

export const getServerSideProps = withServerErrorHandler((ctx) => {
  return { props: { ... } }
})

const Page: NextPageWithInferredProps<typeof getServerSideProps> = (props) => {
  // Now all the props are typed
}

export default Page
```

The only caveat is that you have to ensure that `getServerSideProps` is exported on the apps that consume `ui-components`:

```ts
// Before:
import { default } from '@ui-components/pages/example'

// Now:
import { default, getServerSideProps } from '@ui-components/pages/example'
```

The only exceptions are `_app.tsx` and `_error.tsx`. These still use `getInitialProps` because `getServerSideProps` is not supported as of now:
https://nextjs.org/docs/advanced-features/custom-app#caveats
https://nextjs.org/docs/advanced-features/custom-error-page#caveats

It also ensures that all the props coming from getServerSideProps are typed.

Also fixes a few typing issues along the way as the files were being migrated, most notably the `groups/rules.tsx` page.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
