### PR TITLE
Cache Models and Destinations

### DIFF
--- a/core/__tests__/models/destination/modelCache.ts
+++ b/core/__tests__/models/destination/modelCache.ts
@@ -1,0 +1,152 @@
+import { helper } from "@grouparoo/spec-helper";
+import { Destination } from "../../../src";
+import { DestinationsCache } from "../../../src/modules/caches/destinationsCache";
+
+describe("models/destinationsCache", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
+  beforeEach(() => (DestinationsCache.TTL = 30 * 1000));
+  afterAll(() => (DestinationsCache.expires = 0));
+
+  beforeAll(async () => {
+    await helper.factories.properties();
+    const deletedDestination = await helper.factories.destination();
+    await deletedDestination.update({ state: "deleted" });
+  });
+
+  describe("#findAllWithCache", () => {
+    test("it returns all the instances", async () => {
+      const instances = await DestinationsCache.findAllWithCache();
+      expect(instances.length).toBe(1);
+    });
+
+    test("it can filter to state", async () => {
+      const destination = await helper.factories.destination();
+      expect(destination.state).toBe("ready");
+
+      const instances = await DestinationsCache.findAllWithCache(
+        undefined,
+        "ready"
+      );
+
+      expect(instances.length).toBe(1);
+      expect(instances[0].id).toBe(destination.id);
+
+      await destination.destroy();
+    });
+
+    describe("rpc", () => {
+      let destination: Destination;
+
+      async function makeDestination() {
+        destination = await helper.factories.destination();
+        await helper.sleep(100); // wait for delayed RPC calls
+      }
+
+      afterEach(async () => {
+        await destination.destroy().catch(() => null);
+      });
+
+      test("creating a destination signals RPC", async () => {
+        DestinationsCache.expires = new Date().getTime();
+        await makeDestination();
+        await helper.sleep(10);
+        expect(DestinationsCache.expires).toBe(0);
+      });
+
+      test("updating a destination signals RPC", async () => {
+        await makeDestination();
+        DestinationsCache.expires = new Date().getTime();
+        await destination.update({ name: "new name" });
+        await helper.sleep(10);
+        expect(DestinationsCache.expires).toBe(0);
+      });
+
+      test("calling setOptions signals RPC", async () => {
+        await makeDestination();
+        DestinationsCache.expires = new Date().getTime();
+        await destination.setOptions({ table: "foo" });
+        await helper.sleep(10);
+        expect(DestinationsCache.expires).toBe(0);
+      });
+
+      test("calling setMapping signals RPC", async () => {
+        await makeDestination();
+        DestinationsCache.expires = new Date().getTime();
+        await destination.setMapping({ "primary-id": "userId" });
+        await helper.sleep(10);
+        expect(DestinationsCache.expires).toBe(0);
+      });
+
+      test("destroying a destination signals RPC", async () => {
+        await makeDestination();
+        DestinationsCache.expires = new Date().getTime();
+        await destination.destroy();
+        await helper.sleep(10);
+        expect(DestinationsCache.expires).toBe(0);
+      });
+    });
+  });
+
+  describe("#findOneWithCache", () => {
+    let destination: Destination;
+
+    beforeAll(async () => {
+      destination = await helper.factories.destination();
+      await destination.update({ name: "NEW NAME" });
+      expect(DestinationsCache.expires).toEqual(0);
+    });
+
+    test("after a destination is updated, the local cache should be invalid", async () => {
+      DestinationsCache.expires = new Date().getTime() + 1000 * 30;
+      await destination.update({ key: "LAST NAME" });
+      expect(DestinationsCache.expires).toEqual(0);
+    });
+
+    test("it will find by id by default", async () => {
+      const found = await DestinationsCache.findOneWithCache(destination.id);
+      expect(found.id).toBe(destination.id);
+      expect(found.name).toBe("NEW NAME");
+    });
+
+    test("it will avoid using SQL when a cached destination exists", async () => {
+      const cachedDestination = DestinationsCache.instances.find(
+        (s) => s.id === destination.id
+      );
+      (cachedDestination as any).__isCached = true;
+      const found = await DestinationsCache.findOneWithCache(
+        cachedDestination.id
+      );
+      expect((found as any).__isCached).toBe(true);
+      expect(found.id).toBe(destination.id);
+      expect(found.name).toBe("NEW NAME");
+      expect(DestinationsCache.expires).toBeGreaterThan(0);
+    });
+
+    test("it can find by other keys", async () => {
+      const found = await DestinationsCache.findOneWithCache(
+        "NEW NAME",
+        undefined,
+        undefined,
+        "name"
+      );
+      expect(found.id).toBe(destination.id);
+      expect(found.name).toBe("NEW NAME");
+    });
+
+    test("a cache miss with a secondary find will invalidate the cache", async () => {
+      DestinationsCache.instances = [await helper.factories.destination()];
+      DestinationsCache.expires = new Date().getTime() + 1000 * 30;
+      const found = await DestinationsCache.findOneWithCache(destination.id);
+      expect(found.id).toEqual(destination.id);
+      expect(DestinationsCache.expires).toBe(0);
+    });
+
+    test("a cache miss without a secondary find will not invalidate the cache", async () => {
+      DestinationsCache.expires = new Date().getTime() + 1000 * 30;
+      const found = await DestinationsCache.findOneWithCache("missing");
+      expect(found).toBeNull();
+      expect(DestinationsCache.expires).not.toBe(0);
+    });
+  });
+});

