### PR TITLE
No default values for source mapping 

### DIFF
--- a/ui/ui-components/components/source/FormMappingSelector.tsx
+++ b/ui/ui-components/components/source/FormMappingSelector.tsx
@@ -115,7 +115,7 @@ const FormMappingSelector: React.FC<Props> = ({
             as="select"
             required
             disabled={disabled || !previewColumns.length}
-            defaultValue={columnName || previewColumns?.[0] || ""}
+            defaultValue={""}
             {...register("mapping.sourceColumn")}
           >
             <option value={""} disabled>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -201,8 +201,8 @@ const Page: NextPage<Props> = ({
   }, [preview]);
 
   const mappingColumn = useMemo(
-    () => Object.keys(source.mapping)[0] ?? previewColumns?.[0],
-    [previewColumns, source.mapping]
+    () => Object.keys(source.mapping)[0],
+    [source.mapping]
   );
   const mappingPropertyKey = useMemo(
     () => Object.values(source.mapping)[0],


### PR DESCRIPTION
## Change description

In a previous PR, we removed the defaults for what Grouparoo Property to map to (its `mappingPropertyKey`).  We also don't want to infer or default what the source column is for a mapping (its `sourceColumn`).  

This PR removes part of a hook that updated the `sourceColumn`/`mappingColumn` based on the `sourcePreview` meaning no defaults even when a table is selected:

<img width="1183" alt="Screen Shot 2022-02-14 at 3 10 34 PM" src="https://user-images.githubusercontent.com/63751206/153938832-062e44f6-540f-4c11-96c7-b2e98703f099.png">

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
