### PR TITLE
Increment primary keys by 1 in `demo` command

### DIFF
--- a/plugins/@grouparoo/demo/src/util/sample_data.ts
+++ b/plugins/@grouparoo/demo/src/util/sample_data.ts
@@ -219,12 +219,12 @@ function getRowData(
   const updated_at = getUpdatedAt(myId, tableName, created_at); // updated sometime after that
 
   if (page > 1) {
-    myId = perPage * page + myId;
+    myId = perPage * (page - 1) + myId;
 
     if (isRoot) {
       typeId = myId;
     } else {
-      typeId = numOfRoot * page + typeId;
+      typeId = numOfRoot * (page - 1) + typeId;
     }
   }
 


### PR DESCRIPTION
## Change description

Previously, when use the `--scale` flag, primary keys would skip a page after the first iteration through the data (ie: user id's would be created as 998, 999, 1000, 2001, 2002, etc.)

Now, they always increment by 1.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
