### PR TITLE
Source now only uses name for a unique composite key.

### DIFF
--- a/core/__tests__/models/source/source.ts
+++ b/core/__tests__/models/source/source.ts
@@ -238,7 +238,7 @@ describe("models/source", () => {
     });
 
     test("sources can't share the same name, even if they belong to different apps", async () => {
-      const app2 = await helper.factories.app();
+      const app2: App = await helper.factories.app();
       const sourceOne = await Source.create({
         type: "test-plugin-import",
         appId: app.id,
@@ -268,6 +268,7 @@ describe("models/source", () => {
 
       await sourceOne.destroy();
       await sourceTwo.destroy();
+      await app2.destroy();
     });
 
     test("a source cannot be changed to to the ready state if there are missing required options", async () => {

--- a/core/src/models/Source.ts
+++ b/core/src/models/Source.ts
@@ -141,8 +141,6 @@ export class Source extends CommonModel<Source> {
   @BelongsTo(() => GrouparooModel)
   model: GrouparooModel;
 
-  uniqueIdentifier = ["appId", "name"];
-
   async getOptions(sourceFromEnvironment = true) {
     return OptionHelper.getOptions(this, sourceFromEnvironment);
   }


### PR DESCRIPTION
## Change description

Source now only uses name for a unique ~composite~ key. Explicit test added.

## Checklists

### Development

- [X] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [X] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
