### PR TITLE
fix mapping to non-unique properties in the UI, hide array properties

### DIFF
--- a/ui/ui-components/components/source/FormMappingSelector.tsx
+++ b/ui/ui-components/components/source/FormMappingSelector.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { Col, Form, Row } from "react-bootstrap";
 import { UseFormRegister, UseFormWatch } from "react-hook-form";
 import FormInputContainer from "../lib/form/FormInputContainer";
-import { Actions, Models } from "../../utils/apiData";
+import { Models } from "../../utils/apiData";
 import { FormData } from "../../pages/model/[modelId]/source/[sourceId]/edit";
 
 const renderExamples = (exampleText?: string) => (
@@ -84,17 +84,19 @@ const FormMappingSelector: React.FC<Props> = ({
     // Properties rules:
     // Include unique properties in own source if it has the primary key or the primary key has not been defined
     // Otherwise, it's not the primary source and show all properties from other sources
-    return properties.filter((property) =>
-      isPrimaryKeyInSource || !hasPrimaryKeyProperty
-        ? property.sourceId === source.id && property.unique
-        : property.sourceId !== source.id
+    return properties.filter(
+      (property) =>
+        !property.isArray &&
+        (isPrimaryKeyInSource || !hasPrimaryKeyProperty
+          ? property.sourceId === source.id && property.unique
+          : property.sourceId !== source.id)
     );
   }, [source, properties, hasPrimaryKeyProperty]);
 
   const propertyExample = useMemo<string>(
     () =>
       selectedProperty
-        ? propertyExamples[selectedProperty.id].slice(0, 3).join(", ")
+        ? propertyExamples[selectedProperty.id]?.slice(0, 3).join(", ")
         : undefined,
     [propertyExamples, selectedProperty]
   );

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -401,7 +401,6 @@ const Page: NextPage<Props> = ({
 
       const { properties, examples } =
         await client.request<Actions.PropertiesList>("get", `/properties`, {
-          unique: true,
           includeExamples: true,
           state: "ready",
           modelId: source?.modelId,


### PR DESCRIPTION
## Change description

The page was crashing after saving if you were mapping a secondary source through a non-unique property. This was because the `PropertiesList` call that happened after save was only including unique properties.

Also updated it to hide array properties in the select list, since those can't be mapped to and will error anyway if you try to do it.

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
