### PR TITLE
Fix Import association when multiple Models share the same primary key values

### DIFF
--- a/core/__tests__/tasks/import/associateRecords.ts
+++ b/core/__tests__/tasks/import/associateRecords.ts
@@ -1,7 +1,14 @@
 import { helper } from "@grouparoo/spec-helper";
 import { api, task, specHelper } from "actionhero";
-import { RecordProperty } from "../../../dist";
-import { Import, Source, Schedule, GrouparooRecord } from "../../../src";
+import {
+  Import,
+  Source,
+  Schedule,
+  GrouparooRecord,
+  RecordProperty,
+  GrouparooModel,
+  Property,
+} from "../../../src";
 
 describe("tasks/import:associateRecords", () => {
   helper.grouparooTestServer({ truncate: true, enableTestPlugin: true });
@@ -220,12 +227,7 @@ describe("tasks/import:associateRecords", () => {
     expect(_importA.state).toBe("associating");
     expect(_importB.state).toBe("associating");
 
-    try {
-      await specHelper.runTask("import:associateRecords", {});
-    } catch (e) {
-      console.error(e);
-      throw e;
-    }
+    await specHelper.runTask("import:associateRecords", {});
 
     expect(await GrouparooRecord.count()).toBe(1);
     const record = await GrouparooRecord.findOne();
@@ -247,13 +249,13 @@ describe("tasks/import:associateRecords", () => {
   // Prevent data in Secondary Sources from Creating Records that do not exist in the Primary Sources
   test("prevents import when unable to create record from secondary source", async () => {
     // make a new source and property
-    const source: Source = await helper.factories.source();
+    const source = await helper.factories.source();
     await source.setOptions({ table: "otherTable" });
     await source.setMapping({ user_id: "userId" });
     await source.update({ state: "ready" });
-    const schedule: Schedule = await helper.factories.schedule(source);
+    const schedule = await helper.factories.schedule(source);
     const run = await helper.factories.run(schedule);
-    const _import: Import = await helper.factories.import(run, {
+    const _import = await helper.factories.import(run, {
       thing: "stuff",
       userId: 99999999, // doesn't exist in source
     });
@@ -271,5 +273,68 @@ describe("tasks/import:associateRecords", () => {
     await run.destroy();
     await schedule.destroy();
     await source.destroy();
+  });
+
+  describe("with another model", () => {
+    let otherModel: GrouparooModel;
+    let otherSource: Source;
+    let otherSchedule: Schedule;
+    let otherProperty: Property;
+
+    beforeAll(async () => {
+      otherModel = await helper.factories.model({
+        id: "other_model",
+        name: "other model",
+      });
+      otherSource = await helper.factories.source(null, {
+        modelId: otherModel.id,
+      });
+      await otherSource.setOptions({ table: "admins" });
+      otherProperty = await helper.factories.property(
+        otherSource,
+        {
+          type: "integer",
+          unique: true,
+          key: "adminId",
+        },
+        { column: "adminId" }
+      );
+      otherProperty.update({ state: "ready" });
+      await otherSource.setMapping({ admin_id: otherProperty.key });
+      await otherSource.update({ state: "ready" });
+
+      otherSchedule = await helper.factories.schedule(otherSource);
+    });
+
+    beforeEach(async () => {
+      await api.resque.queue.connection.redis.flushdb();
+      await GrouparooRecord.truncate();
+      await RecordProperty.truncate();
+      await Import.truncate();
+    });
+
+    test("model selection works in batches when primary key values match", async () => {
+      const runA = await helper.factories.run(primarySchedule);
+      const runB = await helper.factories.run(otherSchedule);
+
+      const _importA = await helper.factories.import(runA, { userId: "1" });
+      const _importB = await helper.factories.import(runB, { adminId: "1" });
+
+      await specHelper.runTask("import:associateRecords", {});
+
+      const records = await GrouparooRecord.findAll({
+        include: [RecordProperty],
+      });
+
+      const recordA = records.find((r) => r.modelId === "mod_profiles");
+      const recordB = records.find((r) => r.modelId === "other_model");
+
+      expect(await recordA.simplifiedProperties()).toEqual(
+        expect.objectContaining({ userId: [1] })
+      );
+      expect(await recordB.simplifiedProperties()).toEqual(
+        expect.objectContaining({ adminId: [1] })
+      );
+    });
   });
 });

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -848,13 +848,12 @@ export namespace RecordOps {
       if (data.error) continue;
 
       // the record already exists in the DB and we can find it by property value
-      for (const [key, matchValues] of Object.entries(
+      for (const [propertyId, matchValues] of Object.entries(
         data.uniquePropertiesHash
       )) {
         const recordProperty = recordProperties.find(
           (rp) =>
-            matchValues.includes(rp.rawValue) &&
-            key === properties.find((p) => p.id === rp.propertyId).key
+            propertyId === rp.propertyId && matchValues.includes(rp.rawValue)
         );
         if (recordProperty) {
           data.record = recordProperty.record;

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -830,13 +830,15 @@ export namespace RecordOps {
       i++;
     }
 
+    const uniquePropertyIds = uniqueProperties.map((p) => p.id);
+
     const recordProperties = await RecordProperty.findAll({
       where: { unique: true, rawValue: rawValues },
       include: [GrouparooRecord],
     });
 
     const properties = await PropertiesCache.findAllWithCache(
-      undefined,
+      source instanceof Source ? source.modelId : undefined,
       "ready"
     );
 
@@ -845,8 +847,10 @@ export namespace RecordOps {
 
       // the record already exists in the DB and we can find it by property value
       for (const matchValues of Object.values(data.uniquePropertiesHash)) {
-        const recordProperty = recordProperties.find((rp) =>
-          matchValues.includes(rp.rawValue)
+        const recordProperty = recordProperties.find(
+          (rp) =>
+            uniquePropertyIds.includes(rp.propertyId) &&
+            matchValues.includes(rp.rawValue)
         );
         if (recordProperty) {
           data.record = recordProperty.record;

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -12,8 +12,6 @@ import Sequelize, {
   OrderItem,
   WhereAttributeHash,
   QueryTypes,
-  UniqueConstraintError,
-  Transaction,
 } from "sequelize";
 import { waitForLock } from "../locks";
 import { RecordPropertyOps } from "./recordProperty";

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -830,10 +830,12 @@ export namespace RecordOps {
       i++;
     }
 
-    const uniquePropertyIds = uniqueProperties.map((p) => p.id);
-
     const recordProperties = await RecordProperty.findAll({
-      where: { unique: true, rawValue: rawValues },
+      where: {
+        propertyId: uniqueProperties.map((p) => p.id),
+        unique: true,
+        rawValue: rawValues,
+      },
       include: [GrouparooRecord],
     });
 
@@ -847,10 +849,8 @@ export namespace RecordOps {
 
       // the record already exists in the DB and we can find it by property value
       for (const matchValues of Object.values(data.uniquePropertiesHash)) {
-        const recordProperty = recordProperties.find(
-          (rp) =>
-            uniquePropertyIds.includes(rp.propertyId) &&
-            matchValues.includes(rp.rawValue)
+        const recordProperty = recordProperties.find((rp) =>
+          matchValues.includes(rp.rawValue)
         );
         if (recordProperty) {
           data.record = recordProperty.record;

--- a/core/src/modules/ops/record.ts
+++ b/core/src/modules/ops/record.ts
@@ -848,9 +848,13 @@ export namespace RecordOps {
       if (data.error) continue;
 
       // the record already exists in the DB and we can find it by property value
-      for (const matchValues of Object.values(data.uniquePropertiesHash)) {
-        const recordProperty = recordProperties.find((rp) =>
-          matchValues.includes(rp.rawValue)
+      for (const [key, matchValues] of Object.entries(
+        data.uniquePropertiesHash
+      )) {
+        const recordProperty = recordProperties.find(
+          (rp) =>
+            matchValues.includes(rp.rawValue) &&
+            key === properties.find((p) => p.id === rp.propertyId).key
         );
         if (recordProperty) {
           data.record = recordProperty.record;


### PR DESCRIPTION
A bug was introduced in https://github.com/grouparoo/grouparoo/pull/2968 which incorrectly associated Imports with the same values (e.g. userId=1 and adminId=1) to the same record.

## Change description

Description here

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
