### PR TITLE
Some playwright CI tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     resource_class: "medium+"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -186,7 +186,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -222,7 +222,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -277,7 +277,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -332,7 +332,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -387,7 +387,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -442,7 +442,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -497,7 +497,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -552,7 +552,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -607,7 +607,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -662,7 +662,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -717,7 +717,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -772,7 +772,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -808,7 +808,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -847,7 +847,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -886,7 +886,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -925,7 +925,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -990,7 +990,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1056,7 +1056,7 @@ jobs:
       GROUPAROO_TELEMETRY_ENABLED: "false"
       NODE_ENV: development
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1118,7 +1118,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1183,7 +1183,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1245,7 +1245,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1307,7 +1307,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1362,7 +1362,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1417,7 +1417,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1472,7 +1472,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1527,7 +1527,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1582,7 +1582,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1647,7 +1647,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1702,7 +1702,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1757,7 +1757,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1812,7 +1812,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1867,7 +1867,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1922,7 +1922,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1977,7 +1977,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2032,7 +2032,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2087,7 +2087,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2142,7 +2142,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2197,7 +2197,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2252,7 +2252,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2307,7 +2307,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2362,7 +2362,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2417,7 +2417,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2472,7 +2472,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2527,7 +2527,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2582,7 +2582,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2637,7 +2637,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2696,7 +2696,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2763,7 +2763,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2818,7 +2818,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2873,7 +2873,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2928,7 +2928,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2983,7 +2983,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3038,7 +3038,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3093,7 +3093,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3152,7 +3152,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3207,7 +3207,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3262,7 +3262,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3317,7 +3317,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3372,7 +3372,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3427,7 +3427,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3482,7 +3482,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3537,7 +3537,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3592,7 +3592,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3647,7 +3647,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3702,7 +3702,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3736,7 +3736,7 @@ jobs:
           command: cd cli && pnpm test
   complete:
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:current
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1070,10 +1070,6 @@ jobs:
           password: $DOCKERHUB_PASSWORD
         environment:
           POSTGRES_PASSWORD: password
-      - image: mcr.microsoft.com/playwright:v1.19.0-focal
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - restore_cache:
@@ -1110,7 +1106,7 @@ jobs:
           command: cd core && ./bin/create_test_databases
       - run:
           name: install playwright dependencies
-          command: cd ui/ui-enterprise && ./node_modules/.bin/playwright install && ./node_modules/.bin/playwright install-deps && sudo apt-get install libicu66 libvpx6 ttf-ubuntu-font-family libjpeg-turbo8
+          command: cd ui/ui-enterprise && ./node_modules/.bin/playwright install && ./node_modules/.bin/playwright install-deps
       - run:
           name: test
           command: cd ui/ui-enterprise && ./node_modules/.bin/playwright test --workers 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1110,7 +1110,7 @@ jobs:
           command: cd core && ./bin/create_test_databases
       - run:
           name: install playwright dependencies
-          command: cd ui/ui-enterprise && ./node_modules/.bin/playwright install && ./node_modules/.bin/playwright install-deps && sudo apt-get install libicu66 libvpx6 ttf-ubuntu-font-family libjpeg-turbo8
+          command: cd ui/ui-enterprise && ./node_modules/.bin/playwright install && ./node_modules/.bin/playwright install-deps
       - run:
           name: test
           command: cd ui/ui-enterprise && ./node_modules/.bin/playwright test --workers 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     resource_class: "medium+"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -186,7 +186,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -222,7 +222,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -277,7 +277,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -332,7 +332,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -387,7 +387,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -442,7 +442,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -497,7 +497,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -552,7 +552,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -607,7 +607,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -662,7 +662,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -717,7 +717,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -772,7 +772,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -808,7 +808,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -847,7 +847,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -886,7 +886,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -925,7 +925,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -990,7 +990,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1056,7 +1056,7 @@ jobs:
       GROUPAROO_TELEMETRY_ENABLED: "false"
       NODE_ENV: development
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1110,7 +1110,7 @@ jobs:
           command: cd core && ./bin/create_test_databases
       - run:
           name: install playwright dependencies
-          command: cd ui/ui-enterprise && ./node_modules/.bin/playwright install && ./node_modules/.bin/playwright install-deps
+          command: cd ui/ui-enterprise && ./node_modules/.bin/playwright install && ./node_modules/.bin/playwright install-deps && sudo apt-get install libicu66 libvpx6 ttf-ubuntu-font-family libjpeg-turbo8
       - run:
           name: test
           command: cd ui/ui-enterprise && ./node_modules/.bin/playwright test --workers 2
