### PR TITLE
fix(hubspot): don't modify the options object when getting destination options

### DIFF
--- a/core/__tests__/models/option.ts
+++ b/core/__tests__/models/option.ts
@@ -146,7 +146,31 @@ describe("models/option", () => {
 
       const options = await OptionHelper.getOptions(app);
       expect(options["fileId"]).toEqual(opts.fileId);
-      expect(options["password"]).toBeUndefined();
+      expect(Object.keys(options).includes("password")).toEqual(false);
+    });
+
+    test("undefined options will be ignored", async () => {
+      const opts: OptionHelper.SimpleOptions = {
+        fileId: "abcdba",
+        password: undefined,
+      };
+      await OptionHelper.setOptions(app, opts);
+
+      const options = await OptionHelper.getOptions(app);
+      expect(options["fileId"]).toEqual(opts.fileId);
+      expect(Object.keys(options).includes("password")).toEqual(false);
+    });
+
+    test("null options will be ignored", async () => {
+      const opts: OptionHelper.SimpleOptions = {
+        fileId: "abcdba",
+        password: null,
+      };
+      await OptionHelper.setOptions(app, opts);
+
+      const options = await OptionHelper.getOptions(app);
+      expect(options["fileId"]).toEqual(opts.fileId);
+      expect(Object.keys(options).includes("password")).toEqual(false);
     });
 
     test("I will see passwords by default for Apps", async () => {

--- a/core/src/modules/optionHelper.ts
+++ b/core/src/modules/optionHelper.ts
@@ -381,7 +381,8 @@ export namespace OptionHelper {
     const opts = Object.assign({}, options);
 
     Object.keys(opts).forEach((k) => {
-      if (opts[k] === "") delete opts[k];
+      if (typeof opts[k] === "undefined" || opts[k] === null || opts[k] === "")
+        delete opts[k];
     });
 
     return opts;

--- a/plugins/@grouparoo/hubspot/src/lib/export-contacts/destinationOptions.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/export-contacts/destinationOptions.ts
@@ -4,10 +4,7 @@ import { OptionsHandler } from "../export/options";
 export const destinationOptions: DestinationOptionsMethod = async ({
   appId,
   appOptions,
-  destinationOptions,
 }) => {
   const optionHandler = new OptionsHandler({ appId, appOptions });
-  return await optionHandler.getContactDestinationOptions({
-    destinationOptions,
-  });
+  return await optionHandler.getContactDestinationOptions();
 };

--- a/plugins/@grouparoo/hubspot/src/lib/export/options.ts
+++ b/plugins/@grouparoo/hubspot/src/lib/export/options.ts
@@ -33,13 +33,11 @@ class OptionsHandler {
     return out;
   }
 
-  public async getContactDestinationOptions({
-    destinationOptions,
-  }): Promise<DestinationOptionsMethodResponse> {
+  public async getContactDestinationOptions(): Promise<DestinationOptionsMethodResponse> {
     const { appOptions } = this.cacheData;
     this.client = await connect(appOptions);
     const out: DestinationOptionsMethodResponse = {};
-    Object.assign(out, await this.getContactOptions(destinationOptions));
+    Object.assign(out, await this.getContactOptions());
     return out;
   }
 
@@ -67,9 +65,7 @@ class OptionsHandler {
     );
   }
 
-  private async getContactOptions(
-    destinationOptions: SimpleDestinationOptions
-  ) {
+  private async getContactOptions() {
     const searchableAndUniqueProperties = [
       "website",
       "phone",
@@ -84,13 +80,7 @@ class OptionsHandler {
         descriptions: [],
       },
     };
-    if (
-      !searchableAndUniqueProperties.includes(
-        destinationOptions?.companyKey?.toString()
-      )
-    ) {
-      destinationOptions.companyKey = null;
-    }
+
     return out;
   }
 
@@ -126,12 +116,6 @@ class OptionsHandler {
       const fields = await this.getObjectMatchNames(schemaId);
       out.primaryKey.type = "typeahead";
       out.primaryKey.options = fields;
-      if (!fields.includes(destinationOptions.primaryKey)) {
-        destinationOptions.primaryKey = null;
-      }
-    } else {
-      destinationOptions.schemaId = null;
-      destinationOptions.primaryKey = null;
     }
     return out;
   }


### PR DESCRIPTION
## Change description

This was causing validation to fail because of unexpected `null`s, meaning that hubspot destinations could not be created.

Because these were in here to clear out invalid values, this should no longer be necessary since core's validation introduced in #2988 will prevent these from being set in the first place. 

Also fixed up the `filterEmptyOptions` method to also clear `null`s and `undefined`s 

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
