### PR TITLE
Can use mapped fields if destination field is gone

### DIFF
--- a/ui/ui-components/__tests__/pages/model/[modelId]/destination/[destinationId]/__snapshots__/data.tsx.snap
+++ b/ui/ui-components/__tests__/pages/model/[modelId]/destination/[destinationId]/__snapshots__/data.tsx.snap
@@ -1,25 +1,160 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`model destination data page should render 1`] = `
-<Context.Provider
-  value={
-    Object {
-      "client": Client {
-        "cache": ClientCache {
-          "cache": Object {},
-          "ttl": 5000,
-        },
-        "getRequestContext": [Function],
-      },
-    }
-  }
->
-  <Page
-    props={
-      Object {
-        "hydrationError": "Cannot destructure property 'destinationId' of 'ctx.query' as it is undefined.",
-      }
-    }
-  />
-</Context.Provider>
+<div>
+  <div
+    class="mb-3 media"
+  >
+    <div
+      style="padding: 10px; text-align: center; height: 100px; width: 100px;"
+    >
+      <br />
+      <span
+        class="badge"
+      >
+        <em>
+          no icon
+        </em>
+      </span>
+    </div>
+    <div
+      class="media-body"
+    >
+      <div>
+        <h1
+          class="mr-3"
+          style="display: inline;"
+        >
+          <em>
+            Draft
+          </em>
+        </h1>
+      </div>
+        
+      <span
+        class="badge badge-primary"
+        style="margin-left: 3px; margin-right: 3px; margin-bottom: 20px;"
+      />
+        
+      <span
+        class="badge badge-primary"
+        style="margin-bottom: 20px;"
+      >
+        <span>
+          <a
+            style="color: white;"
+          />
+        </span>
+      </span>
+      
+    </div>
+  </div>
+  <div
+    class="row"
+  >
+    <div
+      class="mb-4 col"
+    >
+      <form
+        class=""
+        id="form"
+      >
+        <fieldset>
+          <div
+            class="row"
+            id="destinationCollection"
+          >
+            <div
+              class="col"
+            >
+              <h5>
+                Who should be sent to
+                 
+                <span
+                  class="text-primary"
+                />
+                ?
+              </h5>
+              <select
+                class="form-control"
+                required=""
+              >
+                <option
+                  value="__none"
+                >
+                  No Model or Group
+                </option>
+                <option
+                  disabled=""
+                >
+                  --- Models ---
+                </option>
+                <option
+                  value="__model"
+                >
+                  All Records in the  Model
+                </option>
+                <option
+                  disabled=""
+                >
+                  --- Groups ---
+                </option>
+              </select>
+            </div>
+          </div>
+          <br />
+          <div
+            class="row"
+            id="destinationData"
+          >
+            <div
+              class="col"
+            >
+              <h5>
+                What data do you want in
+                 
+                <span
+                  class="text-primary"
+                />
+                ?
+              </h5>
+              <br />
+              <div
+                data-screenshotid="destinationRecords"
+              />
+              <br />
+              <div
+                data-screenshotid="destinationGroups"
+              />
+            </div>
+          </div>
+          <div
+            class="row"
+          >
+            <div
+              class="col"
+            >
+              <br />
+              <hr />
+              <button
+                class="btn btn-primary"
+                style="display: inline-flex; align-items: center; justify-content: center;"
+                type="submit"
+              >
+                <span
+                  style="opacity: 1;"
+                >
+                  Save Destination Data
+                </span>
+              </button>
+            </div>
+          </div>
+        </fieldset>
+      </form>
+    </div>
+    <div
+      class="col-xl-5"
+    />
+  </div>
+</div>
 `;

--- a/ui/ui-components/__tests__/pages/model/[modelId]/destination/[destinationId]/__snapshots__/data.tsx.snap
+++ b/ui/ui-components/__tests__/pages/model/[modelId]/destination/[destinationId]/__snapshots__/data.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`model destination data page should render 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "client": Client {
+        "cache": ClientCache {
+          "cache": Object {},
+          "ttl": 5000,
+        },
+        "getRequestContext": [Function],
+      },
+    }
+  }
+>
+  <Page
+    props={
+      Object {
+        "hydrationError": "Cannot destructure property 'destinationId' of 'ctx.query' as it is undefined.",
+      }
+    }
+  />
+</Context.Provider>
+`;