@@ -1118,7 +1118,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1183,7 +1183,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1245,7 +1245,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1307,7 +1307,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1362,7 +1362,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1417,7 +1417,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1472,7 +1472,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1527,7 +1527,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1582,7 +1582,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1647,7 +1647,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1702,7 +1702,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1757,7 +1757,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1812,7 +1812,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1867,7 +1867,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1922,7 +1922,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -1977,7 +1977,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2032,7 +2032,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2087,7 +2087,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2142,7 +2142,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2197,7 +2197,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2252,7 +2252,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2307,7 +2307,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2362,7 +2362,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2417,7 +2417,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2472,7 +2472,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2527,7 +2527,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2582,7 +2582,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2637,7 +2637,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2696,7 +2696,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2763,7 +2763,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2818,7 +2818,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2873,7 +2873,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2928,7 +2928,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -2983,7 +2983,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3038,7 +3038,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3093,7 +3093,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3152,7 +3152,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3207,7 +3207,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3262,7 +3262,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3317,7 +3317,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3372,7 +3372,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3427,7 +3427,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3482,7 +3482,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3537,7 +3537,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3592,7 +3592,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3647,7 +3647,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3702,7 +3702,7 @@ jobs:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -3736,7 +3736,7 @@ jobs:
           command: cd cli && pnpm test
   complete:
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:16.14
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,116 +218,6 @@ jobs:
       - run:
           name: linter
           command: cd monorepo && pnpm run lint
-  test-core-.DS_Store:
-    environment:
-      GROUPAROO_TELEMETRY_ENABLED: "false"
-    docker:
-      - image: circleci/node:16.8.0
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-      - image: redis:latest
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-      - image: circleci/postgres:9
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *module-other-cache
-      - restore_cache:
-          <<: *plugin-1-cache
-      - restore_cache:
-          <<: *plugin-2-cache
-      - restore_cache:
-          <<: *plugin-3-cache
-      - restore_cache:
-          <<: *plugin-4-cache
-      - restore_cache:
-          <<: *dist-1-cache
-      - restore_cache:
-          <<: *dist-2-cache
-      - restore_cache:
-          <<: *dist-3-cache
-      - restore_cache:
-          <<: *dist-4-cache
-      - restore_cache:
-          <<: *core-cache
-      - run:
-          name: update apt
-          command: sudo apt update
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd core && ./node_modules/.bin/jest __tests__/.DS_Store --ci --maxWorkers 2
-  test-core-.pnpm-debug.log:
-    environment:
-      GROUPAROO_TELEMETRY_ENABLED: "false"
-    docker:
-      - image: circleci/node:16.8.0
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-      - image: redis:latest
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-      - image: circleci/postgres:9
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-        environment:
-          POSTGRES_PASSWORD: password
-    steps:
-      - checkout
-      - restore_cache:
-          <<: *module-other-cache
-      - restore_cache:
-          <<: *plugin-1-cache
-      - restore_cache:
-          <<: *plugin-2-cache
-      - restore_cache:
-          <<: *plugin-3-cache
-      - restore_cache:
-          <<: *plugin-4-cache
-      - restore_cache:
-          <<: *dist-1-cache
-      - restore_cache:
-          <<: *dist-2-cache
-      - restore_cache:
-          <<: *dist-3-cache
-      - restore_cache:
-          <<: *dist-4-cache
-      - restore_cache:
-          <<: *core-cache
-      - run:
-          name: update apt
-          command: sudo apt update
-      - run:
-          name: install postgresql client
-          command: sudo apt install -y postgresql-client
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run:
-          name: create test databases
-          command: cd core && ./bin/create_test_databases
-      - run:
-          name: test
-          command: cd core && ./node_modules/.bin/jest __tests__/.pnpm-debug.log --ci --maxWorkers 2
   test-core-actions:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
@@ -1164,7 +1054,7 @@ jobs:
   test-ui-enterprise:
     environment:
       GROUPAROO_TELEMETRY_ENABLED: "false"
-      NODE_ENV: "development"
+      NODE_ENV: development
     docker:
       - image: circleci/node:16.8.0
         auth:
