### PR TITLE
Catch overview page hydration errors from bad record ids

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/overview.tsx
@@ -14,7 +14,6 @@ import ModelOverviewSecondarySources from "../../../components/model/overview/Mo
 import PageHeader from "../../../components/PageHeader";
 import ModelTabs from "../../../components/tabs/Model";
 import { useGrouparooModel } from "../../../contexts/grouparooModel";
-import { errorHandler, successHandler } from "../../../eventHandlers";
 import { Actions, Models } from "../../../utils/apiData";
 import { grouparooUiEdition } from "../../../utils/uiEdition";
 import { withServerErrorHandler } from "../../../utils/withServerErrorHandler";

--- a/ui/ui-components/pages/model/[modelId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/overview.tsx
@@ -14,6 +14,7 @@ import ModelOverviewSecondarySources from "../../../components/model/overview/Mo
 import PageHeader from "../../../components/PageHeader";
 import ModelTabs from "../../../components/tabs/Model";
 import { useGrouparooModel } from "../../../contexts/grouparooModel";
+import { errorHandler, successHandler } from "../../../eventHandlers";
 import { Actions, Models } from "../../../utils/apiData";
 import { grouparooUiEdition } from "../../../utils/uiEdition";
 import { withServerErrorHandler } from "../../../utils/withServerErrorHandler";
@@ -171,12 +172,15 @@ export const getServerSideProps: GetServerSideProps<Props> =
       `sampleRecord:${grouparooUiEdition()}`
     )?.[modelId as string];
 
-    const sampleRecord = sampleRecordId
-      ? await client.request<Actions.RecordView>(
-          "get",
-          `/record/${sampleRecordId}`
-        )
-      : null;
+    let sampleRecord: Actions.RecordView = null;
+    try {
+      sampleRecord = sampleRecordId
+        ? await client.request<Actions.RecordView>(
+            "get",
+            `/record/${sampleRecordId}`
+          )
+        : null;
+    } catch (err) {}
 
     return {
       props: {

--- a/ui/ui-components/pages/model/[modelId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/overview.tsx
@@ -179,7 +179,12 @@ export const getServerSideProps: GetServerSideProps<Props> =
             `/record/${sampleRecordId}`
           )
         : null;
-    } catch (err) {console.log("user had cached sample record id (not found):", sampleRecordId)}
+    } catch (err) {
+      console.log(
+        "user had cached sample record id (not found):",
+        sampleRecordId
+      );
+    }
 
     return {
       props: {

--- a/ui/ui-components/pages/model/[modelId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/overview.tsx
@@ -179,7 +179,7 @@ export const getServerSideProps: GetServerSideProps<Props> =
             `/record/${sampleRecordId}`
           )
         : null;
-    } catch (err) {}
+    } catch (err) {console.log("user had cached sample record id (not found):", sampleRecordId)}
 
     return {
       props: {


### PR DESCRIPTION
## Change description

Changes to the serverside rending of the sample record (introduced in #2941 ) will cause the model overview page to fail when the user has an invalid record id in their browser cookies.

<img width="1080" alt="Screen Shot 2022-02-15 at 3 15 52 PM" src="https://user-images.githubusercontent.com/6589528/154326003-f22086b2-c39e-4262-a64d-8e3e737ba9b7.png">

This change will swallow the error, allowing the page to hydrate and render properly. Instead users will get a toast notification the record was not found on first page load, and front end logic will find a new sample record to display.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact


- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