--- a/ui/ui-components/__tests__/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/__tests__/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -1,0 +1,71 @@
+import { render } from "@testing-library/react";
+import { Client } from "../../../../../../client/client";
+import { ApiContext } from "../../../../../../contexts/api";
+import DataPage, {
+  getServerSideProps,
+} from "../../../../../../pages/model/[modelId]/destination/[destinationId]/data";
+
+const destinationId = "test-destination";
+const modelId = "test-model";
+const groupId = "test-group";
+
+jest.mock("next/router", () => {
+  return {
+    useRouter: () => ({ query: { destinationId } }),
+  };
+});
+
+jest.mock("../../../../../../client/client", () => {
+  const fakeRequest = () =>
+    Promise.resolve({
+      destination: {
+        destinationId,
+        modelId,
+        group: {
+          groupId,
+        },
+        mapping: {},
+        app: {
+          icon: "",
+        },
+      },
+      groups: [],
+      properties: [],
+      options: {
+        properties: {
+          known: [],
+          required: [],
+        },
+      },
+    });
+  class FakeClient {
+    constructor() {
+      return {
+        request: fakeRequest,
+      };
+    }
+  }
+
+  return {
+    Client: FakeClient,
+    generateClient: () => new FakeClient(),
+  };
+});
+
+describe("model destination data page", () => {
+  it("should render", async () => {
+    const props: any = await getServerSideProps({
+      query: {
+        destinationId,
+        modelId,
+      },
+    } as any);
+    expect(
+      render(
+        <ApiContext.Provider value={{ client: new Client() }}>
+          <DataPage {...props.props} />
+        </ApiContext.Provider>
+      ).container
+    ).toMatchSnapshot();
+  }, 10000);
+});

--- a/ui/ui-components/__tests__/pages/model/[modelId]/destination/[destinationId]/data.tsx
+++ b/ui/ui-components/__tests__/pages/model/[modelId]/destination/[destinationId]/data.tsx
@@ -1,9 +1,10 @@
-import { render } from "@testing-library/react";
 import { Client } from "../../../../../../client/client";
 import { ApiContext } from "../../../../../../contexts/api";
+import { GrouparooModelContext } from "../../../../../../contexts/grouparooModel";
 import DataPage, {
   getServerSideProps,
 } from "../../../../../../pages/model/[modelId]/destination/[destinationId]/data";
+import { renderAndWait } from "../../../../../__utils__/renderAndWait";
 
 const destinationId = "test-destination";
 const modelId = "test-model";
@@ -11,9 +12,14 @@ const groupId = "test-group";
 
 jest.mock("next/router", () => {
   return {
-    useRouter: () => ({ query: { destinationId } }),
+    useRouter: () => ({ query: { destinationId }, asPath: "", pathname: "" }),
   };
 });
+
+jest.mock(
+  "../../../../../../components/destination/DestinationSampleRecord",
+  () => () => null
+);
 
 jest.mock("../../../../../../client/client", () => {
   const fakeRequest = () =>
@@ -60,12 +66,14 @@ describe("model destination data page", () => {
         modelId,
       },
     } as any);
-    expect(
-      render(
+
+    const dataPage = await renderAndWait(
+      <GrouparooModelContext.Provider value={{ model: {} }}>
         <ApiContext.Provider value={{ client: new Client() }}>
           <DataPage {...props.props} />
         </ApiContext.Provider>
-      ).container
-    ).toMatchSnapshot();
-  }, 10000);
+      </GrouparooModelContext.Provider>
+    );
+    expect(dataPage.container).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Change description

If a mapped field references a destination field that no longer exists that field would become unusable. Now it is re-mappable, and the old part of the mapping is removed.

I wanted to add in more testing however just getting this up was a pain.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
