### PR TITLE
fix: `incremental` default on sources depends on plugin support

### DIFF
--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -105,7 +105,6 @@ export class Schedule extends CommonModel<Schedule> {
   locked: string;
 
   @AllowNull(false)
-  @Default(true)
   @Column
   incremental: boolean;
 
@@ -353,6 +352,16 @@ export class Schedule extends CommonModel<Schedule> {
     if (!instance.name) {
       const source = await Source.findById(instance.sourceId);
       instance.name = `${source.name} schedule`;
+    }
+  }
+
+  @BeforeValidate
+  static async ensureSetIncremental(instance: Schedule) {
+    if (typeof instance.incremental === "undefined") {
+      const { pluginConnection } = await instance.getPlugin();
+      instance.incremental = Boolean(
+        pluginConnection.supportIncrementalSchedule
+      );
     }
   }
 

--- a/core/src/models/Schedule.ts
+++ b/core/src/models/Schedule.ts
@@ -357,7 +357,7 @@ export class Schedule extends CommonModel<Schedule> {
 
   @BeforeValidate
   static async ensureSetIncremental(instance: Schedule) {
-    if (typeof instance.incremental === "undefined") {
+    if (instance.isNewRecord && typeof instance.incremental === "undefined") {
       const { pluginConnection } = await instance.getPlugin();
       instance.incremental = Boolean(
         pluginConnection.supportIncrementalSchedule


### PR DESCRIPTION
## Change description

Trying to create a schedule for a source that does not support incremental schedules was erroring on the UI:

![image](https://user-images.githubusercontent.com/4368928/153501063-6603ad74-0a1c-40bb-8877-51af2e8eeaf4.png)

This was because it was being set to `true` by default, but this should depend on plugin support.

Added this as part of the model since it affected the UI actions as well as loading older config files that didn't have `incremental` on them.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
