### PR TITLE
Fix source edit page preview so that it always updates when source options change

### DIFF
--- a/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
+++ b/ui/ui-components/pages/model/[modelId]/source/[sourceId]/edit.tsx
@@ -237,8 +237,8 @@ const Page: NextPage<Props> = ({
   });
 
   const loadPreview = useCallback(
-    async (previewAvailable = source.previewAvailable) => {
-      if (!previewAvailable) {
+    async (source: Models.SourceType) => {
+      if (!source.previewAvailable) {
         return;
       }
 
@@ -258,7 +258,7 @@ const Page: NextPage<Props> = ({
         reset(resetFormData(source));
       }
     },
-    [client, resetFormData, reset, source, sourceId]
+    [client, resetFormData, reset, sourceId]
   );
 
   const sourceBadges = useMemo(() => {
@@ -292,8 +292,8 @@ const Page: NextPage<Props> = ({
   }, [client, source.options, sourceId]);
 
   useEffect(() => {
-    loadPreview();
-  }, [loadPreview]);
+    loadPreview(source);
+  }, [loadPreview, source]);
 
   useEffect(() => {
     loadOptions();
@@ -452,9 +452,11 @@ const Page: NextPage<Props> = ({
       setSource((src) => {
         src.options[optKey] = optValue;
         src.mapping = {};
+
+        loadPreview(src);
+
         return src;
       });
-      loadPreview();
     },
     [loadPreview]
   );


### PR DESCRIPTION
## Change description

This fixes an issue when setting the options for a source, it would update the preview with the previous source options. The cause was because of effects related to the source.

When setting the options for the first time, it would fail to load a preview because the preview was loaded with the previous source state. The fix now uses the updated source to load the preview.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