--- a/core/__tests__/models/model/grouparooModel.ts
+++ b/core/__tests__/models/model/grouparooModel.ts
@@ -1,5 +1,5 @@
 import { helper } from "@grouparoo/spec-helper";
-import { GrouparooModel } from "../../src";
+import { GrouparooModel } from "../../../src";
 
 describe("models/grouparooModel", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });

--- a/core/__tests__/models/model/modelCache.ts
+++ b/core/__tests__/models/model/modelCache.ts
@@ -1,0 +1,129 @@
+import { helper } from "@grouparoo/spec-helper";
+import { GrouparooModel } from "../../../src";
+import { ModelsCache } from "../../../src/modules/caches/modelsCache";
+
+describe("models/modelsCache", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
+
+  beforeEach(() => (ModelsCache.TTL = 30 * 1000));
+  afterAll(() => (ModelsCache.expires = 0));
+
+  beforeAll(async () => {
+    const deletedModel = await helper.factories.model();
+    await deletedModel.update({ state: "deleted" });
+  });
+
+  describe("#findAllWithCache", () => {
+    test("it returns all the instances", async () => {
+      const instances = await ModelsCache.findAllWithCache();
+      expect(instances.length).toBe(1);
+    });
+
+    test("it can filter to state", async () => {
+      const newModel = await helper.factories.model({ name: "foo" });
+      await newModel.update({ state: "ready" }, { hooks: false });
+
+      const instances = await ModelsCache.findAllWithCache(undefined, "ready");
+
+      expect(instances.length).toBe(1);
+      expect(instances[0].id).toBe(newModel.id);
+
+      await newModel.destroy();
+    });
+
+    describe("rpc", () => {
+      let model: GrouparooModel;
+
+      async function makeModel() {
+        model = await helper.factories.model({ name: "foo" });
+        await helper.sleep(100); // wait for delayed RPC calls
+      }
+
+      afterEach(async () => {
+        await model.destroy().catch(() => null);
+      });
+
+      test("creating a model signals RPC", async () => {
+        ModelsCache.expires = new Date().getTime();
+        await makeModel();
+        await helper.sleep(10);
+        expect(ModelsCache.expires).toBe(0);
+      });
+
+      test("updating a model signals RPC", async () => {
+        await makeModel();
+        ModelsCache.expires = new Date().getTime();
+        await model.update({ name: "new name" });
+        await helper.sleep(10);
+        expect(ModelsCache.expires).toBe(0);
+      });
+
+      test("destroying a model signals RPC", async () => {
+        await makeModel();
+        ModelsCache.expires = new Date().getTime();
+        await model.destroy();
+        await helper.sleep(10);
+        expect(ModelsCache.expires).toBe(0);
+      });
+    });
+  });
+
+  describe("#findOneWithCache", () => {
+    let model: GrouparooModel;
+
+    beforeAll(async () => {
+      model = await helper.factories.model({ name: "food" });
+      expect(ModelsCache.expires).toEqual(0);
+    });
+
+    test("after an model is updated, the local cache should be invalid", async () => {
+      ModelsCache.expires = new Date().getTime() + 1000 * 30;
+      await model.update({ name: "NEW NAME" });
+      expect(ModelsCache.expires).toEqual(0);
+    });
+
+    test("it will find by id by default", async () => {
+      const found = await ModelsCache.findOneWithCache(model.id);
+      expect(found.id).toBe(model.id);
+      expect(found.name).toBe("NEW NAME");
+    });
+
+    test("it will avoid using SQL when a cached model exists", async () => {
+      const cachedModel = ModelsCache.instances.find((a) => a.id === model.id);
+      (cachedModel as any).__isCached = true;
+      const found = await ModelsCache.findOneWithCache(model.id);
+      expect((cachedModel as any).__isCached).toBe(true);
+      expect(found.id).toBe(model.id);
+      expect(found.name).toBe("NEW NAME");
+      expect(ModelsCache.expires).toBeGreaterThan(0);
+    });
+
+    test("it can find by other keys", async () => {
+      const found = await ModelsCache.findOneWithCache(
+        "NEW NAME",
+        undefined,
+        undefined,
+        "name"
+      );
+      expect(found.id).toBe(model.id);
+      expect(found.name).toBe("NEW NAME");
+    });
+
+    test("a cache miss with a secondary find will invalidate the cache", async () => {
+      ModelsCache.instances = [
+        await helper.factories.model({ name: "other model" }),
+      ];
+      ModelsCache.expires = new Date().getTime() + 1000 * 30;
+      const found = await ModelsCache.findOneWithCache(model.id);
+      expect(found.id).toEqual(model.id);
+      expect(ModelsCache.expires).toBe(0);
+    });
+
+    test("a cache miss without a secondary find will not invalidate the cache", async () => {
+      ModelsCache.expires = new Date().getTime() + 1000 * 30;
+      const found = await ModelsCache.findOneWithCache("missing");
+      expect(found).toBeNull();
+      expect(ModelsCache.expires).not.toBe(0);
+    });
+  });
+});