@@ -1220,8 +1110,7 @@ jobs:
           command: cd core && ./bin/create_test_databases
       - run:
           name: install playwright dependencies
-          command: cd ui/ui-enterprise && ./node_modules/.bin/playwright install && ./node_modules/.bin/playwright install-deps
- && sudo apt-get install libicu66 libvpx6 ttf-ubuntu-font-family libjpeg-turbo8
+          command: cd ui/ui-enterprise && ./node_modules/.bin/playwright install && ./node_modules/.bin/playwright install-deps && sudo apt-get install libicu66 libvpx6 ttf-ubuntu-font-family libjpeg-turbo8
       - run:
           name: test
           command: cd ui/ui-enterprise && ./node_modules/.bin/playwright test --workers 2
@@ -2826,7 +2715,7 @@ jobs:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
         environment:
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
     steps:
       - checkout
       - restore_cache:
@@ -3869,16 +3758,6 @@ workflows:
             <<: *ignored-branches
           requires:
             - build
-      - test-core-.DS_Store:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - build
-      - test-core-.pnpm-debug.log:
-          filters:
-            <<: *ignored-branches
-          requires:
-            - build
       - test-core-actions:
           filters:
             <<: *ignored-branches
@@ -4204,8 +4083,6 @@ workflows:
             <<: *ignored-branches
           requires:
             - linter
-            - test-core-.DS_Store
-            - test-core-.pnpm-debug.log
             - test-core-actions
             - test-core-bin
             - test-core-classes

--- a/tools/merger/data/ci/ui-playwright/job.yml.template
+++ b/tools/merger/data/ci/ui-playwright/job.yml.template
@@ -17,10 +17,6 @@
           password: $DOCKERHUB_PASSWORD
         environment:
           POSTGRES_PASSWORD: password
-      - image: mcr.microsoft.com/playwright:v1.19.0-focal
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
 {{{custom_docker}}}
     steps:
       - checkout
@@ -39,7 +35,7 @@
           command: cd core && ./bin/create_test_databases
       - run:
           name: install playwright dependencies
-          command: cd {{{relative_path}}}/{{{test_section}}} && ./node_modules/.bin/playwright install && ./node_modules/.bin/playwright install-deps && sudo apt-get install libicu66 libvpx6 ttf-ubuntu-font-family libjpeg-turbo8
+          command: cd {{{relative_path}}}/{{{test_section}}} && ./node_modules/.bin/playwright install && ./node_modules/.bin/playwright install-deps
 {{{custom_steps}}} 
       - run:
           name: test

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -5,7 +5,7 @@ const Mustache = require("mustache");
 const { allPackagePaths, allPluginPaths } = require("../../shared/packages");
 const execSync = require("../../shared/exec");
 
-const docker_image = "cimg/node:current";
+const docker_image = "cimg/node:16.14";
 
 module.exports.cmd = async function (vargs) {
   const instance = new Generator(vargs);

--- a/tools/merger/src/ci_generate.js
+++ b/tools/merger/src/ci_generate.js
@@ -5,7 +5,7 @@ const Mustache = require("mustache");
 const { allPackagePaths, allPluginPaths } = require("../../shared/packages");
 const execSync = require("../../shared/exec");
 
-const docker_image = "circleci/node:16.8.0";
+const docker_image = "cimg/node:current";
 
 module.exports.cmd = async function (vargs) {
   const instance = new Generator(vargs);

--- a/ui/ui-community/playwright.config.ts
+++ b/ui/ui-community/playwright.config.ts
@@ -47,7 +47,7 @@ const config: PlaywrightTestConfig = {
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
-    headless: false,
+    headless: true,
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://localhost:3000',
 

--- a/ui/ui-enterprise/playwright.config.ts
+++ b/ui/ui-enterprise/playwright.config.ts
@@ -47,7 +47,7 @@ const config: PlaywrightTestConfig = {
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
-    headless: false,
+    headless: true,
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://localhost:3000',
 


### PR DESCRIPTION
## Change description

merging a fix into @tealjulia 's branch

Migrates to using the `cimg/node` image. The one we've been using is deprecated: https://circleci.com/docs/2.0/circleci-images/

> Legacy images with the prefix "circleci/" will be deprecated on December 31, 2021. For faster builds, upgrade your projects with next-generation convenience images

They changed the base image from debian to ubuntu and this has the nice side effect of making `playwright install-deps` work as expected.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
