### PR TITLE
Do not store HighWaterMark for non-incremental Schedules

### DIFF
--- a/core/__tests__/models/schedule.ts
+++ b/core/__tests__/models/schedule.ts
@@ -895,13 +895,13 @@ describe("models/schedule", () => {
       const firstRun = await schedule.enqueueRun();
       await specHelper.runTask("schedule:run", { runId: firstRun.id });
       await firstRun.reload();
-      expect(firstRun.highWaterMark).toEqual({ updated_at: 100 });
+      expect(firstRun.highWaterMark).toEqual({});
       await firstRun.update({ state: "complete", importsCreated: 100 });
 
       const secondRun = await schedule.enqueueRun();
       await specHelper.runTask("schedule:run", { runId: secondRun.id });
       await secondRun.reload();
-      expect(secondRun.highWaterMark).toEqual({ updated_at: 100 }); // starts over
+      expect(secondRun.highWaterMark).toEqual({});
 
       await schedule.destroy();
     });

--- a/core/src/modules/ops/schedule.ts
+++ b/core/src/modules/ops/schedule.ts
@@ -84,7 +84,7 @@ export namespace ScheduleOps {
 
     return {
       importsCount,
-      highWaterMark: nextHighWaterMark,
+      highWaterMark: schedule.incremental ? nextHighWaterMark : {},
       sourceOffset: nextSourceOffset,
     };
   }

--- a/plugins/@grouparoo/app-templates/src/source/table/records.ts
+++ b/plugins/@grouparoo/app-templates/src/source/table/records.ts
@@ -86,7 +86,6 @@ export const getRecords: GetRecordsMethod = ({ getRows }) => {
 
       if (!schedule.incremental) {
         nextSourceOffset = sourceOffset + limit;
-        nextHighWaterMark[highWaterMarkAndSortColumnASC] = newValue;
       } else if (currentValue && newValue === currentValue) {
         nextSourceOffset = sourceOffset + limit;
       } else {


### PR DESCRIPTION
This PR updates the work added in https://github.com/grouparoo/grouparoo/pull/2800 to not store the High Water Marks from non-incremental Schedules.  This makes it so that should you change a Schedule from non-incremental to incremental, the next run will re-import all of your data rather than re-using what was previously imported.   This more closely matches the other behavior of a changing Schedule to start over whenever a setting changes to ensure that Grouparoo has imported all of your data.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
