### PR TITLE
Spechelper Test Server Error Handling Improvements

### DIFF
--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -256,8 +256,6 @@ export namespace helper {
       }
 
       await new Promise((resolve, reject) => {
-        let resolved = false;
-
         serverProcess = spawn("./bin/start", [], {
           cwd: corePath,
           env: {
@@ -273,12 +271,12 @@ export namespace helper {
         });
 
         serverProcess.stdout.on("data", (data) => {
-          if (!resolved && String(data).includes("Error from Initializer")) {
+          if (String(data).includes("Error from Initializer")) {
             return reject(new Error(data));
           }
 
-          if (!resolved && String(data).match(/@grouparoo\/core Started/)) {
-            resolve(null);
+          if (String(data).match(/@grouparoo\/core Started/)) {
+            return resolve(null);
           }
         });
 

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -53,6 +53,7 @@ import {
   AggregationMethod,
   GrouparooRunMode,
 } from "@grouparoo/core";
+import { rejects } from "assert";
 
 const {
   // modules
@@ -255,8 +256,9 @@ export namespace helper {
         }
       }
 
-      await new Promise((resolve) => {
+      await new Promise((resolve, reject) => {
         let resolved = false;
+
         serverProcess = spawn("./bin/start", [], {
           cwd: corePath,
           env: {
@@ -272,7 +274,10 @@ export namespace helper {
         });
 
         serverProcess.stdout.on("data", (data) => {
-          // console.log(String(data));
+          if (!resolved && String(data).includes("Error from Initializer")) {
+            return reject(new Error(data));
+          }
+
           if (!resolved && String(data).match(/@grouparoo\/core Started/)) {
             resolve(null);
           }

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -53,7 +53,6 @@ import {
   AggregationMethod,
   GrouparooRunMode,
 } from "@grouparoo/core";
-import { rejects } from "assert";
 
 const {
   // modules


### PR DESCRIPTION
## Change description

Found when pairing with @evantahler: When starting a server in detached mode (how front end tests are run), server errors did not previously surface.

Now, these errors are surfaced and will show up in the `jest` error reporting when the server cannot start.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
