### PR TITLE
Fix schedule run value in Source overview and schedule pages

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/overview.tsx
@@ -52,7 +52,7 @@ export const getServerSideProps = withServerErrorHandler(async (ctx) => {
       id: source.schedule.id,
       limit: 1,
     });
-    run = runs[0];
+    run = runs?.[0] ?? null;
   }
 
   return { props: { source, totalSources, run, properties } };

--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/schedule.tsx
@@ -57,6 +57,7 @@ export const getServerSideProps = withServerErrorHandler(async (ctx) => {
     id: source.schedule.id,
     limit: 1,
   });
+  const run = runs?.[0] ?? null;
 
   const { total: totalSources } = await client.request<Actions.SourcesList>(
     "get",
@@ -77,7 +78,7 @@ export const getServerSideProps = withServerErrorHandler(async (ctx) => {
       pluginOptions,
       filterOptions,
       filterOptionDescriptions,
-      run: runs ? runs[0] : null,
+      run,
       totalSources,
       totalProperties,
     },


### PR DESCRIPTION
## Change description

This fixes a minor issue primarily seen in ui-config where sometimes the schedule and overview pages would fail if the list of runs was empty because next expects `null` instead of `undefined` as the return value.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