--- a/core/src/initializers/rpc.ts
+++ b/core/src/initializers/rpc.ts
@@ -3,13 +3,17 @@ import { App } from "../models/App";
 import { AppsCache } from "../modules/caches/appsCache";
 import { SourcesCache } from "../modules/caches/sourcesCache";
 import { PropertiesCache } from "../modules/caches/propertiesCache";
+import { DestinationsCache } from "../modules/caches/destinationsCache";
+import { ModelsCache } from "../modules/caches/modelsCache";
 
 declare module "actionhero" {
   export interface Api {
     rpc: {
+      model: Record<string, (arg: any) => void | Promise<void>>;
       app: Record<string, (arg: any) => void | Promise<void>>;
       source: Record<string, (arg: any) => void | Promise<void>>;
       property: Record<string, (arg: any) => void | Promise<void>>;
+      destination: Record<string, (arg: any) => void | Promise<void>>;
     };
   }
 }
@@ -27,9 +31,11 @@ export class GrouparooRPC extends Initializer {
      * Here is where we list methods which will be invoked by `api.doCluster`
      */
     api.rpc = {
+      model: {},
       app: {},
       source: {},
       property: {},
+      destination: {},
     };
 
     /**
@@ -51,8 +57,10 @@ export class GrouparooRPC extends Initializer {
     /**
      * Clear the caches
      */
+    api.rpc.model.invalidateCache = () => ModelsCache.invalidate();
     api.rpc.app.invalidateCache = () => AppsCache.invalidate();
     api.rpc.source.invalidateCache = () => SourcesCache.invalidate();
     api.rpc.property.invalidateCache = () => PropertiesCache.invalidate();
+    api.rpc.destination.invalidateCache = () => DestinationsCache.invalidate();
   }
 }

