### PR TITLE
array properties can be mapped through non-unique properties

### DIFF
--- a/core/__tests__/models/property/property.ts
+++ b/core/__tests__/models/property/property.ts
@@ -980,15 +980,6 @@ describe("models/property", () => {
           /Unique Property .+ cannot be mapped through a non-unique Property/
         );
       });
-
-      test("properties mapped through non-unique properties cannot be arrays", async () => {
-        await secondarySource.setMapping({ last_name: "lastName" });
-        await expect(
-          secondaryProperty.update({ isArray: true })
-        ).rejects.toThrow(
-          /Array Property .+ cannot be mapped through a non-unique Property/
-        );
-      });
     });
 
     describe("filters", () => {

--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -1363,6 +1363,35 @@ describe("models/source", () => {
         });
       });
 
+      test("it will apply array properties to all records in the batch", async () => {
+        await propertyA.update({ isArray: true, unique: false });
+
+        const records = [mario, luigi];
+        const properties = [propertyA, propertyB];
+        const response = {
+          [mario.id]: {
+            [propertyA.id]: ["hola", "saludos"],
+            [propertyB.id]: ["bonjour"],
+          },
+        };
+        await SourceOps.applyNonUniqueMappedResultsToAllRecords(response, {
+          records,
+          properties,
+          sourceMapping,
+        });
+
+        expect(response).toEqual({
+          [mario.id]: {
+            wordInSpanish: ["hola", "saludos"],
+            wordInFrench: ["bonjour"],
+          },
+          [luigi.id]: {
+            wordInSpanish: ["hola", "saludos"],
+            wordInFrench: ["bonjour"],
+          },
+        });
+      });
+
       test("it returns undefined when the source does not have a record for the property", async () => {
         await luigi.addOrUpdateProperties({ lastName: ["x"] }); // change the value of the property that is mapped
 

--- a/core/src/models/Property.ts
+++ b/core/src/models/Property.ts
@@ -432,11 +432,6 @@ export class Property extends CommonModel<Property> {
       throw new Error(
         `Unique Property ${instance.key} (${instance.id}) cannot be mapped through a non-unique Property - ${mappedProperty.key} (${mappedProperty.id})`
       );
-
-    if (instance.isArray)
-      throw new Error(
-        `Array Property ${instance.key} (${instance.id}) cannot be mapped through a non-unique Property - ${mappedProperty.key} (${mappedProperty.id})`
-      );
   }
 
   @BeforeSave


### PR DESCRIPTION
## Change description

In #2119 we introduced non-unique mappings, and added a restriction on being able to map array properties through non-unique mappings. After looking into this more, it seems there's no reason why we can't map array properties. If plugins return values per record ID for array properties then they will be set normally, and if not then `applyNonUniqueMappedResultsToAllRecords` will take care of fanning it out to all other records.

One thing I did notice, which may have led to the restriction in the first place is that there are some assumptions in the `applyNonUniqueMappedResultsToAllRecords` for the *mapping*, grabbing the first value, which would not work if the *mapping* was an array property. I believe this may have been the intention of the existing validation. However, there's already validations and tests that ensure that a source cannot map to an array property:

https://github.com/grouparoo/grouparoo/blob/d13529835b1e56c284b39bc37209749f531ff6a1/core/src/modules/ops/source.ts#L312-L320

(note the `values[0]`)

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
