### PR TITLE
Fix column overlap on Multiple Properties page

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -192,16 +192,11 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
                 .sort()
                 .map((opt) => (
                   <Form.Group as={Col} key={`opt-${column}-${opt}`}>
-                    <Form.Row>
-                      <Col md={3}>
-                        <code>
-                          <Form.Label>{opt}: </Form.Label>
-                        </code>
-                      </Col>
-                      <Col>
-                        <strong>{options[opt].toString()}</strong>
-                        {/* We actually don't want to allow changes to the provided source options? */}
-                        {/* <Form.Control
+                    <strong>
+                      <code>{options[opt].toString()}</code>
+                    </strong>
+                    {/* We actually don't want to allow changes to the provided source options? */}
+                    {/* <Form.Control
                         size="sm"
                         type="text"
                         value={options[opt].toString()}
@@ -212,8 +207,6 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
                           setOptions(_options);
                         }}
                       /> */}
-                      </Col>
-                    </Form.Row>
                   </Form.Group>
                 ))}
             </Fragment>
@@ -374,7 +367,7 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
           <Table>
             <thead>
               <tr>
-                <th>Source Options</th>
+                <th>Source Option</th>
                 <th>{""}</th>
                 <th>Key</th>
                 <th>Type</th>

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/multipleProperties.tsx
@@ -195,18 +195,6 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
                     <strong>
                       <code>{options[opt].toString()}</code>
                     </strong>
-                    {/* We actually don't want to allow changes to the provided source options? */}
-                    {/* <Form.Control
-                        size="sm"
-                        type="text"
-                        value={options[opt].toString()}
-                        disabled={disabled}
-                        onChange={(e) => {
-                          const _options = makeLocal(options);
-                          _options[opt] = e.target.value;
-                          setOptions(_options);
-                        }}
-                      /> */}
                   </Form.Group>
                 ))}
             </Fragment>
@@ -367,7 +355,7 @@ const Page: NextPageWithInferredProps<typeof getServerSideProps> = ({
           <Table>
             <thead>
               <tr>
-                <th>Source Option</th>
+                <th>Source Column</th>
                 <th>{""}</th>
                 <th>Key</th>
                 <th>Type</th>


### PR DESCRIPTION
We don't really need to say the word "Column" - it's implied!

Before

<img width="1063" alt="Screen Shot 2022-03-01 at 5 24 59 PM" src="https://user-images.githubusercontent.com/303226/156277053-25aefdc4-d196-44b4-9cbe-0a61a5934c2e.png">


After

<img width="1063" alt="Screen Shot 2022-03-01 at 5 25 00 PM" src="https://user-images.githubusercontent.com/303226/156277068-0bbccf3d-198c-4a1d-a580-736d5fbd0d79.png">


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