--- a/core/src/models/App.ts
+++ b/core/src/models/App.ts
@@ -117,7 +117,7 @@ export class App extends CommonModel<App> {
   }
 
   async afterSetOptions(hasChanges: boolean) {
-    if (hasChanges) AppsCache.invalidate();
+    if (hasChanges) await App.invalidateCache();
     if (hasChanges && this.state !== "draft" && !this.isNewRecord) {
       await redis.doCluster(
         "api.rpc.app.disconnect",

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -202,7 +202,7 @@ export class Property extends CommonModel<Property> {
 
   async afterSetOptions(hasChanges: boolean) {
     if (hasChanges) {
-      PropertiesCache.invalidate();
+      await Property.invalidateCache();
       await PropertyOps.enqueueRuns(this);
     }
   }
@@ -236,7 +236,7 @@ export class Property extends CommonModel<Property> {
 
   async afterSetFilters(hasChanges: boolean) {
     if (hasChanges) {
-      PropertiesCache.invalidate();
+      await Property.invalidateCache();
       return PropertyOps.enqueueRuns(this);
     }
   }

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -150,7 +150,7 @@ export class Source extends CommonModel<Source> {
   }
 
   async afterSetOptions(hasChanges: boolean) {
-    if (hasChanges) SourcesCache.invalidate();
+    if (hasChanges) await Source.invalidateCache();
   }
 
   async validateOptions(options?: SimpleSourceOptions) {
@@ -186,8 +186,8 @@ export class Source extends CommonModel<Source> {
   }
 
   async afterSetMapping() {
-    SourcesCache.invalidate();
     await Source.determinePrimaryKeyProperty(this);
+    await Source.invalidateCache();
   }
 
   async validateMapping() {

--- a/core/src/modules/caches/destinationsCache.ts
+++ b/core/src/modules/caches/destinationsCache.ts
@@ -1,0 +1,62 @@
+import { ModelCache } from "../modelCache";
+import { Destination } from "../../models/Destination";
+import { Option } from "../../models/Option";
+import { Mapping } from "../../models/Mapping";
+import { WhereAttributeHash } from "sequelize";
+
+async function findAllWithCache(
+  this: ModelCache<Destination>,
+  modelId?: string,
+  state?: Destination["state"]
+) {
+  const now = new Date().getTime();
+  if (this.expires > now && this.instances.length > 0) {
+    return modelId
+      ? this.instances.filter(
+          (s) => s?.modelId === modelId && (!state || s.state === state)
+        )
+      : this.instances.filter((s) => !state || s.state === state);
+  } else {
+    this.instances = await Destination.unscoped().findAll({
+      include: this.include(),
+    });
+    this.expires = now + this.TTL;
+    return modelId
+      ? this.instances.filter(
+          (s) => s?.modelId === modelId && (!state || s.state === state)
+        )
+      : this.instances.filter((s) => !state || s.state === state);
+  }
+}
+
+async function findOneWithCache(
+  this: ModelCache<Destination>,
+  value: string,
+  modelId?: string,
+  state?: Destination["state"],
+  lookupKey: keyof Destination = "id"
+) {
+  const instances = await this.findAllWithCache(modelId);
+  let instance = instances.find((i) => i[lookupKey] === value);
+
+  if (!instance) {
+    const where: WhereAttributeHash = { [lookupKey]: value };
+    if (state) where.state = state;
+    instance = await Destination.unscoped().findOne({
+      where,
+      include: this.include(),
+    });
+    if (instance) this.invalidate();
+  }
+
+  return instance;
+}
+
+export const DestinationsCache = new ModelCache<Destination>(
+  findAllWithCache,
+  findOneWithCache,
+  () => [
+    { model: Option, required: false },
+    { model: Mapping, required: false },
+  ]
+);

--- a/core/src/modules/caches/modelsCache.ts
+++ b/core/src/modules/caches/modelsCache.ts
@@ -1,0 +1,49 @@
+import { ModelCache } from "../modelCache";
+import { GrouparooModel } from "../../models/GrouparooModel";
+import { WhereAttributeHash } from "sequelize";
+
+async function findAllWithCache(
+  this: ModelCache<GrouparooModel>,
+  modelId?: string,
+  state?: GrouparooModel["state"]
+) {
+  const now = new Date().getTime();
+  if (this.expires > now && this.instances.length > 0) {
+    return this.instances.filter((a) => !state || a.state === state);
+  } else {
+    this.instances = await GrouparooModel.unscoped().findAll({
+      include: this.include(),
+    });
+    this.expires = now + this.TTL;
+    return this.instances.filter((a) => !state || a.state === state);
+  }
+}
+
+async function findOneWithCache(
+  this: ModelCache<GrouparooModel>,
+  value: string,
+  modelId?: string,
+  state?: GrouparooModel["state"],
+  lookupKey: keyof GrouparooModel = "id"
+) {
+  const instances = await this.findAllWithCache();
+  let instance = instances.find((i) => i[lookupKey] === value);
+
+  if (!instance) {
+    const where: WhereAttributeHash = { [lookupKey]: value };
+    if (state) where.state = state;
+    instance = await GrouparooModel.unscoped().findOne({
+      where,
+      include: this.include(),
+    });
+    if (instance) this.invalidate();
+  }
+
+  return instance;
+}
+
+export const ModelsCache = new ModelCache<GrouparooModel>(
+  findAllWithCache,
+  findOneWithCache,
+  () => []
+);

--- a/core/src/modules/modelGuard.ts
+++ b/core/src/modules/modelGuard.ts
@@ -1,18 +1,15 @@
-import { GrouparooModel } from "../models/GrouparooModel";
 import { GrouparooRecord } from "../models/GrouparooRecord";
 import { Source } from "../models/Source";
 import { Destination } from "../models/Destination";
 import { Group } from "../models/Group";
+import { ModelsCache } from "./caches/modelsCache";
 
 export namespace ModelGuard {
   export async function check(
     instance: GrouparooRecord | Source | Destination | Group
   ) {
     if (instance.isNewRecord) {
-      // we are creating a new instance
-      const model = await GrouparooModel.scope(null).findOne({
-        where: { id: instance.modelId },
-      });
+      const model = await ModelsCache.findOneWithCache(instance.modelId);
 
       if (!model) {
         throw new Error(`cannot find model with id "${instance.modelId}"`);

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -25,6 +25,7 @@ import { GrouparooModel } from "../../models/GrouparooModel";
 import { CLS } from "../cls";
 import { DestinationOps } from "./destination";
 import { PropertiesCache } from "../caches/propertiesCache";
+import { ModelsCache } from "../caches/modelsCache";
 
 export interface RecordPropertyValue {
   id: RecordProperty["id"];
@@ -835,7 +836,7 @@ export namespace RecordOps {
         if (source instanceof Source) {
           modelId = source.modelId;
         } else {
-          const models = await GrouparooModel.findAll();
+          const models = await ModelsCache.findAllWithCache();
           if (models.length > 1) throw new Error(`indeterminate model`);
           modelId = models[0].id;
         }

--- a/core/src/tasks/grouparooModel/run.ts
+++ b/core/src/tasks/grouparooModel/run.ts
@@ -1,11 +1,11 @@
 import { config, ParamsFrom } from "actionhero";
 import { Run } from "../../models/Run";
-import { GrouparooModel } from "../../models/GrouparooModel";
 import { GrouparooRecord } from "../../models/GrouparooRecord";
 import { RecordProperty } from "../../models/RecordProperty";
 import { CLSTask } from "../../classes/tasks/clsTask";
 import { GroupMember } from "../../models/GroupMember";
 import { GroupOps } from "../../modules/ops/group";
+import { ModelsCache } from "../../modules/caches/modelsCache";
 
 export class RunModel extends CLSTask {
   name = "grouparooModel:run";
@@ -26,9 +26,7 @@ export class RunModel extends CLSTask {
     const offset: number = run.memberOffset || 0;
     const limit: number = run.memberLimit || config.batchSize.imports;
 
-    const model = await GrouparooModel.findOne({
-      where: { id: run.creatorId },
-    });
+    const model = await ModelsCache.findOneWithCache(run.creatorId);
     if (!model) return;
 
     const records = await GrouparooRecord.findAll({


### PR DESCRIPTION
Adding on to the work of https://github.com/grouparoo/grouparoo/pull/2945, we can also cache Models and Destinations internally to speed up various tasks.  This PR also fixes a bug in which our`@AfterSetOptions` (and similar) hooks for cached models were invalidating the local cache, but not broadcasting the invalidate message to other members of the cluster.

This work will then be used in a later PR to batch the `imports:associate` and `record:export` tasks

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
