### PR TITLE
Fix flaky `modelCache` tests

### DIFF
--- a/core/__tests__/models/app/modelCache.ts
+++ b/core/__tests__/models/app/modelCache.ts
@@ -102,6 +102,7 @@ describe("models/appsCache", () => {
     test("after an app is updated, the local cache should be invalid", async () => {
       AppsCache.expires = new Date().getTime() + 1000 * 30;
       await app.update({ name: "NEW NAME" });
+      await helper.sleep(10);
       expect(AppsCache.expires).toEqual(0);
     });
 
@@ -136,6 +137,7 @@ describe("models/appsCache", () => {
       AppsCache.instances = [await helper.factories.app()];
       AppsCache.expires = new Date().getTime() + 1000 * 30;
       const found = await AppsCache.findOneWithCache(app.id);
+      await helper.sleep(10);
       expect(found.id).toEqual(app.id);
       expect(AppsCache.expires).toBe(0);
     });
@@ -143,6 +145,7 @@ describe("models/appsCache", () => {
     test("a cache miss without a secondary find will not invalidate the cache", async () => {
       AppsCache.expires = new Date().getTime() + 1000 * 30;
       const found = await AppsCache.findOneWithCache("missing");
+      await helper.sleep(10);
       expect(found).toBeNull();
       expect(AppsCache.expires).not.toBe(0);
     });

--- a/core/__tests__/models/destination/modelCache.ts
+++ b/core/__tests__/models/destination/modelCache.ts
@@ -112,7 +112,8 @@ describe("models/destinationsCache", () => {
 
     test("after a destination is updated, the local cache should be invalid", async () => {
       DestinationsCache.expires = new Date().getTime() + 1000 * 30;
-      await destination.update({ key: "LAST NAME" });
+      await destination.update({ name: "NEW NAME" });
+      await helper.sleep(10);
       expect(DestinationsCache.expires).toEqual(0);
     });
 
@@ -151,6 +152,7 @@ describe("models/destinationsCache", () => {
       DestinationsCache.instances = [await helper.factories.destination()];
       DestinationsCache.expires = new Date().getTime() + 1000 * 30;
       const found = await DestinationsCache.findOneWithCache(destination.id);
+      await helper.sleep(10);
       expect(found.id).toEqual(destination.id);
       expect(DestinationsCache.expires).toBe(0);
     });
@@ -158,6 +160,7 @@ describe("models/destinationsCache", () => {
     test("a cache miss without a secondary find will not invalidate the cache", async () => {
       DestinationsCache.expires = new Date().getTime() + 1000 * 30;
       const found = await DestinationsCache.findOneWithCache("missing");
+      await helper.sleep(10);
       expect(found).toBeNull();
       expect(DestinationsCache.expires).not.toBe(0);
     });

--- a/core/__tests__/models/model/modelCache.ts
+++ b/core/__tests__/models/model/modelCache.ts
@@ -92,6 +92,7 @@ describe("models/modelsCache", () => {
     test("after an model is updated, the local cache should be invalid", async () => {
       ModelsCache.expires = new Date().getTime() + 1000 * 30;
       await model.update({ name: "NEW NAME" });
+      await helper.sleep(10);
       expect(ModelsCache.expires).toEqual(0);
     });
 
@@ -128,6 +129,7 @@ describe("models/modelsCache", () => {
       ];
       ModelsCache.expires = new Date().getTime() + 1000 * 30;
       const found = await ModelsCache.findOneWithCache(model.id);
+      await helper.sleep(10);
       expect(found.id).toEqual(model.id);
       expect(ModelsCache.expires).toBe(0);
     });
@@ -135,6 +137,7 @@ describe("models/modelsCache", () => {
     test("a cache miss without a secondary find will not invalidate the cache", async () => {
       ModelsCache.expires = new Date().getTime() + 1000 * 30;
       const found = await ModelsCache.findOneWithCache("missing");
+      await helper.sleep(10);
       expect(found).toBeNull();
       expect(ModelsCache.expires).not.toBe(0);
     });

--- a/core/__tests__/models/property/modelCache.ts
+++ b/core/__tests__/models/property/modelCache.ts
@@ -134,6 +134,7 @@ describe("models/propertiesCache", () => {
         where: { key: "lastName" },
       });
       await lastNameProperty.update({ key: "LAST NAME" });
+      await helper.sleep(10);
       expect(PropertiesCache.expires).toEqual(0);
     });
 
@@ -182,6 +183,7 @@ describe("models/propertiesCache", () => {
       const found = await PropertiesCache.findOneWithCache(
         firstNameProperty.id
       );
+      await helper.sleep(10);
       expect(found.id).toEqual(firstNameProperty.id);
       expect(PropertiesCache.expires).toBe(0);
     });
@@ -189,6 +191,7 @@ describe("models/propertiesCache", () => {
     test("a cache miss without a secondary find will not invalidate the cache", async () => {
       PropertiesCache.expires = new Date().getTime() + 1000 * 30;
       const found = await PropertiesCache.findOneWithCache("missing");
+      await helper.sleep(10);
       expect(found).toBeNull();
       expect(PropertiesCache.expires).not.toBe(0);
     });

--- a/core/__tests__/models/source/modelCache.ts
+++ b/core/__tests__/models/source/modelCache.ts
@@ -111,6 +111,7 @@ describe("models/sourcesCache", () => {
     test("after a source is updated, the local cache should be invalid", async () => {
       SourcesCache.expires = new Date().getTime() + 1000 * 30;
       await source.update({ key: "LAST NAME" });
+      await helper.sleep(10);
       expect(SourcesCache.expires).toEqual(0);
     });
 
@@ -147,6 +148,7 @@ describe("models/sourcesCache", () => {
       SourcesCache.instances = [await helper.factories.source()];
       SourcesCache.expires = new Date().getTime() + 1000 * 30;
       const found = await SourcesCache.findOneWithCache(source.id);
+      await helper.sleep(10);
       expect(found.id).toEqual(source.id);
       expect(SourcesCache.expires).toBe(0);
     });
@@ -154,6 +156,7 @@ describe("models/sourcesCache", () => {
     test("a cache miss without a secondary find will not invalidate the cache", async () => {
       SourcesCache.expires = new Date().getTime() + 1000 * 30;
       const found = await SourcesCache.findOneWithCache("missing");
+      await helper.sleep(10);
       expect(found).toBeNull();
       expect(SourcesCache.expires).not.toBe(0);
     });


### PR DESCRIPTION
This PR should help the flaky tests around the new `modelCache`s.  We need some sleeps to wait for the RPC methods to run their course. 

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
