### PR TITLE
Add `append`, `create` and rename `enrich`, `additive` to `upsert`, `update` destination sync options

### DIFF
--- a/core/__tests__/actions/destinations.ts
+++ b/core/__tests__/actions/destinations.ts
@@ -304,7 +304,7 @@ describe("actions/destinations", () => {
       connection.params = {
         csrfToken,
         id,
-        syncMode: "enrich",
+        syncMode: "update",
       };
       const { destination, error } =
         await specHelper.runAction<DestinationEdit>(
@@ -312,7 +312,7 @@ describe("actions/destinations", () => {
           connection
         );
       expect(error).toBeFalsy();
-      expect(destination.syncMode).toBe("enrich");
+      expect(destination.syncMode).toBe("update");
       expect(configSpy).toBeCalledTimes(1);
     });
 

--- a/core/__tests__/fixtures/codeConfig/duplicate-names/config1/config.js
+++ b/core/__tests__/fixtures/codeConfig/duplicate-names/config1/config.js
@@ -56,7 +56,7 @@ module.exports = async function getConfig() {
       type: "test-plugin-export",
       appId: "data_warehouse",
       modelId: "mod_profiles",
-      syncMode: "additive",
+      syncMode: "upsert",
       options: {
         table: "test-file-path.db",
       },

--- a/core/__tests__/fixtures/codeConfig/duplicate-names/config2/config.js
+++ b/core/__tests__/fixtures/codeConfig/duplicate-names/config2/config.js
@@ -54,7 +54,7 @@ module.exports = async function getConfig() {
       class: "Destination",
       type: "test-plugin-export",
       appId: "data_warehouse_2",
-      syncMode: "additive",
+      syncMode: "upsert",
       modelId: "mod_profiles",
       options: {
         table: "test-file-path.db",

--- a/core/__tests__/fixtures/codeConfig/error-app-destination-remote/config.js
+++ b/core/__tests__/fixtures/codeConfig/error-app-destination-remote/config.js
@@ -33,7 +33,7 @@ module.exports = async function getConfig() {
       type: "test-plugin-export",
       appId: "data_warehouse", // appId -> `data_warehouse`
       modelId: "mod_profiles",
-      syncMode: "additive",
+      syncMode: "upsert",
       options: {
         table: "someTable",
         _failRemoteValidation: true, // this destination is bad

--- a/core/__tests__/fixtures/codeConfig/initial/config.js
+++ b/core/__tests__/fixtures/codeConfig/initial/config.js
@@ -157,7 +157,7 @@ module.exports = async function getConfig() {
       appId: "data_warehouse", // id -> data_warehouse
       groupId: "email_group", // id -> email_group
       collection: "group",
-      syncMode: "additive",
+      syncMode: "upsert",
       options: {
         table: "output",
       },

--- a/core/__tests__/fixtures/codeConfig/multiple-sources/config.js
+++ b/core/__tests__/fixtures/codeConfig/multiple-sources/config.js
@@ -177,7 +177,7 @@ module.exports = async function getConfig() {
       appId: "data_warehouse", // id -> data_warehouse
       groupId: "email_group", // id -> email_group
       collection: "group",
-      syncMode: "additive",
+      syncMode: "upsert",
       modelId: "mod_profiles",
       options: {
         table: "output",

--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -764,14 +764,14 @@ describe("models/destination", () => {
         const destination = await Destination.create({
           appId: app.id,
           modelId: model.id,
-          type: "test-plugin-export-batch", //has default mode "additive"
+          type: "test-plugin-export-batch", //has default mode "upsert"
         });
 
         await destination.setOptions({ table: "some table" });
         await destination.update({ state: "ready" });
 
         const syncMode = await destination.getSyncMode();
-        expect(syncMode).toBe("additive");
+        expect(syncMode).toBe("upsert");
 
         await destination.destroy();
       });

--- a/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
+++ b/core/__tests__/models/destination/plugins/destinationMappingOptions.ts
@@ -386,7 +386,7 @@ describe("models/destination", () => {
             description: "a test app connection",
             apps: ["test-destinationMapping-app"],
             direction: "export",
-            syncModes: ["sync", "additive", "enrich"],
+            syncModes: ["sync", "upsert", "update"],
             options: [],
             methods: {
               destinationMappingOptions: async () => {

--- a/core/__tests__/models/destination/plugins/exportRecord.ts
+++ b/core/__tests__/models/destination/plugins/exportRecord.ts
@@ -90,7 +90,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
           apps: ["test-template-app"],
           direction: "export",
           options: [],
-          syncModes: ["append", "create", "sync", "enrich", "additive"],
+          syncModes: ["append", "create", "sync", "update", "upsert"],
           methods: {
             destinationMappingOptions: async () => {
               return {
@@ -662,7 +662,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
       await record.destroy();
     });
 
-    test.each(["append", "create", "additive", "enrich"])(
+    test.each(["append", "create", "upsert", "update"])(
       "if record is removed from destination's tracked group in %p syncMode, toDelete is false and groups are cleared",
       async (syncMode) => {
         await destination.update({ syncMode });
@@ -899,8 +899,8 @@ describe("models/destination - with custom exportRecord plugin", () => {
         expect(exportArgs.syncOperations.delete).toBe(true);
       });
 
-      test("Enrich syncMode only allows updating records", async () => {
-        await destination.update({ syncMode: "enrich" });
+      test("Update syncMode only allows updating records", async () => {
+        await destination.update({ syncMode: "update" });
 
         await destination.sendExport(_export, true);
         expect(exportArgs.syncOperations.create).toBe(false);
@@ -910,8 +910,8 @@ describe("models/destination - with custom exportRecord plugin", () => {
         await record.destroy();
       });
 
-      test("Additive syncMode only allows creating and updating records", async () => {
-        await destination.update({ syncMode: "additive" });
+      test("Update syncMode only allows creating and updating records", async () => {
+        await destination.update({ syncMode: "upsert" });
 
         await destination.sendExport(_export, true);
         expect(exportArgs.syncOperations.create).toBe(true);

--- a/core/__tests__/models/destination/plugins/exportRecord.ts
+++ b/core/__tests__/models/destination/plugins/exportRecord.ts
@@ -910,7 +910,7 @@ describe("models/destination - with custom exportRecord plugin", () => {
         await record.destroy();
       });
 
-      test("Update syncMode only allows creating and updating records", async () => {
+      test("Upsert syncMode only allows creating and updating records", async () => {
         await destination.update({ syncMode: "upsert" });
 
         await destination.sendExport(_export, true);

--- a/core/__tests__/models/destination/plugins/exportRecords.ts
+++ b/core/__tests__/models/destination/plugins/exportRecords.ts
@@ -72,7 +72,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
           description: "a test app connection",
           apps: ["test-template-app"],
           direction: "export",
-          syncModes: ["sync", "enrich", "additive"],
+          syncModes: ["sync", "update", "upsert"],
           options: [],
           methods: {
             destinationMappingOptions: async () => {
@@ -543,7 +543,7 @@ describe("models/destination - with custom exportRecords plugin", () => {
       await record.destroy();
     });
 
-    test.each(["enrich", "additive"])(
+    test.each(["update", "upsert"])(
       "if record is removed from destination's tracked group in %p syncMode, toDelete is false and groups are cleared",
       async (syncMode) => {
         await destination.update({ syncMode });

--- a/core/__tests__/models/destination/plugins/noExportMethods.ts
+++ b/core/__tests__/models/destination/plugins/noExportMethods.ts
@@ -35,7 +35,7 @@ describe("models/destination", () => {
               description: "a test app connection",
               apps: ["test-template-app"],
               direction: "export",
-              syncModes: ["sync", "additive", "enrich"],
+              syncModes: ["sync", "upsert", "update"],
               options: [],
               methods: {},
             },

--- a/core/__tests__/models/destination/plugins/processExportedProfiles.ts
+++ b/core/__tests__/models/destination/plugins/processExportedProfiles.ts
@@ -98,7 +98,7 @@ describe("models/destination - with custom processExportedRecords", () => {
           description: "a test app connection",
           apps: ["test-template-app"],
           direction: "export",
-          syncModes: ["sync", "enrich", "additive"],
+          syncModes: ["sync", "update", "upsert"],
           options: [],
           methods: {
             destinationMappingOptions: async () => {

--- a/core/__tests__/models/option.ts
+++ b/core/__tests__/models/option.ts
@@ -245,7 +245,7 @@ describe("models/option", () => {
               description: "a test app connection",
               apps: ["test-template-app"],
               direction: "export",
-              syncModes: ["sync", "additive", "enrich"],
+              syncModes: ["sync", "upsert", "update"],
               options: [
                 {
                   key: "test_default_key",

--- a/core/__tests__/modules/codeConfig/codeConfig.ts
+++ b/core/__tests__/modules/codeConfig/codeConfig.ts
@@ -246,7 +246,7 @@ describe("modules/codeConfig", () => {
       expect(destinations[0].id).toBe("test_destination");
       expect(destinations[0].appId).toBe("data_warehouse");
       expect(destinations[0].name).toBe("Test Destination");
-      expect(destinations[0].syncMode).toBe("additive");
+      expect(destinations[0].syncMode).toBe("upsert");
       expect(destinations[0].state).toBe("ready");
       expect(destinations[0].locked).toBe("config:code");
       const options = await destinations[0].getOptions();
@@ -939,7 +939,7 @@ describe("modules/codeConfig", () => {
       expect(destinations[0].id).toBe("test_destination");
       expect(destinations[0].appId).toBe("data_warehouse");
       expect(destinations[0].name).toBe("Test Destination");
-      expect(destinations[0].syncMode).toBe("additive");
+      expect(destinations[0].syncMode).toBe("upsert");
       expect(destinations[0].state).toBe("ready");
       expect(destinations[0].locked).toBe("config:code");
       const options = await destinations[0].getOptions();

--- a/core/__tests__/modules/configLoaders/destination.ts
+++ b/core/__tests__/modules/configLoaders/destination.ts
@@ -1,0 +1,108 @@
+import { helper } from "@grouparoo/spec-helper";
+import {
+  DestinationConfigSyncMode,
+  DestinationConfigurationObject,
+} from "../../../src/classes/codeConfig";
+import {
+  Destination,
+  DestinationSyncMode,
+} from "../../../src/models/Destination";
+import { loadDestination } from "../../../src/modules/configLoaders/destination";
+import { ConfigWriter } from "../../../src/modules/configWriter";
+
+describe("modules/configLoaders/destination", () => {
+  const mockedConfigWriterGetLockKey = jest.fn().mockReturnValue(null);
+
+  const appId = "test-app-id";
+
+  const destinationConfig: DestinationConfigurationObject = {
+    class: "Destination",
+    id: "test_destination",
+    name: "A test destination",
+    type: "test-plugin-export",
+    appId,
+    syncMode: "sync",
+    collection: "none",
+    modelId: "",
+    groupId: undefined,
+    options: { table: "out table" },
+    mapping: {},
+    destinationGroupMemberships: {},
+  };
+
+  helper.grouparooTestServer({
+    truncate: true,
+    enableTestPlugin: true,
+    resetSettings: true,
+  });
+
+  beforeAll(async () => {
+    ConfigWriter.getLockKey = mockedConfigWriterGetLockKey;
+    await helper.factories.app({ id: appId });
+    const { model } = await helper.factories.properties();
+    destinationConfig.modelId = model.id;
+  });
+
+  beforeEach(async () => {
+    process.env.GROUPAROO_RUN_MODE = "cli:config";
+  });
+
+  afterEach(async () => {
+    process.env.GROUPAROO_RUN_MODE = undefined;
+    const destination = await Destination.scope(null).findOne({
+      where: { id: destinationConfig.id },
+    });
+    if (destination) {
+      await destination.destroy();
+    }
+  });
+
+  describe("loadDestination", () => {
+    test("loads all the destination values from config", async () => {
+      const {
+        destination: [destinationId],
+      } = await loadDestination(destinationConfig, false, false);
+
+      const destination = await Destination.scope(null).findOne({
+        where: { id: destinationId },
+      });
+
+      const configObject = await destination.getConfigObject();
+      expect(configObject).toEqual(destinationConfig);
+    });
+
+    const syncModeCases = [
+      { legacySyncMode: "enrich", syncMode: "update" },
+      { legacySyncMode: "additive", syncMode: "upsert" },
+    ] as {
+      legacySyncMode: DestinationConfigSyncMode;
+      syncMode: DestinationSyncMode;
+    }[];
+
+    test.each(syncModeCases)(
+      `converts legacy syncMode "$legacySyncMode" to "$syncMode"`,
+      async ({ legacySyncMode, syncMode }) => {
+        const configToLoad = {
+          ...destinationConfig,
+          syncMode: legacySyncMode,
+        };
+
+        const expectedConfig = {
+          ...configToLoad,
+          syncMode,
+        };
+
+        const {
+          destination: [destinationId],
+        } = await loadDestination(configToLoad, false, false);
+
+        const destination = await Destination.scope(null).findOne({
+          where: { id: destinationId },
+        });
+
+        const configObject = await destination.getConfigObject();
+        expect(configObject).toEqual(expectedConfig);
+      }
+    );
+  });
+});

--- a/core/__tests__/tasks/record/export.ts
+++ b/core/__tests__/tasks/record/export.ts
@@ -90,7 +90,7 @@ describe("tasks/record:export", () => {
               description: "a test app connection",
               apps: ["test-template-app"],
               direction: "export",
-              syncModes: ["sync", "additive", "enrich"],
+              syncModes: ["sync", "upsert", "update"],
               options: [],
               methods: {
                 exportRecord: async () => {

--- a/core/src/classes/codeConfig.ts
+++ b/core/src/classes/codeConfig.ts
@@ -6,6 +6,7 @@ import {
 } from "../modules/ruleOpsDictionary";
 import {
   DestinationCollection,
+  DestinationLegacySyncMode,
   DestinationSyncMode,
 } from "../models/Destination";
 import { PropertyFiltersWithKey } from "../models/Property";
@@ -55,12 +56,16 @@ export interface AppConfigurationObject extends ConfigurationObject {
   options?: { [key: string]: any };
 }
 
+export type DestinationConfigSyncMode =
+  | DestinationSyncMode
+  | DestinationLegacySyncMode;
+
 export interface DestinationConfigurationObject extends ConfigurationObject {
   name: string;
   type: string;
   appId: string;
   modelId: string;
-  syncMode: DestinationSyncMode;
+  syncMode: DestinationConfigSyncMode;
   collection: DestinationCollection;
   groupId?: string;
   options?: { [key: string]: any };

--- a/core/src/migrations/000102-renameToUpdateUpsertSyncModes.ts
+++ b/core/src/migrations/000102-renameToUpdateUpsertSyncModes.ts
@@ -1,0 +1,28 @@
+import Sequelize from "sequelize";
+
+const updateSyncMode = (
+  queryInterface: Sequelize.QueryInterface,
+  prevSyncMode: string,
+  nextSyncMode: string
+) =>
+  queryInterface.bulkUpdate(
+    "destinations",
+    {
+      syncMode: nextSyncMode,
+    },
+    {
+      syncMode: prevSyncMode,
+    }
+  );
+
+export default {
+  up: async (queryInterface: Sequelize.QueryInterface) => {
+    await updateSyncMode(queryInterface, "additive", "upsert");
+    await updateSyncMode(queryInterface, "enrich", "update");
+  },
+
+  down: async (queryInterface: Sequelize.QueryInterface) => {
+    await updateSyncMode(queryInterface, "upsert", "additive");
+    await updateSyncMode(queryInterface, "update", "enrich");
+  },
+};

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -74,14 +74,16 @@ export interface DestinationSyncOperations {
   delete: boolean;
 }
 
+export interface DestinationSyncModeDataValues {
+  key: DestinationSyncMode;
+  displayName: string;
+  description: string;
+  operations: DestinationSyncOperations;
+}
+
 export const DestinationSyncModeData: Record<
   DestinationSyncMode,
-  {
-    key: DestinationSyncMode;
-    displayName: string;
-    description: string;
-    operations: DestinationSyncOperations;
-  }
+  DestinationSyncModeDataValues
 > = {
   append: {
     key: "append",

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -86,7 +86,7 @@ export const DestinationSyncModeData: Record<
   append: {
     key: "append",
     displayName: "Append",
-    description: "Create new records (create)",
+    description: "Always create new records (create)",
     operations: {
       create: true,
       update: false,
@@ -96,7 +96,7 @@ export const DestinationSyncModeData: Record<
   create: {
     key: "create",
     displayName: "Create",
-    description: "Create new records, but only when they don't exist (create)",
+    description: "Create new records if they don‘t already exist (create)",
     operations: {
       create: true,
       update: false,
@@ -116,7 +116,8 @@ export const DestinationSyncModeData: Record<
   upsert: {
     key: "upsert",
     displayName: "Upsert",
-    description: "Sync all records, but do not delete (create, update)",
+    description:
+      "Create new records if they don‘t already exist, or update existing records (create, update)",
     operations: {
       create: true,
       update: true,

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -53,7 +53,7 @@ export interface SimpleDestinationGroupMembership {
 }
 export interface SimpleDestinationOptions extends OptionHelper.SimpleOptions {}
 
-const SYNC_MODES = ["append", "create", "sync", "additive", "enrich"] as const;
+const SYNC_MODES = ["append", "create", "sync", "upsert", "update"] as const;
 export type DestinationSyncMode = typeof SYNC_MODES[number];
 
 const DESTINATION_COLLECTIONS = ["none", "group", "model"] as const;
@@ -104,9 +104,9 @@ export const DestinationSyncModeData: Record<
       delete: true,
     },
   },
-  additive: {
-    key: "additive",
-    displayName: "Additive",
+  upsert: {
+    key: "upsert",
+    displayName: "Upsert",
     description: "Sync all records, but do not delete (create, update)",
     operations: {
       create: true,
@@ -114,9 +114,9 @@ export const DestinationSyncModeData: Record<
       delete: false,
     },
   },
-  enrich: {
-    key: "enrich",
-    displayName: "Enrich",
+  update: {
+    key: "update",
+    displayName: "Update",
     description: "Only update existing records (update)",
     operations: {
       create: false,

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -53,7 +53,7 @@ export interface SimpleDestinationGroupMembership {
 }
 export interface SimpleDestinationOptions extends OptionHelper.SimpleOptions {}
 
-const SYNC_MODES = ["sync", "additive", "enrich"] as const;
+const SYNC_MODES = ["append", "create", "sync", "additive", "enrich"] as const;
 export type DestinationSyncMode = typeof SYNC_MODES[number];
 
 const DESTINATION_COLLECTIONS = ["none", "group", "model"] as const;
@@ -74,6 +74,26 @@ export const DestinationSyncModeData: Record<
     operations: DestinationSyncOperations;
   }
 > = {
+  append: {
+    key: "append",
+    displayName: "Append",
+    description: "Create new records (create)",
+    operations: {
+      create: true,
+      update: false,
+      delete: false,
+    },
+  },
+  create: {
+    key: "create",
+    displayName: "Create",
+    description: "Create new records, but only when they don't exist (create)",
+    operations: {
+      create: true,
+      update: false,
+      delete: false,
+    },
+  },
   sync: {
     key: "sync",
     displayName: "Sync",

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -53,8 +53,17 @@ export interface SimpleDestinationGroupMembership {
 }
 export interface SimpleDestinationOptions extends OptionHelper.SimpleOptions {}
 
-const SYNC_MODES = ["append", "create", "sync", "upsert", "update"] as const;
+export const SYNC_MODES = [
+  "append",
+  "create",
+  "sync",
+  "upsert",
+  "update",
+] as const;
+export const LEGACY_SYNC_MODES = ["additive", "enrich"] as const;
+
 export type DestinationSyncMode = typeof SYNC_MODES[number];
+export type DestinationLegacySyncMode = typeof LEGACY_SYNC_MODES[number];
 
 const DESTINATION_COLLECTIONS = ["none", "group", "model"] as const;
 export type DestinationCollection = typeof DESTINATION_COLLECTIONS[number];

--- a/core/src/modules/configLoaders/destination.ts
+++ b/core/src/modules/configLoaders/destination.ts
@@ -12,6 +12,7 @@ import {
 } from "../../classes/codeConfig";
 import { App, Destination, Group, Property } from "../.."; // configLoader imports need to be from root
 
+import { Deprecation } from "../deprecation";
 import { DestinationSyncMode } from "../../models/Destination";
 import { ConfigWriter } from "../configWriter";
 
@@ -21,9 +22,10 @@ const sanitizeSyncMode = (
 ): DestinationSyncMode => {
   if (syncMode === "additive" || syncMode === "enrich") {
     const newSyncMode = syncMode === "additive" ? "upsert" : "update";
-    log(
-      `[ config ] Found syncMode "${syncMode}" in Destination config "${configId}". "${syncMode}" is still supported but value should be updated to new name: "${newSyncMode}".`,
-      "warning"
+    Deprecation.warnChanged(
+      "config",
+      `syncMode "${syncMode}" used in Destination "${configId}"`,
+      `${newSyncMode}`
     );
     return newSyncMode;
   }

--- a/core/src/modules/configLoaders/destination.ts
+++ b/core/src/modules/configLoaders/destination.ts
@@ -22,7 +22,7 @@ const sanitizeSyncMode = (
   if (syncMode === "additive" || syncMode === "enrich") {
     const newSyncMode = syncMode === "additive" ? "upsert" : "update";
     log(
-      `[ config ] Destination syncMode "${syncMode}" is now known as "${newSyncMode}".`,
+      `[ config ] Found syncMode "${syncMode}" in Destination config "${configId}". "${syncMode}" is still supported but value should be updated to new name: "${newSyncMode}".`,
       "warning"
     );
     return newSyncMode;

--- a/core/src/modules/configLoaders/destination.ts
+++ b/core/src/modules/configLoaders/destination.ts
@@ -1,3 +1,5 @@
+import { log } from "actionhero";
+import { Op } from "sequelize";
 import {
   DestinationConfigurationObject,
   extractNonNullParts,
@@ -6,11 +8,28 @@ import {
   getCodeConfigLockKey,
   validateConfigObjectKeys,
   IdsByClass,
+  DestinationConfigSyncMode,
 } from "../../classes/codeConfig";
 import { App, Destination, Group, Property } from "../.."; // configLoader imports need to be from root
-import { Op } from "sequelize";
 
+import { DestinationSyncMode } from "../../models/Destination";
 import { ConfigWriter } from "../configWriter";
+
+const sanitizeSyncMode = (
+  syncMode: DestinationConfigSyncMode,
+  configId: string
+): DestinationSyncMode => {
+  if (syncMode === "additive" || syncMode === "enrich") {
+    const newSyncMode = syncMode === "additive" ? "upsert" : "update";
+    log(
+      `[ config ] Destination syncMode "${syncMode}" is now known as "${newSyncMode}".`,
+      "warning"
+    );
+    return newSyncMode;
+  }
+
+  return syncMode;
+};
 
 export async function loadDestination(
   configObject: DestinationConfigurationObject,
@@ -37,13 +56,16 @@ export async function loadDestination(
       },
     },
   });
+
+  const syncMode = sanitizeSyncMode(configObject.syncMode, configObject.id);
+
   if (!destination) {
     isNew = true;
     destination = await Destination.create({
       id: configObject.id,
       name: configObject.name,
       type: configObject.type,
-      syncMode: configObject.syncMode,
+      syncMode,
       appId: app.id,
       modelId: configObject.modelId,
     });
@@ -58,7 +80,7 @@ export async function loadDestination(
   await destination.update({
     name: configObject.name,
     type: configObject.type,
-    syncMode: configObject.syncMode,
+    syncMode,
     modelId: configObject.modelId,
     locked: ConfigWriter.getLockKey(configObject),
   });

--- a/plugins/@grouparoo/airtable/__tests__/utils/export-records.ts
+++ b/plugins/@grouparoo/airtable/__tests__/utils/export-records.ts
@@ -74,7 +74,7 @@ export function testExportRecords(baseType: BaseType) {
             toDelete: false,
           },
         ],
-        DestinationSyncModeData.enrich.operations
+        DestinationSyncModeData.update.operations
       );
 
       expect(errors).not.toBeNull();
@@ -281,7 +281,7 @@ export function testExportRecords(baseType: BaseType) {
             toDelete: true,
           },
         ],
-        DestinationSyncModeData.additive.operations
+        DestinationSyncModeData.upsert.operations
       );
 
       expect(errors).not.toBeNull();

--- a/plugins/@grouparoo/airtable/src/lib/destination/connection.ts
+++ b/plugins/@grouparoo/airtable/src/lib/destination/connection.ts
@@ -7,8 +7,8 @@ import { exportArrayProperties } from "./exportArrayProperties";
 
 export const supportedSyncModes: DestinationSyncMode[] = [
   "sync",
-  "additive",
-  "enrich",
+  "upsert",
+  "update",
 ];
 
 export const destinationConnection: PluginConnection = {

--- a/plugins/@grouparoo/airtable/src/lib/destination/exportRecords.ts
+++ b/plugins/@grouparoo/airtable/src/lib/destination/exportRecords.ts
@@ -288,7 +288,7 @@ export async function exportBatch(exportBatchOptions: ExportBatchOptions) {
       findSize,
       batchSize,
       groupMode: BatchGroupMode.TotalMembers,
-      syncMode: BatchSyncMode.Additive,
+      syncMode: BatchSyncMode.Upsert,
       syncOperations,
       appOptions,
       destinationOptions,

--- a/plugins/@grouparoo/app-templates/src/destination/batch/types.ts
+++ b/plugins/@grouparoo/app-templates/src/destination/batch/types.ts
@@ -15,12 +15,34 @@ export enum BatchGroupMode {
 
 export enum BatchSyncMode {
   // these values actually used in destinationOptions settings
+  Append = "Append", // create
+  Create = "Create", // create only if it doesn't exist
   Sync = "Sync", // create, update, delete (default)
   Enrich = "Enrich", // update only (no create or delete)
   Additive = "Additive", // create or update (no delete)
 }
 
-export const BatchSyncModeData = {
+export const BatchSyncModeData: Record<
+  BatchSyncMode,
+  {
+    create: boolean;
+    update: boolean;
+    delete: boolean;
+    description: string;
+  }
+> = {
+  [BatchSyncMode.Append]: {
+    create: true,
+    update: false,
+    delete: false,
+    description: "Create new records (create)",
+  },
+  [BatchSyncMode.Create]: {
+    create: true,
+    update: false,
+    delete: false,
+    description: "Create new records, but only when they don't exist (create)",
+  },
   [BatchSyncMode.Sync]: {
     create: true,
     update: true,

--- a/plugins/@grouparoo/app-templates/src/destination/batch/types.ts
+++ b/plugins/@grouparoo/app-templates/src/destination/batch/types.ts
@@ -18,8 +18,8 @@ export enum BatchSyncMode {
   Append = "Append", // create
   Create = "Create", // create only if it doesn't exist
   Sync = "Sync", // create, update, delete (default)
-  Enrich = "Enrich", // update only (no create or delete)
-  Additive = "Additive", // create or update (no delete)
+  Update = "Update", // update only (no create or delete)
+  Upsert = "Upsert", // create or update (no delete)
 }
 
 export const BatchSyncModeData: Record<
@@ -49,13 +49,13 @@ export const BatchSyncModeData: Record<
     delete: true,
     description: "Sync all records (create, update, delete)",
   },
-  [BatchSyncMode.Enrich]: {
+  [BatchSyncMode.Update]: {
     create: false,
     update: true,
     delete: false,
     description: "Only update existing objects (update)",
   },
-  [BatchSyncMode.Additive]: {
+  [BatchSyncMode.Upsert]: {
     create: true,
     update: true,
     delete: false,

--- a/plugins/@grouparoo/app-templates/src/destination/batch/types.ts
+++ b/plugins/@grouparoo/app-templates/src/destination/batch/types.ts
@@ -7,6 +7,10 @@ import {
   SimpleDestinationOptions,
   ErrorWithRecordId,
 } from "@grouparoo/core";
+import {
+  DestinationSyncModeData,
+  DestinationSyncModeDataValues,
+} from "@grouparoo/core/dist/models/Destination";
 
 export enum BatchGroupMode {
   WithinGroup = "WithinGroup", // update group by group
@@ -22,46 +26,25 @@ export enum BatchSyncMode {
   Upsert = "Upsert", // create or update (no delete)
 }
 
-export const BatchSyncModeData: Record<
-  BatchSyncMode,
-  {
-    create: boolean;
-    update: boolean;
-    delete: boolean;
-    description: string;
-  }
-> = {
-  [BatchSyncMode.Append]: {
-    create: true,
-    update: false,
-    delete: false,
-    description: "Create new records (create)",
-  },
-  [BatchSyncMode.Create]: {
-    create: true,
-    update: false,
-    delete: false,
-    description: "Create new records, but only when they don't exist (create)",
-  },
-  [BatchSyncMode.Sync]: {
-    create: true,
-    update: true,
-    delete: true,
-    description: "Sync all records (create, update, delete)",
-  },
-  [BatchSyncMode.Update]: {
-    create: false,
-    update: true,
-    delete: false,
-    description: "Only update existing objects (update)",
-  },
-  [BatchSyncMode.Upsert]: {
-    create: true,
-    update: true,
-    delete: false,
-    description: "Sync all records, but do not delete (create, update)",
-  },
+type BatchSyncModeDataValues = DestinationSyncModeDataValues["operations"] & {
+  description: string;
 };
+
+const toBatchSyncModeData = (
+  values: DestinationSyncModeDataValues
+): BatchSyncModeDataValues => ({
+  ...values.operations,
+  description: values.description,
+});
+
+export const BatchSyncModeData: Record<BatchSyncMode, BatchSyncModeDataValues> =
+  {
+    [BatchSyncMode.Append]: toBatchSyncModeData(DestinationSyncModeData.append),
+    [BatchSyncMode.Create]: toBatchSyncModeData(DestinationSyncModeData.create),
+    [BatchSyncMode.Sync]: toBatchSyncModeData(DestinationSyncModeData.sync),
+    [BatchSyncMode.Update]: toBatchSyncModeData(DestinationSyncModeData.update),
+    [BatchSyncMode.Upsert]: toBatchSyncModeData(DestinationSyncModeData.upsert),
+  };
 
 export interface BatchExport extends ExportedRecord {
   foreignKeyValue?: string;

--- a/plugins/@grouparoo/braze/__tests__/export/export-records.ts
+++ b/plugins/@grouparoo/braze/__tests__/export/export-records.ts
@@ -95,7 +95,7 @@ describe("braze/exportRecords", () => {
 
     const { success, errors } = await exportBatch({
       appOptions,
-      syncOperations: DestinationSyncModeData.enrich.operations,
+      syncOperations: DestinationSyncModeData.update.operations,
       exports: [
         {
           recordId: id1,
@@ -545,7 +545,7 @@ describe("braze/exportRecords", () => {
     async () => {
       const { success, errors } = await exportBatch({
         appOptions,
-        syncOperations: DestinationSyncModeData.additive.operations,
+        syncOperations: DestinationSyncModeData.upsert.operations,
         exports: [
           {
             recordId: id1,

--- a/plugins/@grouparoo/braze/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/braze/src/initializers/plugin.ts
@@ -15,7 +15,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
 
     plugin.registerPlugin({

--- a/plugins/@grouparoo/closeio/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/closeio/src/initializers/plugin.ts
@@ -17,7 +17,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
 
     plugin.registerPlugin({

--- a/plugins/@grouparoo/customerio/__tests__/export/export-record.ts
+++ b/plugins/@grouparoo/customerio/__tests__/export/export-record.ts
@@ -71,7 +71,7 @@ describe("customer.io/exportRecord", () => {
   test("can not create a customer if sync mode does not allow it", async () => {
     await expect(
       runExport({
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         oldRecordProperties: {},
         newRecordProperties: { customer_id: customerId },
         oldGroups: [],

--- a/plugins/@grouparoo/customerio/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/customerio/src/initializers/plugin.ts
@@ -15,7 +15,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
     plugin.registerPlugin({
       name: packageJSON.name,

--- a/plugins/@grouparoo/eloqua/__tests__/export/export-records.ts
+++ b/plugins/@grouparoo/eloqua/__tests__/export/export-records.ts
@@ -135,7 +135,7 @@ describe("eloqua/exportRecord", () => {
       client,
       appId,
       appOptions,
-      syncOperations: DestinationSyncModeData.enrich.operations,
+      syncOperations: DestinationSyncModeData.update.operations,
       exports: [
         {
           recordId: id1,
@@ -602,7 +602,7 @@ describe("eloqua/exportRecord", () => {
     expect(user1.lastName).toEqual("Saran");
   });
 
-  test("can change the email address (both old and new emails exist) with ADDITIVE sync mode", async () => {
+  test("can change the email address (both old and new emails exist) with upsert sync mode", async () => {
     const exports = [
       {
         recordId: id1,
@@ -622,7 +622,7 @@ describe("eloqua/exportRecord", () => {
       client,
       appId,
       appOptions,
-      syncOperations: DestinationSyncModeData.additive.operations,
+      syncOperations: DestinationSyncModeData.upsert.operations,
       exports,
     });
     await indexUsers(newNock);
@@ -636,7 +636,7 @@ describe("eloqua/exportRecord", () => {
       appOptions,
       remoteKey: processExports.remoteKey,
       exports,
-      syncOperations: DestinationSyncModeData.additive.operations,
+      syncOperations: DestinationSyncModeData.upsert.operations,
     });
 
     expect(success).toBe(true);
@@ -652,7 +652,7 @@ describe("eloqua/exportRecord", () => {
     expect(user1.lastName).toBe("User");
   });
 
-  test("can change the email address with ADDITIVE sync mode", async () => {
+  test("can change the email address with upsert sync mode", async () => {
     const exports = [
       {
         recordId: id1,
@@ -672,7 +672,7 @@ describe("eloqua/exportRecord", () => {
       client,
       appId,
       appOptions,
-      syncOperations: DestinationSyncModeData.additive.operations,
+      syncOperations: DestinationSyncModeData.upsert.operations,
       exports,
     });
     await indexUsers(newNock);
@@ -686,7 +686,7 @@ describe("eloqua/exportRecord", () => {
       appOptions,
       remoteKey: processExports.remoteKey,
       exports,
-      syncOperations: DestinationSyncModeData.additive.operations,
+      syncOperations: DestinationSyncModeData.upsert.operations,
     });
 
     expect(success).toBe(true);
@@ -707,7 +707,7 @@ describe("eloqua/exportRecord", () => {
       client,
       appId,
       appOptions,
-      syncOperations: DestinationSyncModeData.additive.operations,
+      syncOperations: DestinationSyncModeData.upsert.operations,
       exports: [
         {
           recordId: id1,

--- a/plugins/@grouparoo/eloqua/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/eloqua/src/initializers/plugin.ts
@@ -16,7 +16,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
 
     plugin.registerPlugin({

--- a/plugins/@grouparoo/facebook/__tests__/integration/export-records-custom.ts
+++ b/plugins/@grouparoo/facebook/__tests__/integration/export-records-custom.ts
@@ -18,7 +18,7 @@ const destinationOptions = {
 };
 
 const syncOperations = DestinationSyncModeData.sync.operations;
-const additiveSyncOperations = DestinationSyncModeData.additive.operations;
+const upsertSyncOperations = DestinationSyncModeData.upsert.operations;
 
 let client: Client;
 
@@ -649,8 +649,8 @@ describe("facebook/audiences-custom/exportRecords", () => {
     expect(data).toContainEqual([sha(email3), "", sha("sam"), "", ""]);
   });
 
-  describe("Additive destination sync Mode", () => {
-    const syncOperations = additiveSyncOperations;
+  describe("Upsert destination sync Mode", () => {
+    const syncOperations = upsertSyncOperations;
     test("skips deleting", async () => {
       const { success, errors } = await exportRecords({
         appId,

--- a/plugins/@grouparoo/facebook/src/lib/export-custom/connection.ts
+++ b/plugins/@grouparoo/facebook/src/lib/export-custom/connection.ts
@@ -4,7 +4,7 @@ import { destinationMappingOptions } from "./destinationMappingOptions";
 import { exportArrayProperties } from "./exportArrayProperties";
 import { DestinationSyncMode, PluginConnection } from "@grouparoo/core";
 
-export const supportedSyncModes: DestinationSyncMode[] = ["sync", "additive"];
+export const supportedSyncModes: DestinationSyncMode[] = ["sync", "upsert"];
 
 export function buildConnection(): PluginConnection {
   return {

--- a/plugins/@grouparoo/facebook/src/lib/export-lookalike/exportRecords.ts
+++ b/plugins/@grouparoo/facebook/src/lib/export-lookalike/exportRecords.ts
@@ -14,7 +14,7 @@ export const exportRecords: ExportRecordsPluginMethod = async ({
   return exportFacebookRecords({
     appId,
     appOptions,
-    syncOperations: DestinationSyncModeData.additive.operations,
+    syncOperations: DestinationSyncModeData.upsert.operations,
     model: destinationModel(destinationOptions),
     exports: recordsToExport,
   });

--- a/plugins/@grouparoo/google-sheets/__tests__/export/export-records.ts
+++ b/plugins/@grouparoo/google-sheets/__tests__/export/export-records.ts
@@ -94,7 +94,7 @@ describe("google-sheets/exportRecords", () => {
       const { success, errors } = await exportBatch({
         appOptions,
         destinationId,
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         destinationOptions,
         exports: [
           {
@@ -596,7 +596,7 @@ describe("google-sheets/exportRecords", () => {
         appOptions,
         destinationId,
         destinationOptions,
-        syncOperations: DestinationSyncModeData.additive.operations,
+        syncOperations: DestinationSyncModeData.upsert.operations,
         exports: [
           {
             recordId: id1,

--- a/plugins/@grouparoo/google-sheets/src/lib/sheet-export/connection.ts
+++ b/plugins/@grouparoo/google-sheets/src/lib/sheet-export/connection.ts
@@ -7,8 +7,8 @@ import { exportArrayProperties } from "./exportArrayProperties";
 
 export const supportedSyncModes: DestinationSyncMode[] = [
   "sync",
-  "additive",
-  "enrich",
+  "upsert",
+  "update",
 ];
 
 export const destinationConnection: PluginConnection = {

--- a/plugins/@grouparoo/hubspot/__tests__/export-objects/export-records-companies.ts
+++ b/plugins/@grouparoo/hubspot/__tests__/export-objects/export-records-companies.ts
@@ -160,7 +160,7 @@ describe("hubspot/exportRecords", () => {
       const { success, errors } = await exportBatch({
         appOptions,
         destinationOptions,
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         exports: [
           {
             recordId: id1,
@@ -461,7 +461,7 @@ describe("hubspot/exportRecords", () => {
         const { success, errors } = await exportBatch({
           appOptions,
           destinationOptions,
-          syncOperations: DestinationSyncModeData.additive.operations,
+          syncOperations: DestinationSyncModeData.upsert.operations,
           exports: [
             {
               recordId: id1,

--- a/plugins/@grouparoo/hubspot/__tests__/export-objects/export-records-contact.ts
+++ b/plugins/@grouparoo/hubspot/__tests__/export-objects/export-records-contact.ts
@@ -167,7 +167,7 @@ describe("hubspot/exportRecords", () => {
       const { success, errors } = await exportBatch({
         appOptions,
         destinationOptions,
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         exports: [
           {
             recordId: id1,
@@ -444,7 +444,7 @@ describe("hubspot/exportRecords", () => {
         const { success, errors } = await exportBatch({
           appOptions,
           destinationOptions,
-          syncOperations: DestinationSyncModeData.additive.operations,
+          syncOperations: DestinationSyncModeData.upsert.operations,
           exports: [
             {
               recordId: id1,

--- a/plugins/@grouparoo/hubspot/__tests__/export-objects/export-records-custom-object.ts
+++ b/plugins/@grouparoo/hubspot/__tests__/export-objects/export-records-custom-object.ts
@@ -163,7 +163,7 @@ describe("hubspot/exportRecords", () => {
       const { success, errors } = await exportBatch({
         appOptions,
         destinationOptions,
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         exports: [
           {
             recordId: id1,
@@ -466,7 +466,7 @@ describe("hubspot/exportRecords", () => {
         const { success, errors } = await exportBatch({
           appOptions,
           destinationOptions,
-          syncOperations: DestinationSyncModeData.additive.operations,
+          syncOperations: DestinationSyncModeData.upsert.operations,
           exports: [
             {
               recordId: id1,

--- a/plugins/@grouparoo/hubspot/src/lib/export-contacts/connection.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/export-contacts/connection.ts
@@ -7,8 +7,8 @@ import { exportArrayProperties } from "../shared/exportArrayProperties";
 
 export const contactsSupportedSyncModes: DestinationSyncMode[] = [
   "sync",
-  "additive",
-  "enrich",
+  "upsert",
+  "update",
 ];
 
 export const contactsDestinationConnection: PluginConnection = {

--- a/plugins/@grouparoo/hubspot/src/lib/export-objects/connection.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/export-objects/connection.ts
@@ -7,8 +7,8 @@ import { exportArrayProperties } from "../shared/exportArrayProperties";
 
 export const objectsSupportedSyncModes: DestinationSyncMode[] = [
   "sync",
-  "additive",
-  "enrich",
+  "upsert",
+  "update",
 ];
 
 export const objectsDestinationConnection: PluginConnection = {

--- a/plugins/@grouparoo/intercom/__tests__/integration/export-record-no-create.ts
+++ b/plugins/@grouparoo/intercom/__tests__/integration/export-record-no-create.ts
@@ -360,7 +360,7 @@ describe("intercom/contacts/exportRecord/no create", () => {
         oldRecordProperties: {},
         newRecordProperties: {
           email: email3,
-          name: "Not Enrich",
+          name: "Not Update",
         },
         oldGroups: [],
         newGroups: ["Test Group X"],

--- a/plugins/@grouparoo/intercom/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/intercom/src/initializers/plugin.ts
@@ -15,7 +15,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
 
     plugin.registerPlugin({
       name: packageJSON.name,

--- a/plugins/@grouparoo/iterable/__tests__/export/export-record.ts
+++ b/plugins/@grouparoo/iterable/__tests__/export/export-record.ts
@@ -154,7 +154,7 @@ describe("iterable/exportRecord", () => {
   test("can not create a Person if sync mode does not allow it", async () => {
     await expect(
       runExport({
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         oldRecordProperties: {},
         newRecordProperties: { email, name },
         oldGroups: [],

--- a/plugins/@grouparoo/iterable/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/iterable/src/initializers/plugin.ts
@@ -15,7 +15,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
     plugin.registerPlugin({
       name: packageJSON.name,

--- a/plugins/@grouparoo/klaviyo/__tests__/export/export-record.ts
+++ b/plugins/@grouparoo/klaviyo/__tests__/export/export-record.ts
@@ -132,7 +132,7 @@ describe("klaviyo/exportRecord", () => {
   test("can not create a Profile if sync mode does not allow it", async () => {
     await expect(
       runExport({
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         oldRecordProperties: {},
         newRecordProperties: {
           first_name: "Jimmy",

--- a/plugins/@grouparoo/klaviyo/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/klaviyo/src/initializers/plugin.ts
@@ -15,7 +15,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
 
     plugin.registerPlugin({

--- a/plugins/@grouparoo/mailchimp/src/lib/export-id/connection.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/export-id/connection.ts
@@ -5,7 +5,7 @@ import { getDestinationOptions } from "../shared/connectionOptions";
 import { getDestinationMappingOptions } from "../shared/destinationMappingOptions";
 import { exportArrayProperties } from "../shared/exportArrayProperties";
 
-export const idSupportedSyncModes: DestinationSyncMode[] = ["enrich"];
+export const idSupportedSyncModes: DestinationSyncMode[] = ["update"];
 
 export const idDestinationConnection: PluginConnection = {
   name: "mailchimp-export-contacts-by-id",
@@ -15,7 +15,7 @@ export const idDestinationConnection: PluginConnection = {
     "Updates existing contacts in a Mailchimp list based on a known Mailchimp ID.",
   apps: ["mailchimp", "mailchimp-oauth"],
   syncModes: idSupportedSyncModes,
-  defaultSyncMode: "enrich",
+  defaultSyncMode: "update",
   options: [
     {
       key: "listId",

--- a/plugins/@grouparoo/mailchimp/src/lib/export/connection.ts
+++ b/plugins/@grouparoo/mailchimp/src/lib/export/connection.ts
@@ -7,8 +7,8 @@ import { exportArrayProperties } from "../shared/exportArrayProperties";
 
 export const emailSupportedSyncModes: DestinationSyncMode[] = [
   "sync",
-  "additive",
-  "enrich",
+  "upsert",
+  "update",
 ];
 
 export const emailDestinationConnection: PluginConnection = {

--- a/plugins/@grouparoo/mailjet/__tests__/export/export-record.ts
+++ b/plugins/@grouparoo/mailjet/__tests__/export/export-record.ts
@@ -417,7 +417,7 @@ describe("mailjet/exportRecord", () => {
     // mailjet requires creating new user on FK change
     await expect(
       runExport({
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         oldRecordProperties: {
           Email: email,
         },
@@ -443,9 +443,9 @@ describe("mailjet/exportRecord", () => {
     expect(newUser).toBe(null);
   });
 
-  test("change email when only old exists (ADDITIVE mode)", async () => {
+  test("change email when only old exists (upsert mode)", async () => {
     await runExport({
-      syncOperations: DestinationSyncModeData.additive.operations,
+      syncOperations: DestinationSyncModeData.upsert.operations,
       oldRecordProperties: {
         Email: email,
       },
@@ -487,10 +487,10 @@ describe("mailjet/exportRecord", () => {
     );
   });
 
-  test("change email when both exist (ADDITIVE mode)", async () => {
+  test("change email when both exist (upsert mode)", async () => {
     // mailjet requires deleting the old user on FK change
     await runExport({
-      syncOperations: DestinationSyncModeData.additive.operations,
+      syncOperations: DestinationSyncModeData.upsert.operations,
       oldRecordProperties: {
         Email: alternativeEmail,
       },

--- a/plugins/@grouparoo/mailjet/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mailjet/src/initializers/plugin.ts
@@ -15,7 +15,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
 
     plugin.registerPlugin({

--- a/plugins/@grouparoo/marketo/__tests__/integration/export-records.ts
+++ b/plugins/@grouparoo/marketo/__tests__/integration/export-records.ts
@@ -139,7 +139,7 @@ describe("marketo/exportRecords", () => {
     const { success, errors } = await exportBatch({
       appId,
       appOptions,
-      syncOperations: DestinationSyncModeData.enrich.operations,
+      syncOperations: DestinationSyncModeData.update.operations,
       exports: [
         {
           recordId: id1,
@@ -493,7 +493,7 @@ describe("marketo/exportRecords", () => {
     const { success, errors } = await exportBatch({
       appId,
       appOptions,
-      syncOperations: DestinationSyncModeData.additive.operations,
+      syncOperations: DestinationSyncModeData.upsert.operations,
       exports: [
         {
           recordId: id1,

--- a/plugins/@grouparoo/marketo/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/marketo/src/initializers/plugin.ts
@@ -16,7 +16,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
 
     plugin.registerPlugin({

--- a/plugins/@grouparoo/mixpanel/__tests__/export/export-records.ts
+++ b/plugins/@grouparoo/mixpanel/__tests__/export/export-records.ts
@@ -96,7 +96,7 @@ describe("mixpanel/exportRecords", () => {
 
     const { success, errors } = await exportBatch({
       appOptions,
-      syncOperations: DestinationSyncModeData.enrich.operations,
+      syncOperations: DestinationSyncModeData.update.operations,
       exports: [
         {
           recordId: id1,
@@ -557,7 +557,7 @@ describe("mixpanel/exportRecords", () => {
     async () => {
       const { success, errors } = await exportBatch({
         appOptions,
-        syncOperations: DestinationSyncModeData.additive.operations,
+        syncOperations: DestinationSyncModeData.upsert.operations,
         exports: [
           {
             recordId: id1,

--- a/plugins/@grouparoo/mixpanel/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/mixpanel/src/initializers/plugin.ts
@@ -15,7 +15,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
 
     plugin.registerPlugin({

--- a/plugins/@grouparoo/onesignal/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/onesignal/src/initializers/plugin.ts
@@ -15,8 +15,8 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["enrich"];
-    const defaultSyncMode: DestinationSyncMode = "enrich";
+    const syncModes: DestinationSyncMode[] = ["update"];
+    const defaultSyncMode: DestinationSyncMode = "update";
     plugin.registerPlugin({
       name: packageJSON.name,
       icon: "/public/@grouparoo/onesignal/onesignal.png",

--- a/plugins/@grouparoo/pardot/__tests__/export/export-records.ts
+++ b/plugins/@grouparoo/pardot/__tests__/export/export-records.ts
@@ -166,7 +166,7 @@ describe("pardot/exportRecords", () => {
     const { success, errors } = await exportBatch({
       appId,
       appOptions,
-      syncOperations: DestinationSyncModeData.enrich.operations,
+      syncOperations: DestinationSyncModeData.update.operations,
       exports: [
         {
           recordId: id1,
@@ -523,7 +523,7 @@ describe("pardot/exportRecords", () => {
     const { success, errors } = await exportBatch({
       appId,
       appOptions,
-      syncOperations: DestinationSyncModeData.additive.operations,
+      syncOperations: DestinationSyncModeData.upsert.operations,
       exports: [
         {
           recordId: id1,

--- a/plugins/@grouparoo/pardot/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/pardot/src/initializers/plugin.ts
@@ -17,7 +17,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
     plugin.registerPlugin({
       name: packageJSON.name,

--- a/plugins/@grouparoo/pipedrive/__tests__/export-organizations/export-record.ts
+++ b/plugins/@grouparoo/pipedrive/__tests__/export-organizations/export-record.ts
@@ -154,7 +154,7 @@ describe("pipedrive/exportRecord", () => {
   test("can not create a Organization if sync mode does not allow it", async () => {
     await expect(
       runExport({
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         oldRecordProperties: {},
         newRecordProperties: { Name: name2 },
         oldGroups: [],

--- a/plugins/@grouparoo/pipedrive/__tests__/export-persons/export-record.ts
+++ b/plugins/@grouparoo/pipedrive/__tests__/export-persons/export-record.ts
@@ -167,7 +167,7 @@ describe("pipedrive/exportRecord", () => {
   test("can not create a Person if sync mode does not allow it", async () => {
     await expect(
       runExport({
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         oldRecordProperties: {},
         newRecordProperties: { Name: "Jimmy Doe", Email: email2 },
         oldGroups: [],

--- a/plugins/@grouparoo/pipedrive/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/pipedrive/src/initializers/plugin.ts
@@ -17,7 +17,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
 
     plugin.registerPlugin({

--- a/plugins/@grouparoo/postgres/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/postgres/src/initializers/plugin.ts
@@ -21,7 +21,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
     plugin.registerPlugin({
       name: packageJSON.name,

--- a/plugins/@grouparoo/redshift/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/redshift/src/initializers/plugin.ts
@@ -20,7 +20,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
     plugin.registerPlugin({
       name: packageJSON.name,

--- a/plugins/@grouparoo/sailthru/__tests__/export/export-record.ts
+++ b/plugins/@grouparoo/sailthru/__tests__/export/export-record.ts
@@ -115,7 +115,7 @@ describe("sailthru/exportRecord", () => {
   test("cannot create a record if sync mode does not allow it", async () => {
     await expect(
       runExport({
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         oldRecordProperties: {},
         newRecordProperties: { email: email },
         oldGroups: [],

--- a/plugins/@grouparoo/sailthru/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/sailthru/src/initializers/plugin.ts
@@ -15,7 +15,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
     plugin.registerPlugin({
       name: packageJSON.name,

--- a/plugins/@grouparoo/salesforce/__tests__/export-account/destination-mapping-options-enrich.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-account/destination-mapping-options-enrich.ts
@@ -43,7 +43,7 @@ describe("salesforce/sales-cloud/destinationMappingOptions", () => {
     destination = await Destination.create({
       name: "Salesforce Test Destination",
       type: "salesforce-export-accounts",
-      syncMode: DestinationSyncModeData.enrich.key,
+      syncMode: DestinationSyncModeData.update.key,
       appId: app.id,
       modelId: model.id,
     });

--- a/plugins/@grouparoo/salesforce/__tests__/export-account/export-records-additive.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-account/export-records-additive.ts
@@ -10,7 +10,7 @@ import { DestinationSyncModeData } from "@grouparoo/core/dist/models/Destination
 const { newNock } = helper.useNock(__filename, updater);
 const appOptions = loadAppOptions(newNock);
 const appId = "app_f3bb07d8-0c4f-49b5-ad42-545f2e8632e2";
-const syncOperations = DestinationSyncModeData.additive.operations;
+const syncOperations = DestinationSyncModeData.upsert.operations;
 const destinationOptions = {
   primaryKey: "AccountNumber",
 };
@@ -41,7 +41,7 @@ const { findId, getUser, cleanUp, findReferenceId, getReferencedUserIds } =
     deleteReferenceValues,
   });
 
-describe("salesforce/sales-cloud/export-records/additive", () => {
+describe("salesforce/sales-cloud/export-records/upsert", () => {
   beforeAll(async () => {
     await cleanUp(false);
   }, helper.setupTime);

--- a/plugins/@grouparoo/salesforce/__tests__/export-account/export-records-enrich.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-account/export-records-enrich.ts
@@ -10,7 +10,7 @@ import { DestinationSyncModeData } from "@grouparoo/core/dist/models/Destination
 const { newNock } = helper.useNock(__filename, updater);
 const appOptions = loadAppOptions(newNock);
 const appId = "app_f3bb07d8-0c4f-49b5-ad42-545f2e8662e9";
-const syncOperations = DestinationSyncModeData.enrich.operations;
+const syncOperations = DestinationSyncModeData.update.operations;
 const destinationOptions = {
   primaryKey: "AccountNumber",
 };
@@ -40,7 +40,7 @@ const { findId, getUser, cleanUp, getReferencedUserIds } = getModelHelpers({
   deleteReferenceValues,
 });
 
-describe("salesforce/sales-cloud/export-records/enrich", () => {
+describe("salesforce/sales-cloud/export-records/update", () => {
   beforeAll(async () => {
     await cleanUp(false);
   }, helper.setupTime);

--- a/plugins/@grouparoo/salesforce/__tests__/export-contacts/destination-mapping-options-enrich.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-contacts/destination-mapping-options-enrich.ts
@@ -40,7 +40,7 @@ describe("salesforce/sales-cloud/destinationMappingOptions", () => {
     destination = await Destination.create({
       name: "Salesforce Test Destination",
       type: "salesforce-export-contacts",
-      syncMode: DestinationSyncModeData.enrich.key,
+      syncMode: DestinationSyncModeData.update.key,
       appId: app.id,
       modelId: model.id,
     });

--- a/plugins/@grouparoo/salesforce/__tests__/export-contacts/export-records-additive.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-contacts/export-records-additive.ts
@@ -10,7 +10,7 @@ import { DestinationSyncModeData } from "@grouparoo/core/dist/models/Destination
 const { newNock } = helper.useNock(__filename, updater);
 const appOptions = loadAppOptions(newNock);
 const appId = "app_f3bb07d8-0c4f-49b5-ad42-545f2e8632e2";
-const syncOperations = DestinationSyncModeData.additive.operations;
+const syncOperations = DestinationSyncModeData.upsert.operations;
 const destinationOptions = {
   primaryKey: "Email",
   accountKey: "Name",
@@ -55,7 +55,7 @@ const {
   deleteReferenceValues,
 });
 
-describe("salesforce/sales-cloud/export-records/additive", () => {
+describe("salesforce/sales-cloud/export-records/upsert", () => {
   beforeAll(async () => {
     await cleanUp(false);
   }, helper.setupTime);

--- a/plugins/@grouparoo/salesforce/__tests__/export-contacts/export-records-enrich.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-contacts/export-records-enrich.ts
@@ -10,7 +10,7 @@ import { DestinationSyncModeData } from "@grouparoo/core/dist/models/Destination
 const { newNock } = helper.useNock(__filename, updater);
 const appOptions = loadAppOptions(newNock);
 const appId = "app_f3bb07d8-0c4f-49b5-ad42-545f2e8662e9";
-const syncOperations = DestinationSyncModeData.enrich.operations;
+const syncOperations = DestinationSyncModeData.update.operations;
 const destinationOptions = {
   primaryKey: "Email",
   accountKey: "Name",
@@ -55,7 +55,7 @@ const {
   deleteReferenceValues,
 });
 
-describe("salesforce/sales-cloud/export-records/enrich", () => {
+describe("salesforce/sales-cloud/export-records/update", () => {
   beforeAll(async () => {
     await cleanUp(false);
   }, helper.setupTime);

--- a/plugins/@grouparoo/salesforce/__tests__/export-objects/destination-mapping-options-enrich.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-objects/destination-mapping-options-enrich.ts
@@ -40,7 +40,7 @@ describe("salesforce/sales-cloud/destinationMappingOptions", () => {
     destination = await Destination.create({
       name: "Salesforce Test Destination",
       type: "salesforce-export-accounts",
-      syncMode: DestinationSyncModeData.enrich.key,
+      syncMode: DestinationSyncModeData.update.key,
       appId: app.id,
       modelId: model.id,
     });

--- a/plugins/@grouparoo/salesforce/__tests__/export-objects/export-records-additive.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-objects/export-records-additive.ts
@@ -10,7 +10,7 @@ import { DestinationSyncModeData } from "@grouparoo/core/dist/models/Destination
 const { newNock } = helper.useNock(__filename, updater);
 const appOptions = loadAppOptions(newNock);
 const appId = "app_f3bb07d8-0c4f-49b5-ad42-545f2e8632e2";
-const syncOperations = DestinationSyncModeData.additive.operations;
+const syncOperations = DestinationSyncModeData.upsert.operations;
 const destinationOptions = {
   recordObject: "Contact",
   recordMatchField: "Email",
@@ -69,7 +69,7 @@ const {
   deleteReferenceValues,
 });
 
-describe("salesforce/sales-cloud/export-records/additive", () => {
+describe("salesforce/sales-cloud/export-records/upsert", () => {
   beforeAll(async () => {
     await cleanUp(false);
   }, helper.setupTime);

--- a/plugins/@grouparoo/salesforce/__tests__/export-objects/export-records-enrich.ts
+++ b/plugins/@grouparoo/salesforce/__tests__/export-objects/export-records-enrich.ts
@@ -10,7 +10,7 @@ import { DestinationSyncModeData } from "@grouparoo/core/dist/models/Destination
 const { newNock } = helper.useNock(__filename, updater);
 const appOptions = loadAppOptions(newNock);
 const appId = "app_f3bb07d8-0c4f-49b5-ad42-545f2e8662e9";
-const syncOperations = DestinationSyncModeData.enrich.operations;
+const syncOperations = DestinationSyncModeData.update.operations;
 const destinationOptions = {
   recordObject: "Contact",
   recordMatchField: "Email",
@@ -69,7 +69,7 @@ const {
   deleteReferenceValues,
 });
 
-describe("salesforce/sales-cloud/export-records/enrich", () => {
+describe("salesforce/sales-cloud/export-records/update", () => {
   beforeAll(async () => {
     await cleanUp(false);
   }, helper.setupTime);

--- a/plugins/@grouparoo/salesforce/src/lib/export-account/connection.ts
+++ b/plugins/@grouparoo/salesforce/src/lib/export-account/connection.ts
@@ -7,8 +7,8 @@ import { exportArrayProperties } from "../export/exportArrayProperties";
 
 export const accountsSupportedSyncModes: DestinationSyncMode[] = [
   "sync",
-  "additive",
-  "enrich",
+  "upsert",
+  "update",
 ];
 
 export const accountsDestinationConnection: PluginConnection = {

--- a/plugins/@grouparoo/salesforce/src/lib/export-contacts/connection.ts
+++ b/plugins/@grouparoo/salesforce/src/lib/export-contacts/connection.ts
@@ -7,8 +7,8 @@ import { exportArrayProperties } from "../export/exportArrayProperties";
 
 export const contactsSupportedSyncModes: DestinationSyncMode[] = [
   "sync",
-  "additive",
-  "enrich",
+  "upsert",
+  "update",
 ];
 
 export const contactsDestinationConnection: PluginConnection = {

--- a/plugins/@grouparoo/salesforce/src/lib/export-objects/connection.ts
+++ b/plugins/@grouparoo/salesforce/src/lib/export-objects/connection.ts
@@ -7,8 +7,8 @@ import { exportArrayProperties } from "../export/exportArrayProperties";
 
 export const objectsSupportedSyncModes: DestinationSyncMode[] = [
   "sync",
-  "additive",
-  "enrich",
+  "upsert",
+  "update",
 ];
 
 export const objectsDestinationConnection: PluginConnection = {

--- a/plugins/@grouparoo/salesforce/src/lib/export/mapping.ts
+++ b/plugins/@grouparoo/salesforce/src/lib/export/mapping.ts
@@ -200,7 +200,7 @@ const extractFields = async (
     if (!field.nillable && !field.defaultedOnCreate) {
       // needs to be set to create
       const syncMode = await destination.getSyncMode();
-      if (syncMode === DestinationSyncModeData.enrich.key) {
+      if (syncMode === DestinationSyncModeData.update.key) {
         known.push({ key, type, important: true });
       } else {
         required.push({ key, type });

--- a/plugins/@grouparoo/sendgrid/__tests__/export/export-record.ts
+++ b/plugins/@grouparoo/sendgrid/__tests__/export/export-record.ts
@@ -151,7 +151,7 @@ describe("sendgrid/exportRecord", () => {
     expect(user).toBe(null);
     await expect(
       runExport({
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         oldRecordProperties: {},
         newRecordProperties: { email, first_name },
         oldGroups: [],

--- a/plugins/@grouparoo/sendgrid/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/sendgrid/src/initializers/plugin.ts
@@ -15,7 +15,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
     plugin.registerPlugin({
       name: packageJSON.name,

--- a/plugins/@grouparoo/snowflake/__tests__/export/export-records.ts
+++ b/plugins/@grouparoo/snowflake/__tests__/export/export-records.ts
@@ -122,7 +122,7 @@ describe("snowflake/exportRecords", () => {
     const { success, errors } = await exportBatch({
       appOptions,
       destinationOptions,
-      syncOperations: DestinationSyncModeData.enrich.operations,
+      syncOperations: DestinationSyncModeData.update.operations,
       exports: [
         {
           recordId: id1,
@@ -664,7 +664,7 @@ describe("snowflake/exportRecords", () => {
     const { success, errors } = await exportBatch({
       appOptions,
       destinationOptions,
-      syncOperations: DestinationSyncModeData.additive.operations,
+      syncOperations: DestinationSyncModeData.upsert.operations,
       exports: [
         {
           recordId: id1,

--- a/plugins/@grouparoo/snowflake/src/lib/export/connection.ts
+++ b/plugins/@grouparoo/snowflake/src/lib/export/connection.ts
@@ -11,7 +11,7 @@ export const destinationConnection: PluginConnection = {
   description:
     "Export Records to a Snowflake table.  Groups will be exported to a secondary table linked by a foreign key.",
   apps: ["snowflake", "snowflake-keypair"],
-  syncModes: ["sync", "additive", "enrich"],
+  syncModes: ["sync", "upsert", "update"],
   defaultSyncMode: "sync",
   options: [
     {

--- a/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
+++ b/plugins/@grouparoo/spec-helper/src/lib/specHelper.ts
@@ -504,7 +504,7 @@ export namespace helper {
           direction: "export",
           description: "export records to nowhere",
           apps: ["test-plugin-app"],
-          syncModes: ["sync", "enrich", "additive"],
+          syncModes: ["sync", "update", "upsert"],
           options: [
             { key: "table", required: true },
             { key: "where", required: false },
@@ -560,8 +560,8 @@ export namespace helper {
           direction: "export",
           description: "export records to nowhere",
           apps: ["test-plugin-app"],
-          syncModes: ["sync", "enrich", "additive"],
-          defaultSyncMode: "additive",
+          syncModes: ["sync", "update", "upsert"],
+          defaultSyncMode: "upsert",
           options: [
             { key: "table", required: true },
             { key: "where", required: false },

--- a/plugins/@grouparoo/sqlite/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/sqlite/src/initializers/plugin.ts
@@ -20,7 +20,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     const defaultSyncMode: DestinationSyncMode = "sync";
     plugin.registerPlugin({
       name: packageJSON.name,

--- a/plugins/@grouparoo/vero/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/vero/src/initializers/plugin.ts
@@ -16,7 +16,7 @@ export class Plugins extends Initializer {
   }
 
   async initialize() {
-    const syncModes: DestinationSyncMode[] = ["sync", "additive"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert"];
     const defaultSyncMode: DestinationSyncMode = "sync";
 
     plugin.registerPlugin({

--- a/plugins/@grouparoo/zendesk/__tests__/export/export-record.ts
+++ b/plugins/@grouparoo/zendesk/__tests__/export/export-record.ts
@@ -166,7 +166,7 @@ describe("zendesk/exportRecord", () => {
   test("cannot create an user if sync mode does not allow it", async () => {
     await expect(
       runExport({
-        syncOperations: DestinationSyncModeData.enrich.operations,
+        syncOperations: DestinationSyncModeData.update.operations,
         oldRecordProperties: {},
         newRecordProperties: {
           name: "Jimmy Doe",

--- a/plugins/@grouparoo/zendesk/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/zendesk/src/initializers/plugin.ts
@@ -16,7 +16,7 @@ export class Plugins extends Initializer {
 
   async initialize() {
     const defaultSyncMode: DestinationSyncMode = "sync";
-    const syncModes: DestinationSyncMode[] = ["sync", "additive", "enrich"];
+    const syncModes: DestinationSyncMode[] = ["sync", "upsert", "update"];
     plugin.registerPlugin({
       name: packageJSON.name,
       icon: "/public/@grouparoo/zendesk/zendesk.png",


### PR DESCRIPTION
## Change description

This PR adds the ability to support `append` or`create` (`create: true, update: false, delete: false`) in destination apps. It also migrates the `enrich` and `additive` syncMode names to the more commonly known terms `update` and `upsert`.

The db will migrate the syncModes to the new values. In config files, `enrich` and `additive` are still supported but a warning is shown, and will be updated to the new value if the user updates the config via the UI.

All plugins have been updated to use the new terms.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

**Migrations considered:**
1. Enrich and Additive are still supported on config files. When the file is loaded, a warning is shown to the user (also visible in `grouparoo validate`) and will continue to support the legacy values. However, if the user saves the config via the UI, the values are replaced with the new values.
2. Added db migration to update the syncMode

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
