### PR TITLE
Add destination delivery mode, cancel duplicate exports when in "once" mode

### DIFF
--- a/core/__tests__/models/destination/destination.ts
+++ b/core/__tests__/models/destination/destination.ts
@@ -67,6 +67,18 @@ describe("models/destination", () => {
       await destination.destroy();
     });
 
+    test("a new destination will have a default 'continual' delivery mode", async () => {
+      destination = await Destination.create({
+        type: "test-plugin-export",
+        appId: app.id,
+        modelId: model.id,
+      });
+
+      expect(destination.deliveryMode).toBe("continual");
+
+      await destination.destroy();
+    });
+
     test("draft destination can share the same name, but not with ready destination", async () => {
       const destinationOne = await Destination.create({
         type: "test-plugin-export",

--- a/core/__tests__/models/destination/plugins/exportRecord.ts
+++ b/core/__tests__/models/destination/plugins/exportRecord.ts
@@ -963,19 +963,6 @@ describe("models/destination - with custom exportRecord plugin", () => {
         await record.addOrUpdateProperties({
           email: ["newEmail@example.com"],
         });
-        // const group = await helper.factories.group();
-        // await GroupMember.create({ recordId: record.id, groupId: group.id });
-        // await destination.updateTracking("group", group.id);
-
-        // await destination.setMapping({
-        //   customer_email: "email",
-        // });
-
-        // const destinationGroupMemberships: Record<string, any> = {};
-        // destinationGroupMemberships[group.id] = group.name;
-        // await destination.setDestinationGroupMemberships(
-        //   destinationGroupMemberships
-        // );
 
         await destination.exportRecord(record, true);
       });

--- a/core/__tests__/models/destination/plugins/exportRecord.ts
+++ b/core/__tests__/models/destination/plugins/exportRecord.ts
@@ -955,6 +955,85 @@ describe("models/destination - with custom exportRecord plugin", () => {
       });
     });
 
+    describe("when destination delivery mode is", () => {
+      let record: GrouparooRecord = null;
+
+      beforeEach(async () => {
+        record = await helper.factories.record();
+        await record.addOrUpdateProperties({
+          email: ["newEmail@example.com"],
+        });
+        // const group = await helper.factories.group();
+        // await GroupMember.create({ recordId: record.id, groupId: group.id });
+        // await destination.updateTracking("group", group.id);
+
+        // await destination.setMapping({
+        //   customer_email: "email",
+        // });
+
+        // const destinationGroupMemberships: Record<string, any> = {};
+        // destinationGroupMemberships[group.id] = group.name;
+        // await destination.setDestinationGroupMemberships(
+        //   destinationGroupMemberships
+        // );
+
+        await destination.exportRecord(record, true);
+      });
+
+      afterEach(async () => {
+        await record.destroy();
+      });
+
+      test("continual, we can export a record multiple times", async () => {
+        destination.deliveryMode = "continual";
+
+        await destination.exportRecord(record, true);
+
+        const _exports = await Export.findAll({
+          where: { destinationId: destination.id },
+        });
+        expect(_exports).toHaveLength(2);
+
+        expect(_exports[0].state).toBe("complete");
+        expect(_exports[1].state).toBe("complete");
+      });
+
+      test("once, we can only export a record once", async () => {
+        destination.deliveryMode = "once";
+
+        await destination.exportRecord(record, true);
+
+        const _exports = await Export.findAll({
+          where: { destinationId: destination.id },
+        });
+        expect(_exports).toHaveLength(2);
+        expect(_exports[0].state).toBe("complete");
+        expect(_exports[1].state).toBe("canceled");
+        expect(_exports[1].errorMessage).toBe(
+          "Destination is only delivering records once"
+        );
+      });
+
+      test("changed, new exports will use updated delivery mode", async () => {
+        destination.deliveryMode = "once";
+        await destination.exportRecord(record, true);
+
+        destination.deliveryMode = "continual";
+        await destination.exportRecord(record, true);
+
+        const _exports = await Export.findAll({
+          where: { destinationId: destination.id },
+        });
+        expect(_exports).toHaveLength(3);
+        expect(_exports[0].state).toBe("complete");
+        expect(_exports[1].state).toBe("canceled");
+        expect(_exports[1].errorMessage).toBe(
+          "Destination is only delivering records once"
+        );
+        expect(_exports[2].state).toBe("complete");
+      });
+    });
+
     test("exportRecord can return that it is rate limited and the export will have a sendAt in the future", async () => {
       // when the parallelism is not OK
       parallelismResponse = 0;

--- a/core/src/actions/destinations.ts
+++ b/core/src/actions/destinations.ts
@@ -175,6 +175,7 @@ export class DestinationEdit extends AuthenticatedAction {
     state: { required: false },
     options: { required: false, formatter: APIData.ensureObject },
     mapping: { required: false, formatter: APIData.ensureObject },
+    deliveryMode: { required: false },
     syncMode: { required: false },
     destinationGroupMemberships: {
       required: false,
@@ -209,6 +210,7 @@ export class DestinationEdit extends AuthenticatedAction {
       name: params.name,
       state: params.state,
       syncMode: params.syncMode,
+      deliveryMode: params.deliveryMode,
     });
 
     let oldRun: Run;

--- a/core/src/migrations/000102-addDeliveryMode.ts
+++ b/core/src/migrations/000102-addDeliveryMode.ts
@@ -1,0 +1,19 @@
+import Sequelize, { DataTypes } from "sequelize";
+
+export default {
+  up: async (queryInterface: Sequelize.QueryInterface) => {
+    await queryInterface.addColumn("destinations", "deliveryMode", {
+      type: DataTypes.STRING(191),
+      allowNull: false,
+      defaultValue: "continual",
+    });
+    await queryInterface.changeColumn("destinations", "deliveryMode", {
+      type: DataTypes.STRING(191),
+      allowNull: false,
+    });
+  },
+
+  down: async (queryInterface: Sequelize.QueryInterface) => {
+    await queryInterface.removeColumn("destinations", "deliveryMode");
+  },
+};

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -56,6 +56,9 @@ export interface SimpleDestinationOptions extends OptionHelper.SimpleOptions {}
 const SYNC_MODES = ["sync", "additive", "enrich"] as const;
 export type DestinationSyncMode = typeof SYNC_MODES[number];
 
+const DELIVERY_MODES = ["continual", "once"];
+export type DestinationDeliveryMode = typeof DELIVERY_MODES[number];
+
 const DESTINATION_COLLECTIONS = ["none", "group", "model"] as const;
 export type DestinationCollection = typeof DESTINATION_COLLECTIONS[number];
 
@@ -168,6 +171,11 @@ export class Destination extends CommonModel<Destination> {
   syncMode: DestinationSyncMode;
 
   @AllowNull(false)
+  @Default("continual")
+  @Column(DataType.ENUM(...DELIVERY_MODES))
+  deliveryMode: DestinationDeliveryMode;
+
+  @AllowNull(false)
   @Default("none")
   @Column(DataType.ENUM(...DESTINATION_COLLECTIONS))
   collection: DestinationCollection;
@@ -232,6 +240,7 @@ export class Destination extends CommonModel<Destination> {
       locked: this.locked,
       syncMode,
       syncModes: syncModeData,
+      deliveryMode: this.deliveryMode,
       collection: this.collection,
       app: app ? await app.apiData() : null,
       modelId: this.modelId,

--- a/core/src/models/Destination.ts
+++ b/core/src/models/Destination.ts
@@ -56,7 +56,7 @@ export interface SimpleDestinationOptions extends OptionHelper.SimpleOptions {}
 const SYNC_MODES = ["sync", "additive", "enrich"] as const;
 export type DestinationSyncMode = typeof SYNC_MODES[number];
 
-const DELIVERY_MODES = ["continual", "once"];
+const DELIVERY_MODES = ["continual", "once"] as const;
 export type DestinationDeliveryMode = typeof DELIVERY_MODES[number];
 
 const DESTINATION_COLLECTIONS = ["none", "group", "model"] as const;

--- a/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/destination/[destinationId]/edit.tsx
@@ -1,3 +1,4 @@
+import { DestinationDeliveryMode } from "@grouparoo/core/src/models/Destination";
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -24,6 +25,25 @@ import { NextPageWithInferredProps } from "../../../../../utils/pageHelper";
 import { grouparooUiEdition } from "../../../../../utils/uiEdition";
 import { withServerErrorHandler } from "../../../../../utils/withServerErrorHandler";
 
+export const DestinationDeliveryModeData: Record<
+  DestinationDeliveryMode,
+  {
+    key: DestinationDeliveryMode;
+    displayName: string;
+    description: string;
+  }
+> = {
+  continual: {
+    key: "continual",
+    displayName: "Continual",
+    description: "Can deliver the same record multiple times",
+  },
+  once: {
+    key: "once",
+    displayName: "Once",
+    description: "Guaranteed to only deliver a record at-most-once",
+  },
+};
 export const getServerSideProps = withServerErrorHandler(async (ctx) => {
   const client = generateClient(ctx);
   const { destinationId, modelId } = ctx.query;
@@ -82,6 +102,7 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
         state: "ready",
         name: destination.name,
         syncMode: destination.syncMode,
+        deliveryMode: destination.deliveryMode,
         options: destination.options,
       }
     );
@@ -191,6 +212,29 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
                 <Form.Control.Feedback type="invalid">
                   Name is required
                 </Form.Control.Feedback>
+              </Form.Group>
+
+              <Form.Group controlId="deliveryMode">
+                <Form.Label>Delivery Mode</Form.Label>
+                <Form.Control
+                  as="select"
+                  required={true}
+                  disabled={loading}
+                  defaultValue={destination.deliveryMode?.toString() || ""}
+                  onChange={(e) => update(e)}
+                >
+                  <option value={""} disabled>
+                    Select an option
+                  </option>
+                  {Object.values(DestinationDeliveryModeData).map((mode) => (
+                    <option key={mode.key} value={mode.key}>
+                      {mode.displayName} | {mode.description}
+                    </option>
+                  ))}
+                </Form.Control>
+                <Form.Text className="text-muted">
+                  How should this destination sync records?
+                </Form.Text>
               </Form.Group>
 
               {destination.syncModes.length > 0 ? (


### PR DESCRIPTION
## Change description
This adds:

- Delivery mode for destinations. Options are [once, continual]
  - Continual - "Can deliver the same record multiple times" - default
  - Once - "Guaranteed to only deliver a record at-most-once"
- UI for the destination delivery mode

This changes:
- Add a check in `sendExports` that will refuse to run any export whose destination is _currently_ set to "once"

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
